### PR TITLE
Adjust Branding in adminhtml.xmls and system.xmls

### DIFF
--- a/app/code/core/Mage/Api/etc/adminhtml.xml
+++ b/app/code/core/Mage/Api/etc/adminhtml.xml
@@ -38,7 +38,7 @@
                             <config>
                                 <children>
                                     <api translate="title" module="api">
-                                        <title>Magento Core API</title>
+                                        <title>Maho Core API</title>
                                     </api>
                                 </children>
                             </config>

--- a/app/code/core/Mage/Api/etc/system.xml
+++ b/app/code/core/Mage/Api/etc/system.xml
@@ -17,7 +17,7 @@
 <config>
    <sections>
         <api translate="label" module="api">
-            <label>Magento Core API</label>
+            <label>Maho Core API</label>
             <tab>service</tab>
             <sort_order>101</sort_order>
             <show_in_default>1</show_in_default>

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -1156,7 +1156,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
-                            <comment>Make sure that base URL ends with '/' (slash), e.g. http://yourdomain/magento/</comment>
+                            <comment>Make sure that base URL ends with '/' (slash), e.g. http://yourdomain/maho/</comment>
                         </custom>
                         <use_custom_path translate="label">
                             <label>Use Custom Admin Path</label>
@@ -1217,9 +1217,9 @@
                             <show_in_store>0</show_in_store>
                         </session_cookie_lifetime>
                         <domain_policy_backend translate="label comment">
-                            <label>Allow Magento Backend to run in frame</label>
+                            <label>Allow Maho Backend to run in frame</label>
                             <frontend_type>select</frontend_type>
-                            <comment>Enabling ability to run Magento in a frame is not recommended for security reasons.</comment>
+                            <comment>Enabling ability to run Maho in a frame is not recommended for security reasons.</comment>
                             <source_model>adminhtml/system_config_source_security_domainpolicy</source_model>
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
@@ -1227,8 +1227,8 @@
                             <show_in_store>0</show_in_store>
                         </domain_policy_backend>
                         <domain_policy_frontend translate="label comment">
-                            <label>Allow Magento Frontend to run in frame</label>
-                            <comment>Enabling ability to run Magento in a frame is not recommended for security reasons.</comment>
+                            <label>Allow Maho Frontend to run in frame</label>
+                            <comment>Enabling ability to run Maho in a frame is not recommended for security reasons.</comment>
                             <frontend_type>select</frontend_type>
                             <sort_order>5</sort_order>
                             <source_model>adminhtml/system_config_source_security_domainpolicy</source_model>
@@ -1402,7 +1402,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <comment>Make sure that base URL ends with '/' (slash), e.g. http://yourdomain/magento/</comment>
+                            <comment>Make sure that base URL ends with '/' (slash), e.g. http://yourdomain/maho/</comment>
                             <validate>required-entry</validate>
                         </base_url>
                         <base_link_url translate="label comment">
@@ -1412,7 +1412,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <comment>Make sure that base URL ends with '/' (slash), e.g. http://yourdomain/magento/</comment>
+                            <comment>Make sure that base URL ends with '/' (slash), e.g. http://yourdomain/maho/</comment>
                             <validate>required-entry</validate>
                         </base_link_url>
                         <base_skin_url translate="label">

--- a/app/code/core/Mage/Paypal/etc/system.xml
+++ b/app/code/core/Mage/Paypal/etc/system.xml
@@ -1058,7 +1058,7 @@
                                                 <label>Transfer Shipping Options</label>
                                                 <config_path>payment/paypal_express/transfer_shipping_options</config_path>
                                                 <tooltip>If this option is enabled, customer can change shipping address and shipping method on PayPal website. In live mode works via HTTPS protocol only.</tooltip>
-                                                <comment>Notice that PayPal can handle up to 10 shipping options. That is why Magento will transfer only first 10 cheapest shipping options if there are more than 10 available.</comment>
+                                                <comment>Notice that PayPal can handle up to 10 shipping options. That is why Maho will transfer only first 10 cheapest shipping options if there are more than 10 available.</comment>
                                                 <frontend_type>select</frontend_type>
                                                 <source_model>adminhtml/system_config_source_yesno</source_model>
                                                 <sort_order>50</sort_order>

--- a/app/code/core/Mage/Usa/etc/system.xml
+++ b/app/code/core/Mage/Usa/etc/system.xml
@@ -966,7 +966,7 @@
                         </specificerrmsg>
                         <mode_xml translate="label comment">
                             <label>Mode</label>
-                            <comment>Enables/Disables SSL verification of Magento server by UPS.</comment>
+                            <comment>Enables/Disables SSL verification of Maho server by UPS.</comment>
                             <frontend_type>select</frontend_type>
                             <source_model>usa/shipping_carrier_abstract_source_mode</source_model>
                             <sort_order>30</sort_order>


### PR DESCRIPTION
# Description

This PR adjusts the `Maho` branding in adminhtml `System > Configuration`.

# Type of change

Refactor

# How can this fix be tested

1. Branding should be fine in adminhtml `System > Configuration`.