### PR TITLE
Fixed configurable swatches undefined array key warning

### DIFF
--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
@@ -7,6 +7,7 @@
  * @package    Mage_ConfigurableSwatches
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -379,11 +380,11 @@ class Mage_ConfigurableSwatches_Helper_Productimg extends Mage_Core_Helper_Abstr
         }
 
         if (!isset($this->_productImageFilters[$product->getId()])) {
-            $mapping = call_user_func_array('array_merge_recursive', array_values($product->getChildAttributeLabelMapping()));
-            $filters = array_unique($mapping['labels']);
-            $filters = array_merge($filters, array_map(function ($label) {
-                return $label . Mage_ConfigurableSwatches_Helper_Productimg::SWATCH_LABEL_SUFFIX;
-            }, $filters));
+            $mapping = array_merge_recursive(...array_values($product->getChildAttributeLabelMapping()));
+            $filters = array_unique($mapping['labels'] ?? []);
+            foreach ($filters as $label) {
+                $filters[] = $label . Mage_ConfigurableSwatches_Helper_Productimg::SWATCH_LABEL_SUFFIX;
+            }
             $this->_productImageFilters[$product->getId()] = $filters;
         }
 


### PR DESCRIPTION
Go to https://store.example.com/ellis-flat.html and you'll receive warning in dev mode. Happens on OM main branch too.

The main fix was just to use `$mapping['labels'] ?? []`, but I cleaned up the method to use the splat operator instead of `call_user_func_array`, and simplified the `array_merge` / `array_map`.