### PR TITLE
Fixed a bug with swatches shown even for out-of-stock variants

### DIFF
--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Mediafallback.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Mediafallback.php
@@ -432,6 +432,7 @@ class Mage_ConfigurableSwatches_Helper_Mediafallback extends Mage_Core_Helper_Ab
         );
 
         $collection->setFlag('product_children', true)
+            ->setFlag('require_stock_items', true)
             ->addStoreFilter($storeId)
             ->addAttributeToSelect($this->_getChildrenProductsAttributes());
         $collection->addProductSetFilter($productIds);


### PR DESCRIPTION
<!---
    Thank you for contributing to OpenMage LTS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In the product list, all swatches are always shown even if they are not available.
You can verify this on the PDP because only the available ones are displayed correctly.

Tested with both enabled and disabled stock inventory configuration "Display Out of Stock Products"

![inventory_settings](https://github.com/user-attachments/assets/7647e266-1fde-4a49-9d8b-7946d4efc877)

When "Display Out of Stock Products" is enabled shown correctly like this:
![show_out_of_stock](https://github.com/user-attachments/assets/d2848333-968d-49d9-baeb-4395f640436d)

When "Display Out of Stock Products" is disabled all swatches are always shown even if they are not available.
With this patch shown correctly like this:

![not_out_of_stock](https://github.com/user-attachments/assets/08e93a55-4c2d-4394-a0f6-b4827530ede5)

The bug occurs when the " Display Out of Stock Products" configuration is disabled.

### Related Pull Requests
<!-- related pull request placeholder -->
https://github.com/OpenMage/magento-lts/pull/4100

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://github.com/OpenMage/magento-lts/issues/3527

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create configurable product with options as swatch such as color
2. Set stock unavailable for one color option

Example with sample data:
1. In product configurable Name: "Nolita cami" SKU "wbk000c" set all children products with color pink unavailable.

In the product list, all colors are always shown even if they are not available.
You can verify this on the PDP because only the available ones are displayed correctly.

![pdp](https://github.com/user-attachments/assets/6b33df90-c68f-48c5-977d-fb321497e248)
![pl](https://github.com/user-attachments/assets/50f6779f-ad65-436d-bcfb-126fd57c2feb)



### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Add yourself to contributors list
 <!--- 
    Install: `yarn add --dev all-contributors-cli`
    Add yourself: `yarn all-contributors add @YOUR_NAME <types>`
    This updates `.all-contributorsrc, README.md` and commits this changes automatically
    contribution types: code, doc, design
    See other contributions type at https://allcontributors.org/docs/en/emoji-key
 -->