### PR TITLE
Issue 78 fix force format for cached images

### DIFF
--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -200,15 +200,14 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
         if (!is_null($this->quality()) && $this->_fileType == IMAGETYPE_PNG) {
             $functionParameters[] = 9;
         }
-
-        call_user_func_array($this->_getCallback('output'), $functionParameters);
+        call_user_func_array($this->_getCallback('output', $this->targetFileType), $functionParameters);
     }
 
     #[\Override]
     public function display()
     {
         header('Content-type: ' . $this->getMimeTypeWithOutFileType());
-        call_user_func($this->_getCallback('output'), $this->_imageHandler);
+        call_user_func($this->_getCallback('output', $this->targetFileType), $this->_imageHandler);
     }
 
     /**


### PR DESCRIPTION
I think I have solved issue https://github.com/MahoCommerce/maho/issues/78
The same callback was being called for the output because it was based on the original image's mimetype, for example, imagejpeg. 
I forced the use of the correct gd2 function only for the output, while for the create function, it remains based on the original image's mimetype.

Now the image is saved in the correct format, and the file size is smaller as well.
![ls](https://github.com/user-attachments/assets/21514d9d-e88e-46ce-9afe-906d501bee3f)
PS: I think the slight difference from demo version is due to the quality setting.