### PR TITLE
Added `setTranslationHelper` method to `Mage_Core_Block_Abstract`

### DIFF
--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -186,6 +186,13 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     protected $_app;
 
     /**
+     * Translation helper instance
+     *
+     * @var Mage_Core_Helper_Abstract
+     */
+    protected $_translationHelper = null;
+
+    /**
      * Initialize factory instance
      */
     public function __construct(array $args = [])
@@ -1166,6 +1173,30 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     }
 
     /**
+     * Helper getter for translations
+     *
+     * @return Mage_Core_Helper_Abstract
+     */
+    public function getTranslationHelper()
+    {
+        return $this->_translationHelper ?? $this->helper('core');
+    }
+
+    /**
+     * Helper setter for translations
+     *
+     * @param Mage_Core_Helper_Abstract $helper
+     * @return $this
+     */
+    public function setTranslationHelper($helper)
+    {
+        if ($helper instanceof Mage_Core_Helper_Abstract) {
+            $this->_translationHelper = $helper;
+        }
+        return $this;
+    }
+
+    /**
      * Translate block sentence
      *
      * @return string
@@ -1173,6 +1204,9 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     public function __()
     {
         $args = func_get_args();
+        if ($this->_translationHelper instanceof Mage_Core_Helper_Abstract) {
+            return $this->_translationHelper->__(...$args);
+        }
         $expr = new Mage_Core_Model_Translate_Expr(array_shift($args), $this->getModuleName());
         array_unshift($args, $expr);
         return $this->_getApp()->getTranslator()->translate($args);

--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -188,7 +188,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     /**
      * Translation helper instance
      *
-     * @var Mage_Core_Helper_Abstract
+     * @var Mage_Core_Helper_Abstract|null
      */
     protected $_translationHelper = null;
 

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Chooser.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Chooser.php
@@ -20,12 +20,23 @@
  * @method $this setElement(Varien_Data_Form_Element_Abstract $value)
  * @method $this setFieldsetId(string $value)
  * @method string getLabel()
