### PR TITLE
Fixed configurable product attribute configuration being cleared on popup edit and quick create

### DIFF
--- a/public/js/mage/adminhtml/product.js
+++ b/public/js/mage/adminhtml/product.js
@@ -605,40 +605,24 @@ Product.Configurable.prototype = {
             .each(
                 function (row) {
                     var attribute = row.attributeObject;
-                    for (var i = 0, length = attribute.values.length; i < length; i++) {
-                        if (uniqueAttributeValues.keys().indexOf(
-                                attribute.attribute_id) == -1
-                            || uniqueAttributeValues
-                                .get(attribute.attribute_id)
-                                .keys()
-                                .indexOf(
-                                    attribute.values[i].value_index) == -1) {
-                            row.attributeValues
-                                .childElements()
-                                .each(
-                                    function (elem) {
-                                        if (elem.valueObject.value_index == attribute.values[i].value_index) {
-                                            elem.remove();
-                                        }
-                                    });
-                            attribute.values[i] = undefined;
-
-                        } else {
-                            uniqueAttributeValues.get(
-                                attribute.attribute_id).unset(
-                                attribute.values[i].value_index);
-                        }
-                    }
-                    attribute.values = attribute.values.compact();
-                    if (uniqueAttributeValues
-                        .get(attribute.attribute_id)) {
-                        uniqueAttributeValues.get(
-                            attribute.attribute_id).each(
+                    // Instead of removing unused attribute values, only add new ones
+                    // that are used by associated products but not yet displayed
+                    if (uniqueAttributeValues.get(attribute.attribute_id)) {
+                        uniqueAttributeValues.get(attribute.attribute_id).each(
                             function (pair) {
-                                attribute.values.push(pair.value);
-                                this
-                                    .createValueRow(row,
-                                        pair.value);
+                                // Check if this value is already in the attribute values
+                                var valueExists = false;
+                                for (var i = 0; i < attribute.values.length; i++) {
+                                    if (attribute.values[i] && attribute.values[i].value_index == pair.value.value_index) {
+                                        valueExists = true;
+                                        break;
+                                    }
+                                }
+                                // Only add if it doesn't exist yet
+                                if (!valueExists) {
+                                    attribute.values.push(pair.value);
+                                    this.createValueRow(row, pair.value);
+                                }
                             }.bind(this));
                     }
                 }.bind(this));
@@ -752,7 +736,7 @@ Product.Configurable.prototype = {
         }
 
         $(this.idPrefix + 'simple_form').select('td.value').each(function (td) {
-            var adviceContainer = $(Builder.node('div'));
+            var adviceContainer = $(document.createElement('div'));
             td.appendChild(adviceContainer);
             td.select('input', 'select').each(function (element) {
                 element.advaiceContainer = adviceContainer;


### PR DESCRIPTION
  Fixes issue #118 where the "Super product attributes configuration" section would lose all configured attribute values and pricing after editing associated products via popup or using the quick create
  functionality.

  **Problem**

  - Editing an associated product via popup would clear all attribute configuration values in the main window
  - Quick creating new associated products had the same issue
  - Custom pricing and attribute labels would be lost
  - JavaScript error: Builder is not defined when using quick create forms

  **Root Cause**

  The updateValues() method was incorrectly removing attribute values from the configuration if they weren't currently used by associated products. This caused user-configured values (including custom pricing)
   to disappear during product update operations.

  **Solution**

  1. Fixed updateValues() method: Modified the logic to preserve all existing attribute configuration values while only adding new ones from associated products, rather than removing unused values
  2. Fixed Builder dependency: Replaced Builder.node('div') with document.createElement('div') to eliminate dependency on PrototypeJS Builder extension

