### PR TITLE
Revert "Added JsonSerializable interface to Varien_Object (#55)"

### DIFF
--- a/lib/Varien/Object.php
+++ b/lib/Varien/Object.php
@@ -17,7 +17,7 @@
  * @category   Varien
  * @package    Varien_Object
  */
-class Varien_Object implements ArrayAccess, JsonSerializable
+class Varien_Object implements ArrayAccess
 {
     /**
      * Object attributes
@@ -557,17 +557,6 @@ class Varien_Object implements ArrayAccess, JsonSerializable
     public function toJson(array $arrAttributes = [])
     {
         return $this->__toJson($arrAttributes);
-    }
-
-    /**
-     * Implementation of JsonSerializable::jsonSerialize()
-     *
-     * @link https://www.php.net/manual/en/jsonserializable.jsonserialize.php
-     */
-    #[\Override]
-    public function jsonSerialize(): array
-    {
-        return $this->__toArray();
     }
 
     /**


### PR DESCRIPTION
Reverts #55, fixes #69.

While serializing nested data is nice, I had not taken into account circular references.

For example:

```php
$x = new Varien_Object();
$y = new Varien_Object();

$x->setY($y);
$y->setX($x);

json_encode($x, JSON_THROW_ON_ERROR);

// PHP Fatal error:  Uncaught JsonException: Recursion detected
```

I am not sure I see any good solution at the moment. While a class could define its own `jsonSerialize()` method to exclude any circular references, that's just not worth it.