### PR TITLE
Fix BCC recipients being exposed in email headers

### DIFF
--- a/app/code/core/Mage/Core/Model/Email/Queue.php
+++ b/app/code/core/Mage/Core/Model/Email/Queue.php
@@ -200,7 +200,7 @@ class Mage_Core_Model_Email_Queue extends Mage_Core_Model_Abstract
                         [$emailAddress, $name, $type] = $recipient;
                         $address = new Address($emailAddress, $name);
 
-                        match ($type) {
+                        match ((int) $type) {
                             self::EMAIL_TYPE_BCC => $email->addBcc($address),
                             self::EMAIL_TYPE_CC => $email->addCc($address),
                             default => $email->addTo($address),


### PR DESCRIPTION

  - Fixed a critical privacy issue where BCC recipients were visible to all recipients in email headers
  - The issue occurred because email type values from the database were strings, but PHP's match statement uses strict comparison
  - Added type casting to ensure BCC recipients are properly handled

  **Problem**

  When selecting "BCC" as the "Send Order Email Copy Method" in admin configuration, the BCC recipients were incorrectly added as regular "To" recipients, making them visible to all other recipients. This
   violated email privacy standards and user expectations.

  **Root Cause**

  The email_type field is stored as a SMALLINT in the database but retrieved as a string. PHP 8's match statement uses strict comparison (===), so:
  - Database value: "2" (string)
  - Constant value: 2 (integer)
  - Result: No match, falling through to default case which adds as "To" recipient

  **Solution**

  Cast the email type to integer before the match statement: match ((int) $type)

  This ensures:
  - BCC recipients (type 2) → $email->addBcc()
  - CC recipients (type 1) → $email->addCc()
  - TO recipients (type 0) → $email->addTo()

