### PR TITLE
New feature: Improved jstranslator.xml capabilities

### DIFF
--- a/app/code/core/Mage/Adminhtml/etc/jstranslator.xml
+++ b/app/code/core/Mage/Adminhtml/etc/jstranslator.xml
@@ -12,11 +12,41 @@
  */
 -->
 <jstranslator>
-    <script path="validation.js" area="adminhtml" module="adminhtml">
-        <validate-special-price translate="message">
+    <script path="validation.js" area="adminhtml" module="core">
+        <required-file translate="message">
+            <message>Please select a file</message>
+        </required-file>
+        <validate-no-html-tags translate="message">
+            <message>HTML tags are not allowed</message>
+        </validate-no-html-tags>
+        <validate-code translate="message">
+            <message>Please use only letters (a-z), numbers (0-9) or underscore(_) in this field, first character should be a letter.</message>
+        </validate-code>
+        <validate-code-event translate="message">
+            <message>Please do not use "event" for an attribute code.</message>
+        </validate-code-event>
+        <validate-email-sender translate="message">
+            <message>Please use only visible characters and spaces.</message>
+        </validate-email-sender>
+        <validate-admin-password translate="message">
+            <message>Please enter more characters. Password should contain both numeric and alphabetic characters.</message>
+        </validate-admin-password>
+        <validate-identifier translate="message">
+            <message>Please enter a valid URL Key. For example "example-page", "example-page.html" or "anotherlevel/example-page".</message>
+        </validate-identifier>
+        <validate-xml-identifier translate="message">
+            <message>Please enter a valid XML-identifier. For example something_1, block5, id-4.</message>
+        </validate-xml-identifier>
+        <validate-data translate="message">
+            <message>Please use only letters (a-z or A-Z), numbers (0-9) or underscore(_) in this field, first character should be a letter.</message>
+        </validate-data>
+        <validate-css-length translate="message">
+            <message>Please input a valid CSS-length. For example 100px or 77pt or 20em or .5ex or 50%.</message>
+        </validate-css-length>
+        <validate-special-price translate="message" module="adminhtml">
             <message>The Special Price is active only when lower than the Actual Price.</message>
         </validate-special-price>
-        <sales-order-create-addproducts translate="message">
+        <sales-order-create-addproducts translate="message" module="adminhtml">
             <message>Add Products</message>
         </sales-order-create-addproducts>
     </script>

--- a/app/code/core/Mage/Adminhtml/etc/jstranslator.xml
+++ b/app/code/core/Mage/Adminhtml/etc/jstranslator.xml
@@ -7,15 +7,17 @@
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2023 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <jstranslator>
-    <!-- validation.js -->
-    <validate-special-price translate="message" module="adminhtml">
-        <message>The Special Price is active only when lower than the Actual Price.</message>
-    </validate-special-price>
-    <sales-order-create-addproducts translate="message" module="adminhtml">
-        <message>Add Products</message>
-    </sales-order-create-addproducts>
+    <script path="validation.js" area="adminhtml" module="adminhtml">
+        <validate-special-price translate="message">
+            <message>The Special Price is active only when lower than the Actual Price.</message>
+        </validate-special-price>
+        <sales-order-create-addproducts translate="message">
+            <message>Add Products</message>
+        </sales-order-create-addproducts>
+    </script>
 </jstranslator>

--- a/app/code/core/Mage/Checkout/etc/jstranslator.xml
+++ b/app/code/core/Mage/Checkout/etc/jstranslator.xml
@@ -7,25 +7,27 @@
  * @package    Mage_Checkout
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <jstranslator>
-    <!-- opcheckout.js -->
-    <validate-guest translate="message" module="checkout">
-        <message>Please choose to register or to checkout as a guest</message>
-    </validate-guest>
-    <validate-shipping-methods-not-available translate="message" module="checkout">
-        <message>Your order cannot be completed at this time as there is no shipping methods available for it. Please make necessary changes in your shipping address.</message>
-    </validate-shipping-methods-not-available>
-    <validate-shipping-methods-required translate="message" module="checkout">
-        <message>Please specify shipping method.</message>
-    </validate-shipping-methods-required>
-    <validate-payment-methods-not-available translate="message" module="checkout">
-        <message>Your order cannot be completed at this time as there is no payment methods available for it.</message>
-    </validate-payment-methods-not-available>
-    <validate-payment-methods-required translate="message" module="checkout">
-        <message>Please specify payment method.</message>
-    </validate-payment-methods-required>
-    <!-- end opcheckout.js -->
+    <!-- skin_js/js/opcheckout.js -->
+    <layout handle="checkout_onepage_index" module="checkout">
+        <validate-guest translate="message">
+            <message>Please choose to register or to checkout as a guest</message>
+        </validate-guest>
+        <validate-shipping-methods-not-available translate="message">
+            <message>Your order cannot be completed at this time as there is no shipping methods available for it. Please make necessary changes in your shipping address.</message>
+        </validate-shipping-methods-not-available>
+        <validate-shipping-methods-required translate="message">
+            <message>Please specify shipping method.</message>
+        </validate-shipping-methods-required>
+        <validate-payment-methods-not-available translate="message">
+            <message>Your order cannot be completed at this time as there is no payment methods available for it.</message>
+        </validate-payment-methods-not-available>
+        <validate-payment-methods-required translate="message">
+            <message>Please specify payment method.</message>
+        </validate-payment-methods-required>
+    </layout>
 </jstranslator>

