### PR TITLE
Fixed merging of javascript files since the new folder structure

### DIFF
--- a/app/code/core/Mage/Page/Block/Html/Head.php
+++ b/app/code/core/Mage/Page/Block/Html/Head.php
@@ -267,7 +267,9 @@ class Mage_Page_Block_Html_Head extends Mage_Core_Block_Template
         // get static files from the js folder, no need in lookups
         foreach ($staticItems as $params => $rows) {
             foreach ($rows as $name) {
-                $items[$params][] = $mergeCallback ? Mage::getBaseDir() . DS . 'js' . DS . $name : $baseJsUrl . $name;
+                $items[$params][] = $mergeCallback
+                    ? Mage::getBaseDir() . DS . 'public' . DS . 'js' . DS . $name
+                    : $baseJsUrl . $name;
             }
         }
 


### PR DESCRIPTION
# Description

JavaScript merging is currently broken because of the missing `public` directory in the path while collecting the JavaScript files.

Examples of JavaScript errors when visiting the home page:
![grafik](https://github.com/user-attachments/assets/4d7fb692-60ce-48e8-8024-8aa338881dfd)

# Type of change

Fix

# How can this fix be tested

1. Checkout `main` branch.
2. Visit the adminhtml.
3. Go to `System > Configuration > Advanced > Developer`
4. Set `JavaScript Settings > Merge JavaScript Files` to `Yes` and save.
5. Visit any frontend page, e.g. the home page.
6. You will see errors in the console like in the image shown above.
7. Checkout the branch of this PR.
8. Reload the frontend page.
9. These JavaScript errors are gone.