### PR TITLE
Added CLI commands for importing countries and regions with localization support

### DIFF
--- a/maho
+++ b/maho
@@ -66,6 +66,7 @@ $application->add(new \MahoCLI\Commands\Serve());
 $application->add(new \MahoCLI\Commands\Shell());
 
 $application->add(new \MahoCLI\Commands\SysCurrencies());
+$application->add(new \MahoCLI\Commands\SysDirectoryCountriesImport());
 $application->add(new \MahoCLI\Commands\SysDirectoryRegionsImport());
 $application->add(new \MahoCLI\Commands\SysEncryptionKeyRegenerate());
 $application->add(new \MahoCLI\Commands\SysLocales());


### PR DESCRIPTION
This PR introduces two new CLI commands for importing standardized geographic data with comprehensive localization support:

  **New Commands**

`./maho sys:directory:countries:import`

  - Imports country names with localization from ISO 3166-1 standard
  - Updates existing countries in Maho database with standardized names
  - Supports multiple locales with automatic translation
  - Only stores localized names that differ from English defaults (optimization)

`./maho sys:directory:regions:import`

  - Imports states/provinces for countries from ISO 3166-2 standard
  - Creates new regions and updates existing ones with localized names
  - Supports country-specific region imports
  - Handles complex subdivision hierarchies and naming conventions

**Detail**

  - Automatic Package Management: Temporarily installs required ISO packages (sokil/php-isocodes, sokil/php-isocodes-db-i18n, symfony/translation) and removes them after completion
  - Multi-locale Support: Process multiple Maho locales in a single command (e.g., en_US,it_IT,fr_FR)
  - Smart Updates: Only updates existing data when explicitly requested via --update-existing flag
  - Dry Run Mode: Preview all changes before applying them with --dry-run
  - Comprehensive Validation: Validates countries exist in Maho database before processing regions
  - Detailed Reporting: Shows import summaries with counts and affected records


Fixes https://github.com/MahoCommerce/maho/issues/288

---------
**Documentation to be added to the website**

---------

# Geographic Data Import Commands

Import and localize country and region data from international standards (ISO 3166-1 and ISO 3166-2) to provide accurate geographic information for your international customers.

## Quick Start

```bash
# Import localized country names
./maho sys:directory:countries:import --locales=en_US,it_IT,fr_FR

# Import US states with localization
./maho sys:directory:regions:import --country=US --locales=en_US,es_ES

# Preview changes before applying
./maho sys:directory:countries:import --locales=de_DE --dry-run
```

## Commands

### Import Countries

Import country names with localization from ISO 3166-1 standard.

```bash
./maho sys:directory:countries:import [options]
```

**Options:**
- `--locales=LOCALES` - Comma-separated locales (default: en_US)
- `--update-existing` - Update existing translations
- `--dry-run` - Preview changes only
- `--force` - Skip installation confirmations

**Examples:**
```bash
# Basic import for Italian locale
./maho sys:directory:countries:import --locales=it_IT

# Multiple locales with updates
./maho sys:directory:countries:import --locales=en_US,fr_FR,de_DE --update-existing

# Preview German translations
./maho sys:directory:countries:import --locales=de_DE --dry-run
```

### Import Regions

Import states, provinces, and administrative divisions from ISO 3166-2 standard.

```bash
./maho sys:directory:regions:import --country=COUNTRY [options]
```

**Options:**
- `--country=CODE` - ISO-2 country code (required)
- `--locales=LOCALES` - Comma-separated locales (default: en_US)
- `--update-existing` - Update existing regions and translations
- `--dry-run` - Preview changes only
- `--force` - Skip installation confirmations

**Examples:**
```bash
# Import US states
./maho sys:directory:regions:import --country=US

# Canadian provinces with French translation
./maho sys:directory:regions:import --country=CA --locales=en_US,fr_FR

# Preview Italian provinces
./maho sys:directory:regions:import --country=IT --locales=it_IT --dry-run

# Update existing German states
./maho sys:directory:regions:import --country=DE --update-existing
```

## Usage Examples

### Setting Up Multi-Language Store

**Scenario:** Italian store expanding to French and German markets

```bash
# Step 1: Import country names for all locales
./maho sys:directory:countries:import --locales=it_IT,fr_FR,de_DE

# Step 2: Import Italian regions
./maho sys:directory:regions:import --country=IT --locales=it_IT,fr_FR,de_DE

# Step 3: Add French and German regions for shipping
./maho sys:directory:regions:import --country=FR --locales=it_IT,fr_FR,de_DE
./maho sys:directory:regions:import --country=DE --locales=it_IT,fr_FR,de_DE
```

### Expanding to New Markets

**Scenario:** Adding Canadian market with bilingual support

```bash
# Import Canadian provinces with English and French names
./maho sys:directory:regions:import --country=CA --locales=en_US,fr_FR

# Verify with dry run first
./maho sys:directory:regions:import --country=CA --locales=en_US,fr_FR --dry-run
```

### Updating Existing Data

**Scenario:** Refreshing outdated geographic data

```bash
# Preview what will change
./maho sys:directory:countries:import --locales=en_US,es_ES --update-existing --dry-run

# Apply updates
./maho sys:directory:countries:import --locales=en_US,es_ES --update-existing
./maho sys:directory:regions:import --country=US --locales=en_US,es_ES --update-existing
```
