### PR TITLE
Deprecated `Mage_Core_Helper_Data::decorateArray()`

### DIFF
--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -6,7 +6,7 @@
  * @package    Mage_Core
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2016-2025 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -530,6 +530,7 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
      * @param string $prefix
      * @param bool $forceSetAll
      * @return mixed
+     * @deprecated since 25.3.0
      */
     public function decorateArray($array, $prefix = 'decorated_', $forceSetAll = false)
     {
@@ -580,6 +581,7 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
      * @param string $key
      * @param mixed $value
      * @param bool $dontSkip
+     * @deprecated since 25.3.0
      */
     private function _decorateArrayObject($element, $key, $value, $dontSkip)
     {

--- a/app/design/frontend/base/default/template/configurableswatches/catalog/product/view/type/options/configurable/swatches.phtml
+++ b/app/design/frontend/base/default/template/configurableswatches/catalog/product/view/type/options/configurable/swatches.phtml
@@ -5,7 +5,7 @@
  * @package     rwd_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
@@ -34,7 +34,7 @@ $_swatchArray = $_config->attributes->$_id;
         <span id="select_label_<?= $_attrCode ?>" class="select-label"></span>
     </label>
 </dt>
-<dd class="clearfix swatch-attr<?php if ($_attribute->decoratedIsLast) echo ' last'; ?>">
+<dd class="clearfix swatch-attr">
     <div class="input-box">
         <select name="super_attribute[<?= $_attribute->getAttributeId() ?>]" id="attribute<?= $_attribute->getAttributeId() ?>" class="required-entry super-attribute-select no-display swatch-select">
             <option><?= $this->__('Choose an Option...') ?></option>


### PR DESCRIPTION
I removed most of these in #106, but one remained that didn't have anything to do with configurable products, so it's here in a separate PR.

The `Mage_Core_Helper_Data::decorateArray()` method adds `decorated_is_[first|odd|even|last]` values to an array of varien objects. This was used for adding CSS classes to `<li>`, `<dd>`, and other elements.