### PR TITLE
Solved CodeQL issue 68

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
@@ -144,11 +144,13 @@ class Mage_Adminhtml_Catalog_CategoryController extends Mage_Adminhtml_Controlle
         if ($this->getRequest()->isAjax()) {
             $this->_renderTitles();
 
+            $messagesCollection = $this->getLayout()->getMessagesBlock()->getMessageCollection();
             $eventResponse = new Varien_Object([
                 'title' => implode(' / ', array_reverse($this->_titles)),
                 'content' => $this->getLayout()->getBlock('category.edit')->getFormHtml(),
-                'messages' => $this->getLayout()->getMessagesBlock()->getGroupedHtml(),
+                'messages' => $messagesCollection->getItems(),
             ]);
+            $messagesCollection->clear();
 
             Mage::dispatchEvent('category_prepare_ajax_response', [
                 'response' => $eventResponse,

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
@@ -10,6 +10,11 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+/**
+ * Catalog category controller
+ *
+ * @package    Mage_Adminhtml
+ */
 class Mage_Adminhtml_Catalog_CategoryController extends Mage_Adminhtml_Controller_Action
 {
     /**
@@ -139,13 +144,11 @@ class Mage_Adminhtml_Catalog_CategoryController extends Mage_Adminhtml_Controlle
         if ($this->getRequest()->isAjax()) {
             $this->_renderTitles();
 
-            $messagesCollection = $this->getLayout()->getMessagesBlock()->getMessageCollection();
             $eventResponse = new Varien_Object([
                 'title' => implode(' / ', array_reverse($this->_titles)),
                 'content' => $this->getLayout()->getBlock('category.edit')->getFormHtml(),
-                'messages' => $messagesCollection->getItems(),
+                'messages' => $this->getLayout()->getMessagesBlock()->getGroupedHtml(),
             ]);
-            $messagesCollection->clear();
 
             Mage::dispatchEvent('category_prepare_ajax_response', [
                 'response' => $eventResponse,

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/CategoryController.php
@@ -10,11 +10,6 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-/**
- * Catalog category controller
- *
- * @package    Mage_Adminhtml
- */
 class Mage_Adminhtml_Catalog_CategoryController extends Mage_Adminhtml_Controller_Action
 {
     /**

--- a/public/js/mage/adminhtml/form.js
+++ b/public/js/mage/adminhtml/form.js
@@ -72,9 +72,7 @@ varienForm.prototype = {
         }
         var response = transport.responseText.evalJSON();
         if(response.error){
-            if($('messages')){
-                $('messages').innerHTML = response.message;
-            }
+            setMessagesDivHtml(response.message);
         }
         else{
             this._submit();

--- a/public/js/mage/adminhtml/tools.js
+++ b/public/js/mage/adminhtml/tools.js
@@ -777,6 +777,8 @@ function clearMessagesDiv(div = null) {
  * @param {string} type - one of `success|error|notice`
  */
 function setMessagesDiv(message, type = 'success', div = null) {
+    message = escapeHtml(message);
+    type = escapeHtml(type, true);
     setMessagesDivHtml(`<ul class="messages"><li class="${type}-msg"><ul><li><span>${message}</span></li></ul></li></ul>`, div);
 }
 
@@ -787,7 +789,7 @@ function setMessagesDiv(message, type = 'success', div = null) {
 */
 function setMessagesDivHtml(html, div = null) {
     if (div ??= document.getElementById('messages')) {
-        div.innerHTML = html;
+        div.innerHTML = xssFilter(html);
     }
 }
 

--- a/public/js/mage/adminhtml/tools.js
+++ b/public/js/mage/adminhtml/tools.js
@@ -767,9 +767,7 @@ function copyText(event) {
  * Clear <div id="messages"></div>
  */
 function clearMessagesDiv(div = null) {
-    if (div ??= document.getElementById('messages')) {
-        div.textContent = '';
-    }
+    setMessagesDivHtml('', div);
 }
 
 /**
@@ -779,9 +777,17 @@ function clearMessagesDiv(div = null) {
  * @param {string} type - one of `success|error|notice`
  */
 function setMessagesDiv(message, type = 'success', div = null) {
+    setMessagesDivHtml(`<ul class="messages"><li class="${type}-msg"><ul><li><span>${message}</span></li></ul></li></ul>`, div);
+}
+
+/**
+ * Raw function to update <div id="messages"></div>
+ *
+ * @param {string} html
+*/
+function setMessagesDivHtml(html, div = null) {
     if (div ??= document.getElementById('messages')) {
-        message = escapeHtml(message);
-        div.innerHTML = `<ul class="messages"><li class="${type}-msg"><ul><li><span>${message}</span></li></ul></li></ul>`;
+        div.innerHTML = html;
     }
 }
 

--- a/public/js/mage/adminhtml/tools.js
+++ b/public/js/mage/adminhtml/tools.js
@@ -767,7 +767,9 @@ function copyText(event) {
  * Clear <div id="messages"></div>
  */
 function clearMessagesDiv(div = null) {
-    setMessagesDivHtml('', div);
+    if (div ??= document.getElementById('messages')) {
+        div.textContent = '';
+    }
 }
 
 /**
@@ -777,17 +779,8 @@ function clearMessagesDiv(div = null) {
  * @param {string} type - one of `success|error|notice`
  */
 function setMessagesDiv(message, type = 'success', div = null) {
-    setMessagesDivHtml(`<ul class="messages"><li class="${type}-msg"><ul><li><span>${message}</span></li></ul></li></ul>`, div);
-}
-
-/**
- * Raw function to update <div id="messages"></div>
- *
- * @param {string} html
-*/
-function setMessagesDivHtml(html, div = null) {
     if (div ??= document.getElementById('messages')) {
-        div.innerHTML = html;
+        div.innerHTML = `<ul class="messages"><li class="${type}-msg"><ul><li><span>${message}</span></li></ul></li></ul>`;
     }
 }
 

--- a/public/js/mage/adminhtml/tools.js
+++ b/public/js/mage/adminhtml/tools.js
@@ -780,6 +780,7 @@ function clearMessagesDiv(div = null) {
  */
 function setMessagesDiv(message, type = 'success', div = null) {
     if (div ??= document.getElementById('messages')) {
+        message = escapeHtml(message);
         div.innerHTML = `<ul class="messages"><li class="${type}-msg"><ul><li><span>${message}</span></li></ul></li></ul>`;
     }
 }


### PR DESCRIPTION
CodeQL started complaining about this:
https://github.com/MahoCommerce/maho/security/code-scanning/68

There's one usage that we should fix:
<img width="744" alt="Screenshot 2025-05-08 alle 22 22 01" src="https://github.com/user-attachments/assets/6ca04e83-057e-458a-b67f-5829dc0805f9" />

Those are coming from this:
<img width="1016" alt="Screenshot 2025-05-08 alle 22 25 52" src="https://github.com/user-attachments/assets/01f3e068-12a3-4829-a508-5ef06d7fa257" />

I'll leave this PR in draft since at the moment I can't finish it