### PR TITLE
MahoTree Improvements

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Abstract.php
@@ -361,11 +361,12 @@ class Mage_Adminhtml_Block_Catalog_Category_Abstract extends Mage_Adminhtml_Bloc
 
         $item['cls'] .= $node->getIsActive() ? ' active-category' : ' no-active-category';
 
-        if ($node->hasChildren() || $level < $this->getRecursionLevel() || $this->getRecursionLevel() === 0) {
+        if ($node->getChildrenCount() == 0 || $node->hasChildren()) {
             $item['children'] = [];
-            foreach ($node->getChildren() as $child) {
-                $item['children'][] = $this->_getNodeJson($child, $level + 1);
-            }
+        }
+
+        foreach ($node->getChildren() as $child) {
+            $item['children'][] = $this->_getNodeJson($child, $level + 1);
         }
 
         if ($this->getCategory() && $this->getCategoryId() === (int) $node->getId()) {

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Tree.php
@@ -34,6 +34,7 @@ class Mage_Adminhtml_Block_Cms_Wysiwyg_Images_Tree extends Mage_Adminhtml_Block_
                 'text'  => $helper->getShortFilename($item->getBasename(), 20),
                 'id'    => $helper->convertPathToId($item->getFilename()),
                 'cls'   => 'folder',
+                'children' => $item->getSubdirCount() === 0 ? [] : null,
             ];
         }
         return Zend_Json::encode($jsonArray);

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Tree.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Wysiwyg/Images/Tree.php
@@ -7,6 +7,7 @@
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Tree.php
@@ -435,7 +435,7 @@ class Mage_Catalog_Model_Resource_Category_Tree extends Varien_Data_Tree_Dbp
     }
 
     /**
-     * Load category tree including specified categories ids.
+     * Load category tree including specified categories ids, their parents, children, and siblings.
      *
      * @param array $ids
      * @param bool $addCollectionData
@@ -464,7 +464,7 @@ class Mage_Catalog_Model_Resource_Category_Tree extends Varien_Data_Tree_Dbp
             $where[] = $this->_conn->quoteInto("$levelField <= ?", $recursionLevel + 1);
         }
 
-        // collect paths of specified IDs and build query to collect their parents and neighbours
+        // collect paths of specified IDs and build query to collect their parents, children, and siblings
         if (!empty($ids)) {
             $select = $this->_conn->select()
                 ->from($this->_table, ['path', 'level'])
@@ -476,10 +476,9 @@ class Mage_Catalog_Model_Resource_Category_Tree extends Varien_Data_Tree_Dbp
                 }
                 $pathIds  = explode('/', $item['path']);
                 $level = (int) $item['level'];
-                while ($level > $recursionLevel + 1) {
-                    $pathIds[count($pathIds) - 1] = '%';
-                    $path = implode('/', $pathIds);
-                    $where[] = $this->_conn->quoteInto("$levelField = ?", $level)
+                while ($level > $recursionLevel) {
+                    $path = implode('/', $pathIds) . '/%';
+                    $where[] = $this->_conn->quoteInto("$levelField = ?", $level + 1)
                         . ' AND ' . $this->_conn->quoteInto("$pathField LIKE ?", $path);
                     array_pop($pathIds);
                     $level--;

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
@@ -69,7 +69,8 @@ class Mage_Cms_Model_Wysiwyg_Images_Storage extends Varien_Object
         $collection = $this->getCollection($path)
             ->setCollectDirs(true)
             ->setCollectFiles(false)
-            ->setCollectRecursively(false);
+            ->setCollectRecursively(false)
+            ->setCollectSubdirCount(true);
         $storageRootLength = strlen($this->getHelper()->getStorageRoot());
 
         foreach ($collection as $key => $value) {

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage/Collection.php
@@ -7,7 +7,7 @@
  * @package    Mage_Cms
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage/Collection.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage/Collection.php
@@ -22,12 +22,8 @@ class Mage_Cms_Model_Wysiwyg_Images_Storage_Collection extends Varien_Data_Colle
     #[\Override]
     protected function _generateRow($filename)
     {
-        $filename = preg_replace('~[/\\\]+~', DIRECTORY_SEPARATOR, $filename);
-
-        return [
-            'filename' => $filename,
-            'basename' => basename($filename),
-            'mtime'    => filemtime($filename),
-        ];
+        $row = parent::_generateRow($filename);
+        $row['filename'] = preg_replace('~[/\\\]+~', DIRECTORY_SEPARATOR, $row['filename']);
+        return $row;
     }
 }

--- a/app/design/adminhtml/default/default/template/catalog/category/widget/tree.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/category/widget/tree.phtml
@@ -32,7 +32,7 @@
         },
         selectable: {
             mode: useMassaction ? 'simple' : 'radio',
-            hideInputs: !useMassaction,
+            showInputs: useMassaction,
             allowDeselect: false,
             onSelect: <?= $this->getNodeClickListener() ?? 'null' ?>,
         },

--- a/app/design/adminhtml/default/default/template/cms/browser/tree.phtml
+++ b/app/design/adminhtml/default/default/template/cms/browser/tree.phtml
@@ -36,7 +36,7 @@
         },
         selectable: {
             mode: 'radio',
-            hideInputs: true,
+            showInputs: false,
             onSelect: ([node]) => {
                 MediabrowserInstance.selectFolder(node);
             },

--- a/app/design/adminhtml/default/default/template/urlrewrite/categories.phtml
+++ b/app/design/adminhtml/default/default/template/urlrewrite/categories.phtml
@@ -36,7 +36,7 @@
         },
         selectable: {
             mode: 'single',
-            hideInputs: true,
+            showInputs: false,
             onSelect: (selected) => {
                 if (selected.length === 1) {
                     window.location = window.location + '/' + selected[0].id;

--- a/lib/Varien/Data/Collection/Filesystem.php
+++ b/lib/Varien/Data/Collection/Filesystem.php
@@ -64,6 +64,13 @@ class Varien_Data_Collection_Filesystem extends Varien_Data_Collection
     protected $_collectDirs = false;
 
     /**
+     * Whether to collect children directory count
+     *
+     * @var bool
+     */
+    protected $_collectSubdirCount = false;
+
+    /**
      * Directory names regex pre-filter
      *
      * @var string
@@ -174,6 +181,18 @@ class Varien_Data_Collection_Filesystem extends Varien_Data_Collection
     public function setCollectRecursively($value)
     {
         $this->_collectRecursively = (bool) $value;
+        return $this;
+    }
+
+    /**
+     * Set whether to collect children directory count
+     *
+     * @param bool $value
+     * @return $this
+     */
+    public function setCollectSubdirCount($value)
+    {
+        $this->_collectSubdirCount = (bool) $value;
         return $this;
     }
 
