### PR TITLE
Adminhtml: Fixed active menu highlighting

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
@@ -41,7 +41,7 @@ class Mage_Adminhtml_Api_RoleController extends Mage_Adminhtml_Controller_Action
     protected function _initAction()
     {
         $this->loadLayout();
-        $this->_setActiveMenu('system/services/roles');
+        $this->_setActiveMenu('system/api/roles');
         $this->_addBreadcrumb($this->__('Web services'), $this->__('Web services'));
         $this->_addBreadcrumb($this->__('Permissions'), $this->__('Permissions'));
         $this->_addBreadcrumb($this->__('Roles'), $this->__('Roles'));

--- a/app/code/core/Mage/Adminhtml/controllers/Api/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/UserController.php
@@ -39,7 +39,7 @@ class Mage_Adminhtml_Api_UserController extends Mage_Adminhtml_Controller_Action
     protected function _initAction()
     {
         $this->loadLayout()
-            ->_setActiveMenu('system/services/users')
+            ->_setActiveMenu('system/api/users')
             ->_addBreadcrumb($this->__('Web Services'), $this->__('Web Services'))
             ->_addBreadcrumb($this->__('Permissions'), $this->__('Permissions'))
             ->_addBreadcrumb($this->__('Users'), $this->__('Users'))

--- a/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
@@ -155,7 +155,7 @@ class Mage_Adminhtml_CustomerController extends Mage_Adminhtml_Controller_Action
         /**
          * Set active menu item
          */
-        $this->_setActiveMenu('customer/new');
+        $this->_setActiveMenu('customer/manage');
 
         $this->renderLayout();
     }

--- a/app/code/core/Mage/Adminhtml/controllers/NotificationController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/NotificationController.php
@@ -26,7 +26,7 @@ class Mage_Adminhtml_NotificationController extends Mage_Adminhtml_Controller_Ac
         $this->_title($this->__('System'))->_title($this->__('Notifications'));
 
         $this->loadLayout()
-            ->_setActiveMenu('system/notification')
+            ->_setActiveMenu('system/adminnotification')
             ->_addBreadcrumb(Mage::helper('adminnotification')->__('Messages Inbox'), Mage::helper('adminhtml')->__('Messages Inbox'))
             ->_addContent($this->getLayout()->createBlock('adminhtml/notification_inbox'))
             ->renderLayout();

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/BlockController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/BlockController.php
@@ -33,7 +33,7 @@ class Mage_Adminhtml_Permissions_BlockController extends Mage_Adminhtml_Controll
     protected function _initAction()
     {
         $this->loadLayout()
-            ->_setActiveMenu('system/acl')
+            ->_setActiveMenu('system/acl/blocks')
             ->_addBreadcrumb($this->__('System'), $this->__('System'))
             ->_addBreadcrumb($this->__('Permissions'), $this->__('Permissions'))
             ->_addBreadcrumb($this->__('Blocks'), $this->__('Blocks'));

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/OrphanedResourceController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/OrphanedResourceController.php
@@ -28,7 +28,7 @@ class Mage_Adminhtml_Permissions_OrphanedResourceController extends Mage_Adminht
     protected function _initAction()
     {
         $this->loadLayout()
-            ->_setActiveMenu('system/acl')
+            ->_setActiveMenu('system/acl/orphaned_resources')
             ->_addBreadcrumb($this->__('System'), $this->__('System'))
             ->_addBreadcrumb($this->__('Permissions'), $this->__('Permissions'))
             ->_addBreadcrumb($this->__('Orphaned Resources'), $this->__('Orphaned Role Resources'));

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/RoleController.php
@@ -46,7 +46,7 @@ class Mage_Adminhtml_Permissions_RoleController extends Mage_Adminhtml_Controlle
     protected function _initAction()
     {
         $this->loadLayout();
-        $this->_setActiveMenu('system/acl');
+        $this->_setActiveMenu('system/acl/roles');
         $this->_addBreadcrumb($this->__('System'), $this->__('System'));
         $this->_addBreadcrumb($this->__('Permissions'), $this->__('Permissions'));
         $this->_addBreadcrumb($this->__('Roles'), $this->__('Roles'));

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/UserController.php
@@ -39,7 +39,7 @@ class Mage_Adminhtml_Permissions_UserController extends Mage_Adminhtml_Controlle
     protected function _initAction()
     {
         $this->loadLayout()
-            ->_setActiveMenu('system/acl')
+            ->_setActiveMenu('system/acl/users')
             ->_addBreadcrumb($this->__('System'), $this->__('System'))
             ->_addBreadcrumb($this->__('Permissions'), $this->__('Permissions'))
             ->_addBreadcrumb($this->__('Users'), $this->__('Users'))

--- a/app/code/core/Mage/Adminhtml/controllers/Permissions/VariableController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Permissions/VariableController.php
@@ -33,7 +33,7 @@ class Mage_Adminhtml_Permissions_VariableController extends Mage_Adminhtml_Contr
     protected function _initAction()
     {
         $this->loadLayout()
-            ->_setActiveMenu('system/acl')
+            ->_setActiveMenu('system/acl/variables')
             ->_addBreadcrumb($this->__('System'), $this->__('System'))
             ->_addBreadcrumb($this->__('Permissions'), $this->__('Permissions'))
             ->_addBreadcrumb($this->__('Variables'), $this->__('Variables'));

--- a/app/code/core/Mage/Adminhtml/controllers/Report/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/CustomerController.php
@@ -42,7 +42,7 @@ class Mage_Adminhtml_Report_CustomerController extends Mage_Adminhtml_Controller
              ->_title($this->__('New Accounts'));
 
         $this->_initAction()
-            ->_setActiveMenu('report/customer/accounts')
+            ->_setActiveMenu('report/customers/accounts')
             ->_addBreadcrumb(Mage::helper('adminhtml')->__('New Accounts'), Mage::helper('adminhtml')->__('New Accounts'))
             ->_addContent($this->getLayout()->createBlock('adminhtml/report_customer_accounts'))
             ->renderLayout();
@@ -73,7 +73,7 @@ class Mage_Adminhtml_Report_CustomerController extends Mage_Adminhtml_Controller
              ->_title($this->__('Customers by Number of Orders'));
 
         $this->_initAction()
-            ->_setActiveMenu('report/customer/orders')
+            ->_setActiveMenu('report/customers/orders')
             ->_addBreadcrumb(
                 Mage::helper('reports')->__('Customers by Number of Orders'),
                 Mage::helper('reports')->__('Customers by Number of Orders')
@@ -107,7 +107,7 @@ class Mage_Adminhtml_Report_CustomerController extends Mage_Adminhtml_Controller
              ->_title($this->__('Customers by Orders Total'));
 
         $this->_initAction()
-            ->_setActiveMenu('report/customer/totals')
+            ->_setActiveMenu('report/customers/totals')
             ->_addBreadcrumb(
                 Mage::helper('reports')->__('Customers by Orders Total'),
                 Mage::helper('reports')->__('Customers by Orders Total')

--- a/app/code/core/Mage/Adminhtml/controllers/Report/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/ProductController.php
@@ -73,7 +73,7 @@ class Mage_Adminhtml_Report_ProductController extends Mage_Adminhtml_Controller_
              ->_title($this->__('Products Ordered'));
 
         $this->_initAction()
-            ->_setActiveMenu('report/product/sold')
+            ->_setActiveMenu('report/products/sold')
             ->_addBreadcrumb(Mage::helper('reports')->__('Products Ordered'), Mage::helper('reports')->__('Products Ordered'))
             ->_addContent($this->getLayout()->createBlock('adminhtml/report_product_sold'))
             ->renderLayout();
@@ -151,7 +151,7 @@ class Mage_Adminhtml_Report_ProductController extends Mage_Adminhtml_Controller_
              ->_title($this->__('Low Stock'));
 
         $this->_initAction()
-            ->_setActiveMenu('report/product/lowstock')
+            ->_setActiveMenu('report/products/lowstock')
             ->_addBreadcrumb(Mage::helper('reports')->__('Low Stock'), Mage::helper('reports')->__('Low Stock'))
             ->_addContent($this->getLayout()->createBlock('adminhtml/report_product_lowstock'))
             ->renderLayout();
@@ -185,7 +185,7 @@ class Mage_Adminhtml_Report_ProductController extends Mage_Adminhtml_Controller_
              ->_title($this->__('Downloads'));
 
         $this->_initAction()
-            ->_setActiveMenu('report/product/downloads')
+            ->_setActiveMenu('report/products/downloads')
             ->_addBreadcrumb(Mage::helper('reports')->__('Downloads'), Mage::helper('reports')->__('Downloads'))
             ->_addContent($this->getLayout()->createBlock('adminhtml/report_product_downloads'))
             ->renderLayout();

--- a/app/code/core/Mage/Adminhtml/controllers/Report/SalesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Report/SalesController.php
@@ -40,7 +40,7 @@ class Mage_Adminhtml_Report_SalesController extends Mage_Adminhtml_Controller_Re
         $this->_showLastExecutionTime(Mage_Reports_Model_Flag::REPORT_ORDER_FLAG_CODE, 'sales');
 
         $this->_initAction()
-            ->_setActiveMenu('report/sales/sales')
+            ->_setActiveMenu('report/salesroot/sales')
             ->_addBreadcrumb(Mage::helper('adminhtml')->__('Sales Report'), Mage::helper('adminhtml')->__('Sales Report'));
 
         $gridBlock = $this->getLayout()->getBlock('report_sales_sales.grid');
@@ -155,7 +155,7 @@ class Mage_Adminhtml_Report_SalesController extends Mage_Adminhtml_Controller_Re
         $this->_showLastExecutionTime(Mage_Reports_Model_Flag::REPORT_TAX_FLAG_CODE, 'tax');
 
         $this->_initAction()
-            ->_setActiveMenu('report/sales/tax')
+            ->_setActiveMenu('report/salesroot/tax')
             ->_addBreadcrumb(Mage::helper('adminhtml')->__('Tax'), Mage::helper('adminhtml')->__('Tax'));
 
         $gridBlock = $this->getLayout()->getBlock('report_sales_tax.grid');
@@ -196,7 +196,7 @@ class Mage_Adminhtml_Report_SalesController extends Mage_Adminhtml_Controller_Re
         $this->_showLastExecutionTime(Mage_Reports_Model_Flag::REPORT_SHIPPING_FLAG_CODE, 'shipping');
 
         $this->_initAction()
-            ->_setActiveMenu('report/sales/shipping')
+            ->_setActiveMenu('report/salesroot/shipping')
             ->_addBreadcrumb(Mage::helper('adminhtml')->__('Shipping'), Mage::helper('adminhtml')->__('Shipping'));
 
         $gridBlock = $this->getLayout()->getBlock('report_sales_shipping.grid');
@@ -237,7 +237,7 @@ class Mage_Adminhtml_Report_SalesController extends Mage_Adminhtml_Controller_Re
         $this->_showLastExecutionTime(Mage_Reports_Model_Flag::REPORT_INVOICE_FLAG_CODE, 'invoiced');
 
         $this->_initAction()
-            ->_setActiveMenu('report/sales/invoiced')
+            ->_setActiveMenu('report/salesroot/invoiced')
             ->_addBreadcrumb(Mage::helper('adminhtml')->__('Total Invoiced'), Mage::helper('adminhtml')->__('Total Invoiced'));
 
         $gridBlock = $this->getLayout()->getBlock('report_sales_invoiced.grid');
@@ -278,7 +278,7 @@ class Mage_Adminhtml_Report_SalesController extends Mage_Adminhtml_Controller_Re
         $this->_showLastExecutionTime(Mage_Reports_Model_Flag::REPORT_REFUNDED_FLAG_CODE, 'refunded');
 
         $this->_initAction()
-            ->_setActiveMenu('report/sales/refunded')
+            ->_setActiveMenu('report/salesroot/refunded')
             ->_addBreadcrumb(Mage::helper('adminhtml')->__('Total Refunded'), Mage::helper('adminhtml')->__('Total Refunded'));
 
         $gridBlock = $this->getLayout()->getBlock('report_sales_refunded.grid');
@@ -319,7 +319,7 @@ class Mage_Adminhtml_Report_SalesController extends Mage_Adminhtml_Controller_Re
         $this->_showLastExecutionTime(Mage_Reports_Model_Flag::REPORT_COUPONS_FLAG_CODE, 'coupons');
 
         $this->_initAction()
-            ->_setActiveMenu('report/sales/coupons')
+            ->_setActiveMenu('report/salesroot/coupons')
             ->_addBreadcrumb(Mage::helper('adminhtml')->__('Coupons'), Mage::helper('adminhtml')->__('Coupons'));
 
         $gridBlock = $this->getLayout()->getBlock('report_sales_coupons.grid');

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/StatusController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/StatusController.php
@@ -56,8 +56,11 @@ class Mage_Adminhtml_Sales_Order_StatusController extends Mage_Adminhtml_Control
      */
     public function indexAction()
     {
-        $this->_title($this->__('Sales'))->_title($this->__('Order Statuses'));
-        $this->loadLayout()->_setActiveMenu('system')->renderLayout();
+        $this
+            ->_title($this->__('Sales'))->_title($this->__('Order Statuses'))
+            ->loadLayout()
+            ->_setActiveMenu('system/order_statuses')
+            ->renderLayout();
     }
 
     /**
@@ -71,8 +74,10 @@ class Mage_Adminhtml_Sales_Order_StatusController extends Mage_Adminhtml_Control
                 ->setData($data);
             Mage::register('current_status', $status);
         }
-        $this->_title($this->__('Sales'))->_title($this->__('Create New Order Status'));
-        $this->loadLayout()
+        $this
+            ->_title($this->__('Sales'))->_title($this->__('Create New Order Status'))
+            ->loadLayout()
+            ->_setActiveMenu('system/order_statuses')
             ->renderLayout();
     }
 
@@ -84,8 +89,10 @@ class Mage_Adminhtml_Sales_Order_StatusController extends Mage_Adminhtml_Control
         $status = $this->_initStatus();
         if ($status) {
             Mage::register('current_status', $status);
-            $this->_title($this->__('Sales'))->_title($this->__('Edit Order Status'));
-            $this->loadLayout()
+            $this
+                ->_title($this->__('Sales'))->_title($this->__('Edit Order Status'))
+                ->loadLayout()
+                ->_setActiveMenu('system/order_statuses')
                 ->renderLayout();
         } else {
             $this->_getSession()->addError(
@@ -159,8 +166,10 @@ class Mage_Adminhtml_Sales_Order_StatusController extends Mage_Adminhtml_Control
      */
     public function assignAction()
     {
-        $this->_title($this->__('Sales'))->_title($this->__('Assign Order Status to State'));
-        $this->loadLayout()
+        $this
+            ->_title($this->__('Sales'))->_title($this->__('Assign Order Status to State'))
+            ->loadLayout()
+            ->_setActiveMenu('system/order_statuses')
             ->renderLayout();
     }
 

--- a/app/code/core/Mage/Adminhtml/controllers/System/AccountController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/AccountController.php
@@ -32,7 +32,7 @@ class Mage_Adminhtml_System_AccountController extends Mage_Adminhtml_Controller_
         $this->_title($this->__('System'))->_title($this->__('My Account'));
 
         $this->loadLayout();
-        $this->_setActiveMenu('system/account');
+        $this->_setActiveMenu('system/myaccount');
         $this->_addContent($this->getLayout()->createBlock('adminhtml/system_account_edit'));
         $this->renderLayout();
     }

--- a/app/code/core/Mage/Adminhtml/controllers/System/Convert/GuiController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Convert/GuiController.php
@@ -47,7 +47,7 @@ class Mage_Adminhtml_System_Convert_GuiController extends Mage_Adminhtml_System_
         /**
          * Set active menu item
          */
-        $this->_setActiveMenu('system/convert');
+        $this->_setActiveMenu('system/convert/gui');
 
         /**
          * Append profiles block to content
@@ -89,7 +89,7 @@ class Mage_Adminhtml_System_Convert_GuiController extends Mage_Adminhtml_System_
 
         $this->_title($profile->getId() ? $profile->getName() : $this->__('New Profile'));
 
-        $this->_setActiveMenu('system/convert');
+        $this->_setActiveMenu('system/convert/gui');
 
         $this->_addContent(
             $this->getLayout()->createBlock('adminhtml/system_convert_gui_edit')

--- a/app/code/core/Mage/Adminhtml/controllers/System/Convert/ProfileController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Convert/ProfileController.php
@@ -71,7 +71,7 @@ class Mage_Adminhtml_System_Convert_ProfileController extends Mage_Adminhtml_Con
         /**
          * Set active menu item
          */
-        $this->_setActiveMenu('system/convert');
+        $this->_setActiveMenu('system/convert/profiles');
 
         /**
          * Append profiles block to content
@@ -121,7 +121,7 @@ class Mage_Adminhtml_System_Convert_ProfileController extends Mage_Adminhtml_Con
 
         $this->_title($profile->getId() ? $profile->getName() : $this->__('New Profile'));
 
-        $this->_setActiveMenu('system/convert');
+        $this->_setActiveMenu('system/convert/profiles');
 
         $this->_addContent(
             $this->getLayout()->createBlock('adminhtml/system_convert_profile_edit')

--- a/app/code/core/Mage/Adminhtml/controllers/System/CurrencyController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/CurrencyController.php
@@ -50,7 +50,7 @@ class Mage_Adminhtml_System_CurrencyController extends Mage_Adminhtml_Controller
         $this->_title($this->__('System'))->_title($this->__('Manage Currency Rates'));
 
         $this->loadLayout();
-        $this->_setActiveMenu('system/currency');
+        $this->_setActiveMenu('system/currency/rates');
         $this->_addContent($this->getLayout()->createBlock('adminhtml/system_currency'));
         $this->renderLayout();
     }

--- a/app/code/core/Mage/Adminhtml/controllers/System/DesignController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/DesignController.php
@@ -38,12 +38,12 @@ class Mage_Adminhtml_System_DesignController extends Mage_Adminhtml_Controller_A
 
     public function indexAction()
     {
-        $this->_title($this->__('System'))->_title($this->__('Design'));
-
-        $this->loadLayout();
-        $this->_setActiveMenu('system');
-        $this->_addContent($this->getLayout()->createBlock('adminhtml/system_design'));
-        $this->renderLayout();
+        $this
+            ->_title($this->__('System'))->_title($this->__('Design'))
+            ->loadLayout()
+            ->_setActiveMenu('system/design')
+            ->_addContent($this->getLayout()->createBlock('adminhtml/system_design'))
+            ->renderLayout();
     }
 
     public function gridAction()
@@ -58,10 +58,12 @@ class Mage_Adminhtml_System_DesignController extends Mage_Adminhtml_Controller_A
 
     public function editAction()
     {
-        $this->_title($this->__('System'))->_title($this->__('Design'));
+        $this
+            ->_title($this->__('System'))
+            ->_title($this->__('Design'))
+            ->loadLayout()
+            ->_setActiveMenu('system/design');
 
-        $this->loadLayout();
-        $this->_setActiveMenu('system');
         $this->getLayout()->getBlock('head')->setCanLoadExtJs(true);
 
         $id  = (int) $this->getRequest()->getParam('id');

--- a/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/AttributeController.php
+++ b/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/AttributeController.php
@@ -43,17 +43,16 @@ class Mage_Api2_Adminhtml_Api2_AttributeController extends Mage_Adminhtml_Contro
      */
     public function indexAction()
     {
-        $this->_title($this->__('System'))
-             ->_title($this->__('Web Services'))
-             ->_title($this->__('REST Attributes'));
-
-        $this->loadLayout()->_setActiveMenu('system/services/attributes');
-
-        $this->_addBreadcrumb($this->__('Web services'), $this->__('Web services'))
+        $this
+            ->_title($this->__('System'))
+            ->_title($this->__('Web Services'))
+            ->_title($this->__('REST Attributes'))
+            ->loadLayout()
+            ->_setActiveMenu('system/api/rest_attributes')
+            ->_addBreadcrumb($this->__('Web services'), $this->__('Web services'))
             ->_addBreadcrumb($this->__('REST Attributes'), $this->__('REST Attributes'))
-            ->_addBreadcrumb($this->__('Attributes'), $this->__('Attributes'));
-
-        $this->renderLayout();
+            ->_addBreadcrumb($this->__('Attributes'), $this->__('Attributes'))
+            ->renderLayout();
     }
 
     /**
@@ -62,7 +61,7 @@ class Mage_Api2_Adminhtml_Api2_AttributeController extends Mage_Adminhtml_Contro
     public function editAction()
     {
         $this->loadLayout()
-            ->_setActiveMenu('system/services/attributes');
+            ->_setActiveMenu('system/api/rest_attributes');
 
         $type = $this->getRequest()->getParam('type');
 

--- a/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
+++ b/app/code/core/Mage/Api2/controllers/Adminhtml/Api2/RoleController.php
@@ -37,16 +37,16 @@ class Mage_Api2_Adminhtml_Api2_RoleController extends Mage_Adminhtml_Controller_
      */
     public function indexAction()
     {
-        $this->_title($this->__('System'))
-             ->_title($this->__('Web Services'))
-             ->_title($this->__('REST Roles'));
-
-        $this->loadLayout()->_setActiveMenu('system/services/roles');
-        $this->_addBreadcrumb($this->__('Web services'), $this->__('Web services'));
-        $this->_addBreadcrumb($this->__('REST Roles'), $this->__('REST Roles'));
-        $this->_addBreadcrumb($this->__('Roles'), $this->__('Roles'));
-
-        $this->renderLayout();
+        $this
+            ->_title($this->__('System'))
+            ->_title($this->__('Web Services'))
+            ->_title($this->__('REST Roles'))
+            ->loadLayout()
+            ->_setActiveMenu('system/api/rest_roles')
+            ->_addBreadcrumb($this->__('Web services'), $this->__('Web services'))
+            ->_addBreadcrumb($this->__('REST Roles'), $this->__('REST Roles'))
+            ->_addBreadcrumb($this->__('Roles'), $this->__('Roles'))
+            ->renderLayout();
     }
 
     /**
@@ -78,22 +78,18 @@ class Mage_Api2_Adminhtml_Api2_RoleController extends Mage_Adminhtml_Controller_
      */
     public function newAction()
     {
-        $this->_title($this->__('System'))
-             ->_title($this->__('Web Services'))
-             ->_title($this->__('Rest Roles'));
-
-        $this->loadLayout()->_setActiveMenu('system/services/roles');
-        $this->_addBreadcrumb($this->__('Web services'), $this->__('Web services'));
-        $this->_addBreadcrumb($this->__('REST Roles'), $this->__('REST Roles'));
-        $this->_addBreadcrumb($this->__('Roles'), $this->__('Roles'));
-
-        $breadCrumb = $this->__('Add New Role');
-        $breadCrumbTitle = $this->__('Add New Role');
-        $this->_title($this->__('New Role'));
-
-        $this->_addBreadcrumb($breadCrumb, $breadCrumbTitle);
-
-        $this->renderLayout();
+        $this
+            ->_title($this->__('System'))
+            ->_title($this->__('Web Services'))
+            ->_title($this->__('Rest Roles'))
+            ->loadLayout()
+            ->_setActiveMenu('system/api/rest_roles')
+            ->_addBreadcrumb($this->__('Web services'), $this->__('Web services'))
+            ->_addBreadcrumb($this->__('REST Roles'), $this->__('REST Roles'))
+            ->_addBreadcrumb($this->__('Roles'), $this->__('Roles'))
+            ->_title($this->__('New Role'))
+            ->_addBreadcrumb($this->__('Add New Role'), $this->__('Add New Role'))
+            ->renderLayout();
     }
 
     /**
@@ -111,11 +107,12 @@ class Mage_Api2_Adminhtml_Api2_RoleController extends Mage_Adminhtml_Controller_
             return;
         }
 
-        $this->loadLayout()->_setActiveMenu('system/services/roles');
-
-        $this->_title($this->__('System'))
-             ->_title($this->__('Web Services'))
-             ->_title($this->__('Rest Roles'));
+        $this
+            ->loadLayout()
+            ->_setActiveMenu('system/api/rest_roles')
+            ->_title($this->__('System'))
+            ->_title($this->__('Web Services'))
+            ->_title($this->__('Rest Roles'));
 
         $breadCrumb = $this->__('Edit Role');
         $breadCrumbTitle = $this->__('Edit Role');

--- a/app/code/core/Mage/CurrencySymbol/controllers/Adminhtml/System/CurrencysymbolController.php
+++ b/app/code/core/Mage/CurrencySymbol/controllers/Adminhtml/System/CurrencysymbolController.php
@@ -34,7 +34,7 @@ class Mage_CurrencySymbol_Adminhtml_System_CurrencysymbolController extends Mage
     {
         // set active menu and breadcrumbs
         $this->loadLayout()
-            ->_setActiveMenu('system/currency')
+            ->_setActiveMenu('system/currency/symbols')
             ->_addBreadcrumb(
                 Mage::helper('currencysymbol')->__('System'),
                 Mage::helper('currencysymbol')->__('System')

--- a/app/code/core/Mage/ImportExport/controllers/Adminhtml/ExportController.php
+++ b/app/code/core/Mage/ImportExport/controllers/Adminhtml/ExportController.php
@@ -43,9 +43,10 @@ class Mage_ImportExport_Adminhtml_ExportController extends Mage_Adminhtml_Contro
      */
     protected function _initAction()
     {
-        $this->_title($this->__('Import/Export'))
+        $this
+            ->_title($this->__('Import/Export'))
             ->loadLayout()
-            ->_setActiveMenu('system/importexport');
+            ->_setActiveMenu('system/convert/export');
 
         return $this;
     }

--- a/app/code/core/Mage/ImportExport/controllers/Adminhtml/ImportController.php
+++ b/app/code/core/Mage/ImportExport/controllers/Adminhtml/ImportController.php
@@ -43,9 +43,10 @@ class Mage_ImportExport_Adminhtml_ImportController extends Mage_Adminhtml_Contro
      */
     protected function _initAction()
     {
-        $this->_title($this->__('Import/Export'))
+        $this
+            ->_title($this->__('Import/Export'))
             ->loadLayout()
-            ->_setActiveMenu('system/importexport');
+            ->_setActiveMenu('system/convert/import');
 
         return $this;
     }

--- a/app/code/core/Mage/Index/controllers/Adminhtml/ProcessController.php
+++ b/app/code/core/Mage/Index/controllers/Adminhtml/ProcessController.php
@@ -63,15 +63,17 @@ class Mage_Index_Adminhtml_ProcessController extends Mage_Adminhtml_Controller_A
         /** @var Mage_Index_Model_Process $process */
         $process = $this->_initProcess();
         if ($process) {
-            $this->_title($process->getIndexCode());
-
-            $this->_title($this->__('System'))
-                 ->_title($this->__('Index Management'))
-                 ->_title($this->__($process->getIndexer()->getName()));
+            $this
+                ->_title($process->getIndexCode())
+                ->_title($this->__('System'))
+                ->_title($this->__('Index Management'))
+                ->_title($this->__($process->getIndexer()->getName()));
 
             Mage::register('current_index_process', $process);
-            $this->loadLayout();
-            $this->renderLayout();
+            $this
+                ->loadLayout()
+                ->_setActiveMenu('system/index')
+                ->renderLayout();
         } else {
             $this->_getSession()->addError(
                 Mage::helper('index')->__('Cannot initialize the indexer process.')

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/Admin/TokenController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/Admin/TokenController.php
@@ -42,8 +42,10 @@ class Mage_Oauth_Adminhtml_Oauth_Admin_TokenController extends Mage_Adminhtml_Co
      */
     public function indexAction()
     {
-        $this->loadLayout();
-        $this->renderLayout();
+        $this
+            ->loadLayout()
+            ->_setActiveMenu('system/api/oauth_admin_token')
+            ->renderLayout();
     }
 
     /**

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
@@ -40,8 +40,10 @@ class Mage_Oauth_Adminhtml_Oauth_AuthorizedTokensController extends Mage_Adminht
      */
     public function indexAction()
     {
-        $this->loadLayout()->_setActiveMenu('system/oauth');
-        $this->renderLayout();
+        $this
+            ->loadLayout()
+            ->_setActiveMenu('system/api/oauth_authorized_tokens')
+            ->renderLayout();
     }
 
     /**

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/ConsumerController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/ConsumerController.php
@@ -58,8 +58,10 @@ class Mage_Oauth_Adminhtml_Oauth_ConsumerController extends Mage_Adminhtml_Contr
      */
     public function indexAction()
     {
-        $this->loadLayout();
-        $this->renderLayout();
+        $this
+            ->loadLayout()
+            ->_setActiveMenu('system/api/oauth_consumer')
+            ->renderLayout();
     }
 
     /**
@@ -93,8 +95,10 @@ class Mage_Oauth_Adminhtml_Oauth_ConsumerController extends Mage_Adminhtml_Contr
 
         Mage::register('current_consumer', $model);
 
-        $this->loadLayout();
-        $this->renderLayout();
+        $this
+            ->loadLayout()
+            ->_setActiveMenu('system/api/oauth_consumer')
+            ->renderLayout();
     }
 
     /**
@@ -123,8 +127,10 @@ class Mage_Oauth_Adminhtml_Oauth_ConsumerController extends Mage_Adminhtml_Contr
         $model->addData($this->_filter($this->getRequest()->getParams()));
         Mage::register('current_consumer', $model);
 
-        $this->loadLayout();
-        $this->renderLayout();
+        $this
+            ->loadLayout()
+            ->_setActiveMenu('system/api/oauth_consumer')
+            ->renderLayout();
     }
 
     /**

--- a/app/code/core/Mage/Paypal/controllers/Adminhtml/Paypal/ReportsController.php
+++ b/app/code/core/Mage/Paypal/controllers/Adminhtml/Paypal/ReportsController.php
@@ -101,7 +101,7 @@ class Mage_Paypal_Adminhtml_Paypal_ReportsController extends Mage_Adminhtml_Cont
     {
         $this->_title($this->__('Reports'))->_title($this->__('Sales'))->_title($this->__('PayPal Settlement Reports'));
         $this->loadLayout()
-            ->_setActiveMenu('report/sales')
+            ->_setActiveMenu('report/salesroot/paypal_settlement_reports')
             ->_addBreadcrumb(Mage::helper('paypal')->__('Reports'), Mage::helper('paypal')->__('Reports'))
             ->_addBreadcrumb(Mage::helper('paypal')->__('Sales'), Mage::helper('paypal')->__('Sales'))
             ->_addBreadcrumb(Mage::helper('paypal')->__('PayPal Settlement Reports'), Mage::helper('paypal')->__('PayPal Settlement Reports'));

--- a/app/code/core/Mage/Widget/controllers/Adminhtml/Widget/InstanceController.php
+++ b/app/code/core/Mage/Widget/controllers/Adminhtml/Widget/InstanceController.php
@@ -45,7 +45,7 @@ class Mage_Widget_Adminhtml_Widget_InstanceController extends Mage_Adminhtml_Con
     protected function _initAction()
     {
         $this->loadLayout()
-            ->_setActiveMenu('cms/widgets')
+            ->_setActiveMenu('cms/widget_instance')
             ->_addBreadcrumb(
                 Mage::helper('widget')->__('CMS'),
                 Mage::helper('widget')->__('CMS')


### PR DESCRIPTION
# Description

When selecting some menu items in the adminhtml, the entry is not highlighted/underlined (e.g. `System > Notifications`) when the page is loaded because of wrong menu paths in `_setActiveMenu` or the call of this method is completely missing.

This PR fixes the menu highlighting.

# Type of change

Fix

# How can this feature be tested

1. Visit Maho's adminhtml.
2. Click through the different menu entries.
3. The active menu entry should always be highlighted correctly.
