### PR TITLE
Improved PHPStan GitHub Action

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -8,10 +8,14 @@ on:
 
 jobs:
   phpstan:
-    name: Analyze
+    name: Analyze PHP ${{ matrix.php-versions }} (${{ matrix.refs == 'pr-head' && github.head_ref || github.base_ref || github.ref_name }})
     runs-on: [ubuntu-latest]
     strategy:
+      fail-fast: false
       matrix:
+        refs: ['target-branch', 'pr-head']
+        exclude:
+          - refs: ${{ github.event_name != 'pull_request' && 'pr-head' }}
         php-versions: ['8.2', '8.3', '8.4']
 
     steps:
@@ -19,8 +23,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-    
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.refs == 'pr-head' && github.event.pull_request.head.sha || '' }}
 
       - name: Get composer cache directory
         id: composer-cache
@@ -36,19 +42,22 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --ignore-platform-req=ext-*
 
-      - name: "Restore result cache"
+      - name: Restore result cache
+        id: phpstan-result-cache
         uses: actions/cache/restore@v4
         with:
           path: var
-          key: "phpstan-result-cache-${{ runner.os }}-${{ matrix.php-versions }}-${{ github.run_id }}"
-          restore-keys: phpstan-result-cache-
+          key: phpstan-result-cache-${{ matrix.php-versions }}-${{ matrix.refs }}-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            phpstan-result-cache-${{ matrix.php-versions }}-${{ matrix.refs }}-${{ github.ref_name }}
+            phpstan-result-cache-${{ matrix.php-versions }}-target-branch-main
 
       - name: PHPStan Static Analysis
-        run: XDEBUG_MODE=off php vendor/bin/phpstan.phar analyze
+        run: XDEBUG_MODE=off php vendor/bin/phpstan.phar analyze -vvv
 
-      - name: "Save result cache"
+      - name: Save result cache
         uses: actions/cache/save@v4
         if: always()
         with:
           path: var
-          key: "phpstan-result-cache-${{ runner.os }}-${{ matrix.php-versions }}-${{ github.run_id }}"
+          key: ${{ steps.phpstan-result-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
I figured out why the PHPStan check was failing in #25. It turns out that `actions/checkout@v4` clones the target branch with the PR merged into it. This makes sense as you would want to make sure PHPStan passes once the PR is merged to main, but is sort of confusing when you run PHPStan locally and it passes.

So I found out how to add both the base branch and the PR branch into the matrix strategy. For PRs, we will now run **six** PHPStan jobs, one for each PHP version with each branch combination. So for instance, in #25, the base branch checks would fail because I hadn't merged changes into it and fixed the baseline, but the PR branch would pass just fine.

You might think this would make the the workflows take a really long time, but I also figured out there was in fact a bug in the restore-keys cache action. Before, it would try to load the newest cache object starting with `phpstan-result-cache-`. The problem is that 2 out of 3 times it was trying to load the cache generated from a different PHP version, which causes PHPStan to discard the cache entirely. It now runs all six jobs in 30-60s compared to the several minutes from before once an initial cache is generated for the main branch, assuming there isn't another reason PHPStan needs to discard the cache.

I also enabled `-vvv` mode on PHPStan, since it helped me notice the cache error. It doesn't seem to be too noisy at all.