### PR TITLE
Fixed calling getImageInfo on SVGs

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Image.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Image.php
@@ -141,11 +141,17 @@ class Mage_Catalog_Model_Product_Image extends Mage_Core_Model_Abstract
 
     public function getOriginalWidth(): int
     {
+        if (str_ends_with($this->_baseFile, '.svg')) {
+            return (int) Mage::getStoreConfig('catalog/product_image/base_width') ?: 1800;
+        }
         return $this->getImageInfo()[0];
     }
 
     public function getOriginalHeight(): int
     {
+        if (str_ends_with($this->_baseFile, '.svg')) {
+            return (int) Mage::getStoreConfig('catalog/product_image/base_width') ?: 1800;
+        }
         return $this->getImageInfo()[1];
     }
 


### PR DESCRIPTION
this was happening on product pages when the product didn't have an image