### PR TITLE
Removed `<em>*</em>` from frontend templates

### DIFF
--- a/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
@@ -5,7 +5,7 @@
  * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
@@ -17,7 +17,7 @@
             <p class="shipping-desc"><?= $this->__('Enter your destination to get a shipping estimate.') ?></p>
             <ul class="form-list">
                 <li class="shipping-country">
-                    <label for="country" class="required"><em>*</em><?= $this->__('Country') ?></label>
+                    <label for="country" class="required"><?= $this->__('Country') ?></label>
                     <div class="input-box">
                         <?= Mage::getBlockSingleton('directory/data')->getCountryHtmlSelect($this->getEstimateCountryId()) ?>
                     </div>
@@ -27,7 +27,7 @@
                     <?php /* Removing the conditional check for whether the region is required, because it doesn't work
                     <label for="region_id"<?php if ($this->isStateProvinceRequired()) echo ' class="required"' ?>><?php if ($this->isStateProvinceRequired()) echo '<em>*</em>' ?><?= $this->__('State/Province') ?></label>
                     */ ?>
-                    <label for="region_id" class="required"><em>*</em><?= $this->__('State/Province') ?></label>
+                    <label for="region_id" class="required"><?= $this->__('State/Province') ?></label>
                     <div class="input-box">
                         <select id="region_id" name="region_id" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" style="display:none;"<?= ($this->isStateProvinceRequired() ? ' class="validate-select"' : '') ?>>
                             <option value=""><?= $this->__('Please select region, state or province') ?></option>
@@ -41,7 +41,7 @@
             <?php //endif ?>
             <?php if ($this->getCityActive()): ?>
                 <li class="shipping-region">
-                    <label for="city"<?php if ($this->isCityRequired()) echo ' class="required"' ?>><?php if ($this->isCityRequired()) echo '<em>*</em>' ?><?= $this->__('City') ?></label>
+                    <label for="city"<?= $this->isCityRequired() ? ' class="required"' : '' ?>><?= $this->__('City') ?></label>
                     <div class="input-box">
                         <input class="input-text<?php if ($this->isCityRequired()):?> required-entry<?php endif ?>" id="city" type="text" name="estimate_city" value="<?= $this->escapeHtml($this->getEstimateCity()) ?>" />
                     </div>
@@ -51,7 +51,7 @@
                     <?php /* Removing the conditional check for whether the postal code is required, because it doesn't work
                     <label for="postcode"<?php if ($this->isZipCodeRequired()) echo ' class="required"' ?>><?php if ($this->isZipCodeRequired()) echo '<em>*</em>' ?><?= $this->__('Zip/Postal Code') ?></label>
                     */ ?>
-                    <label for="postcode" class="required"><em>*</em><?= $this->__('Zip') ?></label>
+                    <label for="postcode" class="required"><?= $this->__('Zip') ?></label>
                     <div class="input-box">
                         <input class="input-text validate-postcode<?php if ($this->isZipCodeRequired()):?> required-entry<?php endif ?>" type="text" id="postcode" name="estimate_postcode" value="<?= $this->escapeHtml($this->getEstimatePostcode()) ?>" />
                     </div>

--- a/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
@@ -5,7 +5,7 @@
  * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2023 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 /** @var Mage_Checkout_Block_Onepage_Billing $this */
@@ -36,7 +36,7 @@
                     </div>
         <?php if(!$this->isCustomerLoggedIn()): ?>
                     <div class="field">
-                        <label for="billing:email" class="required"><em>*</em><?= $this->__('Email Address') ?></label>
+                        <label for="billing:email" class="required"><?= $this->__('Email Address') ?></label>
                         <div class="input-box">
                             <input type="email" autocapitalize="off" autocorrect="off" spellcheck="false" name="billing[email]" id="billing:email" value="<?= $this->escapeHtml($this->getAddress()->getEmail()) ?>" title="<?= $this->quoteEscape($this->__('Email Address')) ?>" class="input-text validate-email required-entry" />
                         </div>
@@ -45,7 +45,7 @@
                 </li>
         <?php $_streetValidationClass = $this->helper('customer/address')->getAttributeValidationClass('street'); ?>
                 <li class="wide">
-                    <label for="billing:street1" class="required"><em>*</em><?= $this->__('Address') ?></label>
+                    <label for="billing:street1" class="required"><?= $this->__('Address') ?></label>
                     <div class="input-box">
                         <input type="text" title="<?= $this->quoteEscape($this->__('Street Address')) ?>" name="billing[street][]" id="billing:street1" value="<?= $this->escapeHtml($this->getAddress()->getStreet(1)) ?>" class="input-text <?= $_streetValidationClass ?>" />
                     </div>
@@ -69,13 +69,13 @@
                 <?php endif ?>
                 <li class="fields">
                     <div class="field">
-                        <label for="billing:city" class="required"><em>*</em><?= $this->__('City') ?></label>
+                        <label for="billing:city" class="required"><?= $this->__('City') ?></label>
                         <div class="input-box">
                             <input type="text" title="<?= $this->quoteEscape($this->__('City')) ?>" name="billing[city]" value="<?= $this->escapeHtml($this->getAddress()->getCity()) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('city') ?>" id="billing:city" />
                         </div>
                     </div>
                     <div class="field">
-                        <label for="billing:region_id" class="required"><em>*</em><?= $this->__('State/Province') ?></label>
+                        <label for="billing:region_id" class="required"><?= $this->__('State/Province') ?></label>
                         <div class="input-box">
                             <select id="billing:region_id" name="billing[region_id]" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="validate-select" style="display:none;">
                                 <option value=""><?= $this->__('Please select region, state or province') ?></option>
@@ -89,13 +89,13 @@
                 </li>
                 <li class="fields">
                     <div class="field">
-                        <label for="billing:postcode" class="required"><em>*</em><?= $this->__('Zip/Postal Code') ?></label>
+                        <label for="billing:postcode" class="required"><?= $this->__('Zip/Postal Code') ?></label>
                         <div class="input-box">
                             <input type="text" title="<?= $this->quoteEscape($this->__('Zip/Postal Code')) ?>" name="billing[postcode]" id="billing:postcode" value="<?= $this->escapeHtml($this->getAddress()->getPostcode()) ?>" class="input-text validate-zip-international <?= $this->helper('customer/address')->getAttributeValidationClass('postcode') ?>" />
                         </div>
                     </div>
                     <div class="field">
-                        <label for="billing:country_id" class="required"><em>*</em><?= $this->__('Country') ?></label>
+                        <label for="billing:country_id" class="required"><?= $this->__('Country') ?></label>
                         <div class="input-box">
                             <?= $this->getCountryHtmlSelect('billing') ?>
                         </div>
@@ -103,7 +103,7 @@
                 </li>
                 <li class="fields">
                     <div class="field">
-                        <label for="billing:telephone" class="required"><em>*</em><?= $this->__('Telephone') ?></label>
+                        <label for="billing:telephone" class="required"><?= $this->__('Telephone') ?></label>
                         <div class="input-box">
                             <input type="tel" name="billing[telephone]" value="<?= $this->escapeHtml($this->getAddress()->getTelephone()) ?>" title="<?= $this->quoteEscape($this->__('Telephone')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('telephone') ?>" id="billing:telephone" />
                         </div>
@@ -140,7 +140,7 @@
 
                 <li class="fields" id="register-customer-password">
                     <div class="field">
-                        <label for="billing:customer_password" class="required"><em>*</em><?= $this->__('Password') ?></label>
+                        <label for="billing:customer_password" class="required"><?= $this->__('Password') ?></label>
                         <div class="input-box">
                             <?php $minPasswordLength = $this->getQuote()->getCustomer()->getMinPasswordLength(); ?>
                             <input type="password"
