### PR TITLE
Session Fixes for #36

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/Observer.php
+++ b/app/code/core/Mage/Adminhtml/Model/Observer.php
@@ -72,9 +72,10 @@ class Mage_Adminhtml_Model_Observer
      */
     public function setCookieLifetime(Varien_Event_Observer $observer): void
     {
-        /** @var Mage_Core_Model_Session $session */
-        $session = Mage::getSingleton('adminhtml/session');
-        if ($session->getSessionName() === Mage_Adminhtml_Controller_Action::SESSION_NAMESPACE) {
+        if ($observer->getSessionName() === Mage_Adminhtml_Controller_Action::SESSION_NAMESPACE) {
+            /** @var Mage_Core_Model_Session $session */
+            $session = Mage::getSingleton('adminhtml/session');
+
             $lifetime = Mage::getStoreConfigAsInt('admin/security/session_cookie_lifetime');
             $lifetime = min($lifetime, Mage_Adminhtml_Controller_Action::SESSION_MAX_LIFETIME);
             $lifetime = max($lifetime, Mage_Adminhtml_Controller_Action::SESSION_MIN_LIFETIME);

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -192,7 +192,7 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
         }
 
         // Observers can change settings of the cookie such as lifetime, regenerate the session id, etc
-        Mage::dispatchEvent('session_before_renew_cookie', ['cookie' => $cookie]);
+        Mage::dispatchEvent('session_before_renew_cookie', ['cookie' => $cookie, 'session_name' => $sessionName]);
 
         // Set or renew regular session cookie
         $this->setSessionCookie();

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -115,10 +115,8 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
             }
         }
 
-        // If session name is empty, we will use the default cookie name of PHPSESSID
-        if (!empty($sessionName)) {
-            $this->setSessionName($sessionName);
-        }
+        // Set the session name to maho_session, maho_admin_session, etc
+        $this->setSessionName($sessionName);
 
         // Call any custom logic in child classes for setting the session id
         // I.e. Checking the SID query param to enable switching between hosts
@@ -335,7 +333,9 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
      */
     public function setSessionName($name)
     {
-        session_name($name);
+        if (!empty($name)) {
+            session_name($name);
+        }
         return $this;
     }
 

--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -53,6 +53,11 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
             return $this;
         }
 
+        // Do not start a session if no sessionName was provided
+        if (empty($sessionName)) {
+            return $this;
+        }
+
         // getSessionSaveMethod has to return correct version of handler in any case
         $moduleName = $this->getSessionSaveMethod();
         switch ($moduleName) {
@@ -111,7 +116,6 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
         }
 
         // If session name is empty, we will use the default cookie name of PHPSESSID
-        // which should never happen in core.
         if (!empty($sessionName)) {
             $this->setSessionName($sessionName);
         }
@@ -122,7 +126,7 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
 
         // If we still do not have a session id, then read from the cookie value
         // Otherwise, we will be starting a new session.
-        if (empty($this->getSessionId()) && $cookie->get($sessionName)) {
+        if (empty($this->getSessionId()) && is_string($cookie->get($sessionName))) {
             $this->setSessionId($cookie->get($sessionName));
         }
 

--- a/app/code/core/Mage/Customer/Model/Observer.php
+++ b/app/code/core/Mage/Customer/Model/Observer.php
@@ -256,9 +256,10 @@ class Mage_Customer_Model_Observer
      */
     public function setCookieLifetime(Varien_Event_Observer $observer)
     {
-        /** @var Mage_Core_Model_Session $session */
-        $session = Mage::getSingleton('customer/session');
-        if ($session->getSessionName() === Mage_Core_Controller_Front_Action::SESSION_NAMESPACE) {
+        if ($observer->getSessionName() === Mage_Core_Controller_Front_Action::SESSION_NAMESPACE) {
+            /** @var Mage_Core_Model_Session $session */
+            $session = Mage::getSingleton('customer/session');
+
             if ($session->getRememberMe() && Mage::getStoreConfigFlag('web/cookie/remember_enabled')) {
                 $lifetime = Mage::getStoreConfigAsInt('web/cookie/remember_cookie_lifetime');
             } else {

--- a/app/code/core/Mage/Install/Controller/Action.php
+++ b/app/code/core/Mage/Install/Controller/Action.php
@@ -16,6 +16,8 @@
  */
 class Mage_Install_Controller_Action extends Mage_Core_Controller_Varien_Action
 {
+    protected $_sessionNamespace = Mage_Adminhtml_Controller_Action::SESSION_NAMESPACE;
+
     #[\Override]
     protected function _construct()
     {


### PR DESCRIPTION
Includes the patch from https://github.com/MahoCommerce/maho/pull/45#issuecomment-2421029210

I also noticed a new session was being started for every API request, two if Configuration > Maho Core API > Enable WSDL Cache set to "No". So if you call `login` then `magentoInfo`, that's 2-4 new files created at var/session every time. Run the script again and you'll have 4-8 new files. I noticed this after testing the API when my session folder had tons of files. If you call `print_r($client->__getCookies());` you'll see Magento's SOAP server is returning a cookie with the default name PHPSESSID.

The culprit was the Mage_Log_Model_Visitor class, which tries to start a core session object in its constructor. The core session object tries to start a session, but no session namespace is provided, so it creates a cookie named PHPSESSID. This bug also happens in OM.

So I put the following check in `app/code/core/Mage/Core/Model/Session/Abstract/Varien.php`

```php
// Do not start a session if no sessionName was provided
if (empty($sessionName)) {
    return $this;
}
```

I don't think this should cause any problem, because Magento should always call this function with a sessionName. The only place it didn't was on the install page where it was also setting the PHPSESSID cookie. I updated that to use the `maho_admin_session` cookie name.

I also noticed that the customer `setCookieLifetime` observer was causing an issue on the install page, so I just added a new variable to the event. It saves some cycles on a normal page load anyway.

I haven't tested this to the nines yet, but I don't think it will cause issues. If it does, then just the `if (empty($sessionName)) {` check should be reverted, the other changes can stay.

As a side note, Soap clients do support the usage of cookies, so one possible future improvement is to allow this instead of having to pass `$session` to every SOAP call. Of course, we can still support the old way too.