### PR TITLE
Added new events:`controller_action_predispatch_$routeName_$controllerName` and `controller_action_postdispatch_$routeName_$controllerName`

### DIFF
--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -525,6 +525,10 @@ abstract class Mage_Core_Controller_Varien_Action
             ['controller_action' => $this]
         );
         Mage::dispatchEvent(
+            'controller_action_predispatch_' . $this->getRequest()->getRouteName() . '_' . $this->getRequest()->getControllerName(),
+            ['controller_action' => $this]
+        );
+        Mage::dispatchEvent(
             'controller_action_predispatch_' . $this->getFullActionName(),
             ['controller_action' => $this]
         );
@@ -541,6 +545,10 @@ abstract class Mage_Core_Controller_Varien_Action
 
         Mage::dispatchEvent(
             'controller_action_postdispatch_' . $this->getFullActionName(),
+            ['controller_action' => $this]
+        );
+        Mage::dispatchEvent(
+            'controller_action_postdispatch_' . $this->getRequest()->getRouteName() . '_' . $this->getRequest()->getControllerName(),
             ['controller_action' => $this]
         );
         Mage::dispatchEvent(


### PR DESCRIPTION
Simple PR, this just adds two new events per page load.

Events are as follow, same for postdispatch.

- `controller_action_predispatch_$routeName`
- `controller_action_predispatch_$routeName_$controllerName` (This is the new event)
- `controller_action_predispatch_$routeName_$controllerName_$actionName`

This is especially useful in admin, because `$routeName` is always "adminhtml", so you can only observe all admin page loads, or the exact full action name.

Examples:

```
// Category page
Array
(
    [0] => controller_action_predispatch_catalog
    [1] => controller_action_predispatch_catalog_category
    [2] => controller_action_predispatch_catalog_category_view
)

// Admin page
Array
(
    [0] => controller_action_predispatch_adminhtml
    [1] => controller_action_predispatch_adminhtml_catalog_product_attribute
    [2] => controller_action_predispatch_adminhtml_catalog_product_attribute_edit
)
```

Since this is on every page, I timed how long it takes to dispatch an event:

```php
$iter = 1000;
$st = microtime(true);
for ($i = 0; $i < $iter; $i++) {
    Mage::dispatchEvent(uniqid('', true));
}
$et = microtime(true);

echo number_format(($et-$st)/$iter, 10) . ' s/call';

// Result: 0.0000104079 s/call
```

So with two new events, only 0.02 ms per page load.

---

There is also a discrepancy between `getRouteName()`, `getControllerName()`, and `getFullActionName()`. The last one calls the `getRequestedRouteName()`, etc. I tried figuring out the difference, and it only seems like it happens with some config.xml features I've never seen before:

```xml
<global>
    <rewrite>
        <foo>
            <!--<complete>1</complete>-->
            <from>/catalog\/category\/view/</from> <!-- regex search -->
            <to>/checkout/cart/index/</to> <!-- regex replace -->
        </foo>
    </rewrite>
 </global>
```

This causes a discrepancy if the `<complete>` tag is missing. Example:

```
Array (
    [0] => controller_action_predispatch_checkout
    [1] => controller_action_predispatch_checkout_cart
    [2] => controller_action_predispatch_catalog_category_view
)
```

I don't know who uses this feature and how, but the two existing events were already mis-matched.