### PR TITLE
Replaced `Zend_Exception` with `Mage_Core_Exception`

### DIFF
--- a/app/code/core/Mage/Catalog/Exception.php
+++ b/app/code/core/Mage/Catalog/Exception.php
@@ -9,4 +9,4 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Mage_Catalog_Exception extends Zend_Exception {}
+class Mage_Catalog_Exception extends Mage_Core_Exception {}

--- a/app/code/core/Mage/Checkout/Exception.php
+++ b/app/code/core/Mage/Checkout/Exception.php
@@ -9,4 +9,4 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Mage_Checkout_Exception extends Zend_Exception {}
+class Mage_Checkout_Exception extends Mage_Core_Exception {}

--- a/app/code/core/Mage/Oauth/Exception.php
+++ b/app/code/core/Mage/Oauth/Exception.php
@@ -9,4 +9,4 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Mage_Oauth_Exception extends Zend_Exception {}
+class Mage_Oauth_Exception extends Mage_Core_Exception {}

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizeController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizeController.php
@@ -97,11 +97,11 @@ class Mage_Oauth_Adminhtml_Oauth_AuthorizeController extends Mage_Adminhtml_Cont
         $isException = false;
         try {
             $server->checkAuthorizeRequest();
-        } catch (Mage_Core_Exception $e) {
-            $session->addError($e->getMessage());
         } catch (Mage_Oauth_Exception $e) {
             $isException = true;
             $session->addException($e, $this->__('An error occurred. Your authorization request is invalid.'));
+        } catch (Mage_Core_Exception $e) {
+            $session->addError($e->getMessage());
         } catch (Exception $e) {
             $isException = true;
             $session->addException($e, $this->__('An error occurred.'));

--- a/app/code/core/Mage/Oauth/controllers/AuthorizeController.php
+++ b/app/code/core/Mage/Oauth/controllers/AuthorizeController.php
@@ -34,11 +34,11 @@ class Mage_Oauth_AuthorizeController extends Mage_Core_Controller_Front_Action
         $isException = false;
         try {
             $server->checkAuthorizeRequest();
-        } catch (Mage_Core_Exception $e) {
-            $session->addError($e->getMessage());
         } catch (Mage_Oauth_Exception $e) {
             $isException = true;
             $session->addException($e, $this->__('An error occurred. Your authorization request is invalid.'));
+        } catch (Mage_Core_Exception $e) {
+            $session->addError($e->getMessage());
         } catch (Exception $e) {
             $isException = true;
             $session->addException($e, $this->__('An error occurred.'));
@@ -109,10 +109,10 @@ class Mage_Oauth_AuthorizeController extends Mage_Core_Controller_Front_Action
                 $block->setVerifier($token->getVerifier());
                 $session->addSuccess($this->__('Authorization confirmed.'));
             }
-        } catch (Mage_Core_Exception $e) {
-            $session->addError($e->getMessage());
         } catch (Mage_Oauth_Exception $e) {
             $session->addException($e, $this->__('An error occurred. Your authorization request is invalid.'));
+        } catch (Mage_Core_Exception $e) {
+            $session->addError($e->getMessage());
         } catch (Exception $e) {
             $session->addException($e, $this->__('An error occurred on confirm authorize.'));
         }

--- a/app/code/core/Mage/Reports/Exception.php
+++ b/app/code/core/Mage/Reports/Exception.php
@@ -9,4 +9,4 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Mage_Reports_Exception extends Zend_Exception {}
+class Mage_Reports_Exception extends Mage_Core_Exception {}

--- a/app/code/core/Mage/Sales/Exception.php
+++ b/app/code/core/Mage/Sales/Exception.php
@@ -9,4 +9,4 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Mage_Sales_Exception extends Zend_Exception {}
+class Mage_Sales_Exception extends Mage_Core_Exception {}

--- a/app/code/core/Mage/SalesRule/Exception.php
+++ b/app/code/core/Mage/SalesRule/Exception.php
@@ -9,4 +9,4 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Mage_SalesRule_Exception extends Zend_Exception {}
+class Mage_SalesRule_Exception extends Mage_Core_Exception {}

--- a/app/code/core/Mage/Shipping/Exception.php
+++ b/app/code/core/Mage/Shipping/Exception.php
@@ -9,4 +9,4 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Mage_Shipping_Exception extends Zend_Exception {}
+class Mage_Shipping_Exception extends Mage_Core_Exception {}

--- a/lib/Varien/Data/Collection/Db.php
+++ b/lib/Varien/Data/Collection/Db.php
@@ -162,7 +162,7 @@ class Varien_Data_Collection_Db extends Varien_Data_Collection
     public function setConnection($conn)
     {
         if (!$conn instanceof Zend_Db_Adapter_Abstract) {
-            throw new Zend_Exception('dbModel read resource does not implement Zend_Db_Adapter_Abstract');
+            throw new Mage_Core_Exception('dbModel read resource does not implement Zend_Db_Adapter_Abstract');
         }
 
         $this->_conn = $conn;


### PR DESCRIPTION
 - Replaced all Zend_Exception usage with Mage_Core_Exception to reduce dependency on legacy Zend Framework components
  - Updated 7 module-specific exception classes to extend Mage_Core_Exception instead of Zend_Exception
  - Fixed exception catch order in OAuth controllers to prevent dead catch blocks

  Changes Made

  - Module Exception Classes: Updated Mage_Catalog_Exception, Mage_Checkout_Exception, Mage_Oauth_Exception, Mage_Reports_Exception, Mage_Sales_Exception, Mage_SalesRule_Exception, and
  Mage_Shipping_Exception to extend Mage_Core_Exception
  - Direct Usage: Replaced throw new Zend_Exception() in lib/Varien/Data/Collection/Db.php:165 with Mage_Core_Exception
  - Exception Handling: Reordered catch blocks in OAuth controllers to catch more specific exceptions before their parent classes

