### PR TITLE
Removed deprecated `Mage_Core_Model_Store::isCurrentlySecure()` method

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -16315,12 +16315,6 @@ parameters:
 			path: app/code/core/Mage/Core/Model/Email/Template/Abstract.php
 
 		-
-			message: '#^Parameter \#1 \$id of method Mage_Core_Model_App\:\:getStore\(\) expects bool\|int\|Mage_Core_Model_Store\|string\|null, Varien_Object\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Core/Model/Email/Template/Filter.php
-
-		-
 			message: '#^Parameter \#2 \$name of method Mage_Core_Model_Layout\:\:createBlock\(\) expects string, null given\.$#'
 			identifier: argument.type
 			count: 1

--- a/app/code/core/Mage/Authorizenet/Helper/Data.php
+++ b/app/code/core/Mage/Authorizenet/Helper/Data.php
@@ -6,7 +6,7 @@
  * @package    Mage_Authorizenet
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Authorizenet/Helper/Data.php
+++ b/app/code/core/Mage/Authorizenet/Helper/Data.php
@@ -39,7 +39,7 @@ class Mage_Authorizenet_Helper_Data extends Mage_Core_Helper_Abstract
         $params['_type'] = Mage_Core_Model_Store::URL_TYPE_LINK;
         if (isset($params['is_secure'])) {
             $params['_secure'] = (bool) $params['is_secure'];
-        } elseif (Mage::app()->getStore()->isCurrentlySecure()) {
+        } elseif (Mage::app()->isCurrentlySecure()) {
             $params['_secure'] = true;
         }
         return parent::_getUrl($route, $params);

--- a/app/code/core/Mage/CatalogSearch/Helper/Data.php
+++ b/app/code/core/Mage/CatalogSearch/Helper/Data.php
@@ -168,7 +168,7 @@ class Mage_CatalogSearch_Helper_Data extends Mage_Core_Helper_Abstract
     public function getSuggestUrl()
     {
         return $this->_getUrl('catalogsearch/ajax/suggest', [
-            '_secure' => $this->_getApp()->getStore()->isCurrentlySecure(),
+            '_secure' => Mage::app()->isCurrentlySecure(),
         ]);
     }
 

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
@@ -6,7 +6,7 @@
  * @package    Mage_Checkout
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2019-2023 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer.php
@@ -257,7 +257,7 @@ class Mage_Checkout_Block_Cart_Item_Renderer extends Mage_Core_Block_Template
             [
                 'id' => $this->getItem()->getId(),
                 Mage_Core_Controller_Front_Action::PARAM_NAME_URL_ENCODED => $helper->getEncodedUrl(),
-                '_secure' => $this->_getApp()->getStore()->isCurrentlySecure(),
+                '_secure' => Mage::app()->isCurrentlySecure(),
             ],
         );
     }
@@ -277,7 +277,7 @@ class Mage_Checkout_Block_Cart_Item_Renderer extends Mage_Core_Block_Template
             [
                 'id' => $this->getItem()->getId(),
                 Mage_Core_Controller_Front_Action::PARAM_NAME_URL_ENCODED => $helper->getEncodedUrl(),
-                '_secure' => $this->_getApp()->getStore()->isCurrentlySecure(),
+                '_secure' => Mage::app()->isCurrentlySecure(),
             ],
         );
     }

