### PR TITLE
Fixed page-title styling in cart page

### DIFF
--- a/app/design/frontend/base/default/template/checkout/onepage.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage.phtml
@@ -5,7 +5,7 @@
  * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2023 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
@@ -19,7 +19,6 @@
 <?php if (!$this->getChild($_stepId) || !$this->getChild($_stepId)->isShow()): continue; endif; $i++ ?>
     <li id="opc-<?= $_stepId ?>" class="section<?= !empty($_stepInfo['allow'])?' allow':'' ?><?= !empty($_stepInfo['complete'])?' saved':'' ?>">
         <div class="step-title">
-            <span class="number"><?= $i ?></span>
             <h2><?= $_stepInfo['label'] ?></h2>
             <a href="#"><?= $this->__('Edit') ?></a>
         </div>

--- a/public/skin/frontend/base/default/css/checkout.css
+++ b/public/skin/frontend/base/default/css/checkout.css
@@ -119,34 +119,7 @@ td.product-cart-remove a {
  * Checkout - Cart
  * ============================================ */
 .cart .page-title {
-    margin-bottom: 15px;
-}
-.cart .page-title:after {
-    content: '';
-    display: table;
-    clear: both;
-}
-.cart .page-title h1 {
-    float: left;
-    border-bottom: none;
-    margin-bottom: 6px;
-    margin-right: 10px;
-}
-
-.checkout-types {
-    float: right;
-    text-align: right;
-    max-width: 100%;
-    /* We always want this shipping method to display on its own line */
-}
-.checkout-types li {
-    vertical-align: top;
-    margin: 0 0 5px 5px;
-}
-.checkout-types li:after {
-    content: '';
-    display: table;
-    clear: both;
+    margin-bottom: 10px;
 }
 .checkout-types li img {
     display: inline;

--- a/public/skin/frontend/base/default/css/checkout.css
+++ b/public/skin/frontend/base/default/css/checkout.css
@@ -777,26 +777,6 @@ td.product-cart-remove a {
     text-decoration: none;
 }
 
-.opc .section .step-title .number,
-.opc .section.allow.active .step-title .number,
-.no-touch .opc .section.allow:hover .step-title .number {
-    width: 26px;
-    height: 26px;
-    text-align: center;
-    color: var(--maho-color-background);
-    line-height: 26px;
-    background-color: var(--maho-color-primary);
-    display: block;
-    position: absolute;
-    top: 50%;
-    left: 10px;
-    margin-top: -13px;
-}
-
-.opc .section.allow .step-title .number {
-    background-color: var(--maho-color-primary-hover);
-}
-
 .opc .section.allow .step-title h2 {
     color: var(--maho-color-text-secondary);
 }
@@ -897,10 +877,6 @@ td.product-cart-remove a {
     transition: opacity 300ms linear 0;
 }
 
-.opc.opc-firststep-login .section#opc-login .step-title .number {
-    transition: width 80ms linear 0;
-}
-
 .opc.opc-firststep-login .section#opc-login .step-title h2 {
     transition: margin-left 80ms linear 0;
 }
@@ -911,11 +887,6 @@ td.product-cart-remove a {
 body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section:not(#opc-login) .step-title,
 body:not(.opc-has-progressed-from-login) .opc-block-progress-step-login {
     opacity: 0;
-}
-
-body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-login .step-title .number {
-    width: 0px;
-    overflow: hidden;
 }
 
 body:not(.opc-has-progressed-from-login) .opc.opc-firststep-login .section#opc-login .step-title h2 {


### PR DESCRIPTION
This PR fixes a minor problem introduced with https://github.com/MahoCommerce/maho/pull/188, in the cart page the page-title doesn't look good

<img width="1238" alt="Screenshot 2025-06-07 alle 13 07 18" src="https://github.com/user-attachments/assets/553977eb-55a7-419a-90d8-573d790e74fb" />

This PR also removes (not related but I noticed while I was working on this) the "step number" DOM element from the checkout, because it was already hidden since many releases