--- a/app/code/core/Mage/ConfigurableSwatches/etc/jstranslator.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/jstranslator.xml
@@ -7,19 +7,20 @@
  * @package    Mage_ConfigurableSwatches
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <jstranslator>
-    <!-- swatches-product.js -->
-    <add-to-cart translate="message" module="configurableswatches">
-        <message>Add to Cart</message>
-    </add-to-cart>
-    <in-stock translate="message" module="configurableswatches">
-        <message>In Stock</message>
-    </in-stock>
-    <out-of-stock translate="message" module="configurableswatches">
-        <message>Out of Stock</message>
-    </out-of-stock>
-    <!-- end swatches-product.js -->
+    <script path="js/configurableswatches/swatches-product.js" type="skin_js" module="configurableswatches">
+        <add-to-cart translate="message">
+            <message>Add to Cart</message>
+        </add-to-cart>
+        <in-stock translate="message">
+            <message>In Stock</message>
+        </in-stock>
+        <out-of-stock translate="message">
+            <message>Out of Stock</message>
+        </out-of-stock>
+    </script>
 </jstranslator>

--- a/app/code/core/Mage/Core/Helper/Js.php
+++ b/app/code/core/Mage/Core/Helper/Js.php
@@ -51,8 +51,7 @@ class Mage_Core_Helper_Js extends Mage_Core_Helper_Abstract
      */
     public function getTranslateJson()
     {
-        // return Mage::helper('core')->jsonEncode($this->_getTranslateData());
-        return json_encode($this->_getTranslateData(), JSON_PRETTY_PRINT);
+        return Mage::helper('core')->jsonEncode($this->_getTranslateData());
     }
 
     /**
@@ -133,9 +132,9 @@ class Mage_Core_Helper_Js extends Mage_Core_Helper_Abstract
         $messageText = is_array($messageText) ? $messageText : [$messageText];
         foreach ($messageText as $text) {
             $translated = Mage::helper($module)->__($text);
-            // if ($text && $text !== $translated) {
-            $this->_translateData[$text] = $translated;
-            // }
+            if ($text && $text !== $translated) {
+                $this->_translateData[$text] = $translated;
+            }
         }
     }
 

--- a/app/code/core/Mage/Core/Helper/Js.php
+++ b/app/code/core/Mage/Core/Helper/Js.php
@@ -133,9 +133,9 @@ class Mage_Core_Helper_Js extends Mage_Core_Helper_Abstract
         $messageText = is_array($messageText) ? $messageText : [$messageText];
         foreach ($messageText as $text) {
             $translated = Mage::helper($module)->__($text);
-            if (1 || $text && $text !== $translated) {
+            // if ($text && $text !== $translated) {
                 $this->_translateData[$text] = $translated;
-            }
+            // }
         }
     }
 

--- a/app/code/core/Mage/Core/Helper/Js.php
+++ b/app/code/core/Mage/Core/Helper/Js.php
@@ -134,7 +134,7 @@ class Mage_Core_Helper_Js extends Mage_Core_Helper_Abstract
         foreach ($messageText as $text) {
             $translated = Mage::helper($module)->__($text);
             // if ($text && $text !== $translated) {
-                $this->_translateData[$text] = $translated;
+            $this->_translateData[$text] = $translated;
             // }
         }
     }

--- a/app/code/core/Mage/Core/Helper/Js.php
+++ b/app/code/core/Mage/Core/Helper/Js.php
@@ -127,7 +127,7 @@ class Mage_Core_Helper_Js extends Mage_Core_Helper_Abstract
      * @param string|array $messageText a single or array of messages to translate
      * @param ?string $module the helper module to use for translating, defaults to 'core'
      */
