### PR TITLE
Rewrote `adminhtml/sales/packaging.js` without prototypejs

### DIFF
--- a/.phpstan.baseline.neon
+++ b/.phpstan.baseline.neon
@@ -4531,12 +4531,6 @@ parameters:
 			path: app/design/adminhtml/default/default/template/sales/order/shipment/create/items/renderer/configurable.phtml
 
 		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: app/design/adminhtml/default/default/template/sales/order/shipment/packaging/grid.phtml
-
-		-
 			message: '#^Access to an undefined property Mage_Adminhtml_Block_Sales_Order_Shipment_Tracking_Info\:\:\$trackingInfo\.$#'
 			identifier: property.notFound
 			count: 1

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
@@ -6,6 +6,7 @@
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -35,6 +36,7 @@ class Mage_Adminhtml_Block_Sales_Order_Shipment_Packaging extends Mage_Adminhtml
     public function getConfigDataJson()
     {
         $shipmentId = $this->getShipment()->getId();
+        $shippingMethod = $this->getShipment()->getOrder()->getShippingMethod();
         $orderId = $this->getRequest()->getParam('order_id');
         $urlParams = [];
 
@@ -88,6 +90,7 @@ class Mage_Adminhtml_Block_Sales_Order_Shipment_Packaging extends Mage_Adminhtml
             'shipmentItemsProductId'    => $itemsProductId,
             'shipmentItemsOrderItemId'  => $itemsOrderItemId,
             'customizable'              => $this->_getCustomizableContainers(),
+            'girthEnabled'              => Mage::helper('usa')->displayGirthValue($shippingMethod) && $this->isGirthAllowed(),
         ];
         return Mage::helper('core')->jsonEncode($data);
     }
@@ -205,9 +208,9 @@ class Mage_Adminhtml_Block_Sales_Order_Shipment_Packaging extends Mage_Adminhtml
     {
         $items = $this->getShipment()->getAllItems();
         foreach ($items as $item) {
-            if ($itemsOf == 'order' && $item->getOrderItemId() == $itemId) {
+            if ($itemsOf === 'order' && $item->getOrderItemId() == $itemId) {
                 return $item;
-            } elseif ($itemsOf == 'shipment' && $item->getId() == $itemId) {
+            } elseif ($itemsOf === 'shipment' && $item->getId() == $itemId) {
                 return $item;
             }
         }

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging/Grid.php
@@ -6,6 +6,7 @@
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -36,6 +37,29 @@ class Mage_Adminhtml_Block_Sales_Order_Shipment_Packaging_Grid extends Mage_Admi
             $collection = $this->getShipment()->getAllItems();
         }
         return $collection;
+    }
+
+    /**
+     * Return collection of shipment items available to be packed
+     */
+    public function getAvailableItems(): array
+    {
+        $items = [];
+        $order = $this->getShipment()->getOrder();
+        foreach ($this->getCollection() as $item) {
+            if ($item->getIsVirtual()) {
+                continue;
+            }
+            $orderItem = $order->getItemById($item->getOrderItemId());
+            if ($orderItem->isShipSeparately() && !($orderItem->getParentItemId() || $orderItem->getParentItem())) {
+                continue;
+            }
+            if (!$orderItem->isShipSeparately() && ($orderItem->getParentItemId() || $orderItem->getParentItem())) {
+                continue;
+            }
+            $items[] = $item;
+        }
+        return $items;
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/etc/jstranslator.xml
+++ b/app/code/core/Mage/Adminhtml/etc/jstranslator.xml
@@ -61,4 +61,16 @@
             <message>Passkey will be deleted upon saving.</message>
         </passkey-deleted>
     </script>
+
+    <script path="mage/adminhtml/sales/packaging.js" area="adminhtml" module="sales">
+        <invalid-url translate="message" module="core">
+            <message>Invalid URL</message>
+        </invalid-url>
+        <dialog-title translate="message">
+            <message>Create Packages</message>
+        </dialog-title>
+        <submit-shipment translate="message">
+            <message>Submit Shipment</message>
+        </submit-shipment>
+    </script>
 </jstranslator>

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/form.phtml
@@ -5,7 +5,7 @@
  * @package     default_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
@@ -68,34 +68,29 @@
     </div>
 </form>
 <?= $this->getChildHtml('shipment_packaging') ?>
-<script type="text/javascript">
-//<![CDATA[
-    document.observe("dom:loaded", function() {
-        setTimeout(function(){
-            packaging.setConfirmPackagingCallback(function(){
-                packaging.setParamsCreateLabelRequest($('edit_form').serialize(true));
-                packaging.sendCreateLabelRequest();
-            });
-            packaging.setLabelCreatedCallback(function(response){
-                setLocation("<?php echo $this->getUrl(
-                    '*/sales_order/view',
-                    ['order_id' => $this->getShipment()->getOrderId()]
-                ); ?>");
-            });
-            packaging.setCancelCallback(function() {
-                packaging.cleanPackages();
-                $('create_shipping_label').checked = false;
-                toggleCreateLabelCheckbox();
-            });
-            packaging.setItemQtyCallback(function(itemId){
-                var item = $$('[name="shipment[items]['+itemId+']"]')[0];
-                if (item && !isNaN(item.value)) {
-                    return item.value;
-                }
-            });
-        }, 500);
-    });
 
+<script>
     editForm = new varienForm('edit_form');
-//]]>
+
+    document.addEventListener('DOMContentLoaded', () => {
+        packaging.setConfirmPackagingCallback(() => {
+            const formData = new FormData(document.getElementById('edit_form'));
+            packaging.setParamsCreateLabelRequest(Object.fromEntries(formData));
+            return packaging.sendCreateLabelRequest();
+        });
+        packaging.setLabelCreatedCallback((response) => {
+            setLocation("<?= $this->getUrl('*/sales_order/view', ['order_id' => $this->getShipment()->getOrderId()]) ?>");
+        });
+        packaging.setCancelCallback(() => {
+            packaging.cleanPackages();
+            document.getElementById('create_shipping_label').checked = false;
+            toggleCreateLabelCheckbox();
+        });
+        packaging.setItemQtyCallback((itemId) => {
+            const item = document.querySelector(`[name="shipment[items][${itemId}]"]`);
+            if (item && !isNaN(item.value)) {
+                return item.value;
+            }
+        });
+    });
 </script>

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/items.phtml
@@ -83,10 +83,12 @@
 </div>
 <div class="clear"></div>
 <script>
+<?php if ($this->canSendShipmentEmail()): ?>
     document.getElementById('send_email').addEventListener('click', (event) => {
         setElementDisable('notify_customer', !event.target.checked);
     });
-
+<?php endif ?>
+<?php if ($this->canCreateShippingLabel()): ?>
     document.getElementById('create_shipping_label').addEventListener('click', (event) => {
         toggleCreateLabelCheckbox();
     });
@@ -101,6 +103,7 @@
             submitBtn.textContent += '...';
         }
     }
+<?php endif ?>
 
     window.submitShipment = function(submitBtn) {
         for (const item of document.querySelectorAll('.qty-item')) {
@@ -110,13 +113,9 @@
                 return;
             }
         }
