### PR TITLE
Fixed field dependence and coupon code toggle on Sales Rule edit page

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main.php
@@ -6,7 +6,7 @@
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2025 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Quote/Edit/Tab/Main.php
@@ -169,7 +169,6 @@ class Mage_Adminhtml_Block_Promo_Quote_Edit_Tab_Main extends Mage_Adminhtml_Bloc
             'name'  => 'use_auto_generation',
             'label' => Mage::helper('salesrule')->__('Use Auto Generation'),
             'note'  => Mage::helper('salesrule')->__('If you select and save the rule you will be able to generate multiple coupon codes.'),
-            'onclick' => 'handleCouponsTabContentActivity()',
             'checked' => (int) $model->getUseAutoGeneration() > 0 ? 'checked' : '',
         ]);
 

--- a/app/code/core/Mage/Adminhtml/controllers/Promo/QuoteController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Promo/QuoteController.php
@@ -6,7 +6,7 @@
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Adminhtml/controllers/Promo/QuoteController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Promo/QuoteController.php
@@ -161,6 +161,7 @@ class Mage_Adminhtml_Promo_QuoteController extends Mage_Adminhtml_Controller_Act
                 if (isset($data['rule']['actions'])) {
                     $data['actions'] = $data['rule']['actions'];
                 }
+                unset($data['times_used']);
                 unset($data['rule']);
                 $model->loadPost($data);
 
@@ -417,7 +418,7 @@ class Mage_Adminhtml_Promo_QuoteController extends Mage_Adminhtml_Controller_Act
                 Mage::logException($e);
             }
         }
