### PR TITLE
`Mage_Core_Helper_Data::decrypt()` can be called with `NULL` now

### DIFF
--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -228,7 +228,7 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Decrypt data using application key
      */
-    public function decrypt(string $data): string
+    public function decrypt(?string $data): string
     {
         if (!Mage::isInstalled()) {
             return $data;


### PR DESCRIPTION
@justinbeaty this should fix https://github.com/MahoCommerce/maho/pull/140#issuecomment-2981952965, I've added the null possibility here because `Mage_Core_Model_Encryption::decrypt()` already supports null