### PR TITLE
Enhanced category autosuggest with fulltext support

### DIFF
--- a/app/code/core/Mage/CatalogSearch/Block/Autocomplete/Category/List.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Autocomplete/Category/List.php
@@ -29,8 +29,84 @@ class Mage_CatalogSearch_Block_Autocomplete_Category_List extends Mage_Core_Bloc
                 ->addAttributeToSelect('url_path')
                 ->addAttributeToSelect('url_key');
 
-            // Filter by name matching the query
-            $collection->addAttributeToFilter('name', ['like' => "%{$query}%"]);
+            // Apply search filter based on configured search type
+            $searchType = (int) Mage::getStoreConfig(Mage_CatalogSearch_Model_Fulltext::XML_PATH_CATALOG_SEARCH_TYPE);
+            $searchSeparator = strtoupper(Mage::getStoreConfig(Mage_CatalogSearch_Model_Fulltext::XML_PATH_CATALOG_SEARCH_SEPARATOR));
+
+            // Get max query words from configuration
+            $maxQueryWords = (int) Mage::getStoreConfig(Mage_CatalogSearch_Model_Query::XML_PATH_MAX_QUERY_WORDS);
+
+            switch ($searchType) {
+                case Mage_CatalogSearch_Model_Fulltext::SEARCH_TYPE_FULLTEXT:
+                    // Fulltext search: split into words and use AND/OR based on separator config
+                    $words = Mage::helper('core/string')->splitWords($query, true, $maxQueryWords);
+                    if ($words) {
+                        if ($searchSeparator === 'AND') {
+                            // AND logic: all words must be present
+                            foreach ($words as $word) {
+                                $collection->addAttributeToFilter('name', ['like' => "%{$word}%"]);
+                            }
+                        } else {
+                            // OR logic: any word can match
+                            $conditions = [];
+                            foreach ($words as $word) {
+                                $conditions[] = ['like' => "%{$word}%"];
+                            }
+                            $collection->addAttributeToFilter('name', $conditions);
+                        }
+                    }
+                    break;
+
+                case Mage_CatalogSearch_Model_Fulltext::SEARCH_TYPE_COMBINE:
+                    // Combined search: match either the full phrase OR individual words (based on separator)
+                    $words = Mage::helper('core/string')->splitWords($query, true, $maxQueryWords);
+                    if ($words && count($words) > 1) {
+                        if ($searchSeparator === 'AND') {
+                            // AND logic for individual words, but also try full phrase
+                            // This is complex with EAV, so we'll prioritize full phrase
+                            $collection->addAttributeToFilter('name', ['like' => "%{$query}%"]);
+                        } else {
+                            // OR logic: match full phrase OR any individual word
+                            $conditions = [
+                                ['like' => "%{$query}%"], // Full phrase match
+                            ];
+                            foreach ($words as $word) {
+                                if ($word !== $query) {
+                                    $conditions[] = ['like' => "%{$word}%"];
+                                }
+                            }
+                            $collection->addAttributeToFilter('name', $conditions);
+                        }
+                    } else {
+                        // Single word search
+                        $collection->addAttributeToFilter('name', ['like' => "%{$query}%"]);
+                    }
+                    break;
+
+                case Mage_CatalogSearch_Model_Fulltext::SEARCH_TYPE_LIKE:
+                default:
+                    // LIKE search: split into words and use AND/OR based on separator config
+                    $words = Mage::helper('core/string')->splitWords($query, true, $maxQueryWords);
+                    if ($words && count($words) > 1) {
+                        if ($searchSeparator === 'AND') {
+                            // AND logic: all words must be present
+                            foreach ($words as $word) {
+                                $collection->addAttributeToFilter('name', ['like' => "%{$word}%"]);
+                            }
+                        } else {
+                            // OR logic: any word can match
+                            $conditions = [];
+                            foreach ($words as $word) {
+                                $conditions[] = ['like' => "%{$word}%"];
+                            }
+                            $collection->addAttributeToFilter('name', $conditions);
+                        }
+                    } else {
+                        // Single word search
+                        $collection->addAttributeToFilter('name', ['like' => "%{$query}%"]);
+                    }
+                    break;
+            }
 
             // Only show active categories
             $collection->addAttributeToFilter('is_active', 1);

--- a/app/code/core/Mage/Core/Helper/String.php
+++ b/app/code/core/Mage/Core/Helper/String.php
@@ -238,13 +238,14 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
      * @param string $wordSeparatorRegexp
      * @return array
      */
-    public function splitWords($str, $uniqueOnly = false, $maxWordLength = 0, $wordSeparatorRegexp = '\s')
+    public function splitWords($str, $uniqueOnly = false, $maxWordLength = 0, $wordSeparatorRegexp = '\s+')
     {
-        if (is_null($str)) {
+        if (is_null($str) || $str === '') {
             return [];
         }
+
         $result = [];
-        $split = preg_split('#' . $wordSeparatorRegexp . '#siu', $str, -1, PREG_SPLIT_NO_EMPTY);
+        $split = preg_split('#' . $wordSeparatorRegexp . '#siu', trim($str), -1, PREG_SPLIT_NO_EMPTY);
         foreach ($split as $word) {
             if ($uniqueOnly) {
                 $result[$word] = $word;
@@ -255,6 +256,7 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
         if ($maxWordLength && count($result) > $maxWordLength) {
             $result = array_slice($result, 0, $maxWordLength);
         }
+
         return $result;
     }
 


### PR DESCRIPTION
  The category autosuggest now respects the same search configurations as product search:

  - Honors catalog/search/search_type configuration:
    - LIKE and FULLTEXT: Split query into words and search based on separator logic
    - COMBINE: Searches for full phrase OR individual words (with OR separator), or just full phrase (with AND separator)
  - Respects catalog/search/search_separator configuration:
    - AND: All words must be present in category name
    - OR: Any word can match
  - Filters by catalog/search/min_query_length:
    - Words shorter than minimum length are filtered out
    - Falls back to full phrase search if no valid words remain
  - Limits by catalog/search/max_query_words:
    - Restricts the number of words processed
