### PR TITLE
Added possibility to set `local.xml` content via environment variable `MAHO_LOCAL_XML`

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -754,7 +754,7 @@ final class Mage
                 }
             }
 
-            if ($localConfig = simplexml_load_file($localConfigFile)) {
+            if ($localConfig = @simplexml_load_file($localConfigFile)) {
                 date_default_timezone_set('UTC');
                 if (($date = $localConfig->global->install->date) && strtotime((string) $date)) {
                     self::$_isInstalled = true;

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -746,8 +746,15 @@ final class Mage
 
             self::$_isInstalled = false;
 
-            if (is_readable($localConfigFile)) {
-                $localConfig = simplexml_load_file($localConfigFile);
+            $localXmlContent = $_ENV['MAHO_LOCAL_XML'] ?? $_SERVER['MAHO_LOCAL_XML'] ?? null;
+            if (!empty($localXmlContent) && !file_exists($localConfigFile)) {
+                $result = file_put_contents($localConfigFile, $localXmlContent, LOCK_EX);
+                if ($result === false) {
+                    throw new Exception("Failed to write $localConfigFile.");
+                }
+            }
+
+            if ($localConfig = simplexml_load_file($localConfigFile)) {
                 date_default_timezone_set('UTC');
                 if (($date = $localConfig->global->install->date) && strtotime((string) $date)) {
                     self::$_isInstalled = true;

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -752,6 +752,8 @@ final class Mage
                 if ($result === false) {
                     throw new Exception("Failed to write $localConfigFile.");
                 }
+
+                chmod($localConfigFile, 0640);
             }
 
             if ($localConfig = @simplexml_load_file($localConfigFile)) {


### PR DESCRIPTION
This PR is needed for scalable infrastructures where local.xml is not in the container at time of deployment, we need a way to set the contents of local.xml via ENV variable (which is usually managed by dockerized infrastructure providers).

Since this PR adds a file system hit with the file_exists, I've removed the is_readable later, which IMHO is not necessary, so the hits on the file system stay the same.

**Note:**
I chose not to have the possibility to set the `path`of the file, because I didn't want to generate an inclusion of unwanted files like /etc/passwd or something like that