### PR TITLE
Added stdin support to `maho translations:missing`

### DIFF
--- a/lib/MahoCLI/Commands/TranslationsMissing.php
+++ b/lib/MahoCLI/Commands/TranslationsMissing.php
@@ -60,12 +60,28 @@ class TranslationsMissing extends BaseMahoCommand
      */
     protected function getFiles(): array
     {
-        $files = array_merge(
-            // Grep for all files that might call the __ function
-            explode("\n", (string) shell_exec("grep -Frl --exclude-dir='.git' --include=*.php --include=*.phtml '__' .")),
-            // Grep for all XML files that might use the translate attribute
-            explode("\n", (string) shell_exec("grep -Frl --exclude-dir='.git' --include=*.xml 'translate=' .")),
-        );
+        $files = [];
+        $fh = fopen('php://stdin', 'r');
+
+        if ($fh === false) {
+            return $files;
+        }
+
+        stream_set_blocking($fh, false);
+
+        while (($line = fgets($fh)) !== false) {
+            $files[] = $line;
+        }
+
+        if (count($files) === 0) {
+            $files = array_merge(
+                // Grep for all files that might call the __ function
+                explode("\n", (string) shell_exec("grep -Frl --exclude-dir='.git' --include=*.php --include=*.phtml '__' .")),
+                // Grep for all XML files that might use the translate attribute
+                explode("\n", (string) shell_exec("grep -Frl --exclude-dir='.git' --include=*.xml 'translate=' .")),
+            );
+        }
+
         return array_filter(array_map('trim', $files));
     }
 


### PR DESCRIPTION
One small feature that is missing in the Maho command from the original translation script is the ability to pipe a list of files to check. This is useful to check for missing translations that were introduced in a specific PR.

Usage:
```sh
git diff --name-only main | ./maho translations:missing
```

This will check only the files modified in your branch, instead of showing everything.