-        $this->getResponse()->setBody(Mage::helper('core')->jsonEncode($result));
+        $this->getResponse()->setBodyJson($result);
     }
 
     /**

--- a/app/code/core/Mage/Core/etc/jstranslator.xml
+++ b/app/code/core/Mage/Core/etc/jstranslator.xml
@@ -15,6 +15,9 @@
         <error-fetch translate="message">
             <message>Server returned status %s</message>
         </error-fetch>
+        <no-error-message translate="message">
+            <message>An error occured.</message>
+        </no-error-message>
     </global>
 
     <script path="validation.js" module="core">

--- a/app/design/adminhtml/default/default/template/promo/salesrulejs.phtml
+++ b/app/design/adminhtml/default/default/template/promo/salesrulejs.phtml
@@ -5,7 +5,7 @@
  * @package     default_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>

--- a/app/design/adminhtml/default/default/template/promo/salesrulejs.phtml
+++ b/app/design/adminhtml/default/default/template/promo/salesrulejs.phtml
@@ -9,100 +9,90 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<script type="text/javascript">
-//<![CDATA[
-var couponTypeSpecific = '<?= Mage_SalesRule_Model_Rule::COUPON_TYPE_SPECIFIC ?>';
-var tmpButtonsActionsStorage = [];
+<script>
+const couponTypeSpecific = '<?= Mage_SalesRule_Model_Rule::COUPON_TYPE_SPECIFIC ?>';
 
 function disableEnableCouponsTabContent(disable) {
-    var containerId = 'promo_catalog_edit_tabs_coupons_section_content';
-    if($(containerId)){
-        var dataFields = $(containerId).select('input', 'select', 'textarea', 'button');
-        for(var i = 0; i < dataFields.length; i++) {
-            disable ? dataFields[i].disable().addClassName('disabled')
-                : dataFields[i].enable().removeClassName('disabled');
-        }
+    const containerEl = document.getElementById('promo_catalog_edit_tabs_coupons_section_content');
+    if (!containerEl) {
+        return;
     }
-    disable ? $('rule_coupon_code').enable() : $('rule_coupon_code').disable();
+    for (const el of containerEl.querySelectorAll('input, select, textarea, button')) {
+        setElementDisable(el, disable);
+    }
 }
 
 function handleCouponsTabContentActivity() {
-    disableEnableCouponsTabContent(!$('rule_use_auto_generation').checked);
-}
-
-function handleCouponTypeChange() {
-    $('rule_coupon_type').observe('change', function() {
-        var disable = $('rule_coupon_type').value != couponTypeSpecific;
-        if (!disable) {
-            disable = !$('rule_use_auto_generation').checked;
+    const couponType = document.getElementById('rule_coupon_type').value;
+    if (couponType == couponTypeSpecific) {
+        if (document.getElementById('rule_use_auto_generation').checked) {
+            disableEnableCouponsTabContent(false);
+            setElementDisable(document.getElementById('rule_coupon_code'), true);
+        } else {
+            disableEnableCouponsTabContent(true);
+            setElementDisable(document.getElementById('rule_coupon_code'), false);
         }
-        disableEnableCouponsTabContent(disable);
-    });
+    } else {
+        disableEnableCouponsTabContent(true);
+    }
 }
 
-function refreshCouponCodesGrid(grid, gridMassAction, transport) {
+function refreshCouponCodesGrid(grid, gridMassAction) {
     grid.reload();
     gridMassAction.unselectAll();
 }
 
-function generateCouponCodes(idPrefix, generateUrl, grid) {
-    $(idPrefix + 'information_fieldset').removeClassName('ignore-validate');
-    var validationResult = $(idPrefix + 'information_fieldset').select('input',
-            'select', 'textarea').collect( function(elm) {
-        return Validation.validate(elm, {
-            useTitle :false,
-            onElementValidate : function() {
-            }
+async function generateCouponCodes(idPrefix, generateUrl, grid) {
+    const fieldsetEl = document.getElementById(idPrefix + 'information_fieldset');
+    const elements = fieldsetEl.querySelectorAll('input, select, textarea');
+    let validationResult = true;
+
+    fieldsetEl.classList.remove('ignore-validate');
+    for (const el of elements) {
+        validationResult &&= Validation.validate(el, {
+            useTitle: false,
+            onElementValidate: function() {},
         });
-    }).all();
-    $(idPrefix + 'information_fieldset').addClassName('ignore-validate');
+    }
+    fieldsetEl.classList.add('ignore-validate');
 
     if (!validationResult) {
         return;
     }
-    var elements = $(idPrefix + 'information_fieldset').select('input', 'select', 'textarea');
 
-    elements = elements.concat(
-        $$('#rule_uses_per_coupon'),
-        $$('#rule_uses_per_customer'),
-        $$('#rule_to_date')
-    );
+    const formData = new FormData();
+    for (const el of elements) {
+        formData.append(el.name, el.value);
+    }
+    for (const extra of ['rule_uses_per_coupon', 'rule_uses_per_customer', 'rule_to_date']) {
+        const el = document.getElementById(extra);
+        formData.append(el.name, el.value);
+    }
 
-    var params = Form.serializeElements(elements, true);
-    params.form_key = FORM_KEY;
-    $('messages').update();
-    var couponCodesGrid = eval(grid);
-    new Ajax.Request(generateUrl, {
-        parameters :params,
-        method :'post',
-        onComplete : function (transport, param){
-            var response = transport.responseJSON || transport.responseText.evalJSON(true) || {};
+    clearMessagesDiv();
 
-            if (couponCodesGrid) {
-                couponCodesGrid.reload();
-            }
-            if (response && response.messages) {
-                $('messages').update(response.messages);
-            }
-            if (response && response.error) {
-                alert(response.error.stripTags().toString());
-            }
+    try {
+        const result = await mahoFetch(generateUrl, {
+            method: 'POST',
+            body: formData,
+        });
+
+        if (window[grid]) {
+            window[grid].reload();
         }
-    });
+        if (result?.messages) {
+            setMessagesDivHtml(result.messages);
+        }
+    } catch (error) {
+        setMessagesDiv(error.message, 'error');
+    }
+
+    handleCouponsTabContentActivity();
 }
 
-Ajax.Responders.register({
-    onComplete: function() {
-        if ($('promo_catalog_edit_tabs_coupons_section_content')
-            && $('promo_catalog_edit_tabs_coupons_section_content').visible()
-            && Ajax.activeRequestCount == 0
-        ) {
-            handleCouponsTabContentActivity();
-        }
-    }
+document.addEventListener('DOMContentLoaded', () => {
+    handleCouponsTabContentActivity();
+    document.getElementById('rule_coupon_type')?.addEventListener('change', handleCouponsTabContentActivity);
+    document.getElementById('rule_use_auto_generation')?.addEventListener('change', handleCouponsTabContentActivity);
 });
-
-document.observe("dom:loaded", handleCouponsTabContentActivity);
-document.observe("dom:loaded", handleCouponTypeChange);
-//]]>
 </script>

--- a/app/locale/en_US/Mage_Core.csv
+++ b/app/locale/en_US/Mage_Core.csv
@@ -29,6 +29,7 @@
 "Allows customers to stay logged in when switching between different stores.","Allows customers to stay logged in when switching between different stores."
 "Alternative text for next link in pagination menu. If empty, default arrow image will used.","Alternative text for next link in pagination menu. If empty, default arrow image will used."
 "Alternative text for previous link in pagination menu. If empty, default arrow image will used.","Alternative text for previous link in pagination menu. If empty, default arrow image will used."
+"An error occured.","An error occured."
 "An error occurred while saving. Please review the error log.","An error occurred while saving. Please review the error log."
 "Anchor Text for Next","Anchor Text for Next"
 "Anchor Text for Previous","Anchor Text for Previous"

--- a/public/js/mage/adminhtml/form.js
+++ b/public/js/mage/adminhtml/form.js
@@ -604,15 +604,18 @@ class FormElementDependenceController {
                 result = this.evalCondition(subcondition.condition, subcondition.operator);
             } else {
                 // Otherwise check if we have this element in the form, or use fallback value
+                let refValues = Array.isArray(subcondition) ? subcondition : [subcondition];
                 let dependentValues = [];
                 const dependentEl = document.getElementById(this.mapFieldId(dependentField));
                 if (dependentEl) {
                     if (dependentEl.tagName === 'SELECT') {
                         dependentValues = this.getSelectValues(dependentEl);
+                        refValues = refValues.map(String);
                     } else if (dependentEl.tagName === 'INPUT' && ['radio', 'checkbox'].includes(dependentEl.type)) {
                         dependentValues.push(dependentEl.checked);
                     } else {
                         dependentValues.push(dependentEl.value);
+                        refValues = refValues.map(String);
                     }
                 } else {
                     const fallbackValues = this.config.field_values?.[this.mapFieldId(dependentField)];
@@ -620,7 +623,6 @@ class FormElementDependenceController {
                         dependentValues = Array.isArray(fallbackValues) ? fallbackValues : [fallbackValues];
                     }
                 }
-                const refValues = Array.isArray(subcondition) ? subcondition : [subcondition];
                 result = dependentValues.some((val) => refValues.includes(val));
             }
             results.push(result)

--- a/public/js/varien/js.js
+++ b/public/js/varien/js.js
@@ -56,7 +56,8 @@ async function mahoFetch(url, options) {
 
         if (typeof result === 'object' && result !== null) {
             if (result.error) {
-                throw new MahoError(result.message ?? result.error);
+                const message = result.message ?? result.error;
+                throw new MahoError(typeof message === 'string' ? message : 'An error occurred.');
             } else if (result.ajaxExpired && result.ajaxRedirect) {
                 setLocation(result.ajaxRedirect);
                 await new Promise((resolve) => {});


### PR DESCRIPTION
#54 caused two problems with editing a Shopping Cart Price Rule.

1\. The salesrule form set a field dependence like the following:

```php
            ->addFieldDependence(
                $couponCodeFiled->getName(),
                $couponTypeFiled->getName(),
                Mage_SalesRule_Model_Rule::COUPON_TYPE_SPECIFIC, // int(2)
            )
```

The "wanted" value in this case in an integer, but HTML select values are strings. I used JS's `Array.includes()` to compare, but this is a strict equality, so the check failed. All other dependence blocks seemed to set only strings, (i.e. `"2"`) for the wanted value, so I didn't catch this.

2\. The second thing is much more stupid. In `template/promo/salesrulejs.phtml`, the Mage devs toggled the "Coupon Code" input field depending on if the "Use Auto Generation" box was checked. They failed to take into account if the coupon type was set to "No Coupon". However, it worked because their code ran before the dependence block check, which then correctly hid the "Coupon Code" field. There was no particular reason on event ran before the other, so this was very brittle code.

---

A few other improvements:

* Rewrote without PrototypeJS, and removed a useless `eval()`.
* Fixed a bug also present in OM where you cannot save a shopping cart rule if "Use Auto Generation" is checked.