### PR TITLE
Reserve space for scrollbar only on right

### DIFF
--- a/public/skin/frontend/base/default/css/styles.css
+++ b/public/skin/frontend/base/default/css/styles.css
@@ -70,7 +70,7 @@ html {
   /* Prevent tap highlight on iOS/Android */
   -webkit-text-size-adjust: 100%;
   /* Prevent automatic scaling on iOS */
-  scrollbar-gutter: stable both-edges;
+  scrollbar-gutter: stable;
   /* Reserve space for scrollbar to prevent layout shift */
 }
 


### PR DESCRIPTION
Test on chrome and firefox.
Avoid extra space for scrollbar on left 
<img width="619" height="494" alt="" src="https://github.com/user-attachments/assets/e3dc47f5-6057-41c3-9d2f-565facb81061" />