@@ -369,10 +388,20 @@ class Varien_Data_Collection_Filesystem extends Varien_Data_Collection
      */
     protected function _generateRow($filename)
     {
-        return [
+        $row = [
             'filename' => $filename,
             'basename' => basename($filename),
+            'mtime'    => filemtime($filename),
         ];
+
+        if ($this->_collectSubdirCount && is_dir($filename)) {
+            $children = glob($filename . DIRECTORY_SEPARATOR . '*', GLOB_ONLYDIR);
+            if ($children !== false) {
+                $row['subdir_count'] = count($children);
+            }
+        }
+
+        return $row;
     }
 
     /**

--- a/lib/Varien/Data/Collection/Filesystem.php
+++ b/lib/Varien/Data/Collection/Filesystem.php
@@ -7,7 +7,7 @@
  * @package    Varien_Data
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/public/js/mage/adminhtml/browser.js
+++ b/public/js/mage/adminhtml/browser.js
@@ -255,6 +255,7 @@ class Mediabrowser {
             const child = new MahoTreeNode(this.tree, {
                 text: result.short_name,
                 id: result.id,
+                children: [],
             });
 
             this.currentNode.appendChild(child);

--- a/public/js/mage/adminhtml/catalog/category.js
+++ b/public/js/mage/adminhtml/catalog/category.js
@@ -59,7 +59,7 @@ class CategoryEditForm {
             treatAllNodesAsFolders: true,
             selectable: {
                 mode: 'radio',
-                hideInputs: true,
+                showInputs: false,
                 onSelect: this.changeCategory.bind(this),
             },
             sortable: {

--- a/public/js/mage/adminhtml/eav/set.js
+++ b/public/js/mage/adminhtml/eav/set.js
@@ -82,7 +82,7 @@ class EavAttributeSetForm {
             showRootNode: false,
             selectable: this.config.isReadOnly ? false : {
                 mode: 'single',
-                hideInputs: true,
+                showInputs: false,
                 onSelect: this.onSelectGroup.bind(this),
             },
             sortable: this.config.isReadOnly ? false : {

--- a/public/js/maho-tree.js
+++ b/public/js/maho-tree.js
@@ -498,15 +498,15 @@ class MahoTreeNode {
                 window.varienElementMethods?.setHasChanges(this.ui.checkbox);
             }
         });
-        this.ui.label?.addEventListener('dblclick', () => {
-            if (this.ui.details) {
-                if (this.ui.details.open) {
+        this.ui.label?.addEventListener('click', (event) => {
+            if (event.srcElement.tagName === 'INPUT') {
+                return;
+            }
+            if (this.ui.details && this.ui.checkbox?.type === 'radio') {
+                if (this.ui.details.open && this.ui.checkbox.checked) {
                     this.collapse()
                 } else {
                     this.expand();
-                }
-                if (this.ui.checkbox && this.ui.checkbox.type !== 'radio') {
-                    this.ui.checkbox.checked ? this.deselect() : this.select();
                 }
             }
         });

--- a/public/js/maho-tree.js
+++ b/public/js/maho-tree.js
@@ -676,6 +676,18 @@ class MahoTreeNode {
         });
     }
 
+    get hasLoadedChildren() {
+        return this.ui.wrap.hasAttribute('data-loaded');
+    }
+
+    set hasLoadedChildren(value) {
+        if (value) {
+            this.ui.wrap.setAttribute('data-loaded', '');
+        } else {
+            this.ui.wrap.removeAttribute('data-loaded');
+        }
+    }
+
     async loadChildren() {
         if (!this.tree.lazyloadOpts.dataUrl) {
             return;

--- a/public/js/maho-tree.js
+++ b/public/js/maho-tree.js
@@ -16,7 +16,7 @@ class MahoTree {
     /**
      * @typedef {Object} SelectableOpts
      * @prop {string} [mode='nested'] - `radio|single|simple|nested`
-     * @prop {boolean} [hideInputs=false] - hide radio / checkbox inputs and show outline around selected nodes
+     * @prop {boolean} [showInputs=true] - `false` to hide radio / checkbox inputs and show outline around selected nodes
      * @prop {string} [radioName] - if radio mode, then form name of the radio elements
      * @prop {function(Array<MahoTreeNode>):null} [onSelect] - callback when a node is selected
      *
@@ -36,7 +36,7 @@ class MahoTree {
      * @prop {string} [indent='1.25rem'] - length to indent each node level
      * @prop {string} [spacing='0.25rem'] - length to space in between each node
      * @prop {string} [line-style='1px dotted #aaa'] - border style for connecting lines
-     * @prop {string} [outline-style='2px solid #0090FF'] - outline style for selected nodes when `config.selectable.hideInputs=true`
+     * @prop {string} [outline-style='2px solid #0090FF'] - outline style for selected nodes when `config.selectable.showInputs=false`
      * @prop {string} [marker-size='10px'] - size for the [+] and [-] expand icon
      * @prop {string} [icon-size='16px'] - size for the folder or leaf node icons
      * @prop {string} [label-gap='0.25rem'] - length between icon, checkbox, and label
@@ -76,7 +76,7 @@ class MahoTree {
 
         this.selectableOpts = {
             mode: 'nested',
-            hideInputs: false,
+            showInputs: true,
             radioName: this.uniqId,
             onSelect: null,
         };
@@ -168,7 +168,7 @@ class MahoTree {
         for (const [cssVar, cssVal] of Object.entries(this.config.cssVars)) {
             this.rootEl.style.setProperty(`--${cssVar}`, cssVal);
         }
-        if (this.selectableOpts.hideInputs === true) {
+        if (!this.selectableOpts.showInputs) {
             this.rootEl.classList.add('hide-checkbox');
         }
     }

--- a/public/skin/adminhtml/default/default/override.css
+++ b/public/skin/adminhtml/default/default/override.css
@@ -1152,6 +1152,9 @@ ul.tabs a.changed span.changed {
 .maho-tree details[open] > summary::before {
     background-image: url('data:image/svg+xml,<svg width="10" height="10" xmlns="http://www.w3.org/2000/svg"><rect style="fill:%23f6f6f6;stroke:%234a4a4a;stroke-width:1" width="9" height="9" x=".5" y=".5" rx="2" ry="2"/><path style="fill:%234a4a4a" d="M2 4.5h6v1H2z"/></svg>');
 }
+.maho-tree li[data-loaded] > details:has(> ul:empty) summary::before {
+    background: none !important;
+}
 
 .maho-tree .icon {
     background-size: contain;
@@ -1166,7 +1169,7 @@ ul.tabs a.changed span.changed {
 .maho-tree .icon.folder {
     background-image: url('data:image/svg+xml,<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path d="M1.9 2.1a1 1 0 0 0-1 1V13c0 .5.4 1 1 1H14c.6 0 1-.5 1-1V5.2c0-.6-.4-1-1-1H6.8s-.2 0-.2-.2h-.1l-.1-.2v-.2l-.9-1a1 1 0 0 0-.8-.5Z" fill="%23e2ae10"/><rect x=".8" y="4.2" width="14.3" height="9.7" rx="1" fill="%23f2c94c" ry="1"/></svg>');
 }
-.maho-tree details[open] > summary .icon.folder {
+.maho-tree details[open]:has(> ul > li) > summary .icon.folder {
     background-image: url('data:image/svg+xml,<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path d="M1 2.1a1 1 0 0 0-1 1V13c0 .5.5 1 1 1h12.3c.6 0 1-.5 1-1V5.2c0-.6-.4-1-1-1H6c-.1 0-.2 0-.2-.2h-.1l-.1-.2-.1-.2-.8-1a1 1 0 0 0-.9-.5Z" fill="%23e2ae10"/><path d="M2.9 6.8h12.3c.5 0 .9.3.8.7l-1.6 5.6c-.2.5-.7.8-1.3.8H.8c-.5 0-.9-.3-.8-.8l1.6-5.6c.2-.4.7-.7 1.3-.7Z" fill="%23f2c94c"/></svg>');
 }
 .maho-tree .icon.leaf, .maho-tree .icon.paper {


### PR DESCRIPTION
Related #86 and #90 

Empty nodes now no longer have the `[+]` expand icon. 

Clicking a folder now expands / collapses it for `mode='radio'` type trees (i.e. "Manage Categories" and "Insert Image"). I don't think it works well with non-radio modes where clicking again also deselects the node. But in radio mode clicking again would otherwise do nothing. @fballiano, you can remove that check in `maho-tree.js` on line 505 to see how it would work on all types and see if you'd prefer it on all trees.

Renamed `hideInputs` -> `showInputs` and fixed usages. I missed this during initial PR [(ref)](https://github.com/MahoCommerce/maho/pull/81#pullrequestreview-2525010369).

Made the CMS tree detect if there were any children, else the `[+]` sign shows up initially, then clicking it makes it disappear. This is how ExtJS worked, but I didn't really like it.