### PR TITLE
Added `config:get`, `config:set`, and `config:delete` commands to Maho CLI

### DIFF
--- a/lib/MahoCLI/CommandDiscoverer.php
+++ b/lib/MahoCLI/CommandDiscoverer.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI;
 
 use Symfony\Component\Console\Command\Command;

--- a/lib/MahoCLI/Commands/AdminUserChangepassword.php
+++ b/lib/MahoCLI/Commands/AdminUserChangepassword.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/AdminUserChangepassword.php
+++ b/lib/MahoCLI/Commands/AdminUserChangepassword.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/AdminUserCreate.php
+++ b/lib/MahoCLI/Commands/AdminUserCreate.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/AdminUserCreate.php
+++ b/lib/MahoCLI/Commands/AdminUserCreate.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/AdminUserDisable.php
+++ b/lib/MahoCLI/Commands/AdminUserDisable.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/AdminUserDisable.php
+++ b/lib/MahoCLI/Commands/AdminUserDisable.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/AdminUserEnable.php
+++ b/lib/MahoCLI/Commands/AdminUserEnable.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/AdminUserEnable.php
+++ b/lib/MahoCLI/Commands/AdminUserEnable.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/AdminUserList.php
+++ b/lib/MahoCLI/Commands/AdminUserList.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/AdminUserList.php
+++ b/lib/MahoCLI/Commands/AdminUserList.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/BaseMahoCommand.php
+++ b/lib/MahoCLI/Commands/BaseMahoCommand.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/CacheDisable.php
+++ b/lib/MahoCLI/Commands/CacheDisable.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/CacheDisable.php
+++ b/lib/MahoCLI/Commands/CacheDisable.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/CacheEnable.php
+++ b/lib/MahoCLI/Commands/CacheEnable.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/CacheEnable.php
+++ b/lib/MahoCLI/Commands/CacheEnable.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/CacheFlush.php
+++ b/lib/MahoCLI/Commands/CacheFlush.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/CacheMinifyFlush.php
+++ b/lib/MahoCLI/Commands/CacheMinifyFlush.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/ConfigDelete.php
+++ b/lib/MahoCLI/Commands/ConfigDelete.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @package    MahoCLI
+ * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Commands;
+
+use Mage;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+#[AsCommand(
+    name: 'config:delete',
+    description: 'Delete configuration values from core_config_data table',
+)]
+class ConfigDelete extends BaseMahoCommand
+{
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addArgument(
+                'config_id',
+                InputArgument::REQUIRED,
+                'Configuration ID from core_config_data table (use config:get to find the ID)',
+            )
+            ->addOption(
+                'force',
+                'f',
+                InputOption::VALUE_NONE,
+                'Skip confirmation prompt',
+            );
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->initMaho();
+
+        $configId = (int) $input->getArgument('config_id');
+        $force = $input->getOption('force');
+
+        try {
+            $connection = Mage::getSingleton('core/resource')->getConnection('core_write');
+            $table = Mage::getSingleton('core/resource')->getTableName('core_config_data');
+
+            // Check if the configuration exists
+            $select = $connection->select()
+                ->from($table)
+                ->where('config_id = ?', $configId);
+
+            $existing = $connection->fetchRow($select);
+
+            if (!$existing) {
+                $output->writeln('<error>Configuration with ID ' . $configId . ' not found in database</error>');
+                return Command::FAILURE;
+            }
+
+            // Show what will be deleted in a table
+            $output->writeln('<info>Configuration to delete:</info>');
+            $output->writeln('');
+
+            $tableOutput = new Table($output);
+            $tableOutput->setHeaders(['Config ID', 'Path', 'Scope', 'Scope ID', 'Name', 'Value']);
+            $tableOutput->addRow([
+                $existing['config_id'],
+                $existing['path'],
+                $existing['scope'],
+                $existing['scope_id'],
+                $this->getScopeName($existing['scope'], (int) $existing['scope_id']),
+                $existing['value'],
+            ]);
+            $tableOutput->render();
+
+            // Confirm deletion unless --force is used
+            if (!$force) {
+                $output->writeln('');
+                /** @var QuestionHelper $helper */
+                $helper = $this->getHelper('question');
+                $question = new ConfirmationQuestion(
+                    '<question>Are you sure you want to delete this configuration? [y/N]</question> ',
+                    false,
+                );
+
+                if (!$helper->ask($input, $output, $question)) {
+                    $output->writeln('<comment>Deletion cancelled</comment>');
+                    return Command::SUCCESS;
+                }
+            }
+
+
+            // Delete the configuration
+            $connection->delete(
+                $table,
+                ['config_id = ?' => $configId],
+            );
+
+            // Clear configuration cache
+            Mage::app()->getCache()->clean(['config']);
+
+            $output->writeln('');
+            $output->writeln('<info>Configuration deleted successfully</info>');
+            $output->writeln('<info>Configuration cache has been cleared</info>');
+
+        } catch (\Exception $e) {
+            $output->writeln('<error>Error deleting configuration: ' . $e->getMessage() . '</error>');
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function getScopeName(string $scope, int $scopeId): string
+    {
+        if ($scopeId === 0) {
+            return 'Default Config';
+        }
+
+        try {
+            switch ($scope) {
+                case 'websites':
+                    $website = Mage::getModel('core/website')->load($scopeId);
+                    if ($website && $website->getId()) {
+                        return $website->getName() . ' (' . $website->getCode() . ')';
+                    }
+                    break;
+
+                case 'stores':
+                    $store = Mage::getModel('core/store')->load($scopeId);
+                    if ($store && $store->getId()) {
+                        return $store->getName() . ' (' . $store->getCode() . ')';
+                    }
+                    break;
+            }
+        } catch (\Exception $e) {
+            // Ignore errors when getting names
+        }
+
+        return '<comment>[Unknown]</comment>';
+    }
+}

--- a/lib/MahoCLI/Commands/ConfigGet.php
+++ b/lib/MahoCLI/Commands/ConfigGet.php
@@ -1,0 +1,208 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @package    MahoCLI
+ * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Commands;
+
+use Mage;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'config:get',
+    description: 'Get specific configuration path values',
+)]
+class ConfigGet extends BaseMahoCommand
+{
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addArgument(
+                'path',
+                InputArgument::REQUIRED,
+                'Configuration path (e.g., web/url/base, general/store_information/name)',
+            )
+            ->addOption(
+                'scope',
+                's',
+                InputOption::VALUE_OPTIONAL,
+                'Filter by configuration scope (default, websites, stores)',
+            )
+            ->addOption(
+                'scope-id',
+                'i',
+                InputOption::VALUE_OPTIONAL,
+                'Filter by specific scope ID (website ID or store ID)',
+            )
+            ->addOption(
+                'decrypt',
+                'd',
+                InputOption::VALUE_NONE,
+                'Decrypt encrypted values',
+            );
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->initMaho();
+
+        $path = $input->getArgument('path');
+        $scopeFilter = $input->getOption('scope');
+        $scopeIdFilter = $input->getOption('scope-id');
+        $decrypt = $input->getOption('decrypt');
+
+        try {
+            $connection = Mage::getSingleton('core/resource')->getConnection('core_read');
+            $table = Mage::getSingleton('core/resource')->getTableName('core_config_data');
+
+            // Build query to get all values for this path
+            $select = $connection->select()
+                ->from($table)
+                ->where('path = ?', $path)
+                ->order(['scope', 'scope_id']);
+
+            // Apply filters if provided
+            if ($scopeFilter) {
+                $select->where('scope = ?', $scopeFilter);
+            }
+            if ($scopeIdFilter !== null) {
+                $select->where('scope_id = ?', (int) $scopeIdFilter);
+            }
+
+            $results = $connection->fetchAll($select);
+
+            // Also get default value from XML configuration
+            $defaultValue = $this->getDefaultValue($path);
+
+            // If no results and no default value
+            if (empty($results) && $defaultValue === null) {
+                $output->writeln('<comment>Configuration path not found: ' . $path . '</comment>');
+                return Command::SUCCESS;
+            }
+
+            // Build table data
+            $tableData = [];
+
+            // Add default value if exists and not filtered out
+            if ($defaultValue !== null && (!$scopeFilter || $scopeFilter === 'default') && (!$scopeIdFilter || $scopeIdFilter == '0')) {
+                $tableData[] = [
+                    'default',
+                    '0',
+                    '<comment>[XML Default]</comment>',
+                    $this->formatValue($defaultValue),
+                ];
+            }
+
+            // Add database values
+            foreach ($results as $row) {
+                $value = $row['value'];
+
+                // Decrypt if requested
+                if ($decrypt && is_string($value) && $this->looksEncrypted($value)) {
+                    try {
+                        $value = Mage::helper('core')->decrypt($value);
+                    } catch (\Exception $e) {
+                        $value = '<error>[Decryption failed]</error>';
+                    }
+                }
+
+                $tableData[] = [
+                    $row['scope'],
+                    $row['scope_id'],
+                    $this->getScopeName($row['scope'], (int) $row['scope_id']),
+                    $this->formatValue($value),
+                ];
+            }
+
+            // Display results in table
+            $output->writeln('<info>Configuration values for: ' . $path . '</info>');
+            $output->writeln('');
+
+            $table = new Table($output);
+            $table->setHeaders(['Scope', 'Scope ID', 'Name', 'Value']);
+            $table->setRows($tableData);
+            $table->render();
+
+        } catch (\Exception $e) {
+            $output->writeln('<error>Error retrieving configuration: ' . $e->getMessage() . '</error>');
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function looksEncrypted(string $value): bool
+    {
+        // Check if value looks like base64 encoded encrypted data
+        return preg_match('/^[A-Za-z0-9+\/]+=*$/', $value) && strlen($value) > 20;
+    }
+
+    private function formatValue(mixed $value): string
+    {
+        if (is_array($value)) {
+            return json_encode($value, JSON_PRETTY_PRINT);
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if ($value === null) {
+            return 'null';
+        }
+
+        return (string) $value;
+    }
+
+    private function getDefaultValue(string $path): mixed
+    {
+        // Don't show XML defaults since Mage::getConfig()->getNode() returns
+        // already-processed values with placeholders replaced, making it
+        // indistinguishable from database values
+        return null;
+    }
+
+    private function getScopeName(string $scope, int $scopeId): string
+    {
+        if ($scopeId === 0) {
+            return 'Default Config';
+        }
+
+        try {
+            switch ($scope) {
+                case 'websites':
+                    $website = Mage::getModel('core/website')->load($scopeId);
+                    if ($website && $website->getId()) {
+                        return $website->getName() . ' (' . $website->getCode() . ')';
+                    }
+                    break;
+
+                case 'stores':
+                    $store = Mage::getModel('core/store')->load($scopeId);
+                    if ($store && $store->getId()) {
+                        return $store->getName() . ' (' . $store->getCode() . ')';
+                    }
+                    break;
+            }
+        } catch (\Exception $e) {
+            // Ignore errors when getting names
+        }
+
+        return '<comment>[Unknown]</comment>';
+    }
+}

--- a/lib/MahoCLI/Commands/ConfigGet.php
+++ b/lib/MahoCLI/Commands/ConfigGet.php
@@ -72,7 +72,7 @@ class ConfigGet extends BaseMahoCommand
 
             // Build query to get all values for this path
             $select = $connection->select()
-                ->from($table)
+                ->from($table, ['config_id', 'scope', 'scope_id', 'path', 'value'])
                 ->where('path = ?', $path)
                 ->order(['scope', 'scope_id']);
 
@@ -101,6 +101,7 @@ class ConfigGet extends BaseMahoCommand
             // Add default value if exists and not filtered out
             if ($defaultValue !== null && (!$scopeFilter || $scopeFilter === 'default') && (!$scopeIdFilter || $scopeIdFilter == '0')) {
                 $tableData[] = [
+                    '-',
                     'default',
                     '0',
                     '<comment>[XML Default]</comment>',
@@ -122,6 +123,7 @@ class ConfigGet extends BaseMahoCommand
                 }
 
                 $tableData[] = [
+                    $row['config_id'],
                     $row['scope'],
                     $row['scope_id'],
                     $this->getScopeName($row['scope'], (int) $row['scope_id']),
@@ -134,7 +136,7 @@ class ConfigGet extends BaseMahoCommand
             $output->writeln('');
 
             $table = new Table($output);
-            $table->setHeaders(['Scope', 'Scope ID', 'Name', 'Value']);
+            $table->setHeaders(['Config ID', 'Scope', 'Scope ID', 'Name', 'Value']);
             $table->setRows($tableData);
             $table->render();
 

--- a/lib/MahoCLI/Commands/ConfigSet.php
+++ b/lib/MahoCLI/Commands/ConfigSet.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @package    MahoCLI
+ * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Commands;
+
+use Mage;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'config:set',
+    description: 'Set configuration values in core_config_data table',
+)]
+class ConfigSet extends BaseMahoCommand
+{
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addArgument(
+                'path',
+                InputArgument::REQUIRED,
+                'Configuration path (e.g., web/url/base, general/store_information/name)',
+            )
+            ->addArgument(
+                'value',
+                InputArgument::REQUIRED,
+                'Configuration value to set',
+            )
+            ->addOption(
+                'scope',
+                's',
+                InputOption::VALUE_REQUIRED,
+                'Configuration scope (default, websites, stores)',
+            )
+            ->addOption(
+                'scope-id',
+                'i',
+                InputOption::VALUE_REQUIRED,
+                'Scope ID (website ID or store ID)',
+            )
+            ->addOption(
+                'encrypt',
+                'e',
+                InputOption::VALUE_NONE,
+                'Encrypt the value before storing',
+            );
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->initMaho();
+
+        $path = $input->getArgument('path');
+        $value = $input->getArgument('value');
+        $scope = $input->getOption('scope');
+        $scopeId = $input->getOption('scope-id');
+        $encrypt = $input->getOption('encrypt');
+
+        // Check if required options are provided
+        if (!$scope || $scopeId === null) {
+            $output->writeln('<error>Both --scope and --scope-id options are required</error>');
+            $output->writeln('<comment>Examples:</comment>');
+            $output->writeln('  <info>./maho config:set web/url/base "http://example.com/" --scope default --scope-id 0</info>');
+            $output->writeln('  <info>./maho config:set web/url/base "http://store1.com/" --scope stores --scope-id 1</info>');
+            $output->writeln('  <info>./maho config:set web/url/base "http://website2.com/" --scope websites --scope-id 2</info>');
+            return Command::FAILURE;
+        }
+
+        $scopeId = (int) $scopeId;
+
+        // Validate scope
+        if (!in_array($scope, ['default', 'websites', 'stores'])) {
+            $output->writeln('<error>Invalid scope. Must be one of: default, websites, stores</error>');
+            return Command::FAILURE;
+        }
+
+        try {
+            // Encrypt value if requested
+            if ($encrypt) {
+                $value = Mage::helper('core')->encrypt($value);
+            }
+
+            // Get the configuration model
+            $config = Mage::getModel('core/config');
+
+            // Save the configuration value
+            $config->saveConfig($path, $value, $scope, $scopeId);
+
+            // Clear configuration cache
+            Mage::app()->getCache()->clean(['config']);
+
+            $output->writeln('<info>Configuration saved successfully</info>');
+            $output->writeln('<comment>Path:</comment> ' . $path);
+            $output->writeln('<comment>Scope:</comment> ' . $scope . ' (ID: ' . $scopeId . ')');
+            $output->writeln('<comment>Value:</comment> ' . ($encrypt ? '[ENCRYPTED]' : $value));
+
+            if ($encrypt) {
+                $output->writeln('<info>Value was encrypted before storing</info>');
+            }
+
+            $output->writeln('<info>Configuration cache has been cleared</info>');
+
+        } catch (\Exception $e) {
+            $output->writeln('<error>Error saving configuration: ' . $e->getMessage() . '</error>');
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/lib/MahoCLI/Commands/CreateCommand.php
+++ b/lib/MahoCLI/Commands/CreateCommand.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/CreateCommand.php
+++ b/lib/MahoCLI/Commands/CreateCommand.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/CronHistory.php
+++ b/lib/MahoCLI/Commands/CronHistory.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/CronHistory.php
+++ b/lib/MahoCLI/Commands/CronHistory.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/CronList.php
+++ b/lib/MahoCLI/Commands/CronList.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/CronList.php
+++ b/lib/MahoCLI/Commands/CronList.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/CronRun.php
+++ b/lib/MahoCLI/Commands/CronRun.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/CustomerChangepassword.php
+++ b/lib/MahoCLI/Commands/CustomerChangepassword.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/CustomerChangepassword.php
+++ b/lib/MahoCLI/Commands/CustomerChangepassword.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/CustomerCreate.php
+++ b/lib/MahoCLI/Commands/CustomerCreate.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/CustomerCreate.php
+++ b/lib/MahoCLI/Commands/CustomerCreate.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/CustomerDelete.php
+++ b/lib/MahoCLI/Commands/CustomerDelete.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/CustomerDelete.php
+++ b/lib/MahoCLI/Commands/CustomerDelete.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/CustomerList.php
+++ b/lib/MahoCLI/Commands/CustomerList.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/CustomerList.php
+++ b/lib/MahoCLI/Commands/CustomerList.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/DBConnect.php
+++ b/lib/MahoCLI/Commands/DBConnect.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/DBQuery.php
+++ b/lib/MahoCLI/Commands/DBQuery.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/EmailConfigShow.php
+++ b/lib/MahoCLI/Commands/EmailConfigShow.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/EmailQueueClear.php
+++ b/lib/MahoCLI/Commands/EmailQueueClear.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/EmailQueueProcess.php
+++ b/lib/MahoCLI/Commands/EmailQueueProcess.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/EmailTestQueue.php
+++ b/lib/MahoCLI/Commands/EmailTestQueue.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/EmailTestSend.php
+++ b/lib/MahoCLI/Commands/EmailTestSend.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/IndexList.php
+++ b/lib/MahoCLI/Commands/IndexList.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/IndexList.php
+++ b/lib/MahoCLI/Commands/IndexList.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/IndexReindex.php
+++ b/lib/MahoCLI/Commands/IndexReindex.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/IndexReindexAll.php
+++ b/lib/MahoCLI/Commands/IndexReindexAll.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/IndexReindexProduct.php
+++ b/lib/MahoCLI/Commands/IndexReindexProduct.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/Install.php
+++ b/lib/MahoCLI/Commands/Install.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Exception;

--- a/lib/MahoCLI/Commands/LegacyRenameMysql4Classes.php
+++ b/lib/MahoCLI/Commands/LegacyRenameMysql4Classes.php
@@ -9,6 +9,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/lib/MahoCLI/Commands/LogClean.php
+++ b/lib/MahoCLI/Commands/LogClean.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/LogClean.php
+++ b/lib/MahoCLI/Commands/LogClean.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/LogStatus.php
+++ b/lib/MahoCLI/Commands/LogStatus.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/LogStatus.php
+++ b/lib/MahoCLI/Commands/LogStatus.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/PhpstormMetadataGenerate.php
+++ b/lib/MahoCLI/Commands/PhpstormMetadataGenerate.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/Serve.php
+++ b/lib/MahoCLI/Commands/Serve.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/Serve.php
+++ b/lib/MahoCLI/Commands/Serve.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/SysCurrencies.php
+++ b/lib/MahoCLI/Commands/SysCurrencies.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/SysCurrencies.php
+++ b/lib/MahoCLI/Commands/SysCurrencies.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/SysEncryptionKeyRegenerate.php
+++ b/lib/MahoCLI/Commands/SysEncryptionKeyRegenerate.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/SysLocales.php
+++ b/lib/MahoCLI/Commands/SysLocales.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/SysLocales.php
+++ b/lib/MahoCLI/Commands/SysLocales.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/SysTimezones.php
+++ b/lib/MahoCLI/Commands/SysTimezones.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/lib/MahoCLI/Commands/SysTimezones.php
+++ b/lib/MahoCLI/Commands/SysTimezones.php
@@ -8,6 +8,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/TranslationsMissing.php
+++ b/lib/MahoCLI/Commands/TranslationsMissing.php
@@ -9,6 +9,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/lib/MahoCLI/Commands/TranslationsUnused.php
+++ b/lib/MahoCLI/Commands/TranslationsUnused.php
@@ -9,6 +9,8 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace MahoCLI\Commands;
 
 use Mage;

--- a/maho
+++ b/maho
@@ -71,6 +71,7 @@ $application->add(new \MahoCLI\Commands\SysTimezones());
 
 $application->add(new \MahoCLI\Commands\ConfigGet());
 $application->add(new \MahoCLI\Commands\ConfigSet());
+$application->add(new \MahoCLI\Commands\ConfigDelete());
 
 $application->add(new \MahoCLI\Commands\TranslationsMissing());
 $application->add(new \MahoCLI\Commands\TranslationsUnused());

--- a/maho
+++ b/maho
@@ -69,6 +69,9 @@ $application->add(new \MahoCLI\Commands\SysEncryptionKeyRegenerate());
 $application->add(new \MahoCLI\Commands\SysLocales());
 $application->add(new \MahoCLI\Commands\SysTimezones());
 
+$application->add(new \MahoCLI\Commands\ConfigGet());
+$application->add(new \MahoCLI\Commands\ConfigSet());
+
 $application->add(new \MahoCLI\Commands\TranslationsMissing());
 $application->add(new \MahoCLI\Commands\TranslationsUnused());
 


### PR DESCRIPTION
 This PR introduces comprehensive configuration management commands to the Maho CLI, providing developers with powerful tools to view, modify, and delete configuration values from the core_config_data
  table.

  **New Commands Added**

`config:get <path>`

  - Purpose: Retrieve configuration values across all scopes
  - Output: Table format showing Config ID, Scope, Scope ID, Name, and Value
  - Features:
    - Shows all scope levels where a configuration is defined
    - Optional filtering by --scope and --scope-id
    - Decryption support with --decrypt flag
    - Human-readable scope names (e.g., store/website names)

`config:set <path> <value> --scope <scope> --scope-id <id>`

  - Purpose: Set configuration values at specific scopes
  - Output: Table format confirming the saved configuration
  - Features:
    - Mandatory scope and scope-id parameters for safety
    - Validation of scope existence (websites/stores must exist)
    - Encryption support with --encrypt flag
    - Automatic cache clearing
    - Returns the database Config ID for reference

`config:delete <config_id>`

  - Purpose: Delete specific configuration entries by their database ID
  - Output: Table preview with confirmation prompt
  - Features:
    - Uses Config ID for precise targeting (from config:get)
    - Confirmation prompt (bypassable with --force)
    - Automatic cache clearing
    - Safe deletion preventing accidental removal

  **Key Features**

  - Strict typing with declare(strict_types=1) throughout
  - Comprehensive validation of scopes and scope IDs
  - User-friendly error messages with helpful suggestions
  - Cache management - automatic clearing after modifications
  - Security considerations - encryption/decryption support

  **Examples**

```bash
  # View all values for a configuration path
  ./maho config:get web/secure/base_url

  # Set a configuration value
  ./maho config:set web/secure/base_url "https://example.com/" --scope stores --scope-id 1

  # Delete a specific configuration (ID from config:get)
  ./maho config:delete 123
```