### PR TITLE
Fixed infinite redirect loop when accessing uninstalled Maho instance

### DIFF
--- a/app/code/core/Mage/Core/Helper/Url.php
+++ b/app/code/core/Mage/Core/Helper/Url.php
@@ -249,6 +249,10 @@ class Mage_Core_Helper_Url extends Mage_Core_Helper_Abstract
      */
     public function addOrRemoveTrailingSlash(string $url): string
     {
+        if (!Mage::isInstalled()) {
+            return $url;
+        }
+
         if (Mage::helper('adminhtml')->isAdminFrontNameMatched($url)) {
             return $url;
         }


### PR DESCRIPTION

  The `addOrRemoveTrailingSlash()` method was attempting to read store configuration before Maho was installed, causing URL manipulation to fail and create recursive redirects.


  Added `!Mage::isInstalled()` check at the beginning of `addOrRemoveTrailingSlash()` to return URLs unchanged during installation process.
