### PR TITLE
New feature: added Order Status color

### DIFF
--- a/app/code/core/Mage/Admin/sql/maho_setup/maho-24.12.1.php
+++ b/app/code/core/Mage/Admin/sql/maho_setup/maho-24.12.1.php
@@ -16,7 +16,7 @@ $installer->startSetup();
 
 $installer->run("
     ALTER TABLE {$this->getTable('sales/order_status')}
-    ADD COLUMN `color` VARCHAR(20) NULL,
+    ADD COLUMN `color` VARCHAR(20) NULL
 ");
 
 $installer->endSetup();

--- a/app/code/core/Mage/Admin/sql/maho_setup/maho-24.12.1.php
+++ b/app/code/core/Mage/Admin/sql/maho_setup/maho-24.12.1.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @category   Mage
+ * @package    Mage_Core
+ * @copyright  @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Checkout_Model_Resource_Setup $this */
+$installer = $this;
+
+$installer->startSetup();
+
+$installer->run("
+    ALTER TABLE {$this->getTable('sales/order_status')}
+    ADD COLUMN `color` VARCHAR(20) NULL,
+");
+
+$installer->endSetup();

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
@@ -21,6 +21,8 @@ use Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract as MassAction;
  */
 class Mage_Adminhtml_Block_Sales_Order_Grid extends Mage_Adminhtml_Block_Widget_Grid
 {
+    protected ?array $orderStatusColors = null;
+
     public function __construct()
     {
         parent::__construct();
@@ -248,23 +250,19 @@ class Mage_Adminhtml_Block_Sales_Order_Grid extends Mage_Adminhtml_Block_Widget_
 
     public function decorateStatus($value, $row, $column, $isExport): string
     {
-        $colors = Mage::registry('order_status_colors');
-        if ($colors === null) {
+        if ($this->orderStatusColors === null) {
+            $this->orderStatusColors = [];
             $orderStatusCollection = Mage::getResourceModel('sales/order_status_collection')->getItems();
             foreach ($orderStatusCollection as $orderStatus) {
                 $color = $orderStatus->getColor();
                 if ($color) {
-                    $colors[$orderStatus->getStatus()] = $color;
+                    $this->orderStatusColors[$orderStatus->getStatus()] = $color;
                 }
-            }
-
-            if ($colors) {
-                Mage::register('order_status_colors', $colors);
             }
         }
 
-        if ($colors) {
-            $color = $colors[$row['status']] ?? '';
+        if ($this->orderStatusColors) {
+            $color = $this->orderStatusColors[$row['status']] ?? '';
             return "<span style='display:inline-block;width:15px;height:15px;vertical-align:text-bottom;background:{$color}'></span> {$value}";
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
@@ -7,7 +7,7 @@
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
@@ -263,7 +263,7 @@ class Mage_Adminhtml_Block_Sales_Order_Grid extends Mage_Adminhtml_Block_Widget_
 
         if ($this->orderStatusColors) {
             $color = $this->orderStatusColors[$row['status']] ?? '';
-            return "<span style='display:inline-block;width:15px;height:15px;vertical-align:text-bottom;background:{$color}'></span> {$value}";
+            return "<span class='order-status-color-marker' style='background:{$color}'></span> {$value}";
         }
 
         return $value;

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
@@ -108,6 +108,7 @@ class Mage_Adminhtml_Block_Sales_Order_Grid extends Mage_Adminhtml_Block_Widget_
             'type'  => 'options',
             'width' => '150px',
             'options' => Mage::getSingleton('sales/order_config')->getStatuses(),
+            'frame_callback' => [$this, 'decorateStatus'],
         ]);
 
         if (Mage::getSingleton('admin/session')->isAllowed('sales/order/actions/view')) {
@@ -243,5 +244,30 @@ class Mage_Adminhtml_Block_Sales_Order_Grid extends Mage_Adminhtml_Block_Widget_
     public function getGridUrl()
     {
         return $this->getUrl('*/*/grid', ['_current' => true]);
+    }
+
+    public function decorateStatus($value, $row, $column, $isExport): string
+    {
+        $colors = Mage::registry('order_status_colors');
+        if ($colors === null) {
+            $orderStatusCollection = Mage::getResourceModel('sales/order_status_collection')->getItems();
+            foreach ($orderStatusCollection as $orderStatus) {
+                $color = $orderStatus->getColor();
+                if ($color) {
+                    $colors[$orderStatus->getStatus()] = $color;
+                }
+            }
+
+            if ($colors) {
+                Mage::register('order_status_colors', $colors);
+            }
+        }
+
+        if ($colors) {
+            $color = $colors[$row['status']] ?? '';
+            return "<span style='display:inline-block;width:15px;height:15px;vertical-align:text-bottom;background:{$color}'></span> {$value}";
+        }
+
+        return $value;
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
@@ -88,7 +88,7 @@ class Mage_Adminhtml_Block_Sales_Order_Status_Grid extends Mage_Adminhtml_Block_
 
     public function decorateLabel($value, $row, $column, $isExport): string
     {
-        return "<span style='display:inline-block;width:15px;height:15px;vertical-align:text-bottom;background:{$row['color']}'></span> {$value}";
+        return "<span class='order-status-color-marker' style='background:{$row['color']}'></span> {$value}";
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
@@ -7,7 +7,7 @@
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
@@ -45,6 +45,7 @@ class Mage_Adminhtml_Block_Sales_Order_Status_Grid extends Mage_Adminhtml_Block_
         $this->addColumn('label', [
             'header' => Mage::helper('sales')->__('Status'),
             'index' => 'label',
+            'frame_callback' => [$this, 'decorateLabel'],
         ]);
 
         $this->addColumn('status', [
@@ -83,6 +84,11 @@ class Mage_Adminhtml_Block_Sales_Order_Status_Grid extends Mage_Adminhtml_Block_
         ]);
 
         return parent::_prepareColumns();
+    }
+
+    public function decorateLabel($value, $row, $column, $isExport): string
+    {
+        return "<span style='display:inline-block;width:15px;height:15px;vertical-align:text-bottom;background:{$row['color']}'></span> {$value}";
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New/Form.php
@@ -70,6 +70,15 @@ class Mage_Adminhtml_Block_Sales_Order_Status_New_Form extends Mage_Adminhtml_Bl
             ],
         );
 
+        $fieldset->addField(
+            'color',
+            'color',
+            [
+                'name'      => 'color',
+                'label'     => Mage::helper('sales')->__('Status Color'),
+            ],
+        );
+
         $fieldset = $form->addFieldset('store_labels_fieldset', [
             'legend'       => Mage::helper('sales')->__('Store View Specific Labels'),
             'table_class'  => 'form-list stores-tree',

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/New/Form.php
@@ -7,7 +7,7 @@
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/locale/en_US/Mage_Sales.csv
+++ b/app/locale/en_US/Mage_Sales.csv
@@ -714,6 +714,7 @@
 "State/Province","State/Province"
 "Status","Status"
 "Status Code","Status Code"
+"Status Color","Status Color"
 "Status Label","Status Label"
 "Status:","Status:"
 "Store Credit","Store Credit"

--- a/public/skin/adminhtml/default/default/override.css
+++ b/public/skin/adminhtml/default/default/override.css
@@ -257,6 +257,13 @@ small {
   border: none;
 }
 
+.order-status-color-marker {
+  display: inline-block;
+  width: 15px;
+  height: 15px;
+  vertical-align: text-bottom;
+}
+
 .entry-edit {
   margin-top: 10px;
 }


### PR DESCRIPTION
This PR allows for this:

<img width="1029" alt="Screenshot 2025-01-10 alle 16 47 26" src="https://github.com/user-attachments/assets/f82c432c-0a3a-4621-b2dd-042346f3cd18" />

<img width="636" alt="Screenshot 2025-01-10 alle 16 47 30" src="https://github.com/user-attachments/assets/5fdc7881-0438-45b7-b611-6d05ca75e248" />

<img width="1026" alt="Screenshot 2025-01-10 alle 16 47 36" src="https://github.com/user-attachments/assets/b22279de-2d61-4d71-bb42-1994518c2e2d" />
