### PR TITLE
Potential fix for code scanning alert no. 71: DOM text reinterpreted as HTML

### DIFF
--- a/public/js/varien/js.js
+++ b/public/js/varien/js.js
@@ -222,7 +222,7 @@ function xssFilter(str) {
             }
         }
     });
-    return doc.body.innerHTML;
+    return doc.body.textContent;
 }
 
 /**


### PR DESCRIPTION
Potential fix for [https://github.com/MahoCommerce/maho/security/code-scanning/71](https://github.com/MahoCommerce/maho/security/code-scanning/71)

To fix the issue, ensure that the `xssFilter` function returns text content instead of HTML to prevent the possibility of XSS. Instead of returning `doc.body.innerHTML`, we should return `doc.body.textContent`, which strips all HTML tags and ensures only plain text is returned. This guarantees that no potentially unsafe HTML is passed downstream, fully mitigating the risk of XSS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
