### PR TITLE
Removed password from `admin_user_authenticate_after` and added `admin_user_authenticate_failed` event

### DIFF
--- a/app/code/core/Mage/Admin/Model/User.php
+++ b/app/code/core/Mage/Admin/Model/User.php
@@ -488,7 +488,6 @@ class Mage_Admin_Model_User extends Mage_Core_Model_Abstract
 
             Mage::dispatchEvent('admin_user_authenticate_after', [
                 'username' => $username,
-                'password' => $password,
                 'user'     => $this,
                 'result'   => true,
             ]);

--- a/app/code/core/Mage/Admin/Model/User.php
+++ b/app/code/core/Mage/Admin/Model/User.php
@@ -495,6 +495,12 @@ class Mage_Admin_Model_User extends Mage_Core_Model_Abstract
             return true;
 
         } catch (Exception $e) {
+            Mage::dispatchEvent('admin_user_authenticate_after', [
+                'username' => $username,
+                'user'     => $this,
+                'result'   => false,
+            ]);
+
             $this->unsetData();
             throw $e;
         }

--- a/app/code/core/Mage/Admin/Model/User.php
+++ b/app/code/core/Mage/Admin/Model/User.php
@@ -495,10 +495,9 @@ class Mage_Admin_Model_User extends Mage_Core_Model_Abstract
             return true;
 
         } catch (Exception $e) {
-            Mage::dispatchEvent('admin_user_authenticate_after', [
+            Mage::dispatchEvent('admin_user_authenticate_failed', [
                 'username' => $username,
                 'user'     => $this,
-                'result'   => false,
             ]);
 
             $this->unsetData();

--- a/app/code/core/Mage/Admin/Model/User.php
+++ b/app/code/core/Mage/Admin/Model/User.php
@@ -494,12 +494,15 @@ class Mage_Admin_Model_User extends Mage_Core_Model_Abstract
 
             return true;
 
-        } catch (Exception $e) {
+        } catch (Mage_Core_Exception $e) {
             Mage::dispatchEvent('admin_user_authenticate_failed', [
                 'username' => $username,
                 'user'     => $this,
+                'error'    => $e,
             ]);
-
+            $this->unsetData();
+            throw $e;
+        } catch (Exception $e) {
             $this->unsetData();
             throw $e;
         }


### PR DESCRIPTION
Mentioned in https://github.com/MahoCommerce/maho/pull/97#issuecomment-2613082519: 
> [The `admin_user_authenticate_after`] event really shouldn't even be passing the password to observers, and at least in core it's no longer needed.

Since the only other observer that hooks into that event doesn't use the `$password` value, I think we should remove it.