### PR TITLE
API: added `maho_version` to deprecated `magentoInfo` method, also added `mahoInfo` method

### DIFF
--- a/app/code/core/Mage/Core/Model/Magento/Api.php
+++ b/app/code/core/Mage/Core/Model/Magento/Api.php
@@ -25,8 +25,6 @@ class Mage_Core_Model_Magento_Api extends Mage_Api_Model_Resource_Abstract
     public function info()
     {
         $result = [];
-        $result['magento_edition'] = Mage::getEdition();
-        $result['magento_version'] = Mage::getVersion();
         $result['maho_version'] = Mage::getMahoVersion();
 
         return $result;

--- a/app/code/core/Mage/Core/Model/Magento/Api.php
+++ b/app/code/core/Mage/Core/Model/Magento/Api.php
@@ -24,6 +24,7 @@ class Mage_Core_Model_Magento_Api extends Mage_Core_Model_Maho_Api
      *
      * @return array
      */
+    #[\Override]
     public function info()
     {
         Mage::log('Deprecated API call to magentoInfo, use mahoInfo instead');

--- a/app/code/core/Mage/Core/Model/Magento/Api.php
+++ b/app/code/core/Mage/Core/Model/Magento/Api.php
@@ -19,4 +19,19 @@
  */
 class Mage_Core_Model_Magento_Api extends Mage_Core_Model_Maho_Api
 {
+    /**
+     * Retrieve information about the current Maho installation
+     *
+     * @return array
+     */
+    public function info()
+    {
+        Mage::log('Deprecated API call to magentoInfo, use mahoInfo instead');
+
+        $result = parent::info();
+        $result['magento_version'] = Mage::getVersion();
+        $result['magento_edition'] = Mage::getEdition();
+
+        return $result;
+    }
 }

--- a/app/code/core/Mage/Core/Model/Magento/Api/V2.php
+++ b/app/code/core/Mage/Core/Model/Magento/Api/V2.php
@@ -17,6 +17,6 @@
  * @package    Mage_Core
  * @deprecated
  */
-class Mage_Core_Model_Magento_Api_V2 extends Mage_Core_Model_Maho_Api_V2
+class Mage_Core_Model_Magento_Api_V2 extends Mage_Core_Model_Magento_Api
 {
 }

--- a/app/code/core/Mage/Core/Model/Magento/Api/V2.php
+++ b/app/code/core/Mage/Core/Model/Magento/Api/V2.php
@@ -6,6 +6,7 @@
  * @package    Mage_Core
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2023 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -14,7 +15,8 @@
  *
  * @category   Mage
  * @package    Mage_Core
+ * @deprecated
  */
-class Mage_Core_Model_Magento_Api_V2 extends Mage_Core_Model_Magento_Api
+class Mage_Core_Model_Magento_Api_V2 extends Mage_Core_Model_Maho_Api_V2
 {
 }

--- a/app/code/core/Mage/Core/Model/Maho/Api.php
+++ b/app/code/core/Mage/Core/Model/Maho/Api.php
@@ -5,7 +5,6 @@
  * @category   Mage
  * @package    Mage_Core
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2021-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -15,8 +14,19 @@
  *
  * @category   Mage
  * @package    Mage_Core
- * @deprecated
  */
-class Mage_Core_Model_Magento_Api extends Mage_Core_Model_Maho_Api
+class Mage_Core_Model_Maho_Api extends Mage_Api_Model_Resource_Abstract
 {
+    /**
+     * Retrieve information about the current Maho installation
+     *
+     * @return array
+     */
+    public function info()
+    {
+        $result = [];
+        $result['maho_version'] = Mage::getMahoVersion();
+
+        return $result;
+    }
 }

--- a/app/code/core/Mage/Core/Model/Maho/Api/V2.php
+++ b/app/code/core/Mage/Core/Model/Maho/Api/V2.php
@@ -5,18 +5,16 @@
  * @category   Mage
  * @package    Mage_Core
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2021-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
 /**
- * Maho info API
+ * Maho info API V2
  *
  * @category   Mage
  * @package    Mage_Core
- * @deprecated
  */
-class Mage_Core_Model_Magento_Api extends Mage_Core_Model_Maho_Api
+class Mage_Core_Model_Maho_Api_V2 extends Mage_Core_Model_Maho_Api
 {
 }

--- a/app/code/core/Mage/Core/etc/api.xml
+++ b/app/code/core/Mage/Core/etc/api.xml
@@ -38,11 +38,11 @@
             <core_maho translate="title" module="core">
                 <model>core/maho_api</model>
                 <title>Maho info API</title>
-                <acl>core/magento</acl>
+                <acl>core/maho</acl>
                 <methods>
                     <info translate="title" module="core">
                         <title>Get info about current Maho installation</title>
-                        <acl>core/magento/info</acl>
+                        <acl>core/maho/info</acl>
                     </info>
                 </methods>
             </core_maho>
@@ -88,10 +88,16 @@
                             <title>List of stores</title>
                         </list>
                     </store>
-                    <magento translate="title" module="core">
+                    <maho translate="title" module="core">
                         <title>Maho info</title>
                         <info translate="title" module="core">
                             <title>Retrieve info about current Maho installation</title>
+                        </info>
+                    </maho>
+                    <magento translate="title" module="core">
+                        <title>Magento info</title>
+                        <info translate="title" module="core">
+                            <title>(deprecated) Retrieve info about current Magento installation</title>
                         </info>
                     </magento>
                 </core>

--- a/app/code/core/Mage/Core/etc/api.xml
+++ b/app/code/core/Mage/Core/etc/api.xml
@@ -35,6 +35,17 @@
                     </store_not_exists>
                 </faults>
             </core_store>
+            <core_maho translate="title" module="core">
+                <model>core/maho_api</model>
+                <title>Maho info API</title>
+                <acl>core/magento</acl>
+                <methods>
+                    <info translate="title" module="core">
+                        <title>Get info about current Maho installation</title>
+                        <acl>core/magento/info</acl>
+                    </info>
+                </methods>
+            </core_maho>
             <core_magento translate="title" module="core">
                 <model>core/magento_api</model>
                 <title>Maho info API</title>
@@ -49,11 +60,13 @@
         </resources>
         <resources_alias>
             <store>core_store</store>
+            <maho>core_maho</maho>
             <magento>core_magento</magento>
         </resources_alias>
         <v2>
             <resources_function_prefix>
                 <store>store</store>
+                <maho>maho</maho>
                 <magento>magento</magento>
             </resources_function_prefix>
         </v2>

--- a/app/code/core/Mage/Core/etc/wsdl.xml
+++ b/app/code/core/Mage/Core/etc/wsdl.xml
@@ -26,6 +26,7 @@
                 <all>
                     <element name="magento_version" type="xsd:string" />
                     <element name="magento_edition" type="xsd:string" />
+                    <element name="maho_version" type="xsd:string" />
                 </all>
             </complexType>
         </schema>

--- a/app/code/core/Mage/Core/etc/wsdl.xml
+++ b/app/code/core/Mage/Core/etc/wsdl.xml
@@ -25,6 +25,8 @@
             <complexType name="mahoInfoEntity">
                 <all>
                     <element name="maho_version" type="xsd:string" />
+                    <element name="magento_version" type="xsd:string" minOccurs="0" />
+                    <element name="magento_edition" type="xsd:string" minOccurs="0" />
                 </all>
             </complexType>
         </schema>
@@ -65,7 +67,7 @@
             <output message="typens:mahoInfoResponse" />
         </operation>
         <operation name="magentoInfo">
-            <documentation>(deprecated) Alias of mahoInfo</documentation>
+            <documentation>(deprecated) Info about current Magento installation</documentation>
             <input message="typens:mahoInfoRequest" />
             <output message="typens:mahoInfoResponse" />
         </operation>

--- a/app/code/core/Mage/Core/etc/wsdl.xml
+++ b/app/code/core/Mage/Core/etc/wsdl.xml
@@ -59,7 +59,7 @@
             <input message="typens:storeInfoRequest" />
             <output message="typens:storeInfoResponse" />
         </operation>
-        <operation name="mahoInfo">
+        <operation name="magentoInfo">
             <documentation>Info about current Maho installation</documentation>
             <input message="typens:mahoInfoRequest" />
             <output message="typens:mahoInfoResponse" />
@@ -85,7 +85,7 @@
                 <soap:body namespace="urn:Maho" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
-        <operation name="mahoInfo">
+        <operation name="magentoInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
                 <soap:body namespace="urn:Maho" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />

--- a/app/code/core/Mage/Core/etc/wsdl.xml
+++ b/app/code/core/Mage/Core/etc/wsdl.xml
@@ -22,10 +22,8 @@
                     </restriction>
                 </complexContent>
             </complexType>
-            <complexType name="magentoInfoEntity">
+            <complexType name="mahoInfoEntity">
                 <all>
-                    <element name="magento_version" type="xsd:string" />
-                    <element name="magento_edition" type="xsd:string" />
                     <element name="maho_version" type="xsd:string" />
                 </all>
             </complexType>
@@ -37,11 +35,11 @@
     <message name="storeListResponse">
         <part name="stores" type="typens:storeEntityArray" />
     </message>
-    <message name="magentoInfoRequest">
+    <message name="mahoInfoRequest">
         <part name="sessionId" type="xsd:string" />
     </message>
-    <message name="magentoInfoResponse">
-        <part name="info" type="typens:magentoInfoEntity" />
+    <message name="mahoInfoResponse">
+        <part name="info" type="typens:mahoInfoEntity" />
     </message>
     <message name="storeInfoRequest">
         <part name="sessionId" type="xsd:string" />
@@ -61,10 +59,10 @@
             <input message="typens:storeInfoRequest" />
             <output message="typens:storeInfoResponse" />
         </operation>
-        <operation name="magentoInfo">
+        <operation name="mahoInfo">
             <documentation>Info about current Maho installation</documentation>
-            <input message="typens:magentoInfoRequest" />
-            <output message="typens:magentoInfoResponse" />
+            <input message="typens:mahoInfoRequest" />
+            <output message="typens:mahoInfoResponse" />
         </operation>
     </portType>
     <binding name="{{var wsdl.handler}}Binding" type="typens:{{var wsdl.handler}}PortType">
@@ -87,7 +85,7 @@
                 <soap:body namespace="urn:Maho" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
             </output>
         </operation>
-        <operation name="magentoInfo">
+        <operation name="mahoInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
                 <soap:body namespace="urn:Maho" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />

--- a/app/code/core/Mage/Core/etc/wsdl.xml
+++ b/app/code/core/Mage/Core/etc/wsdl.xml
@@ -59,8 +59,13 @@
             <input message="typens:storeInfoRequest" />
             <output message="typens:storeInfoResponse" />
         </operation>
-        <operation name="magentoInfo">
+        <operation name="mahoInfo">
             <documentation>Info about current Maho installation</documentation>
+            <input message="typens:mahoInfoRequest" />
+            <output message="typens:mahoInfoResponse" />
+        </operation>
+        <operation name="magentoInfo">
+            <documentation>(deprecated) Alias of mahoInfo</documentation>
             <input message="typens:mahoInfoRequest" />
             <output message="typens:mahoInfoResponse" />
         </operation>
@@ -77,6 +82,15 @@
             </output>
         </operation>
         <operation name="storeInfo">
+            <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
+            <input>
+                <soap:body namespace="urn:Maho" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+            </input>
+            <output>
+                <soap:body namespace="urn:Maho" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+            </output>
+        </operation>
+        <operation name="mahoInfo">
             <soap:operation soapAction="urn:{{var wsdl.handler}}Action" />
             <input>
                 <soap:body namespace="urn:Maho" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />

--- a/app/code/core/Mage/Core/etc/wsi.xml
+++ b/app/code/core/Mage/Core/etc/wsi.xml
@@ -103,8 +103,13 @@
             <wsdl:input message="typens:storeInfoRequest" />
             <wsdl:output message="typens:storeInfoResponse" />
         </wsdl:operation>
-        <wsdl:operation name="magentoInfo">
+        <wsdl:operation name="mahoInfo">
             <wsdl:documentation>Info about current Maho installation</wsdl:documentation>
+            <wsdl:input message="typens:mahoInfoRequest" />
+            <wsdl:output message="typens:mahoInfoResponse" />
+        </wsdl:operation>
+        <wsdl:operation name="magentoInfo">
+            <wsdl:documentation>(deprecated) Alias of mahoInfo</wsdl:documentation>
             <wsdl:input message="typens:mahoInfoRequest" />
             <wsdl:output message="typens:mahoInfoResponse" />
         </wsdl:operation>
@@ -121,6 +126,15 @@
             </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="storeInfo">
+            <soap:operation soapAction="" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="mahoInfo">
             <soap:operation soapAction="" />
             <wsdl:input>
                 <soap:body use="literal" />

--- a/app/code/core/Mage/Core/etc/wsi.xml
+++ b/app/code/core/Mage/Core/etc/wsi.xml
@@ -28,6 +28,7 @@
                 <xsd:sequence>
                     <xsd:element minOccurs="1" maxOccurs="1" name="magento_version" type="xsd:string" />
                     <xsd:element minOccurs="1" maxOccurs="1" name="magento_edition" type="xsd:string" />
+                    <xsd:element minOccurs="1" maxOccurs="1" name="maho_version" type="xsd:string" />
                 </xsd:sequence>
             </xsd:complexType>
             <xsd:element name="storeListRequestParam">

--- a/app/code/core/Mage/Core/etc/wsi.xml
+++ b/app/code/core/Mage/Core/etc/wsi.xml
@@ -24,10 +24,8 @@
                     <xsd:element minOccurs="0" maxOccurs="unbounded" name="complexObjectArray" type="typens:storeEntity" />
                 </xsd:sequence>
             </xsd:complexType>
-            <xsd:complexType name="magentoInfoEntity">
+            <xsd:complexType name="mahoInfoEntity">
                 <xsd:sequence>
-                    <xsd:element minOccurs="1" maxOccurs="1" name="magento_version" type="xsd:string" />
-                    <xsd:element minOccurs="1" maxOccurs="1" name="magento_edition" type="xsd:string" />
                     <xsd:element minOccurs="1" maxOccurs="1" name="maho_version" type="xsd:string" />
                 </xsd:sequence>
             </xsd:complexType>
@@ -60,17 +58,17 @@
                     </xsd:sequence>
                 </xsd:complexType>
             </xsd:element>
-            <xsd:element name="magentoInfoRequestParam">
+            <xsd:element name="mahoInfoRequestParam">
                 <xsd:complexType>
                     <xsd:sequence>
                         <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
                     </xsd:sequence>
                 </xsd:complexType>
             </xsd:element>
-            <xsd:element name="magentoInfoResponseParam">
+            <xsd:element name="mahoInfoResponseParam">
                 <xsd:complexType>
                     <xsd:sequence>
-                        <xsd:element minOccurs="1" maxOccurs="1" name="result" type="typens:magentoInfoEntity" />
+                        <xsd:element minOccurs="1" maxOccurs="1" name="result" type="typens:mahoInfoEntity" />
                     </xsd:sequence>
                 </xsd:complexType>
             </xsd:element>
@@ -88,11 +86,11 @@
     <wsdl:message name="storeInfoResponse">
         <wsdl:part name="parameters" element="typens:storeInfoResponseParam" />
     </wsdl:message>
-    <wsdl:message name="magentoInfoRequest">
-        <wsdl:part name="parameters" element="typens:magentoInfoRequestParam" />
+    <wsdl:message name="mahoInfoRequest">
+        <wsdl:part name="parameters" element="typens:mahoInfoRequestParam" />
     </wsdl:message>
-    <wsdl:message name="magentoInfoResponse">
-        <wsdl:part name="parameters" element="typens:magentoInfoResponseParam" />
+    <wsdl:message name="mahoInfoResponse">
+        <wsdl:part name="parameters" element="typens:mahoInfoResponseParam" />
     </wsdl:message>
     <wsdl:portType name="{{var wsdl.handler}}PortType">
         <wsdl:operation name="storeList">
@@ -105,10 +103,10 @@
             <wsdl:input message="typens:storeInfoRequest" />
             <wsdl:output message="typens:storeInfoResponse" />
         </wsdl:operation>
-        <wsdl:operation name="magentoInfo">
+        <wsdl:operation name="mahoInfo">
             <wsdl:documentation>Info about current Maho installation</wsdl:documentation>
-            <wsdl:input message="typens:magentoInfoRequest" />
-            <wsdl:output message="typens:magentoInfoResponse" />
+            <wsdl:input message="typens:mahoInfoRequest" />
+            <wsdl:output message="typens:mahoInfoResponse" />
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="{{var wsdl.handler}}Binding" type="typens:{{var wsdl.handler}}PortType">
@@ -131,7 +129,7 @@
                 <soap:body use="literal" />
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="magentoInfo">
+        <wsdl:operation name="mahoInfo">
             <soap:operation soapAction="" />
             <wsdl:input>
                 <soap:body use="literal" />

--- a/app/code/core/Mage/Core/etc/wsi.xml
+++ b/app/code/core/Mage/Core/etc/wsi.xml
@@ -103,7 +103,7 @@
             <wsdl:input message="typens:storeInfoRequest" />
             <wsdl:output message="typens:storeInfoResponse" />
         </wsdl:operation>
-        <wsdl:operation name="mahoInfo">
+        <wsdl:operation name="magentoInfo">
             <wsdl:documentation>Info about current Maho installation</wsdl:documentation>
             <wsdl:input message="typens:mahoInfoRequest" />
             <wsdl:output message="typens:mahoInfoResponse" />
@@ -129,7 +129,7 @@
                 <soap:body use="literal" />
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="mahoInfo">
+        <wsdl:operation name="magentoInfo">
             <soap:operation soapAction="" />
             <wsdl:input>
                 <soap:body use="literal" />

--- a/app/code/core/Mage/Core/etc/wsi.xml
+++ b/app/code/core/Mage/Core/etc/wsi.xml
@@ -29,6 +29,13 @@
                     <xsd:element minOccurs="1" maxOccurs="1" name="maho_version" type="xsd:string" />
                 </xsd:sequence>
             </xsd:complexType>
+            <xsd:complexType name="magentoInfoEntity">
+                <xsd:sequence>
+                    <xsd:element minOccurs="1" maxOccurs="1" name="maho_version" type="xsd:string" />
+                    <xsd:element minOccurs="1" maxOccurs="1" name="magento_version" type="xsd:string" />
+                    <xsd:element minOccurs="1" maxOccurs="1" name="magento_edition" type="xsd:string" />
+                </xsd:sequence>
+            </xsd:complexType>
             <xsd:element name="storeListRequestParam">
                 <xsd:complexType>
                     <xsd:sequence>
@@ -72,6 +79,20 @@
                     </xsd:sequence>
                 </xsd:complexType>
             </xsd:element>
+            <xsd:element name="magentoInfoRequestParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element minOccurs="1" maxOccurs="1" name="sessionId" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="magentoInfoResponseParam">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element minOccurs="1" maxOccurs="1" name="result" type="typens:magentoInfoEntity" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
         </xsd:schema>
     </wsdl:types>
     <wsdl:message name="storeListRequest">
@@ -92,6 +113,12 @@
     <wsdl:message name="mahoInfoResponse">
         <wsdl:part name="parameters" element="typens:mahoInfoResponseParam" />
     </wsdl:message>
+    <wsdl:message name="magentoInfoRequest">
+        <wsdl:part name="parameters" element="typens:magentoInfoRequestParam" />
+    </wsdl:message>
+    <wsdl:message name="magentoInfoResponse">
+        <wsdl:part name="parameters" element="typens:magentoInfoResponseParam" />
+    </wsdl:message>
     <wsdl:portType name="{{var wsdl.handler}}PortType">
         <wsdl:operation name="storeList">
             <wsdl:documentation>List of stores</wsdl:documentation>
@@ -109,9 +136,9 @@
             <wsdl:output message="typens:mahoInfoResponse" />
         </wsdl:operation>
         <wsdl:operation name="magentoInfo">
-            <wsdl:documentation>(deprecated) Alias of mahoInfo</wsdl:documentation>
-            <wsdl:input message="typens:mahoInfoRequest" />
-            <wsdl:output message="typens:mahoInfoResponse" />
+            <wsdl:documentation>(deprecated) Info about current Magento installation</wsdl:documentation>
+            <wsdl:input message="typens:magentoInfoRequest" />
+            <wsdl:output message="typens:magentoInfoResponse" />
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="{{var wsdl.handler}}Binding" type="typens:{{var wsdl.handler}}PortType">


### PR DESCRIPTION
Trying to make sure the new "Dropdown with Other Option" input type is working with the API. I noticed the v2 SOAP API doesn't include `maho_version`.

Just for my own notes, here is how I am connecting to each API type. I had a heck of a time trying to get WS-I compliance mode to work. I saw some related OM issues, and a [sole answer](https://magento.stackexchange.com/a/284379) on Magento Stack Exchange that helped.

```php
$base_url = 'https://store.example.com/api';
$username = 'test';
$password = 'password1';

ini_set("soap.wsdl_cache_enabled", "0");

// Soap V1
$client = new SoapClient("$base_url/soap/?wsdl");
$session = $client->login('test', 'password1');
$result = $client->call($session, 'magento.info');
$client->endSession($session);

// Soap V2
$client = new SoapClient("$base_url/v2_soap/?wsdl");
$session = $client->login('test', 'password1');
$result = $client->magentoInfo($session);
$client->endSession($session);

// Soap V2 WS-I
$client = new SoapClient("$base_url/v2_soap/?wsdl");
$session = $client->login(['username' => $username, 'apiKey' => $password]);
$args = ['sessionId' => $session->result];
$result = $client->magentoInfo([...$args]);
$client->endSession([...$args]);
```