### PR TITLE
Added support for Maho-specific install scripts

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/CacheController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CacheController.php
@@ -68,6 +68,7 @@ class Mage_Adminhtml_CacheController extends Mage_Adminhtml_Controller_Action
             Mage::app()->cleanCache();
             Mage_Core_Model_Resource_Setup::applyAllUpdates();
             Mage_Core_Model_Resource_Setup::applyAllDataUpdates();
+            Mage_Core_Model_Resource_Setup::applyAllMahoUpdates();
             Mage::app()->getCacheInstance()->unbanUse('config');
             Mage::getConfig()->saveCache();
         } finally {

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -350,6 +350,7 @@ class Mage_Core_Model_App
                 $this->_initCurrentStore($scopeCode, $scopeType);
                 $this->_initRequest();
                 Mage_Core_Model_Resource_Setup::applyAllDataUpdates();
+                Mage_Core_Model_Resource_Setup::applyAllMahoUpdates();
             }
 
             $this->getFrontController()->dispatch();

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1289,6 +1289,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
             case 'sql':
                 $dir .= DS . 'sql';
                 break;
+
             case 'data':
                 $dir .= DS . 'data';
                 break;

--- a/app/code/core/Mage/Core/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Core/Model/Resource/Setup.php
@@ -558,7 +558,6 @@ class Mage_Core_Model_Resource_Setup
         $files      = [];
 
         $filesDir   = Mage::getModuleDir('data', $modName) . DS . $this->_resourceName;
-        echo $filesDir;die("a");
         $filesDir   = mahoFindFileInIncludePath($filesDir);
         if (is_dir($filesDir) && is_readable($filesDir)) {
             $regExp     = sprintf('#^%s-(.*)\.php$#i', $actionType);

--- a/app/code/core/Mage/Core/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Core/Model/Resource/Setup.php
@@ -29,6 +29,7 @@ class Mage_Core_Model_Resource_Setup
     public const TYPE_DB_UNINSTALL         = 'uninstall';
     public const TYPE_DATA_INSTALL         = 'data-install';
     public const TYPE_DATA_UPGRADE         = 'data-upgrade';
+    public const TYPE_MAHO                 = 'maho';
 
     /**
      * Setup resource name
@@ -196,8 +197,6 @@ class Mage_Core_Model_Resource_Setup
     }
 
     /**
-     * Apply database updates whenever needed
-     *
      * @return bool
      */
     public static function applyAllUpdates()
@@ -232,10 +231,6 @@ class Mage_Core_Model_Resource_Setup
         return true;
     }
 
-    /**
-     * Apply database data updates whenever needed
-     *
-     */
     public static function applyAllDataUpdates()
     {
         if (!self::$_schemaUpdatesChecked) {
@@ -272,6 +267,41 @@ class Mage_Core_Model_Resource_Setup
             }
         } elseif ($configVer) {
             $this->_installData($configVer);
+        }
+        return $this;
+    }
+
+    public static function applyAllMahoUpdates(): void
+    {
+        if (!self::$_schemaUpdatesChecked) {
+            return;
+        }
+        $resources = Mage::getConfig()->getNode('global/resources')->children();
+        foreach ($resources as $resName => $resource) {
+            if (!$resource->setup) {
+                continue;
+            }
+            $className = __CLASS__;
+            if (isset($resource->setup->class)) {
+                $className = $resource->setup->getClassName();
+            }
+            /** @var Mage_Core_Model_Resource_Setup $setupClass */
+            $setupClass = new $className($resName);
+            $setupClass->applyMahoUpdates();
+        }
+    }
+
+    public function applyMahoUpdates(): self
+    {
+        $dataVer = $this->_getResource()->getMahoVersion($this->_resourceName);
+        $configVer = Mage::getMahoVersion();
+        if ($dataVer !== false) {
+            $status = version_compare($configVer, $dataVer);
+            if ($status == self::VERSION_COMPARE_GREATER) {
+                $this->_upgradeMaho($dataVer, $configVer);
+            }
+        } elseif ($configVer) {
+            $this->_installMaho($configVer);
         }
         return $this;
     }
@@ -395,6 +425,26 @@ class Mage_Core_Model_Resource_Setup
     }
 
     /**
+     * Run Maho install scripts
+     */
+    protected function _installMaho(string $newVersion): self
+    {
+        $this->_modifyResourceDb(self::TYPE_MAHO, '', $newVersion);
+
+        return $this;
+    }
+
+    /**
+     * Run Maho upgrade scripts
+     */
+    protected function _upgradeMaho(string $oldVersion, string $newVersion): self
+    {
+        $this->_modifyResourceDb(self::TYPE_MAHO, $oldVersion, $newVersion);
+
+        return $this;
+    }
+
+    /**
      * Run resource installation file
      *
      * @param string $newVersion
@@ -508,6 +558,7 @@ class Mage_Core_Model_Resource_Setup
         $files      = [];
 
         $filesDir   = Mage::getModuleDir('data', $modName) . DS . $this->_resourceName;
+        echo $filesDir;die("a");
         $filesDir   = mahoFindFileInIncludePath($filesDir);
         if (is_dir($filesDir) && is_readable($filesDir)) {
             $regExp     = sprintf('#^%s-(.*)\.php$#i', $actionType);
@@ -544,13 +595,38 @@ class Mage_Core_Model_Resource_Setup
     }
 
     /**
-     * Save resource version
-     *
-     * @param string $actionType
-     * @param string $version
-     * @return $this
+     * Retrieve available Maho install/upgrade files for current module
      */
