### PR TITLE
Fixed installation dependency on `directory_country_name` table

### DIFF
--- a/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -6,6 +6,7 @@
  * @package    Mage_Directory
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -21,12 +22,10 @@ $installer->getConnection()->insert(
     ],
 );
 
-$countries = [];
-foreach (Mage::helper('directory')->getCountryCollection() as $country) {
-    if ($country->getRegionCollection()->getSize() > 0) {
-        $countries[] = $country->getId();
-    }
-}
+$select = $installer->getConnection()->select()
+    ->distinct()
+    ->from($installer->getTable('directory/country_region'), 'country_id');
+$countries = $installer->getConnection()->fetchCol($select);
 
 $installer->getConnection()->insert(
     $installer->getTable('core/config_data'),

--- a/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -23,8 +23,8 @@ $installer->getConnection()->insert(
 );
 
 $select = $installer->getConnection()->select()
-    ->distinct()
-    ->from($installer->getTable('directory/country_region'), 'country_id');
+    ->from($installer->getTable('directory/country_region'), 'country_id')
+    ->group('country_id');
 $countries = $installer->getConnection()->fetchCol($select);
 
 $installer->getConnection()->insert(

--- a/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -24,7 +24,7 @@ $installer->getConnection()->insert(
 
 $select = $installer->getConnection()->select()
     ->from($installer->getTable('directory/country_region'), 'country_id')
-    ->group('country_id');
+    ->order('country_id');
 $countries = $installer->getConnection()->fetchCol($select);
 
 $installer->getConnection()->insert(


### PR DESCRIPTION
I think https://github.com/MahoCommerce/maho/pull/180 broke Maho's installation, because the collection used in the install script requires a table that gets created later.