### PR TITLE
  Added complete order count filter to payment restrictions

### DIFF
--- a/app/locale/en_US/Mage_Payment.csv
+++ b/app/locale/en_US/Mage_Payment.csv
@@ -203,3 +203,4 @@
 "Wrong or empty billing amount specified.","Wrong or empty billing amount specified."
 "Year","Year"
 "Zero Subtotal Checkout","Zero Subtotal Checkout"
+"Number of Complete Orders","Number of Complete Orders"

--- a/app/locale/en_US/Mage_Payment.csv
+++ b/app/locale/en_US/Mage_Payment.csv
@@ -100,6 +100,7 @@
 "New Restriction","New Restriction"
 "NOT FOUND","NOT FOUND"
 "Number of billing periods that make up one billing cycle.","Number of billing periods that make up one billing cycle."
+"Number of Complete Orders","Number of Complete Orders"
 "Order action is not available.","Order action is not available."
 "Overrides API URL that may be specified by a payment method.","Overrides API URL that may be specified by a payment method."
 "Password","Password"
@@ -203,4 +204,3 @@
 "Wrong or empty billing amount specified.","Wrong or empty billing amount specified."
 "Year","Year"
 "Zero Subtotal Checkout","Zero Subtotal Checkout"
-"Number of Complete Orders","Number of Complete Orders"


### PR DESCRIPTION
 ## Summary
  - Adds the ability to filter customers by their number of complete orders in payment restriction rules
  - Calculates complete order count at runtime for accurate, real-time validation
  - Enables merchants to restrict payment methods based on customer order history

  ## Changes
  - Added `orders_complete_count` attribute to customer condition options in payment restrictions
  - Implemented `_getCustomerCompleteOrderCount()` method to count complete orders dynamically
  - Updated validation logic to handle runtime calculation of order counts
  - Added translation for "Number of Complete Orders" to locale file

  ## Usage
  Merchants can now create payment restriction rules such as:
  - Allow payment method only for customers with 5+ complete orders
  - Restrict payment method for first-time buyers (0 complete orders)
  - Create tiered payment options based on order history
