### PR TITLE
  Fix concurrent duplicate key violation in tax observer during order processing

### DIFF
--- a/app/code/core/Mage/Tax/Model/Observer.php
+++ b/app/code/core/Mage/Tax/Model/Observer.php
@@ -121,7 +121,16 @@ class Mage_Tax_Model_Observer
                                     'tax_id'        => $result->getTaxId(),
                                     'tax_percent'   => $quoteItemId['percent'],
                                 ];
-                                Mage::getModel('tax/sales_order_tax_item')->setData($data)->save();
+
+                                // Use try-catch to handle concurrent duplicate key violations
+                                try {
+                                    Mage::getModel('tax/sales_order_tax_item')->setData($data)->save();
+                                } catch (Zend_Db_Statement_Exception $e) {
+                                    // Ignore duplicate key constraint violations (1062)
+                                    if (strpos($e->getMessage(), '1062') === false) {
+                                        throw $e;
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
 Summary

  - Fixed SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry error occurring during checkout
  - Added exception handling in Tax Observer to gracefully handle concurrent duplicate key violations
  - Prevents order processing failures when multiple processes attempt to create the same tax-item relationships

  Problem

  The Mage_Tax_Model_Observer::salesEventOrderAfterSave method was failing with duplicate key constraint violations on the UNQ_SALES_ORDER_TAX_ITEM_TAX_ID_ITEM_ID unique index. This occurred when:
  - Multiple concurrent processes handled the same order
  - The tax observer attempted to insert identical tax_id and item_id combinations simultaneously

  Solution

  Wrapped the tax item save operation in a try-catch block that:
  - Catches Zend_Db_Statement_Exception with MySQL error code 1062 (duplicate entry)
  - Silently ignores duplicate key violations (expected behavior for concurrent operations)
  - Re-throws all other database exceptions to preserve error handling

  Test Plan

  - Test single item checkout (should continue working)
  - Test multiple item checkout with same tax rates
  - Verify no tax calculation issues
  - Test concurrent order processing scenarios