- * @method $this setTranslationHelper(Mage_Core_Helper_Abstract $value)
  * @method $this setSourceUrl(string $value)
  * @method $this setUniqId(string $value)
  */
 class Mage_Widget_Block_Adminhtml_Widget_Chooser extends Mage_Adminhtml_Block_Template
 {
+    /**
+     * Internal constructor, that is called from real constructor
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function _construct()
+    {
+        parent::_construct();
+        $this->setTranslationHelper($this->helper('widget'));
+    }
+
     /**
      * Chooser source URL getter
      *
@@ -82,19 +93,6 @@ class Mage_Widget_Block_Adminhtml_Widget_Chooser extends Mage_Adminhtml_Block_Te
         $config->setButtons($buttons);
 
         return $this->_getData('config');
-    }
-
-    /**
-     * Helper getter for translations
-     *
-     * @return Mage_Core_Helper_Abstract
-     */
-    public function getTranslationHelper()
-    {
-        if ($this->_getData('translation_helper') instanceof Mage_Core_Helper_Abstract) {
-            return $this->_getData('translation_helper');
-        }
-        return $this->helper('widget');
     }
 
     /**

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Chooser.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Chooser.php
@@ -77,7 +77,7 @@ class Mage_Widget_Block_Adminhtml_Widget_Chooser extends Mage_Adminhtml_Block_Te
 
         // define chooser label
         if (isset($configArray['label'])) {
-            $config->setData('label', $this->getTranslationHelper()->__($configArray['label']));
+            $config->setData('label', $this->__($configArray['label']));
         }
 
         // chooser control buttons
@@ -87,7 +87,7 @@ class Mage_Widget_Block_Adminhtml_Widget_Chooser extends Mage_Adminhtml_Block_Te
         ];
         if (isset($configArray['button']) && is_array($configArray['button'])) {
             foreach ($configArray['button'] as $id => $label) {
-                $buttons[$id] = $this->getTranslationHelper()->__($label);
+                $buttons[$id] = $this->__($label);
             }
         }
         $config->setButtons($buttons);

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Options.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Options.php
@@ -95,7 +95,7 @@ class Mage_Widget_Block_Adminhtml_Widget_Options extends Mage_Adminhtml_Block_Wi
     {
         // get configuration node and translation helper
         if (!$this->getWidgetType()) {
-            Mage::throwException($this->__('Widget Type is not specified'));
+            Mage::throwException($this->helper('widget')->__('Widget Type is not specified'));
         }
         $config = Mage::getSingleton('widget/widget')->getConfigAsObject($this->getWidgetType());
         if (!$config->getParameters()) {
@@ -125,10 +125,10 @@ class Mage_Widget_Block_Adminhtml_Widget_Options extends Mage_Adminhtml_Block_Wi
         $fieldName = $parameter->getKey();
         $data = [
             'name'      => $form->addSuffixToName($fieldName, 'parameters'),
-            'label'     => $this->getTranslationHelper()->__($parameter->getLabel()),
+            'label'     => $this->__($parameter->getLabel()),
             'required'  => $parameter->getRequired(),
             'class'     => 'widget-option',
-            'note'      => $this->getTranslationHelper()->__($parameter->getDescription()),
+            'note'      => $this->__($parameter->getDescription()),
         ];
 
         if ($values = $this->getWidgetValues()) {
@@ -147,7 +147,7 @@ class Mage_Widget_Block_Adminhtml_Widget_Options extends Mage_Adminhtml_Block_Wi
             $data['values'] = [];
             foreach ($values as $option) {
                 $data['values'][] = [
-                    'label' => $this->getTranslationHelper()->__($option['label']),
+                    'label' => $this->__($option['label']),
                     'value' => $option['value']
                 ];
             }

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Options.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Options.php
@@ -30,12 +30,6 @@ class Mage_Widget_Block_Adminhtml_Widget_Options extends Mage_Adminhtml_Block_Wi
     protected $_defaultElementType = 'text';
 
     /**
-     * Translation helper instance, defined by the widget type declaration root config node
-     * @var Mage_Core_Helper_Abstract
-     */
-    protected $_translationHelper = null;
-
-    /**
      * Prepare Widget Options Form and values according to specified type
      *
      * widget_type must be set in data before
@@ -108,7 +102,7 @@ class Mage_Widget_Block_Adminhtml_Widget_Options extends Mage_Adminhtml_Block_Wi
             return $this;
         }
         $module = $config->getModule();
-        $this->_translationHelper = Mage::helper($module ? $module : 'widget');
+        $this->setTranslationHelper(Mage::helper($module ?: 'widget'));
         foreach ($config->getParameters() as $parameter) {
             $this->_addField($parameter);
         }
@@ -131,10 +125,10 @@ class Mage_Widget_Block_Adminhtml_Widget_Options extends Mage_Adminhtml_Block_Wi
         $fieldName = $parameter->getKey();
         $data = [
             'name'      => $form->addSuffixToName($fieldName, 'parameters'),
-            'label'     => $this->_translationHelper->__($parameter->getLabel()),
+            'label'     => $this->getTranslationHelper()->__($parameter->getLabel()),
             'required'  => $parameter->getRequired(),
             'class'     => 'widget-option',
-            'note'      => $this->_translationHelper->__($parameter->getDescription()),
+            'note'      => $this->getTranslationHelper()->__($parameter->getDescription()),
         ];
 
         if ($values = $this->getWidgetValues()) {
@@ -153,7 +147,7 @@ class Mage_Widget_Block_Adminhtml_Widget_Options extends Mage_Adminhtml_Block_Wi
             $data['values'] = [];
             foreach ($values as $option) {
                 $data['values'][] = [
-                    'label' => $this->_translationHelper->__($option['label']),
+                    'label' => $this->getTranslationHelper()->__($option['label']),
                     'value' => $option['value']
                 ];
             }
@@ -184,7 +178,7 @@ class Mage_Widget_Block_Adminhtml_Widget_Options extends Mage_Adminhtml_Block_Wi
             if ($helperBlock instanceof Varien_Object) {
                 $helperBlock->setConfig($helper->getData())
                     ->setFieldsetId($fieldset->getId())
-                    ->setTranslationHelper($this->_translationHelper)
+                    ->setTranslationHelper($this->getTranslationHelper())
                     ->prepareElementHtml($field);
             }
         }

--- a/app/code/core/Mage/Widget/Model/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Widget.php
@@ -89,7 +89,7 @@ class Mage_Widget_Model_Widget extends Varien_Object
         $object->setData($xml->asCanonicalArray());
 
         // Set module for translations etc.
-        $module = $object->getData('@/module');
+        $module = $xml->getAttribute('module');
         if ($module) {
             $object->setModule($module);
         }


### PR DESCRIPTION
In the EAV editor, we do this something like this:
```php
$block = $this->getLayout()->createBlock('eav/widget_text');
```
And then in the text.phtml file:
```php
<?= $this->__($_attribute->getStoreLabel()) ?>
```

The problem is that the translate function will read from Mage_Eav.csv first when translating, when it really should be using Mage_Customer.csv. Of course, if the string isn't found in Mage_Eav.csv, Magento will fall back to other CSV files.

---

I looked into the core code to see if the Magento devs handled this case anywhere else. They did with the Adminhtml "Insert Widget..." dialog box. Funnily enough, their implementation was broken. (more on that later)

I took their idea and moved the functionality all the way up to Mage_Core_Block_Abstract. So on any block, you can call `setTranslationHelper()` which will make all uses of `$this->__()` in that block use a different module's csv files.

Example usages:

```php
class My_Module_Block_Test extends Mage_Core_Block_Template
{
    public function _construct()
    {
        // You can set the translation helper in the _construct method
        parent::_construct();
        $this->setTranslationHelper(Mage::helper('customer'));
    }

    public function _prepareLayout()
    {
        // You can set the translation helper on a programmatically created block
        // This is especially helpful for core/template types, since by default it uses Mage_Core.csv
        $block = $this->getLayout()->createBlock('core/template');
        $block->setTemplate('test.phtml');
        $block->setTranslationHelper(Mage::helper('customer'));
        $this->append($block);
    }

    public function someMethod()
    {
        // You can set the translation helper anywhere else too, but it will only affect later calls of __()
        $this->__('Foobar'); // Uses My_Module.csv
        $this->setTranslationHelper(Mage::helper('customer'));
        $this->__('Foobar'); // Uses Mage_Customer.csv
    }
}
```

---

I also fixed the Widget implementation of this. It was just a simple mistake by Magento devs, where they tried to read an XML attribute after calling `$xml->asCanonicalArray()`, which removes all attributes. This was supposed to translate strings in the Add Widget dialog with the module specified in the widget.xml file. I tested and it is fixed now.

---

Minor breaking change:

The Widget implementation used a magic setter for `setTranslationHelper()`, then the `getTranslationHelper()` method reads it with `$this->_getData('translation_helper')`. I think it's better to use an actual class member variable `$this->_translationHelper`, but that means that the magic getter would return null. This isn't an issue, because their implementation always returned the widget helper anyway.

If any 3rd party module does a similar thing (without a broken implementation) by using a magic setter for `setTranslationHelper()`, but defining a `getTranslationHelper()` method, they simply need to remove their `getTranslationHelper()` method or fix it to read `$this->_translationHelper`. If they don't do anything, it would just fall back to whatever helper they had set as the fallback.

I really don't think the change is an issue, because (in non-developer mode) we read from all csv files if the string isn't found in the preferred one. We could check the magic getter in `Mage_Core_Block_Abstract::getTranslationHelper()`, but I don't think that's necessary.