### PR TITLE
Added JsonSerializable interface to Varien_Object

### DIFF
--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -16,7 +16,7 @@
  * @category   Varien
  * @package    Varien_Object
  */
-class Varien_Object implements ArrayAccess
+class Varien_Object implements ArrayAccess, JsonSerializable
 {
     /**
      * Object attributes
@@ -563,17 +563,15 @@ class Varien_Object implements ArrayAccess
     }
 
     /**
-     * Convert object attributes to string
+     * Implementation of JsonSerializable::jsonSerialize()
      *
-     * @param  array  $arrAttributes array of required attributes
-     * @param  string $valueSeparator
-     * @return string
+     * @link https://www.php.net/manual/en/jsonserializable.jsonserialize.php
      */
-//    public function __toString(array $arrAttributes = array(), $valueSeparator=',')
-//    {
-//        $arrData = $this->toArray($arrAttributes);
-//        return implode($valueSeparator, $arrData);
-//    }
+    #[\Override]
+    public function jsonSerialize(): array
+    {
+        return $this->__toArray();
+    }
 
     /**
      * Public wrapper for __toString

--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -574,6 +574,19 @@ class Varien_Object implements ArrayAccess, JsonSerializable
     }
 
     /**
+     * Convert object attributes to string
+     *
+     * @param  array  $arrAttributes array of required attributes
+     * @param  string $valueSeparator
+     * @return string
+     */
+//    public function __toString(array $arrAttributes = array(), $valueSeparator=',')
+//    {
+//        $arrData = $this->toArray($arrAttributes);
+//        return implode($valueSeparator, $arrData);
+//    }
+
+    /**
      * Public wrapper for __toString
      *
      * Will use $format as an template and substitute {{key}} for attributes


### PR DESCRIPTION
Simple PR to allow Varien Objects to be serialized via `json_encode`.

### Test Code:

```php
// Simple test
$obj = new Varien_Object();
$obj['foo'] = 'bar';
var_dump(json_encode($obj));


// Nested test
$obj = new Varien_Object();
$obj['child'] = new Varien_Object();
$obj['child']['foo'] = 'bar';
var_dump(json_encode($obj));


// Array test
$results = [];
for ($i = 0; $i <3; $i++) {
    $obj = new Varien_Object();
    $obj['foo'] = 'bar' . $i;
    $results[] = $obj;
}
var_dump(json_encode($results));
```

### Results before PR:

```
string(2) "{}"
string(2) "{}"
string(10) "[{},{},{}]"
```

### Results after PR:

```
string(13) "{"foo":"bar"}"
string(23) "{"child":{"foo":"bar"}}"
string(46) "[{"foo":"bar0"},{"foo":"bar1"},{"foo":"bar2"}]"
```

### Comments

First, I just want to point out I had no idea you could get/set data on Varien Objects with array keys, but the class has implemented `ArrayAccess` since Magento 1.3.0...

Anyway, I grepped the source for instances of `json_encode` and I can't see any instances of it currently being called on a Varien Object (probably because it never worked.) So I don't think this should cause any problems. It would only break things is someone called `json_encode` on a Varien Object and actually expected `'{}'` in return. Not sure why anyone would do that...

I also removed the commented out `__toString` function.

### Future Improvements

At some point, we could probably completely remove all calls to `Zend_Json` from the source. The biggest change would be changing the exception from `Zend_Json_Exception` to PHP's built-in `JsonException` type. That could cause problems if some 3rd party code tries to catch an error of that type.