-
-        const checkboxEl = document.getElementById('create_shipping_label');
-        if (checkboxEl?.checked) {
+        if (document.getElementById('create_shipping_label')?.checked) {
             packaging.showWindow();
-            return;
-        }
-        if (editForm.submit()) {
+        } else if (editForm.submit()) {
             disableElements('submit-button');
         }
     }

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/items.phtml
@@ -62,12 +62,12 @@
           <?php if ($this->canCreateShippingLabel()): ?>
           <p>
               <label class="normal" for="create_shipping_label"><?= Mage::helper('sales')->__('Create Shipping Label') ?></label>
-              <input id="create_shipping_label" name="shipment[create_shipping_label]" value="1" type="checkbox"  onclick="toggleCreateLabelCheckbox();" />
+              <input id="create_shipping_label" name="shipment[create_shipping_label]" value="1" type="checkbox" />
           </p>
           <?php endif ?>
           <p>
               <label class="normal" for="notify_customer"><?= Mage::helper('sales')->__('Append Comments') ?></label>
-              <input id="notify_customer" name="shipment[comment_customer_notify]" value="1" type="checkbox" />
+              <input id="notify_customer" name="shipment[comment_customer_notify]" value="1" type="checkbox" disabled />
           </p>
           <?php if ($this->canSendShipmentEmail()): ?>
           <p>
@@ -82,60 +82,42 @@
     </div>
 </div>
 <div class="clear"></div>