-    protected function _setResourceVersion($actionType, $version)
+    protected function _getAvailableMahoFiles(string $actionType, string $fromVersion, string $toVersion): array
+    {
+        $modName    = (string)$this->_moduleConfig[0]->getName();
+        $files      = [];
+
+        $filesDir   = Mage::getModuleDir('sql', $modName) . DS . 'maho_setup';
+        $filesDir   = mahoFindFileInIncludePath($filesDir);
+        if (is_dir($filesDir) && is_readable($filesDir)) {
+            $regExp     = sprintf('#^%s-(.*)\.php$#i', $actionType);
+            $handlerDir = dir($filesDir);
+            while (($file = $handlerDir->read()) !== false) {
+                $matches = [];
+                if (preg_match($regExp, $file, $matches)) {
+                    $files[$matches[1]] = $filesDir . DS . $file;
+                }
+            }
+            $handlerDir->close();
+        }
+
+        if (empty($files)) {
+            return [];
+        }
+
+        return $this->_getModifySqlFiles($actionType, $fromVersion, $toVersion, $files);
+    }
+
+    /**
+     * Save resource version
+     */
+    protected function _setResourceVersion(string $actionType, string $version): self
     {
         switch ($actionType) {
             case self::TYPE_DB_INSTALL:
@@ -561,6 +637,8 @@ class Mage_Core_Model_Resource_Setup
             case self::TYPE_DATA_UPGRADE:
                 $this->_getResource()->setDataVersion($this->_resourceName, $version);
                 break;
+            case self::TYPE_MAHO:
+                $this->_getResource()->setMahoVersion($this->_resourceName, $version);
         }
 
         return $this;
@@ -586,6 +664,9 @@ class Mage_Core_Model_Resource_Setup
             case self::TYPE_DATA_INSTALL:
             case self::TYPE_DATA_UPGRADE:
                 $files = $this->_getAvailableDataFiles($actionType, $fromVersion, $toVersion);
+                break;
+            case self::TYPE_MAHO:
+                $files = $this->_getAvailableMahoFiles($actionType, $fromVersion, $toVersion);
                 break;
             default:
                 $files = [];
@@ -682,16 +763,22 @@ class Mage_Core_Model_Resource_Setup
                 }
                 break;
 
-            case self::TYPE_DB_ROLLBACK:
+            case self::TYPE_MAHO:
+                uksort($arrFiles, 'version_compare');
+                foreach ($arrFiles as $version => $file) {
+                    $arrRes[] = [
+                        'toVersion' => $version,
+                        'fileName'  => $file
+                    ];
+                }
                 break;
 
+            case self::TYPE_DB_ROLLBACK:
             case self::TYPE_DB_UNINSTALL:
                 break;
         }
         return $arrRes;
     }
-
-    /******************* UTILITY METHODS *****************/
 
     /**
      * Retrieve row or field from table by id or string and parent id

--- a/app/code/core/Mage/Core/sql/maho_setup/maho-24.10.0.php
+++ b/app/code/core/Mage/Core/sql/maho_setup/maho-24.10.0.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Maho
+ *
+ * @category   Mage
+ * @package    Mage_Core
+ * @copyright  @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Core_Model_Resource_Setup $installer */
+$installer = $this;
+$installer->startSetup();
+
+$installer->getConnection()
+    ->addColumn($installer->getTable('core/resource'), 'maho_version', 'varchar(50)');
+
+$installer->endSetup();

--- a/app/code/core/Mage/Install/Model/Installer/Console.php
+++ b/app/code/core/Mage/Install/Model/Installer/Console.php
@@ -351,6 +351,7 @@ class Mage_Install_Model_Installer_Console extends Mage_Install_Model_Installer_
 
             // apply data updates
             Mage_Core_Model_Resource_Setup::applyAllDataUpdates();
+            Mage_Core_Model_Resource_Setup::applyAllMahoUpdates();
 
             /**
              * Validate entered data for administrator user


### PR DESCRIPTION
Specifics in https://github.com/MahoCommerce/maho/discussions/37

This PR addes `maho_version` column to the `core_resource` and all the software to manage install scripts specifically made for Maho.

They're stored in the `sql/maho_setup/` subfolder of any module, and the filenames have to have this naming `maho-24.10.0.php` where `24.10` is the date of when the script it added and `.0` is a sequential number.

From my tests it seems to work for both installs/upgrade.

@justinbeaty what do you think about this?

## Todo:

- [x] Test web installer (needs to execute maho's install scripts too)
- [x] Test CLI installer (needs to execute maho's install scripts too)