### PR TITLE
Fixed MahoDialog backward compatibility

### DIFF
--- a/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
@@ -5,7 +5,7 @@
  * @package     default_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 

--- a/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
@@ -5,7 +5,7 @@
  * @package     default_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
@@ -18,7 +18,6 @@
             productConfigure.addListType('product_to_add', {
                 urlFetch: '<?= $this->getUrl('*/sales_order_create/configureProductToAdd') ?>'
             });
-
             productConfigure.addListType('quote_items', {
                 urlFetch: '<?= $this->getUrl('*/sales_order_create/configureQuoteItems') ?>'
             });

--- a/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
@@ -5,7 +5,7 @@
  * @package     default_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright   Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright   Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
@@ -18,7 +18,7 @@
             productConfigure.addListType('product_to_add', {
                 urlFetch: '<?= $this->getUrl('*/sales_order_create/configureProductToAdd') ?>'
             });
-            
+
             productConfigure.addListType('quote_items', {
                 urlFetch: '<?= $this->getUrl('*/sales_order_create/configureQuoteItems') ?>'
             });

--- a/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
@@ -16,79 +16,8 @@
     Event.observe(window, 'load',  function() {
         if (window.productConfigure) {
             productConfigure.addListType('product_to_add', {
-                urlFetch: '<?= $this->getUrl('*/sales_order_create/configureProductToAdd') ?>',
-                urlSubmit: '<?= $this->getUrl('*/sales_order_create/loadBlock') ?>'
+                urlFetch: '<?= $this->getUrl('*/sales_order_create/configureProductToAdd') ?>'
             });
-            
-            // Override the dialog creation to replace the OK button with our custom handler
-            const originalShowWindow = productConfigure._showWindow;
-            productConfigure._showWindow = function() {
-                const result = originalShowWindow.call(this);
-                
-                // Replace the OK button with our custom handler
-                setTimeout(() => {
-                    if (this.window) {
-                        const okButton = this.window.querySelector('.ok');
-                        if (okButton) {
-                            // Remove any existing click handlers and replace with our own
-                            const newOkButton = okButton.cloneNode(true);
-                            okButton.parentNode.replaceChild(newOkButton, okButton);
-                            
-                            newOkButton.addEventListener('click', async (e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                
-                                console.log('OK button clicked - saving configuration');
-                                
-                                const productId = productConfigure.current.itemId;
-                                if (!productId) {
-                                    console.error('No product ID found for configuration');
-                                    return;
-                                }
-                                
-                                try {
-                                    // Validate the form first
-                                    if (!productConfigure.varienForm.validate()) {
-                                        console.log('Form validation failed');
-                                        return;
-                                    }
-                                    
-                                    // Store the configuration (like the original onConfirmBtn does)
-                                    productConfigure._processFieldsData('item_confirm');
-                                    
-                                    // Call any configured confirm callback
-                                    if (typeof productConfigure.confirmCallback[productConfigure.current.listType] === 'function') {
-                                        productConfigure.confirmCallback[productConfigure.current.listType]();
-                                    }
-                                    
-                                    console.log('Configuration saved successfully');
-                                    
-                                    // Close dialog using multiple methods to ensure it closes
-                                    try {
-                                        if (productConfigure.window && productConfigure.window.close) {
-                                            productConfigure.window.close();
-                                        }
-                                        if (typeof Dialog !== 'undefined' && Dialog.close) {
-                                            Dialog.close();
-                                        }
-                                        if (productConfigure.window && productConfigure.window.remove) {
-                                            productConfigure.window.remove();
-                                        }
-                                        console.log('Dialog closed successfully');
-                                    } catch (closeError) {
-                                        console.error('Error closing dialog:', closeError);
-                                    }
-                                    
-                                } catch (error) {
-                                    console.error('Error during configuration saving:', error);
-                                }
-                            });
-                        }
-                    }
-                }, 100);
-                
-                return result;
-            };
             
             productConfigure.addListType('quote_items', {
                 urlFetch: '<?= $this->getUrl('*/sales_order_create/configureQuoteItems') ?>'

--- a/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
@@ -10,14 +10,86 @@
  */
 
 /** @var Mage_Adminhtml_Block_Template $this */
- ?>
+?>
 <script type="text/javascript">
     order.sidebarHide();
     Event.observe(window, 'load',  function() {
         if (window.productConfigure) {
             productConfigure.addListType('product_to_add', {
-                urlFetch: '<?= $this->getUrl('*/sales_order_create/configureProductToAdd') ?>'
+                urlFetch: '<?= $this->getUrl('*/sales_order_create/configureProductToAdd') ?>',
+                urlSubmit: '<?= $this->getUrl('*/sales_order_create/loadBlock') ?>'
             });
+            
+            // Override the dialog creation to replace the OK button with our custom handler
+            const originalShowWindow = productConfigure._showWindow;
+            productConfigure._showWindow = function() {
+                const result = originalShowWindow.call(this);
+                
+                // Replace the OK button with our custom handler
+                setTimeout(() => {
+                    if (this.window) {
+                        const okButton = this.window.querySelector('.ok');
+                        if (okButton) {
+                            // Remove any existing click handlers and replace with our own
+                            const newOkButton = okButton.cloneNode(true);
+                            okButton.parentNode.replaceChild(newOkButton, okButton);
+                            
+                            newOkButton.addEventListener('click', async (e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                
+                                console.log('OK button clicked - saving configuration');
+                                
+                                const productId = productConfigure.current.itemId;
+                                if (!productId) {
+                                    console.error('No product ID found for configuration');
+                                    return;
+                                }
+                                
+                                try {
+                                    // Validate the form first
+                                    if (!productConfigure.varienForm.validate()) {
+                                        console.log('Form validation failed');
+                                        return;
+                                    }
+                                    
+                                    // Store the configuration (like the original onConfirmBtn does)
+                                    productConfigure._processFieldsData('item_confirm');
+                                    
+                                    // Call any configured confirm callback
+                                    if (typeof productConfigure.confirmCallback[productConfigure.current.listType] === 'function') {
+                                        productConfigure.confirmCallback[productConfigure.current.listType]();
+                                    }
+                                    
+                                    console.log('Configuration saved successfully');
+                                    
+                                    // Close dialog using multiple methods to ensure it closes
+                                    try {
+                                        if (productConfigure.window && productConfigure.window.close) {
+                                            productConfigure.window.close();
+                                        }
+                                        if (typeof Dialog !== 'undefined' && Dialog.close) {
+                                            Dialog.close();
+                                        }
+                                        if (productConfigure.window && productConfigure.window.remove) {
+                                            productConfigure.window.remove();
+                                        }
+                                        console.log('Dialog closed successfully');
+                                    } catch (closeError) {
+                                        console.error('Error closing dialog:', closeError);
+                                    }
+                                    
+                                } catch (error) {
+                                    console.error('Error during configuration saving:', error);
+                                }
+                            });
+                        }
+                    }
+                }, 100);
+                
+                return result;
+            };
+            
             productConfigure.addListType('quote_items', {
                 urlFetch: '<?= $this->getUrl('*/sales_order_create/configureQuoteItems') ?>'
             });

--- a/public/js/mage/adminhtml/product/composite/configure.js
+++ b/public/js/mage/adminhtml/product/composite/configure.js
@@ -334,10 +334,8 @@ class ProductConfigure // Maho.Admin.Controller.ProductConfigurePopup
     _showWindow() {
         this.window = Dialog.confirm(null, {
             title: Translator.translate('Configure Product'),
-            ok: true,
-            cancel: true,
-            onOk: this.onConfirmBtn.bind(this),
-            onCancel: this.onCancelBtn.bind(this),
+            ok: this.onConfirmBtn.bind(this),
+            cancel: this.onCancelBtn.bind(this),
         });
 
         this.window.querySelector('.dialog-content').appendChild(this.blockForm);

--- a/public/js/mage/adminhtml/product/composite/configure.js
+++ b/public/js/mage/adminhtml/product/composite/configure.js
@@ -334,8 +334,10 @@ class ProductConfigure // Maho.Admin.Controller.ProductConfigurePopup
     _showWindow() {
         this.window = Dialog.confirm(null, {
             title: Translator.translate('Configure Product'),
-            ok: this.onConfirmBtn.bind(this),
-            cancel: this.onCancelBtn.bind(this),
+            ok: true,
+            cancel: true,
+            onOk: this.onConfirmBtn.bind(this),
+            onCancel: this.onCancelBtn.bind(this),
         });
 
         this.window.querySelector('.dialog-content').appendChild(this.blockForm);

--- a/public/js/mage/adminhtml/sales/packaging.js
+++ b/public/js/mage/adminhtml/sales/packaging.js
@@ -103,9 +103,11 @@ class Packaging
         this.window = Dialog.confirm(template.innerHTML, {
             title: Translator.translate('Create Packages'),
             className: 'packaging-window',
-            ok: this.confirmPackaging.bind(this),
+            ok: true,
+            cancel: true,
             okLabel: Translator.translate('Submit Shipment'),
-            cancel: this.cancelPackaging.bind(this),
+            onOk: this.confirmPackaging.bind(this),
+            onCancel: this.cancelPackaging.bind(this),
         });
 
         this.packagesContent = this.window.querySelector('#packages_content');

--- a/public/js/mage/adminhtml/sales/packaging.js
+++ b/public/js/mage/adminhtml/sales/packaging.js
@@ -103,11 +103,9 @@ class Packaging
         this.window = Dialog.confirm(template.innerHTML, {
             title: Translator.translate('Create Packages'),
             className: 'packaging-window',
-            ok: true,
-            cancel: true,
-            okLabel: Translator.translate('Submit Shipment'),
             onOk: this.confirmPackaging.bind(this),
             onCancel: this.cancelPackaging.bind(this),
+            okLabel: Translator.translate('Submit Shipment'),
         });
 
         this.packagesContent = this.window.querySelector('#packages_content');

--- a/public/js/mage/translate_inline.js
+++ b/public/js/mage/translate_inline.js
@@ -133,9 +133,11 @@ class TranslateInline {
             className: 'magento',
             width: 650,
             height: 470,
+            ok: true,
+            cancel: true,
             okLabel: 'Submit',
-            ok: this.formOk.bind(this),
-            cancel: this.formClose.bind(this),
+            onOk: this.formOk.bind(this),
+            onCancel: this.formClose.bind(this),
             onClose: this.formClose.bind(this)
         });
 

--- a/public/js/mage/translate_inline.js
+++ b/public/js/mage/translate_inline.js
@@ -133,8 +133,6 @@ class TranslateInline {
             className: 'magento',
             width: 650,
             height: 470,
-            ok: true,
-            cancel: true,
             okLabel: 'Submit',
             onOk: this.formOk.bind(this),
             onCancel: this.formClose.bind(this),

--- a/public/js/maho-dialog.js
+++ b/public/js/maho-dialog.js
@@ -77,6 +77,15 @@
     document.head.appendChild(style);
 
     function createDialog(options) {
+        if (typeof options.ok === 'function') {
+            options.onOk = options.ok;
+            options.ok = true;
+        }
+        if (typeof options.cancel === 'function') {
+            options.onCancel = options.cancel;
+            options.cancel = true;
+        }
+
         const dialogCount = document.querySelectorAll('dialog').length;
         const dialog = document.createElement('dialog');
         dialog.id = options.id ?? `dialog-${dialogCount + 1}`;

--- a/public/js/maho-dialog.js
+++ b/public/js/maho-dialog.js
@@ -77,18 +77,18 @@
     document.head.appendChild(style);
 
     function createDialog(options) {
+        if (typeof options.onOk === 'function') {
+            options.ok = true;
+        }
+        if (typeof options.onCancel === 'function') {
+            options.cancel = true;
+        }
         if (typeof options.ok === 'function') {
             options.onOk = options.ok;
             options.ok = true;
         }
         if (typeof options.cancel === 'function') {
             options.onCancel = options.cancel;
-            options.cancel = true;
-        }
-        if (typeof options.onOk === 'function') {
-            options.ok = true;
-        }
-        if (typeof options.onCancel === 'function') {
             options.cancel = true;
         }
 

--- a/public/js/maho-dialog.js
+++ b/public/js/maho-dialog.js
@@ -85,6 +85,12 @@
             options.onCancel = options.cancel;
             options.cancel = true;
         }
+        if (typeof options.onOk === 'function') {
+            options.ok = true;
+        }
+        if (typeof options.onCancel === 'function') {
+            options.cancel = true;
+        }
 
         const dialogCount = document.querySelectorAll('dialog').length;
         const dialog = document.createElement('dialog');


### PR DESCRIPTION
  ## Problem
  When creating an order from the admin panel, configurable products couldn't be added. After selecting product options and clicking "OK" in the configuration dialog, nothing would happen - the dialog would  hang and the product wouldn't be added to the order.

  ## Root Cause
  The issue was caused by a Dialog API mismatch. The product configuration system was using the legacy dialog API pattern (`ok: function`), but the MahoDialog system expected the new API pattern (`ok: true,
  onOk: function`).

  ## Solution
  1. **Fixed invalid HTML attributes** in the product grid renderer that were preventing proper JavaScript event handling
  2. **Enhanced MahoDialog with backward compatibility** to automatically detect and convert between API patterns:
     - Legacy API: `ok: function` → `ok: true, onOk: function`
     - New API with implicit flags: `onOk: function` → automatically adds `ok: true`
     - Same for cancel button handling

  ## Benefits
  - Configurable products can now be added to admin orders correctly
  - MahoDialog is backward compatible with legacy code
  - Developers can use either API pattern without breaking functionality
  - No need to update existing dialog implementations across the codebase