@@ -155,7 +155,7 @@
                         </div>
                     </div>
                     <div class="field">
-                        <label for="billing:confirm_password" class="required"><em>*</em><?= $this->__('Confirm Password') ?></label>
+                        <label for="billing:confirm_password" class="required"><?= $this->__('Confirm Password') ?></label>
                         <div class="input-box">
                             <input type="password" name="billing[confirm_password]" title="<?= $this->quoteEscape($this->__('Confirm Password')) ?>" id="billing:confirm_password" class="input-text required-entry validate-cpassword" autocomplete="new-password" />
                         </div>

--- a/app/design/frontend/base/default/template/checkout/onepage/login.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/login.phtml
@@ -5,7 +5,7 @@
  * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2025 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
@@ -74,13 +74,13 @@ $isAllowedGuestCheckout = $this->helper('checkout')->isAllowedGuestCheckout($thi
             <p><?= $this->__('Please log in below:') ?></p>
             <ul class="form-list">
                 <li>
-                    <label for="login-email" class="required"><em>*</em><?= $this->__('Email Address') ?></label>
+                    <label for="login-email" class="required"><?= $this->__('Email Address') ?></label>
                     <div class="input-box">
                         <input type="email" autocapitalize="off" autocorrect="off" spellcheck="false" class="input-text required-entry validate-email" id="login-email" name="login[username]" value="<?= $this->escapeHtml($this->getUsername()) ?>" />
                     </div>
                 </li>
                 <li>
-                    <label for="login-password" class="required"><em>*</em><?= $this->__('Password') ?></label>
+                    <label for="login-password" class="required"><?= $this->__('Password') ?></label>
                     <div class="input-box">
                         <input type="password" class="input-text required-entry" id="login-password" name="login[password]" autocomplete="off" />
                     </div>

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
@@ -37,7 +37,7 @@
                     </li>
             <?php $_streetValidationClass = $this->helper('customer/address')->getAttributeValidationClass('street'); ?>
                     <li class="wide">
-                        <label for="shipping:street1" class="required"><em>*</em><?= $this->__('Street Address') ?></label>
+                        <label for="shipping:street1" class="required"><?= $this->__('Street Address') ?></label>
                         <div class="input-box">
                             <input type="text" title="<?= $this->quoteEscape($this->__('Street Address')) ?>" name="shipping[street][]" id="shipping:street1" value="<?= $this->escapeHtml($this->getAddress()->getStreet(1)) ?>" class="input-text <?= $_streetValidationClass ?>" onchange="shipping.setSameAsBilling(false);" />
                         </div>
@@ -61,13 +61,13 @@
                     <?php endif ?>
                     <li class="fields">
                         <div class="field">
-                            <label for="shipping:city" class="required"><em>*</em><?= $this->__('City') ?></label>
+                            <label for="shipping:city" class="required"><?= $this->__('City') ?></label>
                             <div class="input-box">
                                 <input type="text" title="<?= $this->quoteEscape($this->__('City')) ?>" name="shipping[city]" value="<?= $this->escapeHtml($this->getAddress()->getCity()) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('city') ?>" id="shipping:city" onchange="shipping.setSameAsBilling(false);" />
                             </div>
                         </div>
                         <div class="field">
-                            <label for="shipping:region" class="required"><em>*</em><?= $this->__('State/Province') ?></label>
+                            <label for="shipping:region" class="required"><?= $this->__('State/Province') ?></label>
                             <div class="input-box">
                                 <select id="shipping:region_id" name="shipping[region_id]" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="validate-select" style="display:none;">
                                     <option value=""><?= $this->__('Please select region, state or province') ?></option>
@@ -81,13 +81,13 @@
                     </li>
                     <li class="fields">
                         <div class="field">
-                            <label for="shipping:postcode" class="required"><em>*</em><?= $this->__('Zip/Postal Code') ?></label>
+                            <label for="shipping:postcode" class="required"><?= $this->__('Zip/Postal Code') ?></label>
                             <div class="input-box">
                                 <input type="text" title="<?= $this->quoteEscape($this->__('Zip/Postal Code')) ?>" name="shipping[postcode]" id="shipping:postcode" value="<?= $this->escapeHtml($this->getAddress()->getPostcode()) ?>" class="input-text validate-zip-international <?= $this->helper('customer/address')->getAttributeValidationClass('postcode') ?>" onchange="shipping.setSameAsBilling(false);" />
                             </div>
                         </div>
                         <div class="field">
-                            <label for="shipping:country_id" class="required"><em>*</em><?= $this->__('Country') ?></label>
+                            <label for="shipping:country_id" class="required"><?= $this->__('Country') ?></label>
                             <div class="input-box">
                                 <?= $this->getCountryHtmlSelect('shipping') ?>
                             </div>
@@ -95,7 +95,7 @@
                     </li>
                     <li class="fields">
                         <div class="field">
-                            <label for="shipping:telephone" class="required"><em>*</em><?= $this->__('Telephone') ?></label>
+                            <label for="shipping:telephone" class="required"><?= $this->__('Telephone') ?></label>
                             <div class="input-box">
                                 <input type="tel" name="shipping[telephone]" value="<?= $this->escapeHtml($this->getAddress()->getTelephone()) ?>" title="<?= $this->quoteEscape($this->__('Telephone')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('telephone') ?>" id="shipping:telephone" onchange="shipping.setSameAsBilling(false);" />
                             </div>

--- a/app/design/frontend/base/default/template/configurableswatches/catalog/product/view/type/options/configurable/swatches.phtml
+++ b/app/design/frontend/base/default/template/configurableswatches/catalog/product/view/type/options/configurable/swatches.phtml
@@ -30,7 +30,7 @@ $_swatchArray = $_config->attributes->$_id;
 ?>
 <dt class="swatch-attr">
     <label id="<?= $_attrCode ?>_label" class="required">
-        <em>*</em><?= $_attribute->getLabel() ?>:
+        <?= $_attribute->getLabel() ?>:
         <span id="select_label_<?= $_attrCode ?>" class="select-label"></span>
     </label>
 </dt>

--- a/app/design/frontend/base/default/template/contacts/form.phtml
+++ b/app/design/frontend/base/default/template/contacts/form.phtml
@@ -21,13 +21,13 @@
         <ul class="form-list">
             <li class="fields">
                 <div class="field">
-                    <label for="name" class="required"><em>*</em><?= Mage::helper('contacts')->__('Name') ?></label>
+                    <label for="name" class="required"><?= Mage::helper('contacts')->__('Name') ?></label>
                     <div class="input-box">
                         <input name="name" id="name" title="<?= $this->quoteEscape(Mage::helper('contacts')->__('Name')) ?>" value="<?= $this->escapeHtml($this->helper('contacts')->getUserName()) ?>" class="input-text required-entry" type="text" />
                     </div>
                 </div>
                 <div class="field">
-                    <label for="email" class="required"><em>*</em><?= Mage::helper('contacts')->__('Email') ?></label>
+                    <label for="email" class="required"><?= Mage::helper('contacts')->__('Email') ?></label>
                     <div class="input-box">
                         <input name="email" id="email" title="<?= $this->quoteEscape(Mage::helper('contacts')->__('Email')) ?>" value="<?= $this->escapeHtml($this->helper('contacts')->getUserEmail()) ?>" class="input-text required-entry validate-email" type="email" autocapitalize="off" autocorrect="off" spellcheck="false" />
                     </div>
@@ -40,7 +40,7 @@
                 </div>
             </li>
             <li class="wide">
-                <label for="comment" class="required"><em>*</em><?= Mage::helper('contacts')->__('Comment') ?></label>
+                <label for="comment" class="required"><?= Mage::helper('contacts')->__('Comment') ?></label>
                 <div class="input-box">
                     <textarea name="comment" id="comment" title="<?= $this->quoteEscape(Mage::helper('contacts')->__('Comment')) ?>" class="required-entry input-text" cols="5" rows="3"></textarea>
                 </div>

--- a/app/design/frontend/base/default/template/customer/address/edit.phtml
+++ b/app/design/frontend/base/default/template/customer/address/edit.phtml
@@ -41,7 +41,7 @@
             </li>
             <li class="fields">
                 <div class="field">
-                    <label for="telephone" class="required"><em>*</em><?= $this->__('Telephone') ?></label>
+                    <label for="telephone" class="required"><?= $this->__('Telephone') ?></label>
                     <div class="input-box">
                         <input type="tel" name="telephone" value="<?= $this->escapeHtml($this->getAddress()->getTelephone()) ?>" title="<?= $this->quoteEscape($this->__('Telephone')) ?>" class="input-text  <?= $this->helper('customer/address')->getAttributeValidationClass('telephone') ?>" id="telephone" />
                     </div>
@@ -60,7 +60,7 @@
         <ul class="form-list">
         <?php $_streetValidationClass = $this->helper('customer/address')->getAttributeValidationClass('street'); ?>
             <li class="wide">
-                <label for="street_1" class="required"><em>*</em><?= $this->__('Street Address') ?></label>
+                <label for="street_1" class="required"><?= $this->__('Street Address') ?></label>
                 <div class="input-box">
                     <input type="text" name="street[]" value="<?= $this->escapeHtml($this->getAddress()->getStreet(1)) ?>" title="<?= $this->quoteEscape($this->__('Street Address')) ?>" id="street_1" class="input-text <?= $_streetValidationClass ?>" />
                 </div>
@@ -84,13 +84,13 @@
             <?php endif ?>
             <li class="fields">
                 <div class="field">
-                    <label for="city" class="required"><em>*</em><?= $this->__('City') ?></label>
+                    <label for="city" class="required"><?= $this->__('City') ?></label>
                     <div class="input-box">
                         <input type="text" name="city" value="<?= $this->escapeHtml($this->getAddress()->getCity()) ?>"  title="<?= $this->quoteEscape($this->__('City')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('city') ?>" id="city" />
                     </div>
                 </div>
                 <div class="field">
-                    <label for="region_id" class="required"><em>*</em><?= $this->__('State/Province') ?></label>
+                    <label for="region_id" class="required"><?= $this->__('State/Province') ?></label>
                     <div class="input-box">
                         <select id="region_id" name="region_id" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="validate-select" style="display:none;">
                            <option value=""><?= $this->__('Please select region, state or province') ?></option>
@@ -104,13 +104,13 @@
             </li>
             <li class="fields">
                 <div class="field">
-                    <label for="zip" class="required"><em>*</em><?= $this->__('Zip/Postal Code') ?></label>
+                    <label for="zip" class="required"><?= $this->__('Zip/Postal Code') ?></label>
                     <div class="input-box">
                         <input type="text" name="postcode" value="<?= $this->escapeHtml($this->getAddress()->getPostcode()) ?>" title="<?= $this->quoteEscape($this->__('Zip/Postal Code')) ?>" id="zip" class="input-text validate-zip-international <?= $this->helper('customer/address')->getAttributeValidationClass('postcode') ?>" />
                     </div>
                 </div>
                 <div class="field">
-                    <label for="country" class="required"><em>*</em><?= $this->__('Country') ?></label>
+                    <label for="country" class="required"><?= $this->__('Country') ?></label>
                     <div class="input-box">
                         <?= $this->getCountryHtmlSelect() ?>
                     </div>

--- a/app/design/frontend/base/default/template/customer/form/confirmation.phtml
+++ b/app/design/frontend/base/default/template/customer/form/confirmation.phtml
@@ -21,7 +21,7 @@
         <p><?= $this->__('Please enter your email below and we\'ll send you confirmation link for it.') ?></p>
         <ul class="form-list">
             <li>
-                <label for="email_address" class="required"><em>*</em><?= $this->__('Email Address') ?></label>
+                <label for="email_address" class="required"><?= $this->__('Email Address') ?></label>
                 <div class="input-box">
                     <input type="email" autocapitalize="off" autocorrect="off" spellcheck="false" name="email" id="email_address" title="<?= $this->quoteEscape($this->__('Email Address')) ?>" class="input-text required-entry validate-email" value="<?= $this->escapeHtml($this->getEmail()) ?>" />
                 </div>

--- a/app/design/frontend/base/default/template/customer/form/edit.phtml
+++ b/app/design/frontend/base/default/template/customer/form/edit.phtml
@@ -25,7 +25,7 @@
                 <?= $this->getLayout()->createBlock('customer/widget_name')->setObject($this->getCustomer())->toHtml() ?>
             </li>
             <li>
-                <label for="email" class="required"><em>*</em><?= $this->__('Email Address') ?></label>
+                <label for="email" class="required"><?= $this->__('Email Address') ?></label>
                 <div class="input-box">
                     <input type="email" autocapitalize="off" autocorrect="off" spellcheck="false" name="email" id="email" value="<?= $this->escapeHtml($this->getCustomer()->getEmail()) ?>" title="<?= $this->quoteEscape($this->__('Email Address')) ?>" class="input-text required-entry validate-email" />
                 </div>
@@ -43,7 +43,7 @@
             <li><?= $_gender->setGender($this->getCustomer()->getGender())->toHtml() ?></li>
         <?php endif ?>
             <li>
-                <label for="current_password" class="required"><em>*</em><?= $this->quoteEscape($this->__('Current Password')) ?></label>
+                <label for="current_password" class="required"><?= $this->quoteEscape($this->__('Current Password')) ?></label>
                 <div class="input-box">
                     <!-- This is a dummy hidden field to trick firefox from automatically filling the password -->
                     <input type="text" class="input-text no-display" name="dummy" id="dummy" />
@@ -60,7 +60,7 @@
         <ul class="form-list">
             <li class="fields">
                 <div class="field">
-                    <label for="password" class="required"><em>*</em><?= $this->__('New Password') ?></label>
+                    <label for="password" class="required"><?= $this->__('New Password') ?></label>
                     <div class="input-box">
                         <?php $minPasswordLength = $this->getCustomer()->getMinPasswordLength(); ?>
                         <input type="password"
@@ -75,7 +75,7 @@
                     </div>
                 </div>
                 <div class="field">
-                    <label for="confirmation" class="required"><em>*</em><?= $this->__('Confirm New Password') ?></label>
+                    <label for="confirmation" class="required"><?= $this->__('Confirm New Password') ?></label>
                     <div class="input-box">
                         <input type="password" title="<?= $this->quoteEscape($this->__('Confirm New Password')) ?>" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" autocomplete="new-password" />
                     </div>

--- a/app/design/frontend/base/default/template/customer/form/forgotpassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/forgotpassword.phtml
@@ -22,7 +22,7 @@
         <p class="required"><?= $this->__('* Required Fields') ?></p>
         <ul class="form-list">
             <li>
-                <label for="email_address" class="required"><em>*</em><?= $this->__('Email Address') ?></label>
+                <label for="email_address" class="required"><?= $this->__('Email Address') ?></label>
                 <div class="input-box">
                     <input type="email" autocapitalize="off" autocorrect="off" spellcheck="false" name="email" alt="email" id="email_address" class="input-text required-entry validate-email" value="<?= $this->escapeHtml($this->getEmailValue()) ?>" />
                 </div>

--- a/app/design/frontend/base/default/template/customer/form/login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/login.phtml
@@ -5,7 +5,7 @@
  * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2023 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
@@ -45,14 +45,14 @@
                     <p class="required"><?= $this->__('* Required Fields') ?></p>
                     <ul class="form-list">
                         <li>
-                            <label for="email" class="required"><em>*</em><?= $this->__('Email Address') ?></label>
+                            <label for="email" class="required"><?= $this->__('Email Address') ?></label>
                             <div class="input-box">
                                 <input type="email" autocapitalize="off" autocorrect="off" spellcheck="false" name="login[username]" value="<?= $this->escapeHtml($this->getUsername()) ?>" id="email" class="input-text required-entry validate-email" title="<?= $this->quoteEscape($this->__('Email Address')) ?>" />
                             </div>
                         </li>
                         <li>
                             <?php $minPasswordLength = $this->getMinPasswordLength(); ?>
-                            <label for="pass" class="required"><em>*</em><?= $this->__('Password') ?></label>
+                            <label for="pass" class="required"><?= $this->__('Password') ?></label>
                             <div class="input-box">
                                 <input type="password" name="login[password]" class="input-text required-entry validate-password min-pass-length-<?= $minPasswordLength ?>" id="pass" title="<?= $this->quoteEscape($this->__('Password')) ?>" autocomplete="off" />
                             </div>

--- a/app/design/frontend/base/default/template/customer/form/register.phtml
+++ b/app/design/frontend/base/default/template/customer/form/register.phtml
@@ -5,7 +5,7 @@
  * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2018-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
@@ -36,7 +36,7 @@
                     <?= $this->getLayout()->createBlock('customer/widget_name')->setObject($this->getFormData())->setForceUseCustomerAttributes(true)->toHtml() ?>
                 </li>
                 <li>
-                    <label for="email_address" class="required"><em>*</em><?= $this->__('Email Address') ?></label>
+                    <label for="email_address" class="required"><?= $this->__('Email Address') ?></label>
                     <div class="input-box">
                         <input type="email" autocapitalize="off" autocorrect="off" spellcheck="false" name="email" id="email_address" value="<?= $this->escapeHtml($this->getFormData()->getEmail()) ?>" title="<?= $this->quoteEscape($this->__('Email Address')) ?>" class="input-text validate-email required-entry" />
                     </div>
@@ -78,7 +78,7 @@
                         </div>
                     </div>
                     <div class="field">
-                        <label for="telephone" class="required"><em>*</em><?= $this->__('Telephone') ?></label>
+                        <label for="telephone" class="required"><?= $this->__('Telephone') ?></label>
                         <div class="input-box">
                             <input type="tel" name="telephone" id="telephone" value="<?= $this->escapeHtml($this->getFormData()->getTelephone()) ?>" title="<?= $this->quoteEscape($this->__('Telephone')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('telephone') ?>" />
                         </div>
@@ -86,7 +86,7 @@
                 </li>
             <?php $_streetValidationClass = $this->helper('customer/address')->getAttributeValidationClass('street'); ?>
                 <li class="wide">
-                    <label for="street_1" class="required"><em>*</em><?= $this->__('Street Address') ?></label>
+                    <label for="street_1" class="required"><?= $this->__('Street Address') ?></label>
                     <div class="input-box">
                         <input type="text" name="street[]" value="<?= $this->escapeHtml($this->getFormData()->getStreet(0)) ?>" title="<?= $this->quoteEscape($this->__('Street Address')) ?>" id="street_1" class="input-text <?= $_streetValidationClass ?>" />
                     </div>
@@ -102,13 +102,13 @@
             <?php endfor ?>
                 <li class="fields">
                     <div class="field">
-                        <label for="city" class="required"><em>*</em><?= $this->__('City') ?></label>
+                        <label for="city" class="required"><?= $this->__('City') ?></label>
                         <div class="input-box">
                             <input type="text" name="city" value="<?= $this->escapeHtml($this->getFormData()->getCity()) ?>" title="<?= $this->quoteEscape($this->__('City')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('city') ?>" id="city" />
                         </div>
                     </div>
                     <div class="field">
-                        <label for="region_id" class="required"><em>*</em><?= $this->__('State/Province') ?></label>
+                        <label for="region_id" class="required"><?= $this->__('State/Province') ?></label>
                         <div class="input-box">
                             <select id="region_id" name="region_id" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="validate-select" style="display:none;">
                                 <option value=""><?= $this->__('Please select region, state or province') ?></option>
@@ -122,13 +122,13 @@
                 </li>
                 <li class="fields">
                     <div class="field">
-                        <label for="zip" class="required"><em>*</em><?= $this->__('Zip/Postal Code') ?></label>
+                        <label for="zip" class="required"><?= $this->__('Zip/Postal Code') ?></label>
                         <div class="input-box">
                             <input type="text" name="postcode" value="<?= $this->escapeHtml($this->getFormData()->getPostcode()) ?>" title="<?= $this->quoteEscape($this->__('Zip/Postal Code')) ?>" id="zip" class="input-text validate-zip-international <?= $this->helper('customer/address')->getAttributeValidationClass('postcode') ?>" />
                         </div>
                     </div>
                     <div class="field">
-                        <label for="country" class="required"><em>*</em><?= $this->__('Country') ?></label>
+                        <label for="country" class="required"><?= $this->__('Country') ?></label>
                         <div class="input-box">
                             <?= $this->getCountryHtmlSelect() ?>
                         </div>
@@ -144,7 +144,7 @@
             <ul class="form-list">
                 <li class="fields">
                     <div class="field">
-                        <label for="password" class="required"><em>*</em><?= $this->__('Password') ?></label>
+                        <label for="password" class="required"><?= $this->__('Password') ?></label>
                         <div class="input-box">
                             <?php $minPasswordLength = $this->getMinPasswordLength(); ?>
                             <input type="password"
@@ -159,7 +159,7 @@
                         </div>
                     </div>
                     <div class="field">
-                        <label for="confirmation" class="required"><em>*</em><?= $this->__('Confirm Password') ?></label>
+                        <label for="confirmation" class="required"><?= $this->__('Confirm Password') ?></label>
                         <div class="input-box">
                             <input type="password" name="confirmation" title="<?= $this->quoteEscape($this->__('Confirm Password')) ?>" id="confirmation" class="input-text required-entry validate-cpassword" autocomplete="new-password" />
                         </div>

--- a/app/design/frontend/base/default/template/customer/form/resetforgottenpassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/resetforgottenpassword.phtml
@@ -22,7 +22,7 @@
         <ul class="form-list">
             <li class="fields">
                 <div class="field">
-                    <label for="password" class="required"><em>*</em><?= $this->__('New Password') ?></label>
+                    <label for="password" class="required"><?= $this->__('New Password') ?></label>
                     <div class="input-box">
                         <?php $minPasswordLength = $this->getMinPasswordLength(); ?>
                         <input type="password"
@@ -36,7 +36,7 @@
                     </div>
                 </div>
                 <div class="field">
-                    <label for="confirmation" class="required"><em>*</em><?= $this->__('Confirm New Password') ?></label>
+                    <label for="confirmation" class="required"><?= $this->__('Confirm New Password') ?></label>
                     <div class="input-box">
                         <input type="password" class="input-text required-entry validate-cpassword" name="confirmation" id="confirmation" autocomplete="new-password" />
                     </div>

--- a/app/design/frontend/base/default/template/customer/widget/dob.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/dob.phtml
@@ -5,7 +5,7 @@
  * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
@@ -32,10 +32,10 @@ NOTE: Regarding styles - if we leave it this way, we'll move it to boxes.css
 
 /**
  * @see Mage_Customer_Block_Widget_Dob
- * @var Mage_Customer_Block_Widget_Dob $this 
+ * @var Mage_Customer_Block_Widget_Dob $this
  */
 ?>
-<label for="<?= $this->getFieldId('month')?>"<?php if ($this->isRequired()) echo ' class="required"' ?>><?php if ($this->isRequired()) echo '<em>*</em>' ?><?= $this->__('Date of Birth') ?></label>
+<label for="<?= $this->getFieldId('month')?>"<?= $this->isRequired() ? ' class="required"' : '' ?>><?= $this->__('Date of Birth') ?></label>
 <div class="input-box customer-dob">
 <?php
     $this->setDateInput('d',

--- a/app/design/frontend/base/default/template/customer/widget/gender.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/gender.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Customer_Block_Widget_Gender $this */
 ?>
-<label for="<?= $this->getFieldId('gender')?>"<?php if ($this->isRequired()) echo ' class="required"' ?>><?php if ($this->isRequired()) echo '<em>*</em>' ?><?= $this->__('Gender') ?></label>
+<label for="<?= $this->getFieldId('gender')?>"<?= $this->isRequired() ? ' class="required"' : '' ?>><?= $this->__('Gender') ?></label>
 <div class="input-box">
     <select id="<?= $this->getFieldId('gender')?>" name="<?= $this->getFieldName('gender') ?>" title="<?= $this->quoteEscape($this->__('Gender')) ?>"<?php if ($this->isRequired()):?> class="validate-select"<?php endif ?> <?= $this->getFieldParams() ?>>
         <?php $options = Mage::getResourceSingleton('customer/customer')->getAttribute('gender')->getSource()->getAllOptions();?>

--- a/app/design/frontend/base/default/template/customer/widget/name.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/name.phtml
@@ -32,7 +32,7 @@ For checkout/onepage/shipping.phtml:
 <div class="<?= $this->getContainerClassName() ?>">
 <?php if ($this->showPrefix()): ?>
     <div class="field name-prefix">
-        <label for="<?= $this->getFieldId('prefix')?>"<?php if ($this->isPrefixRequired()) echo ' class="required"' ?>><?php if ($this->isPrefixRequired()) echo '<em>*</em>' ?><?= $this->getStoreLabel('prefix') ?></label>
+        <label for="<?= $this->getFieldId('prefix')?>"<?= $this->isPrefixRequired() ? ' class="required"' : '' ?>><?= $this->getStoreLabel('prefix') ?></label>
         <div class="input-box">
             <?php if ($this->getPrefixOptions() === false): ?>
                 <input type="text" id="<?= $this->getFieldId('prefix')?>" name="<?= $this->getFieldName('prefix') ?>" value="<?= $this->escapeHtml($this->getObject()->getPrefix()) ?>" title="<?= $this->quoteEscape($this->getStoreLabel('prefix')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('prefix') ?>" <?= $this->getFieldParams() ?> />
@@ -47,29 +47,28 @@ For checkout/onepage/shipping.phtml:
     </div>
 <?php endif ?>
     <div class="field name-firstname">
-        <label for="<?= $this->getFieldId('firstname')?>" class="required"><em>*</em><?= $this->getStoreLabel('firstname') ?></label>
+        <label for="<?= $this->getFieldId('firstname')?>" class="required"><?= $this->getStoreLabel('firstname') ?></label>
         <div class="input-box">
             <input type="text" id="<?= $this->getFieldId('firstname')?>" name="<?= $this->getFieldName('firstname') ?>" value="<?= $this->escapeHtml($this->getObject()->getFirstname()) ?>" title="<?= $this->quoteEscape($this->getStoreLabel('firstname')) ?>" maxlength="255" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('firstname') ?>" <?= $this->getFieldParams() ?> />
         </div>
     </div>
 <?php if ($this->showMiddlename()): ?>
-<?php $isMiddlenameRequired = $this->isMiddlenameRequired(); ?>
     <div class="field name-middlename">
-        <label for="<?= $this->getFieldId('middlename')?>"<?= $isMiddlenameRequired ? ' class="required"' : '' ?>><?= $isMiddlenameRequired ? '<em>*</em>' : '' ?><?= $this->getStoreLabel('middlename') ?></label>
+        <label for="<?= $this->getFieldId('middlename')?>"<?= $this->isMiddlenameRequired() ? ' class="required"' : '' ?>><?= $this->getStoreLabel('middlename') ?></label>
         <div class="input-box">
             <input type="text" id="<?= $this->getFieldId('middlename')?>" name="<?= $this->getFieldName('middlename') ?>" value="<?= $this->escapeHtml($this->getObject()->getMiddlename()) ?>" title="<?= $this->quoteEscape($this->getStoreLabel('middlename')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('middlename') ?>" <?= $this->getFieldParams() ?> />
         </div>
     </div>
 <?php endif ?>
     <div class="field name-lastname">
-        <label for="<?= $this->getFieldId('lastname')?>" class="required"><em>*</em><?= $this->getStoreLabel('lastname') ?></label>
+        <label for="<?= $this->getFieldId('lastname')?>" class="required"><?= $this->getStoreLabel('lastname') ?></label>
         <div class="input-box">
             <input type="text" id="<?= $this->getFieldId('lastname')?>" name="<?= $this->getFieldName('lastname') ?>" value="<?= $this->escapeHtml($this->getObject()->getLastname()) ?>" title="<?= $this->quoteEscape($this->getStoreLabel('lastname')) ?>" maxlength="255" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('lastname') ?>" <?= $this->getFieldParams() ?> />
         </div>
     </div>
 <?php if ($this->showSuffix()): ?>
     <div class="field name-suffix">
-        <label for="<?= $this->getFieldId('suffix')?>"<?php if ($this->isSuffixRequired()) echo ' class="required"' ?>><?php if ($this->isSuffixRequired()) echo '<em>*</em>' ?><?= $this->getStoreLabel('suffix') ?></label>
+        <label for="<?= $this->getFieldId('suffix')?>"<?= $this->isSuffixRequired() ? ' class="required"' : '' ?>><?= $this->getStoreLabel('suffix') ?></label>
         <div class="input-box">
         <?php if ($this->getSuffixOptions() === false): ?>
             <input type="text" id="<?= $this->getFieldId('suffix')?>" name="<?= $this->getFieldName('suffix') ?>" value="<?= $this->escapeHtml($this->getObject()->getSuffix()) ?>" title="<?= $this->quoteEscape($this->getStoreLabel('suffix')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('suffix') ?>" <?= $this->getFieldParams() ?> />

--- a/app/design/frontend/base/default/template/customer/widget/taxvat.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/taxvat.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Customer_Block_Widget_Taxvat $this */
 ?>
-<label for="<?= $this->getFieldId('taxvat')?>"<?php if ($this->isRequired()) echo ' class="required"' ?>><?php if ($this->isRequired()) echo '<em>*</em>' ?><?= $this->__('Tax/VAT number') ?></label>
+<label for="<?= $this->getFieldId('taxvat')?>"<?= $this->isRequired() ? ' class="required"' : '' ?>><?= $this->__('Tax/VAT number') ?></label>
 <div class="input-box">
     <input type="text" id="<?= $this->getFieldId('taxvat')?>" name="<?= $this->getFieldName('taxvat') ?>" value="<?= $this->escapeHtml($this->getTaxvat()) ?>" title="<?= $this->quoteEscape($this->__('Tax/VAT number')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('taxvat') ?>" <?= $this->getFieldParams() ?> />
 </div>

--- a/app/design/frontend/base/default/template/payment/form/cc.phtml
+++ b/app/design/frontend/base/default/template/payment/form/cc.phtml
@@ -16,14 +16,14 @@
 <?php /*
     <li>
         <div class="input-box">
-            <label for="<?= $_code ?>_cc_owner" class="required"><em>*</em><?= $this->__('Name on Card') ?></label>
+            <label for="<?= $_code ?>_cc_owner" class="required"><?= $this->__('Name on Card') ?></label>
             <input type="text" title="<?= $this->__('Name on Card') ?>" class="input-text required-entry" id="<?= $_code ?>_cc_owner" name="payment[cc_owner]" value="<?= $this->escapeHtml($this->getInfoData('cc_owner')) ?>" />
         </div>
     </li>
 */ ?>
     <li>
         <p class="required"><?= $this->__('* Required Fields') ?></p>
-        <label for="<?= $_code ?>_cc_type" class="required"><em>*</em><?= $this->__('Credit Card Type') ?></label>
+        <label for="<?= $_code ?>_cc_type" class="required"><?= $this->__('Credit Card Type') ?></label>
         <div class="input-box">
             <select id="<?= $_code ?>_cc_type" name="payment[cc_type]" class="required-entry validate-cc-type-select" title="<?= $this->quoteEscape($this->__('Credit Card Type')) ?>">
                 <option value=""><?= $this->__('--Please Select--') ?></option>
@@ -35,13 +35,13 @@
         </div>
     </li>
     <li>
-        <label for="<?= $_code ?>_cc_number" class="required"><em>*</em><?= $this->__('Credit Card Number') ?></label>
+        <label for="<?= $_code ?>_cc_number" class="required"><?= $this->__('Credit Card Number') ?></label>
         <div class="input-box">
             <input type="text" pattern="\d*" id="<?= $_code ?>_cc_number" name="payment[cc_number]" title="<?= $this->quoteEscape($this->__('Credit Card Number')) ?>" class="input-text validate-cc-number validate-cc-type" value="" />
         </div>
     </li>
     <li id="<?= $_code ?>_cc_type_exp_div">
-        <label for="<?= $_code ?>_expiration" class="required"><em>*</em><?= $this->__('Expiration Date') ?></label>
+        <label for="<?= $_code ?>_expiration" class="required"><?= $this->__('Expiration Date') ?></label>
         <div class="input-box">
             <div class="v-fix">
                 <select id="<?= $_code ?>_expiration" name="payment[cc_exp_month]" class="month validate-cc-exp required-entry">
@@ -64,7 +64,7 @@
     <?= $this->getChildHtml() ?>
     <?php if($this->hasVerification()): ?>
     <li id="<?= $_code ?>_cc_type_cvv_div">
-        <label for="<?= $_code ?>_cc_cid" class="required"><em>*</em><?= $this->__('Card Verification Number') ?></label>
+        <label for="<?= $_code ?>_cc_cid" class="required"><?= $this->__('Card Verification Number') ?></label>
         <div class="input-box">
             <div class="v-fix">
                 <input type="text" pattern="\d*" title="<?= $this->quoteEscape($this->__('Card Verification Number')) ?>" class="input-text cvv required-entry validate-cc-cvn" id="<?= $_code ?>_cc_cid" name="payment[cc_cid]" value="" />
@@ -77,7 +77,7 @@
     <?php if ($this->hasSsCardType()): ?>
     <li id="<?= $_code ?>_cc_type_ss_div">
         <ul class="inner-form">
-            <li class="form-alt"><label for="<?= $_code ?>_cc_issue" class="required"><em>*</em><?= $this->__('Switch/Solo/Maestro Only') ?></label></li>
+            <li class="form-alt"><label for="<?= $_code ?>_cc_issue" class="required"><?= $this->__('Switch/Solo/Maestro Only') ?></label></li>
             <li>
                 <label for="<?= $_code ?>_cc_issue"><?= $this->__('Issue Number') ?>:</label>
                 <span class="input-box">

--- a/app/design/frontend/base/default/template/payment/form/ccsave.phtml
+++ b/app/design/frontend/base/default/template/payment/form/ccsave.phtml
@@ -15,13 +15,13 @@
 <ul class="form-list" id="payment_form_<?= $_code ?>" style="display:none;">
     <li>
         <p class="required"><?= $this->__('* Required Fields') ?></p>
-        <label for="<?= $_code ?>_cc_owner" class="required"><em>*</em><?= $this->__('Name on Card') ?></label>
+        <label for="<?= $_code ?>_cc_owner" class="required"><?= $this->__('Name on Card') ?></label>
         <div class="input-box">
             <input type="text" title="<?= $this->quoteEscape($this->__('Name on Card')) ?>" class="input-text required-entry" id="<?= $_code ?>_cc_owner" name="payment[cc_owner]" value="<?= $this->escapeHtml($this->getInfoData('cc_owner')) ?>" />
         </div>
     </li>
     <li>
-        <label for="<?= $_code ?>_cc_type" class="required"><em>*</em><?= $this->__('Credit Card Type') ?></label>
+        <label for="<?= $_code ?>_cc_type" class="required"><?= $this->__('Credit Card Type') ?></label>
         <div class="input-box">
             <select id="<?= $_code ?>_cc_type" name="payment[cc_type]" title="<?= $this->quoteEscape($this->__('Credit Card Type')) ?>" class="required-entry validate-cc-type-select">
                 <option value=""><?= $this->__('--Please Select--') ?></option>
@@ -33,13 +33,13 @@
         </div>
     </li>
     <li>
-        <label for="<?= $_code ?>_cc_number" class="required"><em>*</em><?= $this->__('Credit Card Number') ?></label>
+        <label for="<?= $_code ?>_cc_number" class="required"><?= $this->__('Credit Card Number') ?></label>
         <div class="input-box">
             <input type="text" pattern="\d*" id="<?= $_code ?>_cc_number" name="payment[cc_number]" title="<?= $this->quoteEscape($this->__('Credit Card Number')) ?>" class="input-text validate-cc-number validate-cc-type" value="" />
         </div>
     </li>
     <li>
-        <label for="<?= $_code ?>_expiration" class="required"><em>*</em><?= $this->__('Expiration Date') ?></label>
+        <label for="<?= $_code ?>_expiration" class="required"><?= $this->__('Expiration Date') ?></label>
         <div class="input-box">
             <div class="v-fix">
                 <select id="<?= $_code ?>_expiration" name="payment[cc_exp_month]" class="month validate-cc-exp required-entry">
@@ -62,7 +62,7 @@
     <?= $this->getChildHtml() ?>
     <?php if($this->hasVerification()): ?>
     <li>
-        <label for="<?= $_code ?>_cc_cid" class="required"><em>*</em><?= $this->__('Card Verification Number') ?></label>
+        <label for="<?= $_code ?>_cc_cid" class="required"><?= $this->__('Card Verification Number') ?></label>
         <div class="input-box">
             <div class="v-fix">
                 <input type="text" pattern="\d*" title="<?= $this->quoteEscape($this->__('Card Verification Number')) ?>" class="input-text cvv required-entry validate-cc-cvn" id="<?= $_code ?>_cc_cid" name="payment[cc_cid]" value="" />
@@ -74,7 +74,7 @@
     <?php if ($this->hasSsCardType()): ?>
     <li id="<?= $_code ?>_cc_type_ss_div">
         <ul class="inner-form">
-            <li class="form-alt"><label for="<?= $_code ?>_cc_issue" class="required"><em>*</em><?= $this->__('Switch/Solo/Maestro Only') ?></label></li>
+            <li class="form-alt"><label for="<?= $_code ?>_cc_issue" class="required"><?= $this->__('Switch/Solo/Maestro Only') ?></label></li>
             <li>
                 <label for="<?= $_code ?>_cc_issue"><?= $this->__('Issue Number') ?>:</label>
                 <span class="input-box">

--- a/app/design/frontend/base/default/template/payment/form/purchaseorder.phtml
+++ b/app/design/frontend/base/default/template/payment/form/purchaseorder.phtml
@@ -13,7 +13,7 @@
 ?>
 <ul class="form-list" id="payment_form_<?= $this->getMethodCode() ?>" style="display:none;">
     <li>
-        <label for="po_number" class="required"><em>*</em><?= $this->__('Purchase Order Number') ?></label>
+        <label for="po_number" class="required"><?= $this->__('Purchase Order Number') ?></label>
         <div class="input-box">
             <input type="text" id="po_number" name="payment[po_number]" title="<?= $this->quoteEscape($this->__('Purchase Order Number')) ?>" class="input-text required-entry" value="<?= $this->escapeHtml($this->getInfoData('po_number')) ?>" />
         </div>

--- a/app/design/frontend/base/default/template/paypal/express/review/address.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review/address.phtml
@@ -26,7 +26,7 @@
                     </div>
         <?php if(!$this->isCustomerLoggedIn() && !$this->getHideEmailAddress()): ?>
                     <div class="field">
-                        <label for="<?= $prefix ?>:email" class="required"><em>*</em><?= $this->__('Email Address') ?></label>
+                        <label for="<?= $prefix ?>:email" class="required"><?= $this->__('Email Address') ?></label>
                         <div class="input-box">
                             <input type="email" autocapitalize="off" autocorrect="off" spellcheck="false" name="<?= $prefix ?>[email]" id="<?= $prefix ?>:email" value="<?= $this->escapeHtml($this->getAddress()->getEmail()) ?>" title="<?= $this->quoteEscape($this->__('Email Address')) ?>" class="input-text validate-email required-entry" />
                         </div>
@@ -36,7 +36,7 @@
         <?php $_streetValidationClass = $this->helper('customer/address')->getAttributeValidationClass('street'); ?>
                 <li class="fields">
                     <div class="field">
-                        <label for="<?= $prefix ?>:street1" class="required"><em>*</em><?= $this->__('Address') ?></label>
+                        <label for="<?= $prefix ?>:street1" class="required"><?= $this->__('Address') ?></label>
                         <div class="input-box">
                             <input type="text" title="<?= $this->quoteEscape($this->__('Street Address')) ?>" name="<?= $prefix ?>[street][]" id="<?= $prefix ?>:street1" value="<?= $this->escapeHtml($this->getAddress()->getStreet(1)) ?>" class="input-text <?= $_streetValidationClass ?>" />
                         </div>
@@ -65,13 +65,13 @@
                 <?php endif ?>
                 <li class="fields">
                     <div class="field">
-                        <label for="<?= $prefix ?>:city" class="required"><em>*</em><?= $this->__('City') ?></label>
+                        <label for="<?= $prefix ?>:city" class="required"><?= $this->__('City') ?></label>
                         <div class="input-box">
                             <input type="text" title="<?= $this->quoteEscape($this->__('City')) ?>" name="<?= $prefix ?>[city]" value="<?= $this->escapeHtml($this->getAddress()->getCity()) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('city') ?>" id="<?= $prefix ?>:city" />
                         </div>
                     </div>
                     <div class="field">
-                        <label for="<?= $prefix ?>:region_id" class="required"><em>*</em><?= $this->__('State/Province') ?></label>
+                        <label for="<?= $prefix ?>:region_id" class="required"><?= $this->__('State/Province') ?></label>
                         <div class="input-box">
                             <select id="<?= $prefix ?>:region_id" name="<?= $prefix ?>[region_id]" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="validate-select" style="display:none;">
                                 <option value=""><?= $this->__('Please select region, state or province') ?></option>
@@ -85,13 +85,13 @@
                 </li>
                 <li class="fields">
                     <div class="field">
-                        <label for="<?= $prefix ?>:postcode" class="required"><em>*</em><?= $this->__('Zip/Postal Code') ?></label>
+                        <label for="<?= $prefix ?>:postcode" class="required"><?= $this->__('Zip/Postal Code') ?></label>
                         <div class="input-box">
                             <input type="text" title="<?= $this->quoteEscape($this->__('Zip/Postal Code')) ?>" name="<?= $prefix ?>[postcode]" id="<?= $prefix ?>:postcode" value="<?= $this->escapeHtml($this->getAddress()->getPostcode()) ?>" class="input-text validate-zip-international <?= $this->helper('customer/address')->getAttributeValidationClass('postcode') ?>" />
                         </div>
                     </div>
                     <div class="field">
-                        <label for="<?= $prefix ?>:country_id" class="required"><em>*</em><?= $this->__('Country') ?></label>
+                        <label for="<?= $prefix ?>:country_id" class="required"><?= $this->__('Country') ?></label>
                         <div class="input-box">
                             <?= $this->getCountryHtmlSelect($prefix) ?>
                         </div>
@@ -99,7 +99,7 @@
                 </li>
                 <li class="fields">
                     <div class="field">
-                        <label for="<?= $prefix ?>:telephone" class="required"><em>*</em><?= $this->__('Telephone') ?></label>
+                        <label for="<?= $prefix ?>:telephone" class="required"><?= $this->__('Telephone') ?></label>
                         <div class="input-box">
                             <input type="tel" name="<?= $prefix ?>[telephone]" value="<?= $this->escapeHtml($this->getAddress()->getTelephone()) ?>" title="<?= $this->quoteEscape($this->__('Telephone')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('telephone') ?>" id="<?= $prefix ?>:telephone" />
                         </div>

--- a/app/design/frontend/base/default/template/review/form.phtml
+++ b/app/design/frontend/base/default/template/review/form.phtml
@@ -43,21 +43,21 @@
 
                 <ul class="form-list">
                     <li>
-                        <label for="review_field" class="required"><em>*</em><?= $this->__('Let us know your thoughts') ?></label>
+                        <label for="review_field" class="required"><?= $this->__('Let us know your thoughts') ?></label>
                         <div class="input-box">
                             <textarea name="detail" id="review_field" cols="5" rows="3" class="required-entry"><?= $this->escapeHtml($data->getDetail()) ?></textarea>
                         </div>
                     </li>
 
                    <li class="inline-label">
-                        <label for="summary_field" class="required"><em>*</em><?= $this->__('Summary of Your Review') ?></label>
+                        <label for="summary_field" class="required"><?= $this->__('Summary of Your Review') ?></label>
                         <div class="input-box">
                             <input type="text" name="title" id="summary_field" class="input-text required-entry" value="<?= $this->escapeHtml($data->getTitle()) ?>" />
                         </div>
                    </li>
 
                     <li class="inline-label">
-                        <label for="nickname_field" class="required"><em>*</em><?= $this->__("What's your nickname?") ?></label>
+                        <label for="nickname_field" class="required"><?= $this->__("What's your nickname?") ?></label>
                         <div class="input-box">
                             <input type="text" name="nickname" id="nickname_field" class="input-text required-entry" value="<?= $this->escapeHtml($data->getNickname()) ?>" />
                         </div>

--- a/app/design/frontend/base/default/template/sales/guest/form.phtml
+++ b/app/design/frontend/base/default/template/sales/guest/form.phtml
@@ -5,7 +5,7 @@
  * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2025 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
@@ -23,7 +23,7 @@
         <ul class="form-list">
            <li>
                <div class="input-box">
-                   <label for="oar_order_id" class="required"><?= Mage::helper('sales')->__('Order ID') ?> <em>*</em></label>
+                   <label for="oar_order_id" class="required"><?= Mage::helper('sales')->__('Order ID') ?></label>
                </div>
                <div class="input-box">
                    <input type="text" class="input-text required-entry" id="oar_order_id" name="oar_order_id" style="width:300px;"/>
@@ -36,7 +36,7 @@
            </li>
            <li>
                <div class="input-box">
-                   <label for="oar_billing_lastname" class="required"><?= Mage::helper('sales')->__('Billing Last Name') ?> <em>*</em></label>
+                   <label for="oar_billing_lastname" class="required"><?= Mage::helper('sales')->__('Billing Last Name') ?></label>
                </div>
                <div class="input-box">
                    <input type="text" class="input-text required-entry" id="oar_billing_lastname" name="oar_billing_lastname"  style="width:300px;"/>
@@ -55,7 +55,7 @@
            </li>
            <li id="oar-email">
                <div class="input-box">
-                   <label for="oar_email" class="required"><?= Mage::helper('sales')->__('Email Address') ?> <em>*</em></label>
+                   <label for="oar_email" class="required"><?= Mage::helper('sales')->__('Email Address') ?></label>
                </div>
                <div class="input-box">
                    <input type="text" class="input-text validate-email required-entry" id="oar_email" name="oar_email"  style="width:300px;"/>
@@ -63,7 +63,7 @@
            </li>
            <li id="oar-zip" style="display:none;">
                <div class="input-box">
-                   <label for="oar_zip" class="required"><?= Mage::helper('sales')->__('Billing ZIP Code') ?> <em>*</em></label>
+                   <label for="oar_zip" class="required"><?= Mage::helper('sales')->__('Billing ZIP Code') ?></label>
                </div>
                <div class="input-box">
                    <input type="text" class="input-text required-entry" id="oar_zip" name="oar_zip" style="width:300px;"/>

--- a/app/design/frontend/base/default/template/sales/payment/form/billing/agreement.phtml
+++ b/app/design/frontend/base/default/template/sales/payment/form/billing/agreement.phtml
@@ -5,7 +5,7 @@
  * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
@@ -13,7 +13,7 @@
 <?php $_code=$this->getMethodCode() ?>
 <ul class="form-list" id="payment_form_<?= $_code ?>" style="display:none;">
     <li>
-        <label for="<?= $_code ?>_ba_agreement_id" class="required"><em>*</em><?= $this->__('Billing Agreement') ?></label>
+        <label for="<?= $_code ?>_ba_agreement_id" class="required"><?= $this->__('Billing Agreement') ?></label>
         <div class="input-box">
             <select id="<?= $_code ?>_ba_agreement_id" name="payment[<?= $this->getTransportName() ?>]" class="required-entry">
                 <option value=""><?= $this->__('-- Please Select Billing Agreement--') ?></option>

--- a/app/design/frontend/base/default/template/sales/widget/guest/form.phtml
+++ b/app/design/frontend/base/default/template/sales/widget/guest/form.phtml
@@ -5,7 +5,7 @@
  * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 /** @var Mage_Sales_Block_Widget_Guest_Form $this */
@@ -31,25 +31,25 @@
                            </div>
                        </li>
                        <li>
-                           <label for="oar_order_id" class="required"><?= Mage::helper('sales')->__('Order ID') ?> <em>*</em></label>
+                           <label for="oar_order_id" class="required"><?= Mage::helper('sales')->__('Order ID') ?> </label>
                            <div class="input-box">
                                <input type="text" class="input-text required-entry" id="oar_order_id" name="oar_order_id"  autocomplete="off" />
                            </div>
                        </li>
                        <li>
-                           <label for="oar_billing_lastname" class="required"><?= Mage::helper('sales')->__('Billing Last Name') ?> <em>*</em></label>
+                           <label for="oar_billing_lastname" class="required"><?= Mage::helper('sales')->__('Billing Last Name') ?> </label>
                            <div class="input-box">
                                <input type="text" class="input-text required-entry" id="oar_billing_lastname" name="oar_billing_lastname" autocomplete="off" />
                            </div>
                        </li>
                        <li id="oar-email">
-                           <label for="oar_email" class="required"><?= Mage::helper('sales')->__('Email Address') ?> <em>*</em></label>
+                           <label for="oar_email" class="required"><?= Mage::helper('sales')->__('Email Address') ?> </label>
                            <div class="input-box">
                                <input type="email" autocapitalize="off" autocorrect="off" spellcheck="false" class="input-text validate-email required-entry" id="oar_email" name="oar_email" autocomplete="off" />
                            </div>
                        </li>
                        <li id="oar-zip" style="display:none;">
-                           <label for="oar_zip" class="required"><?= Mage::helper('sales')->__('Billing ZIP Code') ?> <em>*</em></label>
+                           <label for="oar_zip" class="required"><?= Mage::helper('sales')->__('Billing ZIP Code') ?> </label>
                            <div class="input-box">
                                <input type="text" class="input-text required-entry" id="oar_zip" name="oar_zip" />
                            </div>

--- a/app/design/frontend/base/default/template/wishlist/sharing.phtml
+++ b/app/design/frontend/base/default/template/wishlist/sharing.phtml
@@ -21,7 +21,7 @@
         <h2 class="legend"><?= $this->__('Sharing Information') ?></h2>
         <ul class="form-list">
             <li class="wide">
-                <label for="email_address" class="required"><em>*</em><?= $this->__('Up to 5 email addresses, separated by commas') ?></label>
+                <label for="email_address" class="required"><?= $this->__('Up to 5 email addresses, separated by commas') ?></label>
                 <div class="input-box">
                     <textarea name="emails" cols="60" rows="5" id="email_address" class="validate-emails required-entry"><?= $this->getEnteredData('emails') ?></textarea>
                 </div>

--- a/public/js/varien/form.js
+++ b/public/js/varien/form.js
@@ -4,7 +4,7 @@
  * @package    js
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2023 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
@@ -98,19 +98,10 @@ class RegionUpdater {
             }
             const label = document.querySelector(`label[for="${currentElement.id}"]`);
             if (label) {
-                let wildCard = label.querySelector('em') || label.querySelector('span.required');
-                if (!wildCard) {
-                    label.insertAdjacentHTML('beforeend', ' <span class="required">*</span>');
-                    wildCard = label.querySelector('span.required');
-                }
                 if (!this.config.show_all_regions) {
                     label.parentElement.style.display = regionRequired ? '' : 'none';
                 }
-
-                if (wildCard) {
-                    wildCard.style.display = regionRequired ? '' : 'none';
-                    label.classList.toggle('required', regionRequired);
-                }
+                label.classList.toggle('required', regionRequired);
             }
 
             currentElement.classList.toggle('required-entry', regionRequired);
@@ -252,32 +243,14 @@ class ZipUpdater {
         if (!this.zipElement) return false;
 
         const label = document.querySelector(`label[for="${this.zipElement.id}"]`);
-        let wildCard;
-        if (label !== null) {
-            wildCard = label.querySelector('em') || label.querySelector('span.required');
-            if (!wildCard) {
-                label.insertAdjacentHTML('beforeend', ' <span class="required">*</span>');
-                wildCard = label.querySelector('span.required');
-            }
-        }
 
         // Make Zip and its label required/optional
         if (optionalZipCountries.indexOf(this.country) != -1) {
-            if (label !== null) {
-                label.classList.remove('required');
-            }
+            label?.classList.remove('required');
             this.zipElement.classList.remove('required-entry');
-            if (wildCard !== undefined) {
-                wildCard.style.display = 'none';
-            }
         } else {
-            if (label !== null) {
-                label.classList.add('required');
-            }
+            label?.classList.add('required');
             this.zipElement.classList.add('required-entry');
-            if (wildCard !== undefined) {
-                wildCard.style.display = '';
-            }
         }
     }
 }


### PR DESCRIPTION
I removed all `<em>*</em>` nodes from `<label class="required">`, since they're hidden by CSS anyway...

Also some JS that liked to create these elements if not exist. f4ed5ad55c9537072f3b91c4056859d7f1ce7a3a