### PR TITLE
Added "redirect to product page if search generates one result" feature

### DIFF
--- a/app/code/core/Mage/CatalogSearch/controllers/ResultController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/ResultController.php
@@ -6,6 +6,7 @@
  * @package    Mage_CatalogSearch
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -65,6 +66,19 @@ class Mage_CatalogSearch_ResultController extends Mage_Core_Controller_Front_Act
 
             if (!Mage::helper('catalogsearch')->isMinQueryLength()) {
                 $query->save();
+            }
+
+            // Redirect to product if there's only one result
+            if (Mage::getStoreConfigFlag('catalog/search/redirect_to_product_if_one_result')) {
+                $searchResultBlock = Mage::app()->getLayout()->getBlock('search_result_list');
+                if ($searchResultBlock) {
+                    /** @var Mage_CatalogSearch_Model_Resource_Fulltext_Collection $productCollection */
+                    $productCollection = $searchResultBlock->getLoadedProductCollection();
+                    if ($productCollection && $productCollection->getSize() === 1) {
+                        $product = $productCollection->getFirstItem();
+                        $this->_redirectUrl($product->getProductUrl());
+                    }
+                }
             }
         } else {
             $this->_redirectReferer();

--- a/app/code/core/Mage/CatalogSearch/controllers/ResultController.php
+++ b/app/code/core/Mage/CatalogSearch/controllers/ResultController.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_CatalogSearch
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */

--- a/app/code/core/Mage/CatalogSearch/etc/system.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/system.xml
@@ -106,6 +106,14 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </show_autocomplete_results_count>
+                        <redirect_to_product_if_one_result translate="label">
+                            <label>Redirect to product in case search generates only one result</label>
+                            <frontend_type>boolean</frontend_type>
+                            <sort_order>80</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </redirect_to_product_if_one_result>
                     </fields>
                 </search>
                 <advanced_search translate="label" module="catalogsearch">

--- a/app/code/core/Mage/CatalogSearch/etc/system.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/system.xml
@@ -107,7 +107,7 @@
                             <show_in_store>1</show_in_store>
                         </show_autocomplete_results_count>
                         <redirect_to_product_if_one_result translate="label">
-                            <label>Redirect to product in case search generates only one result</label>
+                            <label>Redirect to product page if search generates one result</label>
                             <frontend_type>boolean</frontend_type>
                             <sort_order>80</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/locale/en_US/Mage_CatalogSearch.csv
+++ b/app/locale/en_US/Mage_CatalogSearch.csv
@@ -31,6 +31,7 @@
 "Popular Search Terms","Popular Search Terms"
 "Quick Search Form","Quick Search Form"
 "Rebuild Catalog product fulltext search index","Rebuild Catalog product fulltext search index"
+"Redirect to product page if search generates one result","Redirect to product page if search generates one result"
 "Relevance","Relevance"
 "Results","Results"
 "Search","Search"


### PR DESCRIPTION
this feature was in present in many seo modules out there. [good idea they had to implement in in openmage](https://github.com/OpenMage/magento-lts/pull/4697), although I've rewritten it completely because I think it should have been done in a different way, so here it is.