### PR TITLE
Unified image processing quality setting

### DIFF
--- a/app/code/core/Mage/Core/Model/File/Validator/Image.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/Image.php
@@ -6,7 +6,7 @@
  * @package    Mage_Core
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Core/Model/File/Validator/Image.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/Image.php
@@ -80,19 +80,7 @@ class Mage_Core_Model_File_Validator_Image
                 return null;
             }
             if ($this->isImageType($fileType)) {
-                // Config 'general/reprocess_images/active' is deprecated, replacement is the following:
-                $imageQuality = Mage::getStoreConfig('admin/security/reprocess_image_quality');
-                if ($imageQuality != '') {
-                    $imageQuality = (int) $imageQuality;
-                } else {
-                    // Value not set in backend. For BC, if depcrecated config does not exist, default to 85.
-                    $imageQuality = Mage::getStoreConfig('general/reprocess_images/active') === null
-                        ? 85
-                        : (Mage::getStoreConfigFlag('general/reprocess_images/active') ? 85 : 0);
-                }
-                if ($imageQuality === 0) {
-                    return null;
-                }
+                $imageQuality = Mage::getStoreConfigAsInt('system/media_storage_configuration/image_quality');
                 //replace tmp image with re-sampled copy to exclude images with malicious data
                 $image = imagecreatefromstring(file_get_contents($filePath));
                 if ($image !== false) {

--- a/app/code/core/Mage/Core/etc/config.xml
+++ b/app/code/core/Mage/Core/etc/config.xml
@@ -325,6 +325,7 @@
             </smtp>
             <media_storage_configuration>
                 <image_file_type>18</image_file_type>
+                <image_quality>85</image_quality>
                 <media_storage>0</media_storage>
                 <media_database>default_setup</media_database>
                 <configuration_update_time>3600</configuration_update_time>

--- a/app/code/core/Mage/Core/etc/system.xml
+++ b/app/code/core/Mage/Core/etc/system.xml
@@ -939,6 +939,15 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </image_file_type>
+                        <image_quality translate="label comment">
+                            <label>Image quality</label>
+                            <comment>Number from 0 to 100 (default is 85, recommended by Google). Higher values preserve more details but increase file size. For WebP format, you can also use 101 to enable lossless compression.</comment>
+                            <sort_order>60</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <validate>validate-digits validate-zero-or-greater</validate>
+                        </image_quality>
                         <media_storage translate="label">
                             <label>Media Storage</label>
                             <frontend_type>select</frontend_type>
@@ -1202,15 +1211,6 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </crate_admin_user_notification>
-                        <reprocess_image_quality translate="label comment">
-                            <label>Image Reprocess Quality</label>
-                            <comment>The recommended value is 85, a higher value will increase the file size. You can set the value to 0 to disable image processing, but it may cause security risks.</comment>
-                            <validate>validate-digits validate-digits-range digits-range-0-100</validate>
-                            <sort_order>180</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </reprocess_image_quality>
                     </fields>
                 </security>
                 <dashboard translate="label">

--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -182,9 +182,8 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
         $functionParameters[] = $this->_imageHandler;
         $functionParameters[] = $fileName;
 
-        $quality = $this->quality() ?? Mage::getStoreConfigAsInt('system/media_storage_configuration/image_quality');
-        if (!is_null($this->quality()) && ($this->_fileType == IMAGETYPE_JPEG || $this->_fileType == IMAGETYPE_WEBP)) {
-            $functionParameters[] = $this->quality();
+        if ($this->_fileType == IMAGETYPE_JPEG || $this->_fileType == IMAGETYPE_WEBP) {
+            $functionParameters[] = $this->quality() ?? Mage::getStoreConfigAsInt('system/media_storage_configuration/image_quality');
         }
 
         // make jpegs progressive

--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -6,7 +6,7 @@
  * @package    Varien_Image
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2017-2025 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -182,7 +182,7 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
         $functionParameters[] = $this->_imageHandler;
         $functionParameters[] = $fileName;
 
-        // set quality param for JPG file type
+        $quality = $this->quality() ?? Mage::getStoreConfigAsInt('system/media_storage_configuration/image_quality');
         if (!is_null($this->quality()) && ($this->_fileType == IMAGETYPE_JPEG || $this->_fileType == IMAGETYPE_WEBP)) {
             $functionParameters[] = $this->quality();
         }


### PR DESCRIPTION
This PR:
- forces the reprocessing of every image uploaded, which is a security feature (which was enabled by default long time ago)
- sets a unified "quality" for every processing of images (thumbnails or uploads-reprocessing)
- closes https://github.com/MahoCommerce/maho/pull/127

@justinbeaty @empiricompany 