### PR TITLE
Added `./maho shell` command with support for `psysh`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,8 @@
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "rector/rector": "^2",
-        "pestphp/pest": "^3.8"
+        "pestphp/pest": "^3.8",
+        "psy/psysh": "^0.12.10"
     },
     "suggest": {
         "fballiano/openmage-cssjs-minify": "Minification support for CSS/JS",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "509f1b05cd1bf5641f47e64182c9bd5e",
+    "content-hash": "9fa17331e67106c8a819efc5b8432b97",
     "packages": [
         {
             "name": "altcha-org/altcha",
@@ -5657,6 +5657,84 @@
                 "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
             },
             "time": "2021-10-29T13:26:27+00:00"
+        },
+        {
+            "name": "psy/psysh",
+            "version": "v0.12.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bobthecow/psysh.git",
+                "reference": "6e80abe6f2257121f1eb9a4c55bf29d921025b22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/6e80abe6f2257121f1eb9a4c55bf29d921025b22",
+                "reference": "6e80abe6f2257121f1eb9a4c55bf29d921025b22",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "nikic/php-parser": "^5.0 || ^4.0",
+                "php": "^8.0 || ^7.4",
+                "symfony/console": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4",
+                "symfony/var-dumper": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4"
+            },
+            "conflict": {
+                "symfony/console": "4.4.37 || 5.3.14 || 5.3.15 || 5.4.3 || 5.4.4 || 6.0.3 || 6.0.4"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2"
+            },
+            "suggest": {
+                "ext-pcntl": "Enabling the PCNTL extension makes PsySH a lot happier :)",
+                "ext-pdo-sqlite": "The doc command requires SQLite to work.",
+                "ext-posix": "If you have PCNTL, you'll want the POSIX extension as well."
+            },
+            "bin": [
+                "bin/psysh"
+            ],
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": false,
+                    "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-main": "0.12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Psy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Justin Hileman",
+                    "email": "justin@justinhileman.info"
+                }
+            ],
+            "description": "An interactive shell for modern PHP.",
+            "homepage": "https://psysh.org",
+            "keywords": [
+                "REPL",
+                "console",
+                "interactive",
+                "shell"
+            ],
+            "support": {
+                "issues": "https://github.com/bobthecow/psysh/issues",
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.10"
+            },
+            "time": "2025-08-04T12:39:37+00:00"
         },
         {
             "name": "react/cache",

--- a/lib/MahoCLI/Commands/BaseMahoCommand.php
+++ b/lib/MahoCLI/Commands/BaseMahoCommand.php
@@ -20,7 +20,7 @@ abstract class BaseMahoCommand extends Command
     protected function initMaho(): void
     {
         Mage::register('isSecureArea', true);
-        Mage::app();
+        Mage::app('admin');
     }
 
     public function humanReadableSize(int $bytes): string

--- a/lib/MahoCLI/Commands/Shell.php
+++ b/lib/MahoCLI/Commands/Shell.php
@@ -1,0 +1,240 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @package    MahoCLI
+ * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Commands;
+
+use Mage;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'shell',
+    description: 'Opens an interactive PHP shell with Maho bootstrapped',
+)]
+class Shell extends BaseMahoCommand
+{
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->title('Maho Shell');
+        $io->text('Initializing Maho application...');
+
+        $this->initMaho();
+
+        $io->success('Maho application initialized!');
+        $io->text([
+            'You can now interact with Maho using PHP code.',
+            'Type "exit" or press Ctrl+D to quit.',
+            '',
+            'Example commands:',
+            '  $product = Mage::getModel("catalog/product")->load(1);',
+            '  $customer = $getModel("customer/customer")->load(1);',
+            '  $db()->fetchAll("SELECT * FROM core_store");',
+            '',
+        ]);
+
+        if ($this->hasPsysh()) {
+            return $this->runPsysh($io);
+        }
+
+        $io->warning('PsySH is not installed. Using basic REPL instead.');
+        $io->text('For a much better experience, install PsySH:');
+        $io->text('  composer require --dev psy/psysh');
+        $io->newLine();
+
+        return $this->runBasicRepl($io);
+    }
+
+    private function hasPsysh(): bool
+    {
+        return class_exists(\Psy\Shell::class);
+    }
+
+    private function runPsysh(SymfonyStyle $io): int
+    {
+        $io->text('Starting enhanced shell with PsySH...');
+
+        $config = new \Psy\Configuration();
+        $config->setUpdateCheck('never');
+        $config->setColorMode(\Psy\Configuration::COLOR_MODE_FORCED);
+
+        // Add custom commands if needed
+        $config->setStartupMessage(
+            "Maho Shell - PsySH Enhanced\n" .
+            "===========================\n" .
+            "Helper functions:\n" .
+            "  \$db()         - Database connection (auto-reconnects)\n" .
+            "  \$getModel('catalog/product')\n" .
+            "  \$getCollection('customer/customer')\n" .
+            "  \$reconnect()  - Refresh DB connections\n\n" .
+            "PsySH commands:\n" .
+            "  ls       - List variables/methods\n" .
+            "  show     - Show source code\n" .
+            "  doc      - Show documentation\n" .
+            "  help     - Show PsySH help\n",
+        );
+
+        // Get database connection for convenience
+        $resource = Mage::getSingleton('core/resource');
+
+        $shell = new \Psy\Shell($config);
+        $shell->setScopeVariables([
+            'db' => function () use ($resource) {
+                // Always get fresh connection to avoid timeout issues
+                $conn = $resource->getConnection('core_read');
+                // Reconnect if connection was lost
+                if (!$conn->isConnected()) {
+                    $conn->closeConnection();
+                    $conn->getConnection();
+                }
+                return $conn;
+            },
+            // Add some helpful shortcuts
+            'getModel' => function ($modelClass) {
+                // Ensure DB connection is fresh
+                $resource = Mage::getSingleton('core/resource');
+                $conn = $resource->getConnection('core_read');
+                if (!$conn->isConnected()) {
+                    $conn->closeConnection();
+                    $conn->getConnection();
+                }
+                return Mage::getModel($modelClass);
+            },
+            'getCollection' => function ($modelClass) {
+                // Ensure DB connection is fresh
+                $resource = Mage::getSingleton('core/resource');
+                $conn = $resource->getConnection('core_read');
+                if (!$conn->isConnected()) {
+                    $conn->closeConnection();
+                    $conn->getConnection();
+                }
+                return Mage::getModel($modelClass)->getCollection();
+            },
+            'reconnect' => function () {
+                // Helper function to manually reconnect
+                $resource = Mage::getSingleton('core/resource');
+                $connections = ['core_read', 'core_write'];
+                foreach ($connections as $connName) {
+                    $conn = $resource->getConnection($connName);
+                    $conn->closeConnection();
+                    $conn->getConnection();
+                }
+                echo "Database connections refreshed.\n";
+            },
+        ]);
+
+        $shell->run();
+
+        return Command::SUCCESS;
+    }
+
+    private function runBasicRepl(SymfonyStyle $io): int
+    {
+        $io->text('Starting interactive Maho shell...');
+        $io->newLine();
+
+        $readline = function_exists('readline');
+        $prompt = 'maho> ';
+
+        while (true) {
+            if ($readline) {
+                $input = readline($prompt);
+                if ($input === false) {
+                    break; // Ctrl+D
+                }
+                if (trim($input) !== '') {
+                    readline_add_history($input);
+                }
+            } else {
+                echo $prompt;
+                $input = fgets(STDIN);
+                if ($input === false) {
+                    break;
+                }
+            }
+
+            $input = trim($input);
+
+            if ($input === 'exit' || $input === 'quit') {
+                break;
+            }
+
+            if ($input === '') {
+                continue;
+            }
+
+            // Handle special commands
+            if ($input === 'help') {
+                $io->text([
+                    'Examples:',
+                    '  $product = Mage::getModel("catalog/product")->load(1);',
+                    '  $customers = Mage::getModel("customer/customer")->getCollection();',
+                    '  Mage::getConfig()->getNode("global/install/date");',
+                    '',
+                    'Type "exit" to quit.',
+                ]);
+                continue;
+            }
+
+            // Add semicolon if missing (unless it's a control structure)
+            if (!str_ends_with($input, ';') && !str_ends_with($input, '}') && !str_ends_with($input, '{')) {
+                $input .= ';';
+            }
+
+            // Replace dd() calls with var_dump() to prevent exit
+            $safeInput = preg_replace('/\bdd\s*\(/', 'var_dump(', $input);
+
+            try {
+                ob_start();
+                $result = eval("return ($safeInput);");
+                $output = ob_get_clean();
+
+                if ($output !== '') {
+                    echo $output;
+                }
+
+                if ($result !== null) {
+                    if (is_object($result) || is_array($result)) {
+                        print_r($result);
+                    } else {
+                        var_export($result);
+                        echo "\n";
+                    }
+                }
+            } catch (\ParseError $e) {
+                // Try without return for statements like echo, print, etc.
+                try {
+                    ob_start();
+                    eval($safeInput);
+                    $output = ob_get_clean();
+                    if ($output !== '') {
+                        echo $output;
+                    }
+                } catch (\Throwable $e) {
+                    $io->error('Error: ' . $e->getMessage());
+                }
+            } catch (\Throwable $e) {
+                $io->error('Error: ' . $e->getMessage());
+            }
+        }
+
+        $io->newLine();
+        $io->text('Goodbye!');
+
+        return Command::SUCCESS;
+    }
+}

--- a/maho
+++ b/maho
@@ -63,6 +63,7 @@ $application->add(new \MahoCLI\Commands\LegacyRenameMysql4Classes());
 $application->add(new \MahoCLI\Commands\PhpstormMetadataGenerate());
 
 $application->add(new \MahoCLI\Commands\Serve());
+$application->add(new \MahoCLI\Commands\Shell());
 
 $application->add(new \MahoCLI\Commands\SysCurrencies());
 $application->add(new \MahoCLI\Commands\SysEncryptionKeyRegenerate());


### PR DESCRIPTION
https://github.com/user-attachments/assets/c8ec11f3-bd75-4b74-aeb4-6816220053be

It supports psysh but has fallback for readline and a super basic version for systems with neither of them.