-    public function addTranslateData(string|array $messageText, ?string $module)
+    public function addTranslateData(string|array $messageText, ?string $module): void
     {
         $module = $module ?: 'core';
         $messageText = is_array($messageText) ? $messageText : [$messageText];

--- a/app/code/core/Mage/Core/Helper/Js.php
+++ b/app/code/core/Mage/Core/Helper/Js.php
@@ -51,7 +51,8 @@ class Mage_Core_Helper_Js extends Mage_Core_Helper_Abstract
      */
     public function getTranslateJson()
     {
-        return Mage::helper('core')->jsonEncode($this->_getTranslateData());
+        // return Mage::helper('core')->jsonEncode($this->_getTranslateData());
+        return json_encode($this->_getTranslateData(), JSON_PRETTY_PRINT);
     }
 
     /**
@@ -132,7 +133,7 @@ class Mage_Core_Helper_Js extends Mage_Core_Helper_Abstract
         $messageText = is_array($messageText) ? $messageText : [$messageText];
         foreach ($messageText as $text) {
             $translated = Mage::helper($module)->__($text);
-            if ($text && $text !== $translated) {
+            if (1 || $text && $text !== $translated) {
                 $this->_translateData[$text] = $translated;
             }
         }

--- a/app/code/core/Mage/Core/Model/Translate/Config.php
+++ b/app/code/core/Mage/Core/Model/Translate/Config.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Maho
+ *
+ * @category   Mage
+ * @package    Mage_Core
+ * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Config model for loading jstranslate.xml files
+ *
+ * @category   Mage
+ * @package    Mage_Core
+ */
+class Mage_Core_Model_Translate_Config extends Varien_Simplexml_Config
+{
+    /**
+     * Extends current node with xml from $source, appending nodes without merging
+     *
+     * @param Varien_Simplexml_Config $config
+     * @param boolean $overwrite Argument has no effect, included for PHP 7.2 method signature compatibility
+     * @return $this
+     */
+    public function extend(Varien_Simplexml_Config $config, $overwrite = true)
+    {
+        foreach ($config->getNode()->children() as $child) {
+            $this->getNode()->appendChild($child);
+        }
+        return $this;
+    }
+}

--- a/app/code/core/Mage/Core/etc/jstranslator.xml
+++ b/app/code/core/Mage/Core/etc/jstranslator.xml
@@ -7,190 +7,191 @@
  * @package    Mage_Core
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <jstranslator>
-    <!-- validation.js -->
-    <validate-no-html-tags translate="message" module="core">
-        <message>HTML tags are not allowed</message>
-    </validate-no-html-tags>
-    <validate-select translate="message" module="core">
-        <message>Please select an option.</message>
-    </validate-select>
-    <required-entry translate="message" module="core">
-        <message>This is a required field.</message>
-    </required-entry>
-    <validate-number translate="message" module="core">
-        <message>Please enter a valid number in this field.</message>
-    </validate-number>
-    <validate-number-range translate="message" module="core">
-        <message>The value is not within the specified range.</message>
-    </validate-number-range>
-    <validate-digits translate="message" module="core">
-        <message>Please use numbers only in this field. Please avoid spaces or other characters such as dots or commas.</message>
-    </validate-digits>
-    <validate-digits-range translate="message" module="core">
-        <message>The value is not within the specified range.</message>
-    </validate-digits-range>
-    <validate-alpha translate="message" module="core">
-        <message>Please use letters only (a-z or A-Z) in this field.</message>
-    </validate-alpha>
-    <validate-code translate="message" module="core">
-        <message>Please use only letters (a-z), numbers (0-9) or underscore(_) in this field, first character should be a letter.</message>
-    </validate-code>
-    <validate-code-event translate="message" module="core">
-        <message>Please do not use "event" for an attribute code.</message>
-    </validate-code-event>
-    <validate-alphanum translate="message" module="core">
-        <message>Please use only letters (a-z or A-Z) or numbers (0-9) only in this field. No spaces or other characters are allowed.</message>
-    </validate-alphanum>
-    <validate-street translate="message" module="core">
-        <message>Please use only letters (a-z or A-Z) or numbers (0-9) or spaces and # only in this field.</message>
-    </validate-street>
-    <validate-phone-strict translate="message" module="core">
-        <message>Please enter a valid phone number. For example (123) 456-7890 or 123-456-7890.</message>
-    </validate-phone-strict>
-    <validate-phone-lax translate="message" module="core">
-        <message>Please enter a valid phone number. For example (123) 456-7890 or 123-456-7890.</message>
-    </validate-phone-lax>
-    <validate-fax translate="message" module="core">
-        <message>Please enter a valid fax number. For example (123) 456-7890 or 123-456-7890.</message>
-    </validate-fax>
-    <validate-date translate="message" module="core">
-        <message>Please enter a valid date.</message>
-    </validate-date>
-    <validate-date-range translate="message" module="core">
-        <message>The From Date value should be less than or equal to the To Date value.</message>
-    </validate-date-range>
-    <validate-email translate="message" module="core">
-        <message>Please enter a valid email address. For example johndoe@domain.com.</message>
-    </validate-email>
-    <validate-email-sender translate="message" module="core">
-        <message>Please use only visible characters and spaces.</message>
-    </validate-email-sender>
-    <validate-password translate="message" module="core">
-        <message>Please enter more characters or clean leading or trailing spaces.</message>
-    </validate-password>
-    <validate-admin-password translate="message" module="core">
-        <message>Please enter more characters. Password should contain both numeric and alphabetic characters.</message>
-    </validate-admin-password>
-    <validate-cpassword translate="message" module="core">
-        <message>Please make sure your passwords match.</message>
-    </validate-cpassword>
-    <validate-url translate="message" module="core">
-        <message>Please enter a valid URL. Protocol is required (http://, https:// or ftp://)</message>
-    </validate-url>
-    <validate-clean-url translate="message" module="core">
-        <message>Please enter a valid URL. For example http://www.example.com or www.example.com</message>
-    </validate-clean-url>
-    <validate-identifier translate="message" module="core">
-        <message>Please enter a valid URL Key. For example "example-page", "example-page.html" or "anotherlevel/example-page".</message>
-    </validate-identifier>
-    <validate-xml-identifier translate="message" module="core">
-        <message>Please enter a valid XML-identifier. For example something_1, block5, id-4.</message>
-    </validate-xml-identifier>
-    <validate-ssn translate="message" module="core">
-        <message>Please enter a valid social security number. For example 123-45-6789.</message>
-    </validate-ssn>
-    <validate-zip translate="message" module="core">
-        <message>Please enter a valid zip code. For example 90602 or 90602-1234.</message>
-    </validate-zip>
-    <validate-zip-international translate="message" module="core">
-        <message>Please enter a valid zip code.</message>
-    </validate-zip-international>
-    <validate-date-au translate="message" module="core">
-        <message>Please use this date format: dd/mm/yyyy. For example 17/03/2006 for the 17th of March, 2006.</message>
-    </validate-date-au>
-    <validate-currency-dollar translate="message" module="core">
-        <message>Please enter a valid $ amount. For example $100.00.</message>
-    </validate-currency-dollar>
-    <validate-one-required translate="message" module="core">
-        <message>Please select one of the above options.</message>
-    </validate-one-required>
-    <validate-one-required-by-name translate="message" module="core">
-        <message>Please select one of the options.</message>
-    </validate-one-required-by-name>
-    <validate-not-negative-number translate="message" module="core">
-        <message>Please enter a valid number in this field.</message>
-    </validate-not-negative-number>
-    <validate-state translate="message" module="core">
-        <message>Please select State/Province.</message>
-    </validate-state>
-    <validate-new-password translate="message" module="core">
-        <message>Please enter more characters or clean leading or trailing spaces.</message>
-    </validate-new-password>
-    <validate-greater-than-zero translate="message" module="core">
-        <message>Please enter a number greater than 0 in this field.</message>
-    </validate-greater-than-zero>
-    <validate-zero-or-greater translate="message" module="core">
-        <message>Please enter a number 0 or greater in this field.</message>
-    </validate-zero-or-greater>
-    <validate-cc-number translate="message" module="core">
-        <message>Please enter a valid credit card number.</message>
-    </validate-cc-number>
-    <validate-cc-type translate="message" module="core">
-        <message>Credit card number does not match credit card type.</message>
-    </validate-cc-type>
-    <validate-cc-type-select translate="message" module="core">
-        <message>Card type does not match credit card number.</message>
-    </validate-cc-type-select>
-    <validate-cc-exp translate="message" module="core">
-        <message>Incorrect credit card expiration date.</message>
-    </validate-cc-exp>
-    <validate-cc-cvn translate="message" module="core">
-        <message>Please enter a valid credit card verification number.</message>
-    </validate-cc-cvn>
-    <validate-data translate="message" module="core">
-        <message>Please use only letters (a-z or A-Z), numbers (0-9) or underscore(_) in this field, first character should be a letter.</message>
-    </validate-data>
-    <validate-css-length translate="message" module="core">
-        <message>Please input a valid CSS-length. For example 100px or 77pt or 20em or .5ex or 50%.</message>
-    </validate-css-length>
-    <validate-length translate="message" module="core">
-        <message>Text length does not satisfy specified text range.</message>
-    </validate-length>
-    <validate-percents translate="message" module="core">
-        <message>Please enter a number lower than 100.</message>
-    </validate-percents>
-    <required-file translate="message" module="core">
-        <message>Please select a file</message>
-    </required-file>
-    <validate-cc-ukss translate="message" module="core">
-        <message>Please enter issue number or start date for switch/solo card type.</message>
-    </validate-cc-ukss>
-    <!-- end validation.js -->
+    <script path="validation.js" module="core">
+        <validate-no-html-tags translate="message">
+            <message>HTML tags are not allowed</message>
+        </validate-no-html-tags>
+        <validate-select translate="message">
+            <message>Please select an option.</message>
+        </validate-select>
+        <required-entry translate="message">
+            <message>This is a required field.</message>
+        </required-entry>
+        <validate-number translate="message">
+            <message>Please enter a valid number in this field.</message>
+        </validate-number>
+        <validate-number-range translate="message">
+            <message>The value is not within the specified range.</message>
+        </validate-number-range>
+        <validate-digits translate="message">
+            <message>Please use numbers only in this field. Please avoid spaces or other characters such as dots or commas.</message>
+        </validate-digits>
+        <validate-digits-range translate="message">
+            <message>The value is not within the specified range.</message>
+        </validate-digits-range>
+        <validate-alpha translate="message">
+            <message>Please use letters only (a-z or A-Z) in this field.</message>
+        </validate-alpha>
+        <validate-code translate="message">
+            <message>Please use only letters (a-z), numbers (0-9) or underscore(_) in this field, first character should be a letter.</message>
+        </validate-code>
+        <validate-code-event translate="message">
+            <message>Please do not use "event" for an attribute code.</message>
+        </validate-code-event>
+        <validate-alphanum translate="message">
+            <message>Please use only letters (a-z or A-Z) or numbers (0-9) only in this field. No spaces or other characters are allowed.</message>
+        </validate-alphanum>
+        <validate-street translate="message">
+            <message>Please use only letters (a-z or A-Z) or numbers (0-9) or spaces and # only in this field.</message>
+        </validate-street>
+        <validate-phone-strict translate="message">
+            <message>Please enter a valid phone number. For example (123) 456-7890 or 123-456-7890.</message>
+        </validate-phone-strict>
+        <validate-phone-lax translate="message">
+            <message>Please enter a valid phone number. For example (123) 456-7890 or 123-456-7890.</message>
+        </validate-phone-lax>
+        <validate-fax translate="message">
+            <message>Please enter a valid fax number. For example (123) 456-7890 or 123-456-7890.</message>
+        </validate-fax>
+        <validate-date translate="message">
+            <message>Please enter a valid date.</message>
+        </validate-date>
+        <validate-date-range translate="message">
+            <message>The From Date value should be less than or equal to the To Date value.</message>
+        </validate-date-range>
+        <validate-email translate="message">
+            <message>Please enter a valid email address. For example johndoe@domain.com.</message>
+        </validate-email>
+        <validate-email-sender translate="message">
+            <message>Please use only visible characters and spaces.</message>
+        </validate-email-sender>
+        <validate-password translate="message">
+            <message>Please enter more characters or clean leading or trailing spaces.</message>
+        </validate-password>
+        <validate-admin-password translate="message">
+            <message>Please enter more characters. Password should contain both numeric and alphabetic characters.</message>
+        </validate-admin-password>
+        <validate-cpassword translate="message">
+            <message>Please make sure your passwords match.</message>
+        </validate-cpassword>
+        <validate-url translate="message">
+            <message>Please enter a valid URL. Protocol is required (http://, https:// or ftp://)</message>
+        </validate-url>
+        <validate-clean-url translate="message">
+            <message>Please enter a valid URL. For example http://www.example.com or www.example.com</message>
+        </validate-clean-url>
+        <validate-identifier translate="message">
+            <message>Please enter a valid URL Key. For example "example-page", "example-page.html" or "anotherlevel/example-page".</message>
+        </validate-identifier>
+        <validate-xml-identifier translate="message">
+            <message>Please enter a valid XML-identifier. For example something_1, block5, id-4.</message>
+        </validate-xml-identifier>
+        <validate-ssn translate="message">
+            <message>Please enter a valid social security number. For example 123-45-6789.</message>
+        </validate-ssn>
+        <validate-zip translate="message">
+            <message>Please enter a valid zip code. For example 90602 or 90602-1234.</message>
+        </validate-zip>
+        <validate-zip-international translate="message">
+            <message>Please enter a valid zip code.</message>
+        </validate-zip-international>
+        <validate-date-au translate="message">
+            <message>Please use this date format: dd/mm/yyyy. For example 17/03/2006 for the 17th of March, 2006.</message>
+        </validate-date-au>
+        <validate-currency-dollar translate="message">
+            <message>Please enter a valid $ amount. For example $100.00.</message>
+        </validate-currency-dollar>
+        <validate-one-required translate="message">
+            <message>Please select one of the above options.</message>
+        </validate-one-required>
+        <validate-one-required-by-name translate="message">
+            <message>Please select one of the options.</message>
+        </validate-one-required-by-name>
+        <validate-not-negative-number translate="message">
+            <message>Please enter a valid number in this field.</message>
+        </validate-not-negative-number>
+        <validate-state translate="message">
+            <message>Please select State/Province.</message>
+        </validate-state>
+        <validate-new-password translate="message">
+            <message>Please enter more characters or clean leading or trailing spaces.</message>
+        </validate-new-password>
+        <validate-greater-than-zero translate="message">
+            <message>Please enter a number greater than 0 in this field.</message>
+        </validate-greater-than-zero>
+        <validate-zero-or-greater translate="message">
+            <message>Please enter a number 0 or greater in this field.</message>
+        </validate-zero-or-greater>
+        <validate-cc-number translate="message">
+            <message>Please enter a valid credit card number.</message>
+        </validate-cc-number>
+        <validate-cc-type translate="message">
+            <message>Credit card number does not match credit card type.</message>
+        </validate-cc-type>
+        <validate-cc-type-select translate="message">
+            <message>Card type does not match credit card number.</message>
+        </validate-cc-type-select>
+        <validate-cc-exp translate="message">
+            <message>Incorrect credit card expiration date.</message>
+        </validate-cc-exp>
+        <validate-cc-cvn translate="message">
+            <message>Please enter a valid credit card verification number.</message>
+        </validate-cc-cvn>
+        <validate-data translate="message">
+            <message>Please use only letters (a-z or A-Z), numbers (0-9) or underscore(_) in this field, first character should be a letter.</message>
+        </validate-data>
+        <validate-css-length translate="message">
+            <message>Please input a valid CSS-length. For example 100px or 77pt or 20em or .5ex or 50%.</message>
+        </validate-css-length>
+        <validate-length translate="message">
+            <message>Text length does not satisfy specified text range.</message>
+        </validate-length>
+        <validate-percents translate="message">
+            <message>Please enter a number lower than 100.</message>
+        </validate-percents>
+        <required-file translate="message">
+            <message>Please select a file</message>
+        </required-file>
+        <validate-cc-ukss translate="message">
+            <message>Please enter issue number or start date for switch/solo card type.</message>
+        </validate-cc-ukss>
+    </script>
 
-    <!-- rules.js -->
-    <loading translate="message" module="core">
-        <message>Please wait, loading...</message>
-    </loading>
-    <!-- end rules.js -->
+    <script path="mage/adminhtml/rules.js" module="core">
+        <loading translate="message">
+            <message>Please wait, loading...</message>
+        </loading>
+    </script>
 
-    <!-- js.js -->
-    <validate-date-required translate="message" module="core">
-        <message>This date is a required value.</message>
-    </validate-date-required>
-    <validate-date-day translate="message" module="core">
-        <message>Please enter a valid day (1-%d).</message>
-    </validate-date-day>
-    <validate-date-month translate="message" module="core">
-        <message>Please enter a valid month (1-12).</message>
-    </validate-date-month>
-    <validate-date-year translate="message" module="core">
-        <message>Please enter a valid year (1900-%d).</message>
-    </validate-date-year>
-    <validate-date-full-date translate="message" module="core">
-        <message>Please enter a valid full date</message>
-    </validate-date-full-date>
-    <validate-date-date-between translate="message" module="core">
-        <message>Please enter a valid date between %s and %s</message>
-    </validate-date-date-between>
-    <validate-date-greater translate="message" module="core">
-        <message>Please enter a valid date equal to or greater than %s</message>
-    </validate-date-greater>
-    <validate-date-less translate="message" module="core">
-        <message>Please enter a valid date less than or equal to %s</message>
-    </validate-date-less>
-    <!-- end js.js -->
+    <script path="varien/js.js" module="core">
+        <validate-date-required translate="message">
+            <message>This date is a required value.</message>
+        </validate-date-required>
+        <validate-date-day translate="message">
+            <message>Please enter a valid day (1-%d).</message>
+        </validate-date-day>
+        <validate-date-month translate="message">
+            <message>Please enter a valid month (1-12).</message>
+        </validate-date-month>
+        <validate-date-year translate="message">
+            <message>Please enter a valid year (1900-%d).</message>
+        </validate-date-year>
+        <validate-date-full-date translate="message">
+            <message>Please enter a valid full date</message>
+        </validate-date-full-date>
+        <validate-date-date-between translate="message">
+            <message>Please enter a valid date between %s and %s</message>
+        </validate-date-date-between>
+        <validate-date-greater translate="message">
+            <message>Please enter a valid date equal to or greater than %s</message>
+        </validate-date-greater>
+        <validate-date-less translate="message">
+            <message>Please enter a valid date less than or equal to %s</message>
+        </validate-date-less>
+    </script>
 </jstranslator>

--- a/app/code/core/Mage/Core/etc/jstranslator.xml
+++ b/app/code/core/Mage/Core/etc/jstranslator.xml
@@ -13,9 +13,6 @@
 -->
 <jstranslator>
     <script path="validation.js" module="core">
-        <validate-no-html-tags translate="message">
-            <message>HTML tags are not allowed</message>
-        </validate-no-html-tags>
         <validate-select translate="message">
             <message>Please select an option.</message>
         </validate-select>
@@ -37,12 +34,6 @@
         <validate-alpha translate="message">
             <message>Please use letters only (a-z or A-Z) in this field.</message>
         </validate-alpha>
-        <validate-code translate="message">
-            <message>Please use only letters (a-z), numbers (0-9) or underscore(_) in this field, first character should be a letter.</message>
-        </validate-code>
-        <validate-code-event translate="message">
-            <message>Please do not use "event" for an attribute code.</message>
-        </validate-code-event>
         <validate-alphanum translate="message">
             <message>Please use only letters (a-z or A-Z) or numbers (0-9) only in this field. No spaces or other characters are allowed.</message>
         </validate-alphanum>
@@ -67,30 +58,15 @@
         <validate-email translate="message">
             <message>Please enter a valid email address. For example johndoe@domain.com.</message>
         </validate-email>
-        <validate-email-sender translate="message">
-            <message>Please use only visible characters and spaces.</message>
-        </validate-email-sender>
         <validate-password translate="message">
             <message>Please enter more characters or clean leading or trailing spaces.</message>
         </validate-password>
-        <validate-admin-password translate="message">
-            <message>Please enter more characters. Password should contain both numeric and alphabetic characters.</message>
-        </validate-admin-password>
         <validate-cpassword translate="message">
             <message>Please make sure your passwords match.</message>
         </validate-cpassword>
         <validate-url translate="message">
             <message>Please enter a valid URL. Protocol is required (http://, https:// or ftp://)</message>
         </validate-url>
-        <validate-clean-url translate="message">
-            <message>Please enter a valid URL. For example http://www.example.com or www.example.com</message>
-        </validate-clean-url>
-        <validate-identifier translate="message">
-            <message>Please enter a valid URL Key. For example "example-page", "example-page.html" or "anotherlevel/example-page".</message>
-        </validate-identifier>
-        <validate-xml-identifier translate="message">
-            <message>Please enter a valid XML-identifier. For example something_1, block5, id-4.</message>
-        </validate-xml-identifier>
         <validate-ssn translate="message">
             <message>Please enter a valid social security number. For example 123-45-6789.</message>
         </validate-ssn>
@@ -142,21 +118,12 @@
         <validate-cc-cvn translate="message">
             <message>Please enter a valid credit card verification number.</message>
         </validate-cc-cvn>
-        <validate-data translate="message">
-            <message>Please use only letters (a-z or A-Z), numbers (0-9) or underscore(_) in this field, first character should be a letter.</message>
-        </validate-data>
-        <validate-css-length translate="message">
-            <message>Please input a valid CSS-length. For example 100px or 77pt or 20em or .5ex or 50%.</message>
-        </validate-css-length>
         <validate-length translate="message">
             <message>Text length does not satisfy specified text range.</message>
         </validate-length>
         <validate-percents translate="message">
             <message>Please enter a number lower than 100.</message>
         </validate-percents>
-        <required-file translate="message">
-            <message>Please select a file</message>
-        </required-file>
         <validate-cc-ukss translate="message">
             <message>Please enter issue number or start date for switch/solo card type.</message>
         </validate-cc-ukss>

--- a/app/code/core/Mage/Uploader/etc/jstranslator.xml
+++ b/app/code/core/Mage/Uploader/etc/jstranslator.xml
@@ -7,24 +7,26 @@
  * @package    Mage_Uploader
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <jstranslator>
-    <uploader-exceed_max-1 translate="message" module="uploader">
-        <message>Maximum allowed file size for upload is</message>
-    </uploader-exceed_max-1>
-    <uploader-exceed_max-2 translate="message" module="uploader">
-        <message>Please check your server PHP settings.</message>
-    </uploader-exceed_max-2>
-    <uploader-tab-change-event-confirm translate="message" module="uploader">
-        <message>There are files that were selected but not uploaded yet. After switching to another tab your selections will be lost. Do you wish to continue ?</message>
-    </uploader-tab-change-event-confirm>
-    <uploader-complete-event-text translate="message" module="uploader">
-        <message>Complete</message>
-    </uploader-complete-event-text>
-    <uploader-uploading-progress translate="message" module="uploader">
-        <message>Uploading...</message>
-    </uploader-uploading-progress>
+    <script path="mage/adminhtml/uploader/instance.js" module="uploader">
+        <uploader-exceed_max-1 translate="message">
+            <message>Maximum allowed file size for upload is</message>
+        </uploader-exceed_max-1>
+        <uploader-exceed_max-2 translate="message">
+            <message>Please check your server PHP settings.</message>
+        </uploader-exceed_max-2>
+        <uploader-tab-change-event-confirm translate="message">
+            <message>There are files that were selected but not uploaded yet. After switching to another tab your selections will be lost. Do you wish to continue ?</message>
+        </uploader-tab-change-event-confirm>
+        <uploader-complete-event-text translate="message">
+            <message>Complete</message>
+        </uploader-complete-event-text>
+        <uploader-uploading-progress translate="message">
+            <message>Uploading...</message>
+        </uploader-uploading-progress>
+    </script>
 </jstranslator>
-

--- a/app/code/core/Mage/Widget/etc/jstranslator.xml
+++ b/app/code/core/Mage/Widget/etc/jstranslator.xml
@@ -7,13 +7,14 @@
  * @package    Mage_Widget
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <jstranslator>
-    <!-- widget.js -->
-    <widget-ui-insert translate="message" module="widget">
-        <message>Insert Widget...</message>
-    </widget-ui-insert>
-    <!-- end widget.js -->
+    <script path="mage/adminhtml/wysiwyg/widget.js" module="widget">
+        <widget-ui-insert translate="message" module="widget">
+            <message>Insert Widget...</message>
+        </widget-ui-insert>
+    </script>
 </jstranslator>

--- a/public/js/mage/translate.js
+++ b/public/js/mage/translate.js
@@ -5,6 +5,7 @@
  * @package     js
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
@@ -13,11 +14,9 @@ class Translate {
         this.data = new Map(Object.entries(data));
     }
 
-    translate(text) {
-        if(this.data.has(text)) {
-            return this.data.get(text);
-        }
-        return text;
+    translate(text, ...args) {
+        const translated = this.data.get(text) ?? text;
+        return translated.replaceAll(/%[ds]/g, (match) => args.shift() ?? match);
     }
 
     add(keyOrObject, value) {


### PR DESCRIPTION
## Description
Improved the jstranslator.xml syntax to allow including strings based on the scope, layout handle, and/or script included in `<head>`. Also added support very basic `sprintf` like syntax in the JS Translate class.

## Rationale
I wanted to utilize the jstranslator.xml feature, but it has one very glaring problem: every string is included on every page load on both adminhtml and frontend. So if I add 10 new strings meant only for the admin panel, they'll also be included on the frontend. This could even be a security issue if you include strings that leak information about the server setup or installed modules.

Of course, this only happens if you're on a language pack other than English, so to illustrate the problem comment out the `unset()` line below. This simulates a language pack with all strings defined.

https://github.com/MahoCommerce/maho/blob/fddaaf97b9386183331efef84ee9105b6379d031/app/code/core/Mage/Core/Helper/Js.php#L143-L146

Then view the source of the homepage, and you'll see messages that are only used in the admin panel. I highlighted an example where it could be a security issue.

![image](https://github.com/user-attachments/assets/4e51d747-797d-4cfb-9bbd-9b45a009c029)

With this PR the string count goes from 70 -> 41, and will prevent future strings from being included unnecessarily.

## Solution

I added some new syntax options to jstranslator.xml, here is what's possible:

```xml
<?xml version="1.0"?>
<jstranslator>

    <!-- Legacy style, backwards compatible with existing XML files -->
    <my-string-1 translate="message" module="core">
        <message>This string is included everywhere</message>
    </my-string-1>

    <!--
         Global scope node, this is equivalent to the legacy style,
         except you only need to define the module="" attribute once.

         Note: the module="" attribute is always optional, defaults to 'core'
    -->
    <global module="core">
        <my-string-2 translate="message">
            <message>This string is also included everywhere</message>
        </my-string-2>
        <my-string-3 translate="message">
            <message>Another global string</message>
        </my-string-3>
        <!-- You can override the parent module attribute if you like -->
        <my-string-4 translate="message" module="catalog">
            <message>Global string translated with another module</message>
        </my-string-4>
    </global>

    <!-- Frontend only -->
    <frontend module="core">
        <my-string-4 translate="message">
            <message>This string is included only on the frontend</message>
        </my-string-4>
    </frontend>

    <!-- Adminhtml only -->
    <adminhtml module="core">
        <my-string-5 translate="message">
            <message>This string is included only on the admin panel</message>
        </my-string-5>
    </adminhtml>

    <!--
         Layout node, include only if the handle="" attribute matches the current layout

         Example handles:
           - STORE_default
           - THEME_frontend_rwd_default
           - catalog_product_view
           - PRODUCT_TYPE_configurable
           - customer_logged_in
           - cms_page
           - cms_index_index
           - etc

         Note: you can specify multiple handles by separating them with a comma
    -->
    <layout handle="cms_index_index" module="core">
        <my-string-6 translate="message">
            <message>This string is included only on the home page</message>
        </my-string-6>
    </layout>

    <!--
        Script node, include only if the script was added to the head block.
        This ONLY detects scripts added to the head block with addJs or addItem, it does not
        detect hardcoded <script src=""></script> tags.

        path="" attribute should match the parameter passed to addJs or addItem
        type="" attribute can be either 'js' or 'skin_js', defaults to 'js' if omitted

        Note: you can specify multiple scripts by separating them with a comma, but they all must be of the same type
    -->
    <script path="validation.js" type="js" module="core">
        <my-string-7 translate="message">
            <message>This string is only included if validation.js is loaded</message>
        </my-string-7>
    </script>

    <script path="js/msrp_rwd.js,js/opcheckout_rwd.js" type="skin_js" module="core">
        <my-string-8 translate="message">
            <message>This string is only included if msrp_rwd.js or opcheckout_rwd.js is loaded</message>
        </my-string-8>
    </script>

    <!--
         Scope attribute, you can combine the legacy style, layout, and script nodes with the
         area="" attribute to further limit loading strings
    -->
    <script path="validation.js" area="adminhtml" module="adminhtml">
        <my-string-9 translate="message">
            <message>This string is only included if validation.js is loaded AND we're on the admin panel</message>
        </my-string-9>
    </script>

</jstranslator>
```

Additionally, you can add messages manually with PHP code. You could do this either in a controller or block class, as long as it's before the head block is rendered (i.e. don't do it in a blocks `_toHtml()` method).

```php
// Add a single string translated with the 'core' module
Mage::helper('core/js')->addTranslateData('Some string'); 

// Add multiple strings translated with the 'adminhtml' module
Mage::helper('core/js')->addTranslateData([
    'My string 1',
    'My string 2',
    'My string 3',
], 'adminhtml');
```

Of course, you can also add messages in phtml files as before:
```php
<script>
    Translator.add('Some string', '<?= $this->__('Some string') ?>');

    Translator.add({
        'My string 1': '<?= $this->__('My string 1') ?>',
        'My string 2': '<?= $this->__('My string 2') ?>',
        'My string 3': '<?= $this->__('My string 3') ?>',
    });
</script>
```

## Basic sprintf compatibility 

I also added a *very* basic sprintf feature to the JS translate class. It only matches `%s` and `%d` tokens, but that's pretty much all that is ever used in Magento translation files. Example:

```js
Translator.translate('Please enter a password with at most %s characters.', 256);
```

## Comments

Most of the still included strings on the frontend are from `validation.js`. I moved some that are clearly admin only to `Mage/Adminhtml/etc/jstranslator.xml`. 

I also included a debug commit here that will be reverted. It simply includes all messages without a translation pack and pretty prints the JSON array in the source code.