-<script type="text/javascript">
-//<![CDATA[
-var sendEmailCheckbox = $('send_email');
-if (sendEmailCheckbox) {
-    var notifyCustomerCheckbox = $('notify_customer');
-    var shipmentCommentText = $('shipment_comment_text');
-    Event.observe(sendEmailCheckbox, 'change', bindSendEmail);
-    bindSendEmail();
-}
-function bindSendEmail() {
-    if (sendEmailCheckbox.checked == true) {
-        notifyCustomerCheckbox.disabled = false;
-        //shipmentCommentText.disabled = false;
-    }
-    else {
-        notifyCustomerCheckbox.disabled = true;
-        //shipmentCommentText.disabled = true;
-    }
-}
-function toggleCreateLabelCheckbox() {
-    var checkbox = $('create_shipping_label');
-    var submitButton = checkbox.up('.order-totals').select('.submit-button span')[0];
-    if (checkbox.checked) {
-        submitButton.innerText += '...';
-    } else {
-        submitButton.innerText = submitButton.innerText.replace(/\.\.\.$/, '');
-    }
-}
-function submitShipment(btn) {
-    var checkbox = $(btn).up('.order-totals').select('#create_shipping_label')[0];
-
-    if (!validQtyItems()) {
-        return;
-    }
-
-    if (checkbox && checkbox.checked) {
-        packaging.showWindow();
-    } else if(editForm.submit()) {
-        disableElements('submit-button');
-    }
-}
-
-function validQtyItems() {
-    var valid = true;
-    var errorMessage = '<?= $this->jsQuoteEscape($this->helper('sales')->__('Invalid value(s) for Qty to Ship')) ?>';
-    $$('.qty-item').each(function(item) {
-        var val = parseFloat(item.value);
-        if (isNaN(val) || val < 0) {
-            valid = false;
-            alert(errorMessage);
-            throw $break;
-        }
+<script>
+    document.getElementById('send_email').addEventListener('click', (event) => {
+        setElementDisable('notify_customer', !event.target.checked);
     });
-    return valid;
-}
-//]]>
+
+    document.getElementById('create_shipping_label').addEventListener('click', (event) => {
+        toggleCreateLabelCheckbox();
+    });
+
+    window.toggleCreateLabelCheckbox = function() {
+        const checkboxEl = document.getElementById('create_shipping_label');
+        const submitBtn = checkboxEl.closest('.order-totals').querySelector('.submit-button');
+        if (submitBtn.textContent.endsWith('...')) {
+            submitBtn.textContent = submitBtn.textContent.slice(0, -3);
+        }
+        if (checkboxEl.checked) {
+            submitBtn.textContent += '...';
+        }
+    }
+
+    window.submitShipment = function(submitBtn) {
+        for (const item of document.querySelectorAll('.qty-item')) {
+            const value = parseFloat(item.value);
+            if (isNaN(value) || value < 0) {
+                alert('<?= $this->jsQuoteEscape($this->helper('sales')->__('Invalid value(s) for Qty to Ship')) ?>');
+                return;
+            }
+        }
+
+        const checkboxEl = document.getElementById('create_shipping_label');
+        if (checkboxEl?.checked) {
+            packaging.showWindow();
+            return;
+        }
+        if (editForm.submit()) {
+            disableElements('submit-button');
+        }
+    }
 </script>

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/grid.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/grid.phtml
@@ -17,28 +17,21 @@
             <table cellspacing="0" class="data">
                 <thead>
                 <tr class="headings">
-                    <th class=" no-link"><span class="nobr"><?= Mage::helper('sales')->__('Product Name') ?></span></th>
-                    <th class=" no-link"><span class="nobr"><?= Mage::helper('sales')->__('Weight') ?></span></th>
-                    <th class=" no-link" <?= $this->displayCustomsValue() ? '' : 'style="display: none;"' ?> width="100">
+                    <th class="no-link"><span class="nobr"><?= Mage::helper('sales')->__('Product Name') ?></span></th>
+                    <th class="no-link"><span class="nobr"><?= Mage::helper('sales')->__('Weight') ?></span></th>
+                    <th class="no-link<?= $this->displayCustomsValue() ? '' : ' no-display' ?>" width="100">
                         <span class="nobr"><?= Mage::helper('sales')->__('Customs Value') ?></span>
                     </th>
                     <th class="a-center no-link" width="100">
                         <span class="nobr"><input type="checkbox" name="" onclick="packaging.checkAllItems(this);" class="checkbox" title="<?= Mage::helper('sales')->__('Select All') ?>"></span>
                     </th>
-                    <th class=" no-link" width="100"><span class="nobr"><?= Mage::helper('sales')->__('Qty Ordered') ?></span></th>
-                    <th class=" no-link last" width="100"><span class="nobr"><?= Mage::helper('sales')->__('Qty') ?></span></th>
+                    <th class="no-link" width="100"><span class="nobr"><?= Mage::helper('sales')->__('Qty Ordered') ?></span></th>
+                    <th class="no-link last" width="150"><span class="nobr"><?= Mage::helper('sales')->__('Qty') ?></span></th>
                 </tr>
                 </thead>
 
                 <tbody>
-                <?php foreach($this->getCollection() as $item): ?>
-                    <?php $_order = $this->getShipment()->getOrder() ?>
-                    <?php $_orderItem = $_order->getItemById($item->getOrderItemId()); ?>
-                    <?php if ($item->getIsVirtual()
-                              || ($_orderItem->isShipSeparately() && !($_orderItem->getParentItemId() || $_orderItem->getParentItem()))
-                              || (!$_orderItem->isShipSeparately() && ($_orderItem->getParentItemId() || $_orderItem->getParentItem()))): ?>
-                        <?php continue; ?>
-                    <?php endif ?>
+                <?php foreach($this->getAvailableItems() as $item): ?>
                     <tr title="#" id="" class="">
                         <td class="name">
                             <?= $item->getName() ?>
@@ -46,28 +39,19 @@
                         <td class="a-center weight ">
                             <?= $item->getWeight() ?>
                         </td>
-                        <?php
-                            if ($this->displayCustomsValue()) {
-                                $customsValueDisplay = '';
-                                $customsValueValidation = ' validate-zero-or-greater ';
-                            } else {
-                                $customsValueDisplay = ' style="display: none;" ';
-                                $customsValueValidation = '';
-                            }
-                        ?>
-                        <td <?= $customsValueDisplay ?>>
-                            <input type="text" name="customs_value" class="input-text <?= $customsValueValidation ?>" value="<?= $this->formatPrice($item->getPrice()) ?>" size="10" onblur="packaging.recalcContainerWeightAndCustomsValue(this);">
+                        <td<?= $this->displayCustomsValue() ? '' : ' class="no-display"' ?>>
+                            <input type="text" name="customs_value" class="input-text<?= $this->displayCustomsValue() ? ' validate-zero-or-greater' : '' ?>" value="<?= $this->formatPrice($item->getPrice()) ?>" size="10" onblur="packaging.recalcContainerWeightAndCustomsValue(this);">
                         </td>
-                        <td class="a-center ">
+                        <td class="a-center">
                             <input type="checkbox" name="" value="<?= $item->getId() ? $item->getId() : $item->getOrderItemId() ?>" class="checkbox">
                         </td>
-                        <td class="a-center ">
+                        <td class="a-center">
                             <?= $item->getOrderItem()->getQtyOrdered()*1 ?>
                         </td>
-                        <td class="a-right last">
+                        <td class="a-right nobr last">
                             <input type="hidden" name="price" value="<?= $item->getPrice() ?>">
-                            <input type="text" name="qty" value="<?= $item->getQty()*1 ?>" class="input-text qty<?php if ($item->getOrderItem()->getIsQtyDecimal()): ?> qty-decimal<?php endif ?>">&nbsp;
-                            <button type="button" class="scalable delete icon-btn" onclick="packaging.deleteItem(this);" style="display:none;">
+                            <input type="text" name="qty" value="<?= $item->getQty()*1 ?>" class="input-text qty<?= $item->getOrderItem()->getIsQtyDecimal() ? ' qty-decimal' : '' ?>">
+                            <button type="button" class="delete icon-btn no-display" onclick="packaging.deleteItem(this);">
                                 <span><?= Mage::helper('sales')->__('Delete') ?></span>
                             </button>
                         </td>

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/grid.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/grid.phtml
@@ -5,7 +5,7 @@
  * @package     default_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2025 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/packed.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/packed.phtml
@@ -5,33 +5,35 @@
  * @package     default_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
 /** @var Mage_Adminhtml_Block_Sales_Order_Shipment_Packaging $this */
 ?>
 
-<div id="packed_window" style="display:none;" class="packed-window">
-    <div class="entry-edit">
-        <div class="entry-edit-head">
-            <h4 class="icon-head fieldset-legend"><?= Mage::helper('sales')->__('Packages') ?></h4>
-        </div>
-        <div class="packed-content">
-            <?php foreach ($this->getPackages() as $packageId => $package): ?>
-                <div class="package">
-                    <?php $package = new Varien_Object($package) ?>
-                    <?php $params = new Varien_Object($package->getParams()) ?>
-                    <h4><?= Mage::helper('sales')->__('Package') . ' ' . $packageId ?></h4>
+<template id="packed_window_template">
+    <div class="buttons-set">
+        <?= $this->getPrintButton() ?>
+    </div>
+    <div class="packed-content">
+        <?php foreach ($this->getPackages() as $packageId => $package): ?>
+            <div class="package entry-edit">
+                <?php $package = new Varien_Object($package) ?>
+                <?php $params = new Varien_Object($package->getParams()) ?>
+                <div class="entry-edit-head">
+                    <h4><?= Mage::helper('sales')->__('Package') . " $packageId" ?></h4>
+                </div>
+                <div class="fieldset">
                     <div class="package-info">
                         <table class="package-options" cellspacing="0">
                             <colgroup>
-                                <col width="80"/>
-                                <col width="*"/>
-                                <col width="60"/>
-                                <col width="70"/>
-                                <col width="140"/>
-                                <col width="*"/>
+                                <col width="80">
+                                <col width="*">
+                                <col width="60">
+                                <col width="70">
+                                <col width="140">
+                                <col width="*">
                             </colgroup>
                             <tbody>
                                 <tr>
@@ -49,8 +51,8 @@
                                         <th><?= Mage::helper('sales')->__('Signature Confirmation') ?></th>
                                         <td><?= $this->getDeliveryConfirmationTypeByCode($params->getDeliveryConfirmation()) ?></td>
                                     <?php else: ?>
-                                        <th>&nbsp;</th>
-                                        <td>&nbsp;</td>
+                                        <th></th>
+                                        <td></td>
                                     <?php endif ?>
                                 </tr>
                                 <tr>
@@ -77,8 +79,8 @@
                                             <td><?= $this->getContentTypeByCode($params->getContentType()) ?></td>
                                         <?php endif ?>
                                     <?php else: ?>
-                                        <th>&nbsp;</th>
-                                        <td>&nbsp;</td>
+                                        <th></th>
+                                        <td></td>
                                     <?php endif ?>
                                 </tr>
                                 <tr>
@@ -86,8 +88,8 @@
                                         <th><?= Mage::helper('sales')->__('Total Weight') ?></th>
                                         <td><?= $params->getWeight() .' '. Mage::helper('usa')->getMeasureWeightName($params->getWeightUnits()) ?></td>
                                     <?php else: ?>
-                                        <th>&nbsp;</th>
-                                        <td>&nbsp;</td>
+                                        <th></th>
+                                        <td></td>
                                     <?php endif ?>
                                     <th><?= Mage::helper('sales')->__('Height') ?></th>
                                     <td>
@@ -97,26 +99,26 @@
                                             --
                                         <?php endif ?>
                                     <td>
-                                    <th>&nbsp;</th>
-                                    <td>&nbsp;</td>
+                                    <th></th>
+                                    <td></td>
                                 </tr>
                                 <tr>
                                     <?php if ($params->getSize()): ?>
                                         <th><?= Mage::helper('sales')->__('Size') ?></th>
                                         <td><?= ucfirst(strtolower($params->getSize())) ?></td>
                                     <?php else: ?>
-                                        <th>&nbsp;</th>
-                                        <td>&nbsp;</td>
+                                        <th></th>
+                                        <td></td>
                                     <?php endif ?>
                                     <?php if ($params->getGirth()): ?>
                                         <th><?= Mage::helper('sales')->__('Girth') ?></th>
                                         <td><?= $params->getGirth() .' '. Mage::helper('usa')->getMeasureDimensionName($params->getGirthDimensionUnits()) ?></td>
                                     <?php else: ?>
-                                        <th>&nbsp;</th>
-                                        <td>&nbsp;</td>
+                                        <th></th>
+                                        <td></td>
                                     <?php endif ?>
-                                    <th>&nbsp;</th>
-                                    <td>&nbsp;</td>
+                                    <th></th>
+                                    <td></td>
                                 </tr>
                             </tbody>
                         </table>
@@ -136,13 +138,23 @@
                                 </colgroup>
                                 <thead>
                                 <tr class="headings">
-                                    <th class=" no-link"><span class="nobr"><?= Mage::helper('sales')->__('Product') ?></span></th>
-                                    <th class=" no-link"><span class="nobr"><?= Mage::helper('sales')->__('Weight') ?></span></th>
+                                    <th class="no-link">
+                                        <span class="nobr"><?= Mage::helper('sales')->__('Product') ?></span>
+                                    </th>
+                                    <th class="no-link">
+                                        <span class="nobr"><?= Mage::helper('sales')->__('Weight') ?></span>
+                                    </th>
                                     <?php if ($this->displayCustomsValue()): ?>
-                                        <th class=" no-link"><span class="nobr"><?= Mage::helper('sales')->__('Customs Value') ?></span></th>
+                                    <th class="no-link">
+                                        <span class="nobr"><?= Mage::helper('sales')->__('Customs Value') ?></span>
+                                    </th>
                                     <?php endif ?>
-                                    <th class=" no-link"><span class="nobr"><?= Mage::helper('sales')->__('Qty Ordered') ?></span></th>
-                                    <th class=" no-link last"><span class="nobr"><?= Mage::helper('sales')->__('Qty') ?></span></th>
+                                    <th class="no-link">
+                                        <span class="nobr"><?= Mage::helper('sales')->__('Qty Ordered') ?></span>
+                                    </th>
+                                    <th class="no-link last">
+                                        <span class="nobr"><?= Mage::helper('sales')->__('Qty') ?></span>
+                                    </th>
                                 </tr>
                                 </thead>
 
@@ -153,11 +165,13 @@
                                         <td class="name">
                                             <?= $item->getName() ?>
                                         </td>
-                                        <td class="a-center weight ">
+                                        <td class="a-center weight">
                                             <?= $item->getWeight() ?>
                                         </td>
                                         <?php if ($this->displayCustomsValue()): ?>
-                                            <td class="a-right"><?= $this->displayCustomsPrice($item->getCustomsValue()) ?></td>
+                                        <td class="a-right">
+                                            <?= $this->displayCustomsPrice($item->getCustomsValue()) ?>
+                                        </td>
                                         <?php endif ?>
                                         <td class="a-right">
                                             <?= $this->getQtyOrderedItem($item->getOrderItemId()) ?>
@@ -172,31 +186,20 @@
                         </div>
                     </div>
                 </div>
-            <?php endforeach ?>
-        </div>
-        <div class="buttons-set a-right">
-            <?= $this->getPrintButton() ?>
-            <button type="button" class="scalable SavePackagesBtn save" onclick="hidePackedWindow();" title="<?= Mage::helper('sales')->__('Products should be added to package(s)') ?>">
-                <span><?= Mage::helper('sales')->__('OK') ?></span>
-            </button>
-        </div>
+            </div>
+        <?php endforeach ?>
     </div>
-</div>
+</template>
 
-<script type="text/javascript">
-//<![CDATA[
-    function showPackedWindow() {
-        var window = $('packed_window');
-        window.show().setStyle({
-            'marginLeft': -window.getDimensions().width/2 + 'px'
+<script type="module">
+    let dialog = null;
+    window.showPackedWindow = function() {
+        dialog = Dialog.info(document.getElementById('packed_window_template').innerHTML, {
+            title: '<?= Mage::helper('sales')->__('Packages') ?>',
+            className: 'packed-window',
         });
-        $('popup-window-mask').setStyle({
-            height: $('html-body').getHeight() + 'px'
-        }).show();
     }
-    function hidePackedWindow() {
-        $('packed_window').hide();
-        $('popup-window-mask').hide();
+    window.hidePackedWindow = function() {
+        dialog.close();
     }
-//]]>
 </script>

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/popup.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/packaging/popup.phtml
@@ -5,203 +5,211 @@
  * @package     default_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
 /** @var Mage_Adminhtml_Block_Sales_Order_Shipment_Packaging $this */
- ?>
-<?php
+
+$containers = $this->getContainers();
+$contentTypes = $this->getContentTypes();
 $shippingMethod = $this->getShipment()->getOrder()->getShippingMethod();
 $sizeSource = Mage::getModel('usa/shipping_carrier_usps_source_size')->toOptionArray();
-$girthEnabled = Mage::helper('usa')->displayGirthValue($shippingMethod) && $this->isGirthAllowed() ? 1 : 0;
+$girthEnabled = Mage::helper('usa')->displayGirthValue($shippingMethod) && $this->isGirthAllowed();
 ?>
-<script type="text/javascript">
-//<![CDATA[
-document.observe("dom:loaded", function() {
-    packaging = new Packaging(<?= $this->getConfigDataJson() ?>);
-    packaging.changeContainerType($$('select[name=package_container]')[0]);
-    packaging.checkSizeAndGirthParameter(
-        $$('select[name=package_container]')[0],
-        <?= $girthEnabled ?>
-    );
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    window.packaging = new Packaging({
+        girthEnabled: <?= var_export($girthEnabled, true) ?>,
+        ...<?= $this->getConfigDataJson() ?>,
+    });
 });
-//]]>
 </script>
-<div id="popup-window-mask" style="display:none;"></div>
-<div id="packaging_window" class="packaging-window" style="display:none;">
-    <div class="entry-edit">
-        <div class="entry-edit-head">
-            <button type="button" class="scalable AddPackageBtn" onclick="packaging.newPackage();">
-                <span><?= Mage::helper('sales')->__('Add Package') ?></span>
-            </button>
-            <h4 class="icon-head fieldset-legend"><?= Mage::helper('sales')->__('Create Packages') ?></h4>
-        </div>
-        <div class="packaging-content">
-            <div class="messages" style="display:none;"></div>
-            <div id="package_template" style="display:none;">
-                <div class="package-number"><?= Mage::helper('sales')->__('Package') ?><span></span></div>
-                <table class="package-options" cellspacing="0">
-                    <thead>
-                        <th><?= Mage::helper('sales')->__('Type') ?></th>
-                        <?php if ($girthEnabled == 1): ?>
-                            <th><?= Mage::helper('sales')->__('Size') ?></th>
-                            <th><?= Mage::helper('sales')->__('Girth') ?></th>
-                            <th>&nbsp;</th>
-                        <?php endif ?>
-                        <th <?= $this->displayCustomsValue() ? '' : 'style="display: none;"' ?>>
-                            <?= Mage::helper('sales')->__('Customs Value') ?>
-                        </th>
-                        <th><?= Mage::helper('sales')->__('Total Weight') ?></th>
-                        <th><?= Mage::helper('sales')->__('Length') ?></th>
-                        <th><?= Mage::helper('sales')->__('Width') ?></th>
-                        <th><?= Mage::helper('sales')->__('Height') ?></th>
-                        <th>&nbsp;</th>
-                        <?php if ($this->getDeliveryConfirmationTypes()): ?>
-                            <th><?= Mage::helper('sales')->__('Signature Confirmation') ?></th>
-                        <?php endif ?>
-                        <th>&nbsp;</th>
-                        <th>&nbsp;</th>
-                    </thead>
-                    <tbody>
-                        <td>
-                            <?php $containers = $this->getContainers(); ?>
-                            <select name="package_container" onchange="packaging.changeContainerType(this);packaging.checkSizeAndGirthParameter(this, <?=  $girthEnabled ?>);"<?php if (empty($containers)):?>
-                                title="<?= Mage::helper('sales')->__('Package types are disregarded for USPS domestic shipments.') ?>"
-                                disabled="" class="disabled"
-                            <?php endif ?>>
-                                <?php foreach ($this->getContainers() as $key => $value): ?>
-                                    <option value="<?= $key ?>" >
-                                        <?= $value ?>
-                                    </option>
-                                <?php endforeach ?>
-                            </select>
-                        </td>
-                        <?php if ($girthEnabled == 1): ?>
-                            <td>
-                                <select name="package_size" onchange="packaging.checkSizeAndGirthParameter(this, <?=  $girthEnabled ?>);">
-                                    <?php foreach ($sizeSource as $key => $value): ?>
-                                    <option value="<?= $sizeSource[$key]['value'] ?>">
-                                        <?= $sizeSource[$key]['label'] ?>
-                                    </option>
-                                    <?php endforeach ?>
-                                </select>
-                            </td>
-                            <td><input type="text" class="input-text validate-greater-than-zero" name="container_girth" /></td>
-                            <td>
-                                <select name="container_girth_dimension_units" class="options-units-dimensions measures" onchange="packaging.changeMeasures(this);">
-                                    <option value="<?= Zend_Measure_Length::INCH ?>" selected="selected" ><?= Mage::helper('sales')->__('in') ?></option>
-                                    <option value="<?= Zend_Measure_Length::CENTIMETER ?>" ><?= Mage::helper('sales')->__('cm') ?></option>
-                                </select>
-                            </td>
-                        <?php endif ?>
-                        <?php
-                            if ($this->displayCustomsValue()) {
-                                $customsValueDisplay = '';
-                                $customsValueValidation = ' validate-zero-or-greater ';
-                            } else {
-                                $customsValueDisplay = ' style="display: none;" ';
-                                $customsValueValidation = '';
-                            }
-                        ?>
-                        <td <?= $customsValueDisplay ?>>
-                            <input type="text" class="customs-value input-text <?= $customsValueValidation ?>" name="package_customs_value" />
-                            <span class="customs-value-currency">[<?= $this->getCustomValueCurrencyCode() ?>]</span>
-                        </td>
-                        <td>
-                            <input type="text" class="options-weight input-text required-entry validate-greater-than-zero" name="container_weight" />
-                            <select name="container_weight_units" class="options-units-weight measures" onchange="packaging.changeMeasures(this);">
-                                <option value="<?= Zend_Measure_Weight::POUND ?>" selected="selected"  ><?= Mage::helper('sales')->__('lb') ?></option>
-                                <option value="<?= Zend_Measure_Weight::KILOGRAM ?>" ><?= Mage::helper('sales')->__('kg') ?></option>
-                            </select>
-                        </td>
-                        <td>
-                            <input type="text" class="input-text validate-greater-than-zero" name="container_length" />
-                        </td>
-                        <td>
-                            <input type="text" class="input-text validate-greater-than-zero" name="container_width" />
-                        </td>
-                        <td>
-                            <input type="text" class="input-text validate-greater-than-zero" name="container_height" />
-                        </td>
-                        <td>
-                            <select name="container_dimension_units" class="options-units-dimensions measures" onchange="packaging.changeMeasures(this);">
-                                <option value="<?= Zend_Measure_Length::INCH ?>" selected="selected" ><?= Mage::helper('sales')->__('in') ?></option>
-                                <option value="<?= Zend_Measure_Length::CENTIMETER ?>" ><?= Mage::helper('sales')->__('cm') ?></option>
-                            </select>
-                        </td>
-                        <?php if ($this->getDeliveryConfirmationTypes()): ?>
-                        <td>
-                            <select name="delivery_confirmation_types">
-                                <?php foreach ($this->getDeliveryConfirmationTypes() as $key => $value): ?>
-                                    <option value="<?= $key ?>" >
-                                        <?= $value ?>
-                                    </option>
-                                <?php endforeach ?>
-                            </select>
-                        </td>
-                        <?php endif ?>
-                        <td>
-                            <button type="button" class="scalable AddItemsBtn" onclick="packaging.getItemsForPack(this);">
-                                <span><?= Mage::helper('sales')->__('Add Products') ?></span>
-                            </button>
-                        </td>
-                        <td>
-                            <button type="button" class="scalable DeletePackageBtn" onclick="packaging.deletePackage(this);">
-                                <span><?= Mage::helper('sales')->__('Delete Package') ?></span>
-                            </button>
-                        </td>
-                    </tbody>
-                </table>
 
-                <?php if ($this->getContentTypes()): ?>
-                <table class="package-options package-options-contents" cellspacing="0">
-                    <colgroup>
-                        <col width="150">
-                        <col width="*">
-                    </colgroup>
-                    <thead>
-                        <th><?= Mage::helper('sales')->__('Contents') ?></th>
-                        <th><?= Mage::helper('sales')->__('Explanation') ?></th>
-                    </thead>
-                    <tbody>
-                        <td>
-                            <select name="content_type" onchange="packaging.changeContentTypes(this);">
-                                <?php foreach ($this->getContentTypes() as $key => $value): ?>
-                                    <option value="<?= $key ?>" >
-                                        <?= $value ?>
-                                    </option>
-                                <?php endforeach ?>
-                            </select>
-                        </td>
-                        <td>
-                            <input name="content_type_other" type="text" class="input-text options-content-type disabled" disabled="disabled" />
-                        </td>
-                    </tbody>
-                </table>
-                <?php endif ?>
+<template id="packaging_window_template">
+    <div class="buttons-set">
+        <button type="button" class="scalable AddPackageBtn">
+            <?= Mage::helper('sales')->__('Add Package') ?>
+        </button>
+    </div>
+    <div class="packaging-content">
+        <div class="messages no-display"></div>
+        <div id="packages_content"></div>
+    </div>
+</template>
 
-                <div class="package-add-products">
-                    <div class="package_prapare" style="display:none">
-                        <div class="entry-edit-head">
-                            <button type="button" class="scalable AddSelectedBtn" onclick="packaging.packItems(this);">
-                                <span><?= Mage::helper('sales')->__('Add Selected Product(s) to Package') ?></span>
-                            </button>
-                            <h4><?= Mage::helper('sales')->__('Please Select Products to Add') ?></h4>
-                        </div>
-                        <div class="grid_prepare"></div>
-                    </div>
-                </div>
-            </div>
-            <div id="packages_content"></div>
-        </div>
-        <div class="buttons-set a-right">
-            <button type="button" class="scalable disabled SavePackagesBtn" disabled="disabled" onclick="packaging.confirmPackaging();" title="<?= Mage::helper('sales')->__('Products should be added to package(s)') ?>">
-                <span><?= Mage::helper('sales')->__('OK') ?></span>
+<template id="packaging_package_template" class="entry-edit">
+    <div class="entry-edit-head">
+        <h4 class="package-number"><?= Mage::helper('sales')->__('Package') ?> <span></span></h4>
+        <div class="buttons-set">
+            <button type="button" class="scalable AddItemsBtn">
+                <span><?= Mage::helper('sales')->__('Add Products') ?></span>
             </button>
-            <button type="button" class="scalable" onclick="packaging.cancelPackaging();">
-                <span><?= Mage::helper('sales')->__('Cancel') ?></span>
+            <button type="button" class="scalable DeletePackageBtn">
+                <span><?= Mage::helper('sales')->__('Delete Package') ?></span>
             </button>
         </div>
     </div>
-</div>
+    <div class="fieldset">
+        <table class="package-options">
+            <colgroup>
+            <?php if (!empty($containers)): ?>
+                <col>
+            <?php endif ?>
+            <?php if ($girthEnabled): ?>
+                <col>
+                <col width="0">
+                <col>
+            <?php endif ?>
+            <?php if ($this->displayCustomsValue() && count($contentTypes) === 0): ?>
+                <col>
+            <?php endif ?>
+                <col>
+                <col width="0">
+                <col width="0">
+                <col width="0">
+                <col>
+            <?php if ($this->getDeliveryConfirmationTypes()): ?>
+                <col>
+            <?php endif ?>
+            </colgroup>
+            <thead>
+            <?php if (!empty($containers)): ?>
+                <th><?= Mage::helper('sales')->__('Type') ?></th>
+            <?php endif ?>
+            <?php if ($girthEnabled): ?>
+                <th><?= Mage::helper('sales')->__('Size') ?></th>
+                <th><?= Mage::helper('sales')->__('Girth') ?></th>
+                <th></th>
+            <?php endif ?>
+            <?php if ($this->displayCustomsValue() && count($contentTypes) === 0): ?>
+                <th><?= Mage::helper('sales')->__('Customs Value') ?></th>
+            <?php endif ?>
+                <th><?= Mage::helper('sales')->__('Total Weight') ?></th>
+                <th><?= Mage::helper('sales')->__('Length') ?></th>
+                <th><?= Mage::helper('sales')->__('Width') ?></th>
+                <th><?= Mage::helper('sales')->__('Height') ?></th>
+                <th></th>
+            <?php if ($this->getDeliveryConfirmationTypes()): ?>
+                <th><?= Mage::helper('sales')->__('Signature Confirmation') ?></th>
+            <?php endif ?>
+            </thead>
+            <tbody>
+            <?php if (!empty($containers)): ?>
+                <td>
+                    <select name="package_container">
+                    <?php foreach ($this->getContainers() as $key => $value): ?>
+                        <option value="<?= $key ?>" ><?= $value ?></option>
+                    <?php endforeach ?>
+                    </select>
+                </td>
+            <?php endif ?>
+            <?php if ($girthEnabled): ?>
+                <td>
+                    <select name="package_size">
+                    <?php foreach ($sizeSource as $key => $value): ?>
+                        <option value="<?= $sizeSource[$key]['value'] ?>"><?= $sizeSource[$key]['label'] ?></option>
+                    <?php endforeach ?>
+                    </select>
+                </td>
+                <td>
+                    <input class="input-text validate-greater-than-zero" name="container_girth" />
+                </td>
+                <td>
+                    <select name="container_girth_dimension_units" class="options-units-dimensions measures">
+                        <option value="<?= Zend_Measure_Length::INCH ?>" selected><?= Mage::helper('sales')->__('in') ?></option>
+                        <option value="<?= Zend_Measure_Length::CENTIMETER ?>" ><?= Mage::helper('sales')->__('cm') ?></option>
+                    </select>
+                </td>
+            <?php endif ?>
+            <?php if ($this->displayCustomsValue() && count($contentTypes) === 0): ?>
+                <td>
+                    <input class="customs-value input-text validate-zero-or-greater" name="package_customs_value" />
+                    <span class="customs-value-currency">[<?= $this->getCustomValueCurrencyCode() ?>]</span>
+                </td>
+            <?php endif ?>
+                <td>
+                    <input class="options-weight input-text required-entry validate-greater-than-zero" name="container_weight" />
+                    <select name="container_weight_units" class="options-units-weight measures">
+                        <option value="<?= Zend_Measure_Weight::POUND ?>" selected><?= Mage::helper('sales')->__('lb') ?></option>
+                        <option value="<?= Zend_Measure_Weight::KILOGRAM ?>" ><?= Mage::helper('sales')->__('kg') ?></option>
+                    </select>
+                </td>
+                <td>
+                    <input class="options-dimension input-text validate-greater-than-zero" name="container_length" />
+                </td>
+                <td>
+                    <input class="options-dimension input-text validate-greater-than-zero" name="container_width" />
+                </td>
+                <td>
+                    <input class="options-dimension input-text validate-greater-than-zero" name="container_height" />
+                </td>
+                <td>
+                    <select name="container_dimension_units" class="options-units-dimensions measures">
+                        <option value="<?= Zend_Measure_Length::INCH ?>" selected><?= Mage::helper('sales')->__('in') ?></option>
+                        <option value="<?= Zend_Measure_Length::CENTIMETER ?>" ><?= Mage::helper('sales')->__('cm') ?></option>
+                    </select>
+                </td>
+                <?php if ($this->getDeliveryConfirmationTypes()): ?>
+                <td>
+                    <select name="delivery_confirmation_types">
+                    <?php foreach ($this->getDeliveryConfirmationTypes() as $key => $value): ?>
+                        <option value="<?= $key ?>" ><?= $value ?></option>
+                    <?php endforeach ?>
+                    </select>
+                </td>
+                <?php endif ?>
+            </tbody>
+        </table>
+
+        <?php if (count($contentTypes) > 0): ?>
+        <table class="package-options package-options-contents" cellspacing="0">
+            <colgroup>
+            <?php if ($this->displayCustomsValue()): ?>
+                <col width="150">
+            <?php endif ?>
+                <col width="150">
+                <col width="*">
+            </colgroup>
+            <thead>
+            <?php if ($this->displayCustomsValue()): ?>
+                <th><?= Mage::helper('sales')->__('Customs Value') ?></th>
+            <?php endif ?>
+                <th><?= Mage::helper('sales')->__('Contents') ?></th>
+                <th><?= Mage::helper('sales')->__('Explanation') ?></th>
+            </thead>
+            <tbody>
+            <?php if ($this->displayCustomsValue()): ?>
+                <td>
+                    <input class="customs-value input-text validate-zero-or-greater" name="package_customs_value" />
+                    <span class="customs-value-currency">[<?= $this->getCustomValueCurrencyCode() ?>]</span>
+                </td>
+            <?php endif ?>
+                <td>
+                    <select name="content_type">
+                    <?php foreach ($contentTypes as $key => $value): ?>
+                        <option value="<?= $key ?>" ><?= $value ?></option>
+                    <?php endforeach ?>
+                    </select>
+                </td>
+                <td>
+                    <input name="content_type_other" class="input-text options-content-type disabled" disabled />
+                </td>
+            </tbody>
+        </table>
+        <?php endif ?>
+
+        <div class="package-add-products">
+            <div class="package_prepare no-display">
+                <div class="entry-edit-head">
+                    <h4><?= Mage::helper('sales')->__('Please Select Products to Add') ?></h4>
+                    <button type="button" class="scalable AddSelectedBtn">
+                        <span><?= Mage::helper('sales')->__('Add Selected Product(s) to Package') ?></span>
+                    </button>
+                </div>
+                <div class="grid_prepare"></div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/form.phtml
@@ -67,22 +67,15 @@
             <div><?= $this->getChildHtml('shipment_tracking') ?></div>
         </fieldset>
     <?= $this->getChildHtml('shipment_packaging') ?>
-    <script type="text/javascript">
-    //<![CDATA[
-        document.observe("dom:loaded", function() {
-            setTimeout(function(){
-                packaging.setConfirmPackagingCallback(function(){
-                    packaging.sendCreateLabelRequest();
-                });
-                packaging.setLabelCreatedCallback(function(response){
-                    setLocation("<?php echo $this->getUrl(
-                        '*/sales_order_shipment/view',
-                        ['shipment_id' => $this->getShipment()->getId()]
-                    ); ?>");
-                });
-            }, 500);
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            packaging.setConfirmPackagingCallback(() => {
+                return packaging.sendCreateLabelRequest();
+            });
+            packaging.setLabelCreatedCallback((response) => {
+                setLocation("<?= $this->getUrl('*/sales_order_shipment/view', ['shipment_id' => $this->getShipment()->getId()]) ?>");
+            });
         });
-    //]]>
     </script>
     </div>
 </div>

--- a/app/locale/en_US/Mage_Core.csv
+++ b/app/locale/en_US/Mage_Core.csv
@@ -169,6 +169,7 @@
 "Incorrect credit card expiration date.","Incorrect credit card expiration date."
 "Input type ""%value%"" not found in the input types list.","Input type ""%value%"" not found in the input types list."
 "Invalid MIME type.","Invalid MIME type."
+"Invalid URL","Invalid URL"
 "Invalid URL '%value%'.","Invalid URL '%value%'."
 "Invalid URL scheme.","Invalid URL scheme."
 "Invalid base url type","Invalid base url type"

--- a/public/js/mage/adminhtml/tools.js
+++ b/public/js/mage/adminhtml/tools.js
@@ -22,10 +22,15 @@ function deleteConfirm(message, url) {
     confirmSetLocation(message, url);
 }
 
-function setElementDisable(element, disable){
-    if($(element)){
-        $(element).disabled = disable;
+function setElementDisable(element, disable) {
+    if (typeof element === 'string' || element instanceof String) {
+        element = document.getElementById(element);
     }
+    if (!element instanceof Element) {
+        throw new TypeError('Argument must be type of String or Element');
+    }
+    element.disabled = disable;
+    element.classList.toggle('disabled', disable);
 }
 
 function toggleParentVis(element, force = null) {

--- a/public/skin/adminhtml/default/default/boxes.css
+++ b/public/skin/adminhtml/default/default/boxes.css
@@ -914,19 +914,15 @@ ul.item-options li { padding-left:.7em; }
 /* Packaging for Shipping Popup */
 #popup-window-mask,
 .popup-window-mask { background:url(images/bg_window_mask.png) repeat 0 0; background:rgba(239, 239, 239, 0.5); position:absolute; top:0; right:0; bottom:0; left:0; width:100%; height:100%; z-index:399; }
-.packaging-window,
-.packed-window { background:#fafafa; border:1px solid #d6d6d6; left:50%; margin:-200px 0 0 -471px; position:fixed; top:50%; width:1100px; z-index:400; -webkit-box-shadow: 0px 3px 5px #ccc; -moz-box-shadow:0px 3px 5px #ccc; box-shadow:0px 3px 5px #ccc; z-index:400; }
 .packaging-window .entry-edit-head { padding:3px 5px; }
 .packaging-window .entry-edit-head button { float:right; }
 .packaging-window .messages { border:1px solid #f16048; color:#df280a; background:#faebe7 url(images/error_msg_icon.gif) no-repeat 10px 10px; font-weight:bold; margin-bottom:10px; padding:10px 10px 10px 35px; }
 .packaging-window .validation-failed { background:#fef0eD; border:1px dashed #D6340E; }
-.packaging-window .packaging-content { overflow:auto; height:400px; height:auto !important; max-height:400px; margin:0 0 10px; padding:10px 10px 0; }
-.packaging-window .package-block { background:#f6f6f6; border:2px solid #d4d4d4; margin:0 0 10px; padding:10px; }
 .packaging-window .package-options { width:100%; border-top:1px solid #ccc; padding:10px 0 0; margin:3px 0 0; }
 .packaging-window .package-options td { vertical-align:middle; }
 .packaging-window .package-options select { width:130px; }
 .packaging-window .package-options .input-text { width:50px; }
-.packaging-window .package_prapare { margin-bottom:15px; }
+.packaging-window .package_prepare { margin-bottom:15px; }
 .packaging-window .package-options .customs-value { width:80px; }
 .packaging-window .package-options .options-weight { width:75px; }
 .packaging-window .package-options .options-units-weight { width:45px; }
@@ -940,9 +936,10 @@ ul.item-options li { padding-left:.7em; }
 .packaging-window .package-add-products .grid button { vertical-align:middle; }
 .packaging-window .package-number {font-weight: bold;}
 .packaging-window .package-number span {margin-left: 5px;}
+.packaging-window .package_items { th,td { &:has(input[type=checkbox]) { display: none; } } }
+.packaging-window .package_items td:last-child { button.delete { display: unset !important; } }
 
 .packed-window .entry-edit-head { padding:3px 5px; }
-.packed-window .packed-content { padding:10px 10px 0; overflow:auto; max-height:400px; }
 .packed-window .package { background:#fefefe; border:7px solid #d5d5d5; margin-bottom:10px; padding:10px; }
 .packed-window .package h4 { background:#fefefe; border:solid #ccc; border-width:0 0 1px 1px; float:right; color:#222; font-size:12px; margin:-10px -10px 0 0; padding:5px 10px; position:relative; z-index:100; }
 .packed-window .package strong{ display:block; padding:0 0 3px; }


### PR DESCRIPTION
## Description
This was such a pain to rewrite for a feature that I never even knew existed. But, it used the old style pop-up JS/CSS and was a blocker for the adminhtml theme rewrite so here we are. 😃 

Actually, this is really neat feature which I unknowingly recreated (a simplified version) for my own store. It lets you create one or more packages per shipment, organize products into different boxes, define customs values, then sends the data to your shipping carrier to create a shipping label. You can see this implemented in Mage_Usa if you `git grep doShipmentRequest`.

As always, I've cleaned up templates, removed PrototypeJS, and generally improved functionality. I had always seen that `packaging.js` file and wondered what it contained. Now I know the answer was very outdated code.

I haven't tested the actual label creation yet as I haven't entered any credentials for USPS, UPS, FedEx, or DHL. However I have compared the POST results to the server and it matches what is sent by OM, so I presume it should work.

To make testing easier, here's a [debug.patch](https://github.com/user-attachments/files/19113342/debug.patch) that will just enable things like `canCreateShippingLabel`, `displayCustomsValue`, etc.

Here are screenshots and POST outputs for comparison. Note that I submitted a shipment for different order in OM / Maho, so the item ids, quantities, etc may be different, but the package params and items objects should match structure.

<details><summary>OM Screenshot</summary>
<img src="https://github.com/user-attachments/assets/a5e2e448-be40-40fc-98cc-d1145fbd81cd" />
</details>

<details><summary>OM Post</summary>
<pre><code>
shipment[items][575]: 1
shipment[items][576]: 3
shipment[items][577]: 1
shipment[items][578]: 1
shipment[items][579]: 1
shipment[comment_text]: 
shipment[create_shipping_label]: 1
packages[1][params][container]: 00
packages[1][params][weight]: 2
packages[1][params][customs_value]: 390
packages[1][params][length]: 1
packages[1][params][width]: 2
packages[1][params][height]: 3
packages[1][params][weight_units]: POUND
packages[1][params][dimension_units]: INCH
packages[1][params][content_type]: 
packages[1][params][content_type_other]: 
packages[1][params][delivery_confirmation]: 0
packages[1][items][575][qty]: 1
packages[1][items][575][customs_value]: 340
packages[1][items][575][price]: 340.0000
packages[1][items][575][name]: Isla Crossbody Handbag
packages[1][items][575][weight]: 1.0000
packages[1][items][575][product_id]: 370
packages[1][items][575][order_item_id]: 575
packages[1][items][577][qty]: 1
packages[1][items][577][customs_value]: 50
packages[1][items][577][price]: 50.0000
packages[1][items][577][name]: Virtual and Physical Gift Card
packages[1][items][577][weight]: 1.0000
packages[1][items][577][product_id]: 454
packages[1][items][577][order_item_id]: 577
packages[2][params][container]: 04
packages[2][params][weight]: 2
packages[2][params][customs_value]: 50
packages[2][params][length]: 
packages[2][params][width]: 
packages[2][params][height]: 
packages[2][params][weight_units]: POUND
packages[2][params][dimension_units]: INCH
packages[2][params][content_type]: 
packages[2][params][content_type_other]: 
packages[2][params][delivery_confirmation]: 0
packages[2][items][576][qty]: 2
packages[2][items][576][customs_value]: 25
packages[2][items][576][price]: 25.0000
packages[2][items][576][name]: Bath Minerals and Salt
packages[2][items][576][weight]: 1.0000
packages[2][items][576][product_id]: 379
packages[2][items][576][order_item_id]: 576
packages[3][params][container]: 02
packages[3][params][weight]: 2.25
packages[3][params][customs_value]: 115
packages[3][params][length]: 4
packages[3][params][width]: 5
packages[3][params][height]: 6
packages[3][params][weight_units]: POUND
packages[3][params][dimension_units]: INCH
packages[3][params][content_type]: 
packages[3][params][content_type_other]: 
packages[3][params][delivery_confirmation]: 0
packages[3][items][576][qty]: 1
packages[3][items][576][customs_value]: 25
packages[3][items][576][price]: 25.0000
packages[3][items][576][name]: Bath Minerals and Salt
packages[3][items][576][weight]: 1.0000
packages[3][items][576][product_id]: 379
packages[3][items][576][order_item_id]: 576
packages[3][items][578][qty]: 1
packages[3][items][578][customs_value]: 55
packages[3][items][578][price]: 55.0000
packages[3][items][578][name]: Blue Horizons Bracelets
packages[3][items][578][weight]: 0.2500
packages[3][items][578][product_id]: 549
packages[3][items][578][order_item_id]: 578
packages[3][items][579][qty]: 1
packages[3][items][579][customs_value]: 35
packages[3][items][579][price]: 35.0000
packages[3][items][579][name]: Madison Earbuds
packages[3][items][579][weight]: 1.0000
packages[3][items][579][product_id]: 397
packages[3][items][579][order_item_id]: 579
</code></pre>
</details> 

<details><summary>Maho Screenshot</summary>
<img src="https://github.com/user-attachments/assets/525c04fd-e7fd-453a-9b6a-227be0c91dcb" />
</details>

<details><summary>Maho Post</summary>
<pre><code>
shipment[items][141]: 4
shipment[items][142]: 1
shipment[comment_text]: 
shipment[create_shipping_label]: 1
packages[1][params][weight_units]: POUND
packages[1][params][dimension_units]: INCH
packages[1][params][weight]: 2
packages[1][params][length]: 1
packages[1][params][width]: 2
packages[1][params][height]: 3
packages[1][params][container]: 00
packages[1][params][customs_value]: 210
packages[1][params][content_type]: 
packages[1][params][content_type_other]: 
packages[1][params][delivery_confirmation]: 0
packages[1][items][141][qty]: 2
packages[1][items][141][customs_value]: 210
packages[1][items][141][price]: 210.0000
packages[1][items][141][name]: Houston Travel Wallet
packages[1][items][141][weight]: 1.0000
packages[1][items][141][product_id]: 374
packages[1][items][141][order_item_id]: 141
packages[2][params][weight_units]: POUND
packages[2][params][dimension_units]: INCH
packages[2][params][weight]: 1
packages[2][params][length]: 
packages[2][params][width]: 
packages[2][params][height]: 
packages[2][params][container]: 04
packages[2][params][customs_value]: 120
packages[2][params][content_type]: 
packages[2][params][content_type_other]: 
packages[2][params][delivery_confirmation]: 0
packages[2][items][142][qty]: 1
packages[2][items][142][customs_value]: 120
packages[2][items][142][price]: 120.0000
packages[2][items][142][name]: NoLIta Cami
packages[2][items][142][weight]: 1.0000
packages[2][items][142][product_id]: 417
packages[2][items][142][order_item_id]: 142
packages[3][params][weight_units]: POUND
packages[3][params][dimension_units]: INCH
packages[3][params][weight]: 2
packages[3][params][length]: 4
packages[3][params][width]: 5
packages[3][params][height]: 6
packages[3][params][container]: 00
packages[3][params][customs_value]: 210
packages[3][params][content_type]: 
packages[3][params][content_type_other]: 
packages[3][params][delivery_confirmation]: 0
packages[3][items][141][qty]: 2
packages[3][items][141][customs_value]: 210
packages[3][items][141][price]: 210.0000
packages[3][items][141][name]: Houston Travel Wallet
packages[3][items][141][weight]: 1.0000
packages[3][items][141][product_id]: 374
packages[3][items][141][order_item_id]: 141
</code></pre>
</details> 

## Testing

1. Ship an order
2. Select the "Create Shipping Label" box
3. Press "Submit Shipment..."
4. Press "Add Products"
5. Select one or more products, you may enter a quantity lower than ordered
6. Press "Add Selected Product(s) to Package"
7. Optionally press "Add Package" and repeat
8. Press "Submit Shipment"

If you get the error message *"Insufficient information to create shipping label(s). Please verify your Store Information and Shipping Settings."*, then go to System Config and make sure you enter Store Name, Store Telephone Number, and Shipping Origin address.

Instead, you should get the error message *"Authentication error"*, which if there were credentials then it should work. I simulated the resulting redirect and it works with the success message *"The shipping label has been created."*.

You can also view an existing shipment (Sales > Shipments) and pack the items and create the shipping label from there. On that screen there is a "Show Packages" button, which I was unable to test because all our test shipments have that column empty ( `select * from sales_flat_shipment where packages is not null;`) However, I didn't modified the existing template in anyway that would break this.

## Notes
It's not very obvious that you click "Create Shipment..." to package the items. The only indication is the addition of the ellipsis:
![image](https://github.com/user-attachments/assets/9ccfc1bb-7995-4df0-91fe-84449f01bfdd)

I actually think this would work better as inline blocks in the create shipment grid, but that's all for another day...

Also, no rush on reviewing this at all, I know you're busy.