### PR TITLE
Made MAHO_ROOT_DIR constant available globally

### DIFF
--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -365,8 +365,8 @@ function mahoFindFileInIncludePath(string $relativePath): string|false
 function mahoListDirectories($path)
 {
     list($packages, $packageDirectories) = mahoGetComposerInstallationData();
-    if (!defined('MAGENTO_ROOT')) {
-        Mage::throwException('MAGENTO_ROOT constant is not defined.');
+    if (!defined('MAHO_ROOT_DIR')) {
+        Mage::throwException('MAHO_ROOT_DIR constant is not defined.');
     }
 
     foreach ($packages as $package) {
@@ -376,7 +376,7 @@ function mahoListDirectories($path)
     $path = ltrim($path, '/');
 
     $results = [];
-    array_unshift($packageDirectories, MAGENTO_ROOT);
+    array_unshift($packageDirectories, MAHO_ROOT_DIR);
     foreach ($packageDirectories as $packageDirectory) {
         $tmpList = glob($packageDirectory . DS . $path . '/*', GLOB_ONLYDIR);
         foreach ($tmpList as $folder) {

--- a/public/api.php
+++ b/public/api.php
@@ -10,14 +10,16 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+/** @deprecated Use MAHO_ROOT_DIR instead. */
 define('MAGENTO_ROOT', dirname(__DIR__));
+define('MAHO_ROOT_DIR', dirname(__DIR__));
 
-if (file_exists(MAGENTO_ROOT . DIRECTORY_SEPARATOR . 'app/bootstrap.php')) {
-    require MAGENTO_ROOT . '/app/bootstrap.php';
-    require MAGENTO_ROOT . '/app/Mage.php';
+if (file_exists(MAHO_ROOT_DIR . DIRECTORY_SEPARATOR . 'app/bootstrap.php')) {
+    require MAHO_ROOT_DIR . '/app/bootstrap.php';
+    require MAHO_ROOT_DIR . '/app/Mage.php';
 } else {
-    require MAGENTO_ROOT . '/vendor/mahocommerce/maho/app/bootstrap.php';
-    require MAGENTO_ROOT . '/vendor/mahocommerce/maho/app/Mage.php';
+    require MAHO_ROOT_DIR . '/vendor/mahocommerce/maho/app/bootstrap.php';
+    require MAHO_ROOT_DIR . '/vendor/mahocommerce/maho/app/Mage.php';
 }
 
 if (!Mage::isInstalled()) {

--- a/public/index.php
+++ b/public/index.php
@@ -10,14 +10,16 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+/** @deprecated Use MAHO_ROOT_DIR instead. */
 define('MAGENTO_ROOT', dirname(__DIR__));
+define('MAHO_ROOT_DIR', dirname(__DIR__));
 
-if (file_exists(MAGENTO_ROOT . DIRECTORY_SEPARATOR . 'app/bootstrap.php')) {
-    require MAGENTO_ROOT . '/app/bootstrap.php';
-    require MAGENTO_ROOT . '/app/Mage.php';
+if (file_exists(MAHO_ROOT_DIR . DIRECTORY_SEPARATOR . 'app/bootstrap.php')) {
+    require MAHO_ROOT_DIR . '/app/bootstrap.php';
+    require MAHO_ROOT_DIR . '/app/Mage.php';
 } else {
-    require MAGENTO_ROOT . '/vendor/mahocommerce/maho/app/bootstrap.php';
-    require MAGENTO_ROOT . '/vendor/mahocommerce/maho/app/Mage.php';
+    require MAHO_ROOT_DIR . '/vendor/mahocommerce/maho/app/bootstrap.php';
+    require MAHO_ROOT_DIR . '/vendor/mahocommerce/maho/app/Mage.php';
 }
 
 #Varien_Profiler::enable();


### PR DESCRIPTION
# Description

In the Maho CLI (`maho:12`) `MAHO_ROOT_DIR` is already in use. This PR makes `MAHO_ROOT_DIR` globally available outside the Maho CLI.

The uses of `MAGENTO_ROOT` have been replaced by `MAHO_ROOT_DIR`.

Unfortunately, we can't simply use `__DIR__` in `index.php` and `api.php` (like it has been solved in the Maho CLI), because these files are located in `public`. Therefore, there has been no change in behavior compared to `MAGENTO_ROOT` for the time being.

`MAGENTO_ROOT` has not been removed for compatibility reasons with custom code. However, a `@deprecated` note has been added.

# Type of change

* Feature
* Refactor

# How can this be tested

1. You can use `MAHO_ROOT_DIR` instead of `MAGENTO_ROOT` now.
2. Nothing else should have changed or could break.