### PR TITLE
Fixed bug with `Mage::getModel('core/url')->getUrl('', ['_current' => true, '_query' => false])`

### DIFF
--- a/app/code/core/Mage/Core/Model/Url.php
+++ b/app/code/core/Mage/Core/Model/Url.php
@@ -869,7 +869,7 @@ class Mage_Core_Model_Url extends Varien_Object
     public function purgeQueryParams()
     {
         $this->unsetData('query');
-        $this->setData('query_params', []);
+        $this->unsetData('query_params');
         return $this;
     }
 

--- a/app/code/core/Mage/Core/Model/Url.php
+++ b/app/code/core/Mage/Core/Model/Url.php
@@ -868,6 +868,7 @@ class Mage_Core_Model_Url extends Varien_Object
      */
     public function purgeQueryParams()
     {
+        $this->unsetData('query');
         $this->setData('query_params', []);
         return $this;
     }
@@ -995,7 +996,7 @@ class Mage_Core_Model_Url extends Varien_Object
                 $this->setQueryParams($query);
             }
             if ($query === false) {
-                $this->setQueryParams([]);
+                $this->purgeQueryParams();
             }
         }
 


### PR DESCRIPTION
Actually I'm unsure if this is exactly a bug since looking way back at Magento 1.1 this seems to be expected behavior, but it makes no sense.

If you have this code:

```php
Mage::getModel('core/url')->getUrl('*/*/*', ['_current' => true, '_query' => false]);
```

The `_current=true` part copies all URL params to the result, both path params (`/id/1/`) and query params (`?foo=bar`). But if we want only the path params but not the query params, this is not possible since `_current=true` overrides `_query=false`. 

Part of me does believe this is a bug for the following reasons:

1\. This part of code I replaced had absolutely no effect, because the method `setQueryParams()` actually *adds* query params from the argument array, instead of replacing them with an empty array.

```php
if ($query === false) {
    $this->setQueryParams([]); // This line does nothing
}
```

2\. Several places in Magento the devs used `['_current' => true, '_query' => false]`, but if this had no effect then why did they do it? This usage was in the category tree blocks which I already worked around, but that's how I found the issue.

3\. There should be a way to get the current url with no query params. There are a few stackoverflow posts with various convoluted solutions, and none of them are great.

4\. If you want the current url *with query params*, just don't pass `_query=false`...

---

The other line I added in the `purgeQueryParams()` method also makes sure it really does purge all query params. While I don't think the model is ever used like this, the following is valid code:

```php
$model = Mage::getModel('core/url');

$model->setQuery('foo=1');

$model->purgeQueryParams();

$url = $model->getUrl('foo/bar/baz');

var_dump($url);

// Before: "https://store.example.com/foo/bar/baz/?foo=1"

// After: "https://store.example.com/foo/bar/baz/"
```