--- a/app/code/core/Mage/Core/Controller/Varien/Front.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Front.php
@@ -337,7 +337,7 @@ class Mage_Core_Controller_Varien_Front extends Varien_Object
 
         $baseUrl = Mage::getBaseUrl(
             Mage_Core_Model_Store::URL_TYPE_WEB,
-            Mage::app()->getStore()->isCurrentlySecure(),
+            Mage::app()->isCurrentlySecure(),
         );
         if (!$baseUrl) {
             return;

--- a/app/code/core/Mage/Core/Model/Email/Template/Filter.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Filter.php
@@ -428,7 +428,7 @@ class Mage_Core_Model_Email_Template_Filter extends Varien_Filter_Template
         if (isset($params['store'])) {
             $store = Mage::app()->getSafeStore($params['store']);
         }
-        $isSecure = Mage::app()->getStore($store)->isCurrentlySecure();
+        $isSecure = Mage::app()->isCurrentlySecure();
         $protocol = $isSecure ? 'https' : 'http';
         if (isset($params['url'])) {
             return $protocol . '://' . $params['url'];

--- a/app/code/core/Mage/Core/Model/Email/Template/Filter.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Filter.php
@@ -6,7 +6,7 @@
  * @package    Mage_Core
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2019-2025 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -679,17 +679,6 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
     }
 
     /**
-     * Check if request was secure
-     *
-     * @deprecated
-     * @return bool
-     */
-    public function isCurrentlySecure()
-    {
-        return Mage::app()->isCurrentlySecure();
-    }
-
-    /**
      * Retrieve store base currency code
      *
      * @return string
@@ -1024,7 +1013,7 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
             ltrim(Mage::app()->getRequest()->getRequestString(), '/'),
         );
 
-        $storeUrl = Mage::app()->getStore()->isCurrentlySecure()
+        $storeUrl = Mage::app()->isCurrentlySecure()
             ? $this->getUrl('', ['_secure' => true])
             : $this->getUrl('');
         $storeParsedUrl = parse_url($storeUrl);

--- a/app/code/core/Mage/Core/Model/Translate/Inline.php
+++ b/app/code/core/Mage/Core/Model/Translate/Inline.php
@@ -5,7 +5,7 @@
  * @package    Mage_Core
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2019-2025 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Core/Model/Translate/Inline.php
+++ b/app/code/core/Mage/Core/Model/Translate/Inline.php
@@ -234,7 +234,7 @@ class Mage_Core_Model_Translate_Inline
         $urlPrefix = Mage::app()->getStore()->isAdmin() ? 'adminhtml' : 'core';
         $ajaxUrl = Mage::getUrl(
             $urlPrefix . '/ajax/translate',
-            ['_secure' => Mage::app()->getStore()->isCurrentlySecure()],
+            ['_secure' => Mage::app()->isCurrentlySecure()],
         );
         $trigImg = Mage::getDesign()->getSkinUrl('images/fam_book_open.png');
 

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -133,7 +133,7 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
         $this->addData([
             'server_addr'           => $this->_httpHelper->getServerAddr(true),
             'remote_addr'           => $this->_httpHelper->getRemoteAddr(true),
-            'http_secure'           => Mage::app()->getStore()->isCurrentlySecure(),
+            'http_secure'           => Mage::app()->isCurrentlySecure(),
             'http_host'             => $this->_httpHelper->getHttpHost(true),
             'http_user_agent'       => $this->_httpHelper->getHttpUserAgent(true),
             'http_accept_language'  => $this->_httpHelper->getHttpAcceptLanguage(true),

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -6,7 +6,7 @@
  * @package    Mage_Log
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2019-2023 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Page/Block/Html/Footer.php
+++ b/app/code/core/Mage/Page/Block/Html/Footer.php
@@ -38,7 +38,7 @@ class Mage_Page_Block_Html_Footer extends Mage_Core_Block_Template
         return [
             $this->getIsMinimal() ? 'PAGE_FOOTER_MINIMAL' : 'PAGE_FOOTER',
             Mage::app()->getStore()->getId(),
-            (int) Mage::app()->getStore()->isCurrentlySecure(),
+            (int) Mage::app()->isCurrentlySecure(),
             Mage::getDesign()->getPackageName(),
             Mage::getDesign()->getTheme('template'),
             Mage::getSingleton('customer/session')->isLoggedIn(),

--- a/app/code/core/Mage/Page/Block/Html/Footer.php
+++ b/app/code/core/Mage/Page/Block/Html/Footer.php
@@ -6,7 +6,7 @@
  * @package    Mage_Page
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Paypal/Model/Hostedpro.php
+++ b/app/code/core/Mage/Paypal/Model/Hostedpro.php
@@ -6,7 +6,7 @@
  * @package    Mage_Paypal
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Paypal/Model/Hostedpro.php
+++ b/app/code/core/Mage/Paypal/Model/Hostedpro.php
@@ -239,7 +239,7 @@ class Mage_Paypal_Model_Hostedpro extends Mage_Paypal_Model_Direct
         $store = Mage::app()->getStore($storeId);
         return Mage::getUrl($path, [
             '_store'   => $store,
-            '_secure'  => is_null($secure) ? $store->isCurrentlySecure() : $secure,
+            '_secure'  => is_null($secure) ? Mage::app()->isCurrentlySecure() : $secure,
         ]);
     }
 }

--- a/app/code/core/Mage/Rss/controllers/OrderController.php
+++ b/app/code/core/Mage/Rss/controllers/OrderController.php
@@ -27,7 +27,7 @@ class Mage_Rss_OrderController extends Mage_Rss_Controller_Abstract
     public function customerAction()
     {
         if ($this->checkFeedEnable('order/customer')) {
-            if (Mage::app()->getStore()->isCurrentlySecure()) {
+            if (Mage::app()->isCurrentlySecure()) {
                 Mage::helper('rss')->authFrontend();
             } else {
                 $this->_redirect('rss/order/customer', ['_secure' => true]);

--- a/app/code/core/Mage/Rss/controllers/OrderController.php
+++ b/app/code/core/Mage/Rss/controllers/OrderController.php
@@ -6,7 +6,7 @@
  * @package    Mage_Rss
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 


### PR DESCRIPTION
This PR removes the deprecated `isCurrentlySecure()` method from the Store model and updates all usages throughout the codebase to call `Mage::app()->isCurrentlySecure()` directly.

- Removed the deprecated `Mage_Core_Model_Store::isCurrentlySecure()` method
- Updated all calls to use `Mage::app()->isCurrentlySecure()` directly
- Updated PHPStan baseline to remove the now-fixed type error