### PR TITLE
Removed `Zend_Controller` dependency

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -14941,12 +14941,6 @@ parameters:
 			path: app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/Product/EditController.php
 
 		-
-			rawMessage: Dead catch - Mage_Core_Exception is never thrown in the try block.
-			identifier: catch.neverThrown
-			count: 2
-			path: app/code/core/Mage/Downloadable/controllers/DownloadController.php
-
-		-
 			rawMessage: 'Method Mage_Customer_Model_Session::setBeforeAuthUrl() invoked with 2 parameters, 1 required.'
 			identifier: arguments.count
 			count: 1
@@ -26925,13 +26919,13 @@ parameters:
 			path: lib/Varien/Simplexml/Element.php
 
 		-
-			rawMessage: 'Parameter #1 $request (Mage_Api2_Model_Request) of method Mage_Api2_Model_Route_Abstract::match() should be compatible with parameter $path (string) of method Zend_Controller_Router_Route::match()'
-			identifier: method.childParameterType
-			count: 1
-			path: app/code/core/Mage/Api2/Model/Route/Abstract.php
-
-		-
 			rawMessage: 'Call to internal method Symfony\Component\HttpFoundation\Request::get() from outside its root namespace Symfony.'
 			identifier: method.internal
 			count: 1
 			path: app/code/core/Mage/Core/Controller/Request/Http.php
+
+		-
+			rawMessage: 'Parameter #1 $request (Mage_Api2_Model_Request) of method Mage_Api2_Model_Route_Abstract::match() should be compatible with parameter $path (string) of method Mage_Api2_Model_Route_Base::match()'
+			identifier: method.childParameterType
+			count: 1
+			path: app/code/core/Mage/Api2/Model/Route/Abstract.php

--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -5430,11 +5430,6 @@ parameters:
 			count: 1
 			path: app/code/core/Mage/Adminhtml/controllers/Customer/GroupController.php
 
-		-
-			rawMessage: 'Parameter #1 $content of method Zend_Controller_Response_Abstract::setBody() expects string, int given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Adminhtml/controllers/Customer/System/Config/ValidatevatController.php
 
 		-
 			rawMessage: 'Parameter #2 $timestamp of function date expects int|null, array|bool given.'
@@ -5442,11 +5437,6 @@ parameters:
 			count: 1
 			path: app/code/core/Mage/Adminhtml/controllers/CustomerController.php
 
-		-
-			rawMessage: 'Parameter #2 $value of method Zend_Controller_Response_Abstract::setHeader() expects string, array|bool given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Adminhtml/controllers/CustomerController.php
 
 		-
 			rawMessage: 'Method Mage_Adminhtml_IndexController::_getDeniedIframe() has no return type specified.'
@@ -6534,11 +6524,6 @@ parameters:
 			count: 1
 			path: app/code/core/Mage/Api2/Model/Response.php
 
-		-
-			rawMessage: 'Parameter #1 $request (Mage_Api2_Model_Request) of method Mage_Api2_Model_Route_Abstract::match() should be compatible with parameter $path (string) of method Zend_Controller_Router_Route::match()'
-			identifier: method.childParameterType
-			count: 1
-			path: app/code/core/Mage/Api2/Model/Route/Abstract.php
 
 		-
 			rawMessage: Constructor of class Mage_Api2_Model_Route_ApiType has an unused parameter $defaults.
@@ -10852,12 +10837,6 @@ parameters:
 			path: app/code/core/Mage/Checkout/controllers/MultishippingController.php
 
 		-
-			rawMessage: 'Parameter #2 $loginUrl of method Mage_Customer_Model_Session::authenticate() expects bool|null, string given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Checkout/controllers/MultishippingController.php
-
-		-
 			rawMessage: 'Call to an undefined method Mage_Sales_Model_Service_Order::register().'
 			identifier: method.notFound
 			count: 1
@@ -11259,53 +11238,6 @@ parameters:
 			count: 1
 			path: app/code/core/Mage/Core/Block/Text.php
 
-		-
-			rawMessage: 'Parameter #2 $value of method Zend_Controller_Response_Abstract::setHeader() expects string, int|false given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Core/Controller/Front/Action.php
-
-		-
-			rawMessage: Property Mage_Core_Controller_Request_Http::$_controllerModule has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/code/core/Mage/Core/Controller/Request/Http.php
-
-		-
-			rawMessage: Property Mage_Core_Controller_Request_Http::$_directFrontNames has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/code/core/Mage/Core/Controller/Request/Http.php
-
-		-
-			rawMessage: Property Mage_Core_Controller_Request_Http::$_requestString has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/code/core/Mage/Core/Controller/Request/Http.php
-
-		-
-			rawMessage: Property Mage_Core_Controller_Request_Http::$_requestedRouteName has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/code/core/Mage/Core/Controller/Request/Http.php
-
-		-
-			rawMessage: Property Mage_Core_Controller_Request_Http::$_route has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/code/core/Mage/Core/Controller/Request/Http.php
-
-		-
-			rawMessage: Property Mage_Core_Controller_Request_Http::$_routingInfo has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/code/core/Mage/Core/Controller/Request/Http.php
-
-		-
-			rawMessage: Property Mage_Core_Controller_Request_Http::$_storeCode has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/code/core/Mage/Core/Controller/Request/Http.php
 
 		-
 			rawMessage: Constructor of class Mage_Core_Controller_Varien_Action has an unused parameter $invokeArgs.
@@ -11349,23 +11281,8 @@ parameters:
 			count: 1
 			path: app/code/core/Mage/Core/Controller/Varien/Action.php
 
-		-
-			rawMessage: 'Parameter #2 $value of method Zend_Controller_Response_Abstract::setHeader() expects string, int|false given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Core/Controller/Varien/Action.php
 
-		-
-			rawMessage: 'Property Mage_Core_Controller_Varien_Action::$_request (Mage_Core_Controller_Request_Http) does not accept Zend_Controller_Request_Abstract.'
-			identifier: assign.propertyType
-			count: 1
-			path: app/code/core/Mage/Core/Controller/Varien/Action.php
 
-		-
-			rawMessage: 'Property Mage_Core_Controller_Varien_Action::$_response (Mage_Core_Controller_Response_Http) does not accept Zend_Controller_Response_Abstract.'
-			identifier: assign.propertyType
-			count: 1
-			path: app/code/core/Mage/Core/Controller/Varien/Action.php
 
 		-
 			rawMessage: Property Mage_Core_Controller_Varien_Exception::$_defaultActionName has no type specified.
@@ -12399,11 +12316,6 @@ parameters:
 			count: 1
 			path: app/code/core/Mage/Core/Model/Translate/Inline.php
 
-		-
-			rawMessage: 'Method Mage_Core_Model_Url::getRequest() should return Mage_Core_Controller_Request_Http but returns Zend_Controller_Request_Http.'
-			identifier: return.type
-			count: 1
-			path: app/code/core/Mage/Core/Model/Url.php
 
 		-
 			rawMessage: 'Method Mage_Core_Model_Url_Rewrite::setTags() invoked with 2 parameters, 1 required.'
@@ -13215,11 +13127,6 @@ parameters:
 			count: 1
 			path: app/code/core/Mage/Customer/Model/Resource/Setup.php
 
-		-
-			rawMessage: 'Parameter #1 $url of method Mage_Core_Controller_Response_Http::setRedirect() expects string, bool given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Customer/Model/Session.php
 
 		-
 			rawMessage: 'Method Mage_Customer_AccountController::_addSessionError() has no return type specified.'
@@ -15032,12 +14939,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/Product/EditController.php
-
-		-
-			rawMessage: 'Parameter #2 $loginUrl of method Mage_Customer_Model_Session::authenticate() expects bool|null, string given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Downloadable/controllers/CustomerController.php
 
 		-
 			rawMessage: Dead catch - Mage_Core_Exception is never thrown in the try block.
@@ -18655,11 +18556,6 @@ parameters:
 			count: 1
 			path: app/code/core/Mage/Paypal/Model/Observer.php
 
-		-
-			rawMessage: 'Parameter #1 $spec of method Zend_Controller_Response_Abstract::getBody() expects bool, string given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Paypal/Model/Observer.php
 
 		-
 			rawMessage: 'Method Mage_Paypal_Model_Payflowlink::_addTransaction() has no return type specified.'
@@ -21717,12 +21613,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: app/code/core/Mage/Sales/controllers/DownloadController.php
-
-		-
-			rawMessage: 'Parameter #2 $loginUrl of method Mage_Customer_Model_Session::authenticate() expects bool|null, string given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Sales/controllers/OrderController.php
 
 		-
 			rawMessage: 'Parameter #1 $select of method Varien_Db_Adapter_Interface::updateFromSelect() expects Varien_Db_Select, Zend_Db_Select given.'
@@ -27033,3 +26923,15 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: lib/Varien/Simplexml/Element.php
+
+		-
+			rawMessage: 'Parameter #1 $request (Mage_Api2_Model_Request) of method Mage_Api2_Model_Route_Abstract::match() should be compatible with parameter $path (string) of method Zend_Controller_Router_Route::match()'
+			identifier: method.childParameterType
+			count: 1
+			path: app/code/core/Mage/Api2/Model/Route/Abstract.php
+
+		-
+			rawMessage: 'Call to internal method Symfony\Component\HttpFoundation\Request::get() from outside its root namespace Symfony.'
+			identifier: method.internal
+			count: 1
+			path: app/code/core/Mage/Core/Controller/Request/Http.php

--- a/app/code/core/Mage/Admin/Model/Redirectpolicy.php
+++ b/app/code/core/Mage/Admin/Model/Redirectpolicy.php
@@ -34,7 +34,7 @@ class Mage_Admin_Model_Redirectpolicy
      */
     public function getRedirectUrl(
         Mage_Admin_Model_User $user,
-        ?Zend_Controller_Request_Http $request = null,
+        ?Mage_Core_Controller_Request_Http $request = null,
         $alternativeUrl = null,
     ) {
         if (empty($request)) {

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/System/Config/ValidatevatController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/System/Config/ValidatevatController.php
@@ -37,7 +37,7 @@ class Mage_Adminhtml_Customer_System_Config_ValidatevatController extends Mage_A
     public function validateAction(): void
     {
         $result = $this->_validate();
-        $this->getResponse()->setBody((int) $result->getIsValid());
+        $this->getResponse()->setBody((string) (int) $result->getIsValid());
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/CustomerController.php
@@ -793,7 +793,7 @@ class Mage_Adminhtml_CustomerController extends Mage_Adminhtml_Controller_Action
                 ->setHttpResponseCode(200)
                 ->setHeader('Pragma', 'public', true)
                 ->setHeader('Content-type', $contentType, true)
-                ->setHeader('Content-Length', $contentLength)
+                ->setHeader('Content-Length', (string) $contentLength)
                 ->setHeader('Last-Modified', date('r', $contentModify))
                 ->clearBody();
             $this->getResponse()->sendHeaders();

--- a/app/code/core/Mage/Api2/Model/Multicall.php
+++ b/app/code/core/Mage/Api2/Model/Multicall.php
@@ -166,7 +166,7 @@ class Mage_Api2_Model_Multicall
         $apiTypeRoute = Mage::getModel('api2/route_apiType');
 
         $chain = $apiTypeRoute->chain(
-            new Zend_Controller_Router_Route($this->_getConfig()->getMainRoute($subresourceName)),
+            $this->_getConfig()->getMainRoute($subresourceName),
         );
         $params = [];
         $params['api_type'] = 'rest';

--- a/app/code/core/Mage/Api2/Model/Request.php
+++ b/app/code/core/Mage/Api2/Model/Request.php
@@ -10,7 +10,7 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Mage_Api2_Model_Request extends Zend_Controller_Request_Http
+class Mage_Api2_Model_Request extends Mage_Core_Controller_Request_Http
 {
     /**
      * Character set which must be used in request

--- a/app/code/core/Mage/Api2/Model/Request/Internal.php
+++ b/app/code/core/Mage/Api2/Model/Request/Internal.php
@@ -71,11 +71,9 @@ class Mage_Api2_Model_Request_Internal extends Mage_Api2_Model_Request
 
     /**
      * Override parent method for request emulation during internal call
-     *
-     * @return string
      */
     #[\Override]
-    public function getMethod()
+    public function getMethod(): string
     {
         $method = $this->_method;
         if (!$method) {

--- a/app/code/core/Mage/Api2/Model/Resource.php
+++ b/app/code/core/Mage/Api2/Model/Resource.php
@@ -862,7 +862,7 @@ abstract class Mage_Api2_Model_Resource
         $apiTypeRoute = Mage::getModel('api2/route_apiType');
 
         $chain = $apiTypeRoute->chain(
-            new Zend_Controller_Router_Route($this->getConfig()->getRouteWithEntityTypeAction($this->getResourceType())),
+            $this->getConfig()->getRouteWithEntityTypeAction($this->getResourceType()),
         );
         $params = [
             'api_type' => $this->getRequest()->getApiType(),

--- a/app/code/core/Mage/Api2/Model/Response.php
+++ b/app/code/core/Mage/Api2/Model/Response.php
@@ -9,7 +9,7 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Mage_Api2_Model_Response extends Zend_Controller_Response_Http
+class Mage_Api2_Model_Response extends Mage_Core_Controller_Response_Http
 {
     /**
      * Character set which must be used in response
@@ -34,7 +34,7 @@ class Mage_Api2_Model_Response extends Zend_Controller_Response_Http
      * Set header appropriate to specified MIME type
      *
      * @param string $mimeType MIME type
-     * @return $this
+     * @return Mage_Core_Controller_Response_Http
      */
     public function setMimeType($mimeType)
     {

--- a/app/code/core/Mage/Api2/Model/Route/Abstract.php
+++ b/app/code/core/Mage/Api2/Model/Route/Abstract.php
@@ -6,36 +6,34 @@
  * @package    Mage_Api2
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2023 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-abstract class Mage_Api2_Model_Route_Abstract extends Zend_Controller_Router_Route
+abstract class Mage_Api2_Model_Route_Abstract extends Mage_Api2_Model_Route_Base
 {
     /**
-     * Names for Zend_Controller_Router_Route::__construct params
+     * Names for parent::__construct params
      */
     public const PARAM_ROUTE      = 'route';
     public const PARAM_DEFAULTS   = 'defaults';
     public const PARAM_REQS       = 'reqs';
-    public const PARAM_TRANSLATOR = 'translator';
-    public const PARAM_LOCALE     = 'locale';
 
     /**
      * Default values of parent::__construct() params
      *
-     * @var array
+     * @var array<string, mixed>
      */
-    protected $_paramsDefaultValues = [
-        self::PARAM_ROUTE      => null,
+    protected array $_paramsDefaultValues = [
+        self::PARAM_ROUTE      => '',
         self::PARAM_DEFAULTS   => [],
         self::PARAM_REQS       => [],
-        self::PARAM_TRANSLATOR => null,
-        self::PARAM_LOCALE     => null,
     ];
 
     /**
      * Process construct param and call parent::__construct() with params
+     *
+     * @param array<string, mixed> $arguments
      */
     public function __construct(array $arguments)
     {
@@ -43,8 +41,6 @@ abstract class Mage_Api2_Model_Route_Abstract extends Zend_Controller_Router_Rou
             $this->_getArgumentValue(self::PARAM_ROUTE, $arguments),
             $this->_getArgumentValue(self::PARAM_DEFAULTS, $arguments),
             $this->_getArgumentValue(self::PARAM_REQS, $arguments),
-            $this->_getArgumentValue(self::PARAM_TRANSLATOR, $arguments),
-            $this->_getArgumentValue(self::PARAM_LOCALE, $arguments),
         );
     }
 
@@ -52,9 +48,9 @@ abstract class Mage_Api2_Model_Route_Abstract extends Zend_Controller_Router_Rou
      * Retrieve argument value
      *
      * @param string $name argument name
-     * @return mixed
+     * @param array<string, mixed> $arguments
      */
-    protected function _getArgumentValue($name, array $arguments)
+    protected function _getArgumentValue(string $name, array $arguments): mixed
     {
         return $arguments[$name] ?? $this->_paramsDefaultValues[$name];
     }
@@ -65,10 +61,10 @@ abstract class Mage_Api2_Model_Route_Abstract extends Zend_Controller_Router_Rou
      *
      * @param Mage_Api2_Model_Request $request
      * @param bool $partial Partial path matching
-     * @return array|bool An array of assigned values or a boolean false on a mismatch
+     * @return array<string, mixed>|false An array of assigned values or false on a mismatch
      */
     #[\Override]
-    public function match($request, $partial = false)
+    public function match($request, bool $partial = false): array|false
     {
         return parent::match(ltrim($request->getPathInfo(), $this->_urlDelimiter), $partial);
     }

--- a/app/code/core/Mage/Api2/Model/Route/ApiType.php
+++ b/app/code/core/Mage/Api2/Model/Route/ApiType.php
@@ -45,10 +45,10 @@ class Mage_Api2_Model_Route_ApiType extends Mage_Api2_Model_Route_Abstract imple
      *
      * @param Mage_Api2_Model_Request $request Request to get the named path info arguments
      * @param bool $partial OPTIONAL Partial path matching (default: false)
-     * @return array|false An array of assigned values or false on a mismatch
+     * @return array<string, mixed>|false An array of assigned values or false on a mismatch
      */
     #[\Override]
-    public function match($request, $partial = false)
+    public function match($request, bool $partial = false): array|false
     {
         // First try normal PATH_INFO matching
         $result = parent::match($request, $partial);

--- a/app/code/core/Mage/Api2/Model/Route/Base.php
+++ b/app/code/core/Mage/Api2/Model/Route/Base.php
@@ -1,0 +1,322 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @package    Mage_Api2
+ * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Base route class for API2 routing
+ *
+ * Simplified route matching for REST API patterns like /api/:api_type/products/:id
+ * Supports variables (:varName) and regex requirements
+ *
+ * - Pattern parsing with :variables
+ * - Regex requirements for variables
+ * - Default values
+ * - URL path matching
+ */
+class Mage_Api2_Model_Route_Base
+{
+    /**
+     * URI delimiter
+     */
+    public const URI_DELIMITER = '/';
+
+    /**
+     * Variable prefix in route pattern
+     */
+    protected string $_urlVariable = ':';
+
+    /**
+     * URI delimiter for splitting paths
+     */
+    protected string $_urlDelimiter = self::URI_DELIMITER;
+
+    /**
+     * Regex delimiter for pattern matching
+     */
+    protected string $_regexDelimiter = '#';
+
+    /**
+     * Default regex for variables (null = match anything)
+     */
+    protected ?string $_defaultRegex = null;
+
+    /**
+     * Holds names of all route's pattern variable names. Array index holds a position in URL.
+     *
+     * @var array<int, string>
+     */
+    protected array $_variables = [];
+
+    /**
+     * Holds Route patterns for all URL parts.
+     * - For a variable: stores its regex requirement or null
+     * - For a static part: stores its literal value
+     *
+     * @var array<int, string|null>
+     */
+    protected array $_parts = [];
+
+    /**
+     * Holds user submitted default values for route's variables
+     *
+     * @var array<string, mixed>
+     */
+    protected array $_defaults = [];
+
+    /**
+     * Holds user submitted regular expression patterns for route's variables' values
+     *
+     * @var array<string, string>
+     */
+    protected array $_requirements = [];
+
+    /**
+     * Associative array filled on match() that holds matched path values
+     *
+     * @var array<string, string>
+     */
+    protected array $_values = [];
+
+    /**
+     * Count of route pattern's static parts for validation
+     */
+    protected int $_staticCount = 0;
+
+    /**
+     * Path matched by this route
+     */
+    protected ?string $_matchedPath = null;
+
+    /**
+     * Prepares the route for mapping by splitting (exploding) it
+     * to corresponding atomic parts.
+     *
+     * @param string $route Map used to match with later submitted URL path (e.g., "api/:api_type/products/:id")
+     * @param array<string, mixed> $defaults Defaults for map variables with keys as variable names
+     * @param array<string, string> $reqs Regular expression requirements for variables (keys as variable names)
+     */
+    public function __construct(
+        string $route,
+        array $defaults = [],
+        array $reqs = [],
+    ) {
+        $route               = trim($route, $this->_urlDelimiter);
+        $this->_defaults     = $defaults;
+        $this->_requirements = $reqs;
+
+        if ($route !== '') {
+            foreach (explode($this->_urlDelimiter, $route) as $pos => $part) {
+                // Check if this part is a variable (starts with : but not ::)
+                if (str_starts_with($part, $this->_urlVariable) && !str_starts_with($part, $this->_urlVariable . $this->_urlVariable)) {
+                    $name = substr($part, 1);
+
+                    $this->_parts[$pos]     = $reqs[$name] ?? $this->_defaultRegex;
+                    $this->_variables[$pos] = $name;
+                } else {
+                    // Escape literal : if pattern is ::something
+                    if (str_starts_with($part, $this->_urlVariable)) {
+                        $part = substr($part, 1);
+                    }
+
+                    $this->_parts[$pos] = $part;
+                    $this->_staticCount++;
+                }
+            }
+        }
+    }
+
+    /**
+     * Matches a user submitted path with parts defined by a map.
+     * Assigns and returns an array of variables on a successful match.
+     *
+     * @param string $path Path used to match against this routing map
+     * @param bool $partial Allow partial path matching (default: false)
+     * @return array<string, mixed>|false An array of assigned values or false on a mismatch
+     */
+    public function match(string $path, bool $partial = false): array|false
+    {
+        $pathStaticCount = 0;
+        $values          = [];
+        $matchedPath     = '';
+
+        if (!$partial) {
+            $path = trim($path, $this->_urlDelimiter);
+        }
+
+        if ($path !== '') {
+            $pathParts = explode($this->_urlDelimiter, $path);
+
+            foreach ($pathParts as $pos => $pathPart) {
+                // Path is longer than a route, it's not a match
+                if (!array_key_exists($pos, $this->_parts)) {
+                    if ($partial) {
+                        break;
+                    }
+                    return false;
+                }
+
+                $matchedPath .= $pathPart . $this->_urlDelimiter;
+
+                $name     = $this->_variables[$pos] ?? null;
+                $pathPart = urldecode($pathPart);
+                $part     = $this->_parts[$pos];
+
+                // If it's a static part, match directly
+                if ($name === null && $part !== $pathPart) {
+                    return false;
+                }
+
+                // If it's a variable with requirement, match a regex. If not - everything matches
+                if ($part !== null
+                    && !preg_match(
+                        $this->_regexDelimiter . '^' . $part . '$' . $this->_regexDelimiter . 'iu',
+                        $pathPart,
+                    )
+                ) {
+                    return false;
+                }
+
+                // If it's a variable store its value for later
+                if ($name !== null) {
+                    $values[$name] = $pathPart;
+                } else {
+                    $pathStaticCount++;
+                }
+            }
+        }
+
+        // Check if all static mappings have been matched
+        if ($this->_staticCount !== $pathStaticCount) {
+            return false;
+        }
+
+        $return = $values + $this->_defaults;
+
+        // Check if all map variables have been initialized
+        foreach ($this->_variables as $var) {
+            if (!array_key_exists($var, $return)) {
+                return false;
+            } elseif ($return[$var] === '' || $return[$var] === null) {
+                // Empty variable? Replace with the default value.
+                $return[$var] = $this->_defaults[$var] ?? null;
+            }
+        }
+
+        $this->setMatchedPath(rtrim($matchedPath, $this->_urlDelimiter));
+
+        $this->_values = $values;
+
+        return $return;
+    }
+
+    /**
+     * Set partially matched path
+     */
+    public function setMatchedPath(string $path): void
+    {
+        $this->_matchedPath = $path;
+    }
+
+    /**
+     * Get partially matched path
+     */
+    public function getMatchedPath(): ?string
+    {
+        return $this->_matchedPath;
+    }
+
+    /**
+     * Return a single parameter of route's defaults
+     */
+    public function getDefault(string $name): mixed
+    {
+        return $this->_defaults[$name] ?? null;
+    }
+
+    /**
+     * Return an array of defaults
+     *
+     * @return array<string, mixed>
+     */
+    public function getDefaults(): array
+    {
+        return $this->_defaults;
+    }
+
+    /**
+     * Get all variables which are used by the route
+     *
+     * @return array<int, string>
+     */
+    public function getVariables(): array
+    {
+        return $this->_variables;
+    }
+
+    /**
+     * Create a new chain by combining this route with another
+     *
+     * Returns a chain object that can match/assemble both routes in sequence.
+     * Used for API2 to combine api/:api_type with resource-specific routes.
+     *
+     * @param Mage_Api2_Model_Route_Base|string $route Route object or route pattern string
+     * @param string $separator Separator between routes
+     */
+    public function chain($route, string $separator = '/'): Mage_Api2_Model_Route_Chain
+    {
+        // If route is a string pattern, convert it to a route object
+        if (is_string($route)) {
+            $route = new Mage_Api2_Model_Route_Base($route);
+        }
+
+        return new Mage_Api2_Model_Route_Chain($this, $route, $separator);
+    }
+
+    /**
+     * Assembles user submitted parameters forming a URL path defined by this route
+     *
+     * Takes route pattern like "api/:api_type/products/:id" and fills in variables
+     * from $data to create "api/rest/products/123"
+     *
+     * @param array<string, mixed> $data An array of variable and value pairs used as parameters
+     * @param bool $reset Whether or not to set route defaults with those provided in $data
+     * @param bool $encode Whether to URL encode the assembled path
+     * @param bool $partial Whether to allow partial URL assembly
+     * @return string Route path with user submitted parameters
+     */
+    public function assemble(array $data = [], bool $reset = false, bool $encode = false, bool $partial = false): string
+    {
+        $url = [];
+
+        // Build URL from parts, replacing variables with data values
+        foreach ($this->_parts as $key => $part) {
+            $name = $this->_variables[$key] ?? null;
+
+            if ($name !== null) {
+                // This is a variable - get its value from data
+                if (isset($data[$name])) {
+                    $value = $data[$name];
+                    unset($data[$name]);
+                } elseif (isset($this->_defaults[$name])) {
+                    $value = $this->_defaults[$name];
+                } else {
+                    // Required variable is missing
+                    continue;
+                }
+
+                $url[$key] = $encode ? urlencode((string) $value) : (string) $value;
+            } else {
+                // This is a static part
+                $url[$key] = $part;
+            }
+        }
+
+        return implode($this->_urlDelimiter, $url);
+    }
+}

--- a/app/code/core/Mage/Api2/Model/Route/Chain.php
+++ b/app/code/core/Mage/Api2/Model/Route/Chain.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @package    Mage_Api2
+ * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Route chain for combining multiple routes
+ *
+ * Allows chaining routes like: api/:api_type + products/:id = api/:api_type/products/:id
+ * Used by API2 to build compound routes.
+ */
+class Mage_Api2_Model_Route_Chain extends Mage_Api2_Model_Route_Base
+{
+    /**
+     * First route in the chain
+     */
+    protected Mage_Api2_Model_Route_Base $_route1;
+
+    /**
+     * Second route in the chain
+     */
+    protected Mage_Api2_Model_Route_Base $_route2;
+
+    /**
+     * Separator between routes
+     */
+    protected string $_separator;
+
+    /**
+     * Create a chain of two routes
+     *
+     * @param Mage_Api2_Model_Route_Base $route1 First route
+     * @param Mage_Api2_Model_Route_Base $route2 Second route
+     * @param string $separator Separator between routes (default: '/')
+     */
+    public function __construct(
+        Mage_Api2_Model_Route_Base $route1,
+        Mage_Api2_Model_Route_Base $route2,
+        string $separator = '/',
+    ) {
+        $this->_route1 = $route1;
+        $this->_route2 = $route2;
+        $this->_separator = $separator;
+
+        // Don't call parent constructor - we don't have a route pattern
+    }
+
+    /**
+     * Match path against chained routes
+     *
+     * Matches first route, then matches remainder against second route.
+     *
+     * @param string $path Path to match
+     * @param bool $partial Allow partial matching
+     * @return array<string, mixed>|false
+     */
+    #[\Override]
+    public function match(string $path, bool $partial = false): array|false
+    {
+        // Match first route
+        $result1 = $this->_route1->match($path, true);
+        if ($result1 === false) {
+            return false;
+        }
+
+        // Get matched path and calculate remainder
+        $matchedPath = $this->_route1->getMatchedPath();
+        if ($matchedPath) {
+            $pathRemainder = ltrim(substr($path, strlen($matchedPath)), $this->_separator);
+        } else {
+            $pathRemainder = $path;
+        }
+
+        // Match remainder against second route
+        $result2 = $this->_route2->match($pathRemainder, $partial);
+        if ($result2 === false) {
+            return false;
+        }
+
+        // Combine results
+        $this->setMatchedPath($matchedPath . $this->_separator . $this->_route2->getMatchedPath());
+
+        return $result1 + $result2;
+    }
+
+    /**
+     * Assemble URL from chained routes
+     *
+     * Assembles both routes and joins them with separator.
+     *
+     * @param array<string, mixed> $data Parameters for assembly
+     * @param bool $reset Reset to defaults
+     * @param bool $encode URL encode the result
+     * @param bool $partial Allow partial assembly
+     */
+    #[\Override]
+    public function assemble(array $data = [], bool $reset = false, bool $encode = false, bool $partial = false): string
+    {
+        $url1 = $this->_route1->assemble($data, $reset, $encode, $partial);
+        $url2 = $this->_route2->assemble($data, $reset, $encode, $partial);
+
+        if ($url1 && $url2) {
+            return $url1 . $this->_separator . $url2;
+        }
+
+        return $url1 . $url2;
+    }
+
+    /**
+     * Get defaults from both routes
+     *
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    public function getDefaults(): array
+    {
+        return $this->_route1->getDefaults() + $this->_route2->getDefaults();
+    }
+}

--- a/app/code/core/Mage/Api2/Model/Route/Interface.php
+++ b/app/code/core/Mage/Api2/Model/Route/Interface.php
@@ -6,6 +6,7 @@
  * @package    Mage_Api2
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -17,7 +18,7 @@ interface Mage_Api2_Model_Route_Interface
      *
      * @param Mage_Api2_Model_Request $request
      * @param bool $partial Partial path matching
-     * @return array|false An array of assigned values or a false on a mismatch
+     * @return array<string, mixed>|false An array of assigned values or false on a mismatch
      */
-    public function match($request, $partial = false);
+    public function match($request, bool $partial = false): array|false;
 }

--- a/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/SelectionController.php
+++ b/app/code/core/Mage/Bundle/controllers/Adminhtml/Bundle/SelectionController.php
@@ -25,7 +25,7 @@ class Mage_Bundle_Adminhtml_Bundle_SelectionController extends Mage_Adminhtml_Co
     }
 
     /**
-     * @return Zend_Controller_Response_Abstract
+     * @return Mage_Core_Controller_Response_Http
      */
     public function searchAction()
     {
@@ -39,7 +39,7 @@ class Mage_Bundle_Adminhtml_Bundle_SelectionController extends Mage_Adminhtml_Co
     }
 
     /**
-     * @return Zend_Controller_Response_Abstract
+     * @return Mage_Core_Controller_Response_Http
      */
     public function gridAction()
     {

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Category/Rest/Admin/V1.php
@@ -121,9 +121,9 @@ class Mage_Catalog_Model_Api2_Product_Category_Rest_Admin_V1 extends Mage_Catalo
         /** @var Mage_Api2_Model_Route_ApiType $apiTypeRoute */
         $apiTypeRoute = Mage::getModel('api2/route_apiType');
 
-        $chain = $apiTypeRoute->chain(new Zend_Controller_Router_Route(
+        $chain = $apiTypeRoute->chain(
             $this->getConfig()->getRouteWithEntityTypeAction($this->getResourceType()),
-        ));
+        );
         $params = [
             'api_type' => $this->getRequest()->getApiType(),
             'id' => $this->getRequest()->getParam('id'),

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Admin/V1.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Admin/V1.php
@@ -211,7 +211,7 @@ class Mage_Catalog_Model_Api2_Product_Image_Rest_Admin_V1 extends Mage_Catalog_M
         $apiTypeRoute = Mage::getModel('api2/route_apiType');
 
         $chain = $apiTypeRoute->chain(
-            new Zend_Controller_Router_Route($this->getConfig()->getRouteWithEntityTypeAction($this->getResourceType())),
+            $this->getConfig()->getRouteWithEntityTypeAction($this->getResourceType()),
         );
         $params = [
             'api_type' => $this->getRequest()->getApiType(),

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest.php
@@ -215,7 +215,7 @@ abstract class Mage_Catalog_Model_Api2_Product_Website_Rest extends Mage_Catalog
         $apiTypeRoute = Mage::getModel('api2/route_apiType');
 
         $chain = $apiTypeRoute->chain(
-            new Zend_Controller_Router_Route($this->getConfig()->getRouteWithEntityTypeAction($this->getResourceType())),
+            $this->getConfig()->getRouteWithEntityTypeAction($this->getResourceType()),
         );
         $params = [
             'api_type' => $this->getRequest()->getApiType(),

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Abstract.php
@@ -74,7 +74,7 @@ abstract class Mage_Catalog_Model_Layer_Filter_Abstract extends Varien_Object
      * @param null $filterBlock deprecated
      * @return $this
      */
-    public function apply(Zend_Controller_Request_Abstract $request, $filterBlock)
+    public function apply(Mage_Core_Controller_Request_Http $request, $filterBlock)
     {
         return $this;
     }

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Attribute.php
@@ -62,7 +62,7 @@ class Mage_Catalog_Model_Layer_Filter_Attribute extends Mage_Catalog_Model_Layer
      * @return  Mage_Catalog_Model_Layer_Filter_Attribute
      */
     #[\Override]
-    public function apply(Zend_Controller_Request_Abstract $request, $filterBlock)
+    public function apply(Mage_Core_Controller_Request_Http $request, $filterBlock)
     {
         $filter = $request->getParam($this->_requestVar);
         if (is_array($filter)) {

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Category.php
@@ -62,7 +62,7 @@ class Mage_Catalog_Model_Layer_Filter_Category extends Mage_Catalog_Model_Layer_
      * @return  Mage_Catalog_Model_Layer_Filter_Category
      */
     #[\Override]
-    public function apply(Zend_Controller_Request_Abstract $request, $filterBlock)
+    public function apply(Mage_Core_Controller_Request_Http $request, $filterBlock)
     {
         $filter = (int) $request->getParam($this->getRequestVar());
         if (!$filter) {

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Decimal.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Decimal.php
@@ -58,7 +58,7 @@ class Mage_Catalog_Model_Layer_Filter_Decimal extends Mage_Catalog_Model_Layer_F
      * @return $this
      */
     #[\Override]
-    public function apply(Zend_Controller_Request_Abstract $request, $filterBlock)
+    public function apply(Mage_Core_Controller_Request_Http $request, $filterBlock)
     {
         parent::apply($request, $filterBlock);
 

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Price.php
@@ -357,7 +357,7 @@ class Mage_Catalog_Model_Layer_Filter_Price extends Mage_Catalog_Model_Layer_Fil
      * @return $this
      */
     #[\Override]
-    public function apply(Zend_Controller_Request_Abstract $request, $filterBlock)
+    public function apply(Mage_Core_Controller_Request_Http $request, $filterBlock)
     {
         /**
          * Filter must be string: $fromPrice-$toPrice

--- a/app/code/core/Mage/Checkout/controllers/OnepageController.php
+++ b/app/code/core/Mage/Checkout/controllers/OnepageController.php
@@ -667,7 +667,7 @@ class Mage_Checkout_OnepageController extends Mage_Checkout_Controller_Action
      * Prepare JSON formatted data for response to client
      *
      * @param mixed $response
-     * @return Zend_Controller_Response_Abstract
+     * @return Mage_Core_Controller_Response_Http
      */
     protected function _prepareDataJSON($response)
     {

--- a/app/code/core/Mage/Cms/Controller/Router.php
+++ b/app/code/core/Mage/Cms/Controller/Router.php
@@ -27,11 +27,9 @@ class Mage_Cms_Controller_Router extends Mage_Core_Controller_Varien_Router_Abst
 
     /**
      * Validate and Match Cms Page and modify request
-     *
-     * @return bool
      */
     #[\Override]
-    public function match(Mage_Core_Controller_Request_Http $request)
+    public function match(Mage_Core_Controller_Request_Http $request): bool
     {
         if (!Mage::isInstalled()) {
             Mage::app()->getFrontController()->getResponse()

--- a/app/code/core/Mage/Cms/Controller/Router.php
+++ b/app/code/core/Mage/Cms/Controller/Router.php
@@ -31,7 +31,7 @@ class Mage_Cms_Controller_Router extends Mage_Core_Controller_Varien_Router_Abst
      * @return bool
      */
     #[\Override]
-    public function match(Zend_Controller_Request_Http $request)
+    public function match(Mage_Core_Controller_Request_Http $request)
     {
         if (!Mage::isInstalled()) {
             Mage::app()->getFrontController()->getResponse()

--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -112,7 +112,7 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
     /**
      * Request object
      *
-     * @var Zend_Controller_Request_Http
+     * @var Mage_Core_Controller_Request_Http
      */
     protected $_request;
 

--- a/app/code/core/Mage/Core/Controller/Front/Action.php
+++ b/app/code/core/Mage/Core/Controller/Front/Action.php
@@ -120,7 +120,7 @@ class Mage_Core_Controller_Front_Action extends Mage_Core_Controller_Varien_Acti
             ->setHeader('Pragma', 'public', true)
             ->setHeader('Cache-Control', 'must-revalidate, post-check=0, pre-check=0', true)
             ->setHeader('Content-type', $contentType, true)
-            ->setHeader('Content-Length', is_null($contentLength) ? strlen($content) : $contentLength)
+            ->setHeader('Content-Length', (string) (is_null($contentLength) ? strlen($content) : $contentLength))
             ->setHeader('Content-Disposition', 'attachment; filename="' . $fileName . '"')
             ->setHeader('Last-Modified', date('r'));
 

--- a/app/code/core/Mage/Core/Controller/Request/Http.php
+++ b/app/code/core/Mage/Core/Controller/Request/Http.php
@@ -10,114 +10,443 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
 /**
- * Custom Zend_Controller_Request_Http class (formally)
+ * HTTP Request class wrapping Symfony Request
  *
- * Allows dispatching before and after events for each controller action
+ * Provides compatibility layer for Mage_Core_Controller_Request_Http while using Symfony HttpFoundation
  */
-class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
+class Mage_Core_Controller_Request_Http
 {
     public const XML_NODE_DIRECT_FRONT_NAMES = 'global/request/direct_front_name';
     public const DEFAULT_HTTP_PORT = 80;
     public const DEFAULT_HTTPS_PORT = 443;
+    public const SCHEME_HTTP = 'http';
+    public const SCHEME_HTTPS = 'https';
+
+    /**
+     * Symfony Request instance
+     */
+    protected SymfonyRequest $symfonyRequest;
 
     /**
      * ORIGINAL_PATH_INFO
-     * @var string
      */
-    protected $_originalPathInfo = '';
-    protected $_storeCode       = null;
-    protected $_requestString   = '';
+    protected string $_originalPathInfo = '';
+    protected ?string $_storeCode = null;
+    protected string $_requestString = '';
 
     /**
      * Path info array used before applying rewrite from config
-     *
-     * @var null|array
      */
-    protected $_rewritedPathInfo = null;
-    protected $_requestedRouteName = null;
-    protected $_routingInfo = [];
-
-    protected $_route;
-
-    protected $_directFrontNames = null;
-    protected $_controllerModule = null;
+    protected ?array $_rewritedPathInfo = null;
+    protected ?string $_requestedRouteName = null;
+    protected array $_routingInfo = [];
+    protected ?string $_route = null;
+    protected ?array $_directFrontNames = null;
+    protected ?string $_controllerModule = null;
 
     /**
-     * Streight request flag.
+     * Straight request flag.
      * If flag is determined no additional logic is applicable
-     *
-     * @var bool $_isStraight
      */
-    protected $_isStraight = false;
+    protected bool $_isStraight = false;
 
     /**
      * Request's original information before forward.
-     *
-     * @var array
      */
-    protected $_beforeForwardInfo = [];
+    protected array $_beforeForwardInfo = [];
 
     /**
      * Flag for recognizing if request internally forwarded
-     *
-     * @var bool
      */
-    protected $_internallyForwarded = false;
+    protected bool $_internallyForwarded = false;
 
     /**
-     * Returns ORIGINAL_PATH_INFO.
-     * This value is calculated instead of reading PATH_INFO
-     * directly from $_SERVER due to cross-platform differences.
-     *
-     * @return string 'something.html'|'/'|'/path0'|'/path0/path1/'|'/path0/path1/path2'|etc
+     * Has the action been dispatched?
      */
-    public function getOriginalPathInfo()
+    protected bool $_dispatched = false;
+
+    /**
+     * Module/Controller/Action info
+     */
+    protected ?string $_module = null;
+    protected ?string $_controller = null;
+    protected ?string $_action = null;
+
+    /**
+     * Keys for retrieving MCA from params
+     */
+    protected string $_moduleKey = 'module';
+    protected string $_controllerKey = 'controller';
+    protected string $_actionKey = 'action';
+
+    /**
+     * Request parameters
+     */
+    protected array $_params = [];
+
+    /**
+     * Aliases
+     */
+    protected array $_aliases = [];
+
+    /**
+     * PATH_INFO
+     */
+    protected string $_pathInfo = '';
+
+    /**
+     * Base URL
+     */
+    protected ?string $_baseUrl = null;
+
+    /**
+     * Base path
+     */
+    protected ?string $_basePath = null;
+
+    /**
+     * REQUEST_URI
+     */
+    protected ?string $_requestUri = null;
+
+    /**
+     * Allowed parameter sources
+     */
+    protected array $_paramSources = ['_GET', '_POST'];
+
+    /**
+     * Raw request body
+     */
+    protected string|false|null $_rawBody = null;
+
+    public function __construct(string|null $uri = null)
     {
-        if (empty($this->_originalPathInfo)) {
-            $this->setPathInfo();
+        // Create Symfony Request from globals or URI
+        if ($uri !== null) {
+            // Parse URI and create request
+            $parsedUrl = parse_url($uri);
+            $this->symfonyRequest = SymfonyRequest::create($uri);
+        } else {
+            $this->symfonyRequest = SymfonyRequest::createFromGlobals();
         }
-        return $this->_originalPathInfo;
     }
 
     /**
-     * @return string|null
-     * @throws Mage_Core_Model_Store_Exception
+     * Get the Symfony Request instance (for internal use)
      */
-    public function getStoreCodeFromPath()
+    public function getSymfonyRequest(): SymfonyRequest
     {
-        if (!$this->_storeCode) {
-            // get store view code
-            if ($this->_canBeStoreCodeInUrl()) {
-                $p = explode('/', trim($this->getPathInfo(), '/'));
-                $storeCode = $p[0];
+        return $this->symfonyRequest;
+    }
 
-                $stores = Mage::app()->getStores(true, true);
+    // ========== Mage_Core_Controller_Request_Http Methods ==========
 
-                if ($storeCode !== '' && isset($stores[$storeCode])) {
-                    array_shift($p);
-                    $this->setPathInfo(implode('/', $p));
-                    $this->_storeCode = $storeCode;
-                    Mage::app()->setCurrentStore($storeCode);
-                } else {
-                    $this->_storeCode = Mage::app()->getStore()->getCode();
-                }
-            } else {
-                $this->_storeCode = Mage::app()->getStore()->getCode();
+    public function getModuleName(): ?string
+    {
+        if ($this->_module === null) {
+            $this->_module = $this->getParam($this->getModuleKey());
+        }
+        return $this->_module;
+    }
+
+    public function setModuleName(string|null $value): self
+    {
+        $this->_module = $value;
+        return $this;
+    }
+
+    public function getControllerName(): ?string
+    {
+        if ($this->_controller === null) {
+            $this->_controller = $this->getParam($this->getControllerKey());
+        }
+        return $this->_controller;
+    }
+
+    public function setControllerName(string|null $value): self
+    {
+        $this->_controller = $value;
+        return $this;
+    }
+
+    public function getActionName(): ?string
+    {
+        if ($this->_action === null) {
+            $this->_action = $this->getParam($this->getActionKey());
+        }
+        return $this->_action;
+    }
+
+    public function setActionName(string|null $value): self
+    {
+        $this->_action = $value;
+        if ($value === null) {
+            $this->setParam($this->getActionKey(), $value);
+        }
+        return $this;
+    }
+
+    public function getModuleKey(): string
+    {
+        return $this->_moduleKey;
+    }
+
+    public function setModuleKey(string $key): self
+    {
+        $this->_moduleKey = (string) $key;
+        return $this;
+    }
+
+    public function getControllerKey(): string
+    {
+        return $this->_controllerKey;
+    }
+
+    public function setControllerKey(string $key): self
+    {
+        $this->_controllerKey = (string) $key;
+        return $this;
+    }
+
+    public function getActionKey(): string
+    {
+        return $this->_actionKey;
+    }
+
+    public function setActionKey(string $key): self
+    {
+        $this->_actionKey = (string) $key;
+        return $this;
+    }
+
+    public function getParam(string|int|null $key, mixed $default = null): mixed
+    {
+        return $this->_params[$key] ?? $this->symfonyRequest->get($key, $default);
+    }
+
+    public function getUserParams(): array
+    {
+        return $this->_params;
+    }
+
+    public function getUserParam(string|int $key, mixed $default = null): mixed
+    {
+        return $this->_params[$key] ?? $default;
+    }
+
+    public function setParam(string|int $key, mixed $value): self
+    {
+        $this->_params[$key] = $value;
+        return $this;
+    }
+
+    public function setParams(array $array): self
+    {
+        $this->_params = $array + $this->_params;
+        return $this;
+    }
+
+    public function getParams(): array
+    {
+        $params = $this->_params;
+        foreach ($this->_paramSources as $source) {
+            if (isset($GLOBALS[$source]) && is_array($GLOBALS[$source])) {
+                $params += $GLOBALS[$source];
             }
         }
-        return $this->_storeCode;
+        return $params;
     }
 
-    /**
-     * Set the PATH_INFO string
-     * Set the ORIGINAL_PATH_INFO string
-     *
-     * @param string|null $pathInfo
-     * @return Zend_Controller_Request_Http
-     */
-    #[\Override]
-    public function setPathInfo($pathInfo = null)
+    public function clearParams(): self
+    {
+        $this->_params = [];
+        return $this;
+    }
+
+    public function setDispatched(bool $flag = true): self
+    {
+        $this->_dispatched = (bool) $flag;
+        return $this;
+    }
+
+    public function isDispatched(): bool
+    {
+        return $this->_dispatched;
+    }
+
+    // ========== Mage_Core_Controller_Request_Http Methods ==========
+
+    public function __get(string $key): mixed
+    {
+        if (isset($this->_params[$key])) {
+            return $this->_params[$key];
+        } elseif (isset($_GET[$key])) {
+            return $_GET[$key];
+        } elseif (isset($_POST[$key])) {
+            return $_POST[$key];
+        } elseif (isset($_COOKIE[$key])) {
+            return $_COOKIE[$key];
+        } elseif (isset($_SERVER[$key])) {
+            return $_SERVER[$key];
+        } elseif (isset($_ENV[$key])) {
+            return $_ENV[$key];
+        }
+        return null;
+    }
+
+    public function get(string $key): mixed
+    {
+        return $this->__get($key);
+    }
+
+    public function __set(string $key, mixed $value): void
+    {
+        throw new Exception('Setting values via the overloading operator is prohibited; use setPost(), setQuery(), or setParam()');
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        throw new Exception('Setting values via set() is prohibited; use setPost(), setQuery(), or setParam()');
+    }
+
+    public function __isset(string $key): bool
+    {
+        return isset($this->_params[$key])
+            || isset($_GET[$key])
+            || isset($_POST[$key])
+            || isset($_COOKIE[$key])
+            || isset($_SERVER[$key])
+            || isset($_ENV[$key]);
+    }
+
+    public function has(string $key): bool
+    {
+        return $this->__isset($key);
+    }
+
+    public function setQuery(array|string $spec, mixed $value = null): self
+    {
+        if (is_array($spec)) {
+            $_GET = $spec;
+        } else {
+            $_GET[$spec] = $value;
+        }
+        return $this;
+    }
+
+    public function getQuery(string|null $key = null, mixed $default = null): mixed
+    {
+        if ($key === null) {
+            return $_GET;
+        }
+        return $_GET[$key] ?? $default;
+    }
+
+    public function setPost(array|string $spec, mixed $value = null): self
+    {
+        if (is_array($spec)) {
+            $_POST = $spec;
+        } else {
+            $_POST[$spec] = $value;
+        }
+        return $this;
+    }
+
+    public function getPost(string|null $key = null, mixed $default = null): mixed
+    {
+        if ($key === null) {
+            return $_POST;
+        }
+        return $_POST[$key] ?? $default;
+    }
+
+    public function getCookie(string|null $key = null, mixed $default = null): mixed
+    {
+        if ($key === null) {
+            return $_COOKIE;
+        }
+        return $_COOKIE[$key] ?? $default;
+    }
+
+    public function getServer(string|null $key = null, mixed $default = null): mixed
+    {
+        if ($key === null) {
+            return $_SERVER;
+        }
+        return $_SERVER[$key] ?? $default;
+    }
+
+    public function getEnv(string|null $key = null, mixed $default = null): mixed
+    {
+        if ($key === null) {
+            return $_ENV;
+        }
+        return $_ENV[$key] ?? $default;
+    }
+
+    public function setRequestUri(string|null $requestUri = null): self
+    {
+        if ($requestUri === null) {
+            $requestUri = $this->symfonyRequest->getRequestUri();
+        }
+        $this->_requestUri = $requestUri;
+        return $this;
+    }
+
+    public function getRequestUri(): ?string
+    {
+        if ($this->_requestUri === null) {
+            $this->_requestUri = $this->symfonyRequest->getRequestUri();
+        }
+        return $this->_requestUri;
+    }
+
+    public function setBaseUrl(string|null $baseUrl = null): self
+    {
+        if ($baseUrl === null) {
+            $baseUrl = $this->symfonyRequest->getBaseUrl();
+        }
+        $this->_baseUrl = $baseUrl;
+        return $this;
+    }
+
+    public function getBaseUrl(bool $raw = false): string
+    {
+        if ($this->_baseUrl === null) {
+            $this->_baseUrl = $this->symfonyRequest->getBaseUrl();
+        }
+        $url = $this->_baseUrl;
+        $url = str_replace('\\', '/', $url);
+        return $url;
+    }
+
+    public function setBasePath(string|null $basePath = null): self
+    {
+        if ($basePath === null) {
+            $basePath = $this->symfonyRequest->getBasePath();
+        }
+        $this->_basePath = $basePath;
+        return $this;
+    }
+
+    public function getBasePath(): string
+    {
+        if ($this->_basePath === null) {
+            $this->_basePath = $this->symfonyRequest->getBasePath();
+        }
+        $path = $this->_basePath;
+        if (empty($path)) {
+            $path = '/';
+        } else {
+            $path = str_replace('\\', '/', $path);
+        }
+        return $path;
+    }
+
+    public function setPathInfo(string|null $pathInfo = null): self
     {
         if ($pathInfo === null) {
             $requestUri = $this->getRequestUri();
@@ -137,9 +466,9 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
             if ($baseUrl && $pathInfo && (stripos($pathInfo, '/') !== 0)) {
                 $pathInfo = '';
                 $this->setActionName('noRoute');
-            } elseif ($baseUrl !== null && !$pathInfo) {
+            } elseif ($baseUrl && !$pathInfo) {
                 $pathInfo = '';
-            } elseif ($baseUrl === null) {
+            } elseif (!$baseUrl) {
                 $pathInfo = $requestUri;
             }
 
@@ -166,14 +495,193 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
         return $this;
     }
 
+    public function getPathInfo(): string
+    {
+        if ($this->_pathInfo === '') {
+            $this->setPathInfo();
+        }
+        return $this->_pathInfo;
+    }
+
+    public function setParamSources(array $paramSources = []): self
+    {
+        $this->_paramSources = $paramSources;
+        return $this;
+    }
+
+    public function getParamSources(): array
+    {
+        return $this->_paramSources;
+    }
+
+    public function setAlias(string $name, string $target): self
+    {
+        $this->_aliases[$name] = $target;
+        return $this;
+    }
+
+    public function getAlias(string $name): ?string
+    {
+        $aliases = $this->getAliases();
+        return $aliases[$name] ?? null;
+    }
+
+    public function getAliases(): array
+    {
+        return $this->_routingInfo['aliases'] ?? $this->_aliases;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->symfonyRequest->getMethod();
+    }
+
+    public function isPost(): bool
+    {
+        return $this->symfonyRequest->isMethod('POST');
+    }
+
+    public function isGet(): bool
+    {
+        return $this->symfonyRequest->isMethod('GET');
+    }
+
+    public function isPut(): bool
+    {
+        return $this->symfonyRequest->isMethod('PUT');
+    }
+
+    public function isDelete(): bool
+    {
+        return $this->symfonyRequest->isMethod('DELETE');
+    }
+
+    public function isHead(): bool
+    {
+        return $this->symfonyRequest->isMethod('HEAD');
+    }
+
+    public function isOptions(): bool
+    {
+        return $this->symfonyRequest->isMethod('OPTIONS');
+    }
+
+    public function isPatch(): bool
+    {
+        return $this->symfonyRequest->isMethod('PATCH');
+    }
+
+    public function isXmlHttpRequest(): bool
+    {
+        return $this->symfonyRequest->isXmlHttpRequest();
+    }
+
+    public function isFlashRequest(): bool
+    {
+        $header = strtolower($this->getHeader('USER_AGENT'));
+        return str_contains($header, ' flash');
+    }
+
+    public function isSecure(): bool
+    {
+        return $this->symfonyRequest->isSecure();
+    }
+
+    public function getRawBody(): string|false
+    {
+        if ($this->_rawBody === null) {
+            $this->_rawBody = $this->symfonyRequest->getContent();
+        }
+        return $this->_rawBody;
+    }
+
+    public function getHeader(string $header): string|false
+    {
+        // Symfony uses a different format for headers
+        $header = str_replace('-', '_', strtoupper($header));
+        if (!str_starts_with($header, 'HTTP_')) {
+            $header = 'HTTP_' . $header;
+        }
+        return $this->symfonyRequest->server->get($header, false);
+    }
+
+    public function getScheme(): string
+    {
+        return $this->getServer('HTTPS') == 'on'
+          || $this->getServer('HTTP_X_FORWARDED_PROTO') == 'https'
+          || (Mage::isInstalled() && Mage::app()->isCurrentlySecure()) ?
+            self::SCHEME_HTTPS :
+            self::SCHEME_HTTP;
+    }
+
+    public function getHttpHost(bool $trimPort = true): false|string
+    {
+        if (!isset($_SERVER['HTTP_HOST'])) {
+            return false;
+        }
+        $host = $_SERVER['HTTP_HOST'];
+        if ($trimPort) {
+            $hostParts = explode(':', $_SERVER['HTTP_HOST']);
+            $host = $hostParts[0];
+        }
+
+        if (str_contains($host, ',') || str_contains($host, ';')) {
+            $response = new Mage_Core_Controller_Response_Http();
+            $response->setHttpResponseCode(400)->sendHeaders();
+            exit();
+        }
+
+        return $host;
+    }
+
+    public function getClientIp(bool $checkProxy = true): ?string
+    {
+        return $this->symfonyRequest->getClientIp();
+    }
+
+    // ========== Maho-specific Methods ==========
+
+    public function getOriginalPathInfo(): string
+    {
+        if (empty($this->_originalPathInfo)) {
+            $this->setPathInfo();
+        }
+        return $this->_originalPathInfo;
+    }
+
+    /**
+     * @throws Mage_Core_Model_Store_Exception
+     */
+    public function getStoreCodeFromPath(): ?string
+    {
+        if (!$this->_storeCode) {
+            // get store view code
+            if ($this->_canBeStoreCodeInUrl()) {
+                $p = explode('/', trim($this->getPathInfo(), '/'));
+                $storeCode = $p[0];
+
+                $stores = Mage::app()->getStores(true, true);
+
+                if ($storeCode !== '' && isset($stores[$storeCode])) {
+                    array_shift($p);
+                    $this->setPathInfo(implode('/', $p));
+                    $this->_storeCode = $storeCode;
+                    Mage::app()->setCurrentStore($storeCode);
+                } else {
+                    $this->_storeCode = Mage::app()->getStore()->getCode();
+                }
+            } else {
+                $this->_storeCode = Mage::app()->getStore()->getCode();
+            }
+        }
+        return $this->_storeCode;
+    }
+
     /**
      * Specify new path info
      * It happen when occur rewrite based on configuration
-     *
-     * @param   string $pathInfo
-     * @return  Mage_Core_Controller_Request_Http
      */
-    public function rewritePathInfo($pathInfo)
+    public function rewritePathInfo(string $pathInfo): self
     {
         if (($pathInfo != $this->getPathInfo()) && ($this->_rewritedPathInfo === null)) {
             $this->_rewritedPathInfo = explode('/', trim($this->getPathInfo(), '/'));
@@ -184,10 +692,8 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
 
     /**
      * Check if can be store code as part of url
-     *
-     * @return bool
      */
-    protected function _canBeStoreCodeInUrl()
+    protected function _canBeStoreCodeInUrl(): bool
     {
         return Mage::isInstalled() && Mage::getStoreConfigFlag(Mage_Core_Model_Store::XML_PATH_STORE_IN_URL);
     }
@@ -195,11 +701,8 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
     /**
      * Check if code declared as direct access frontend name
      * this mean what this url can be used without store code
-     *
-     * @param   string $code
-     * @return  bool
      */
-    public function isDirectAccessFrontendName($code)
+    public function isDirectAccessFrontendName(string $code): bool
     {
         $names = $this->getDirectFrontNames();
         return isset($names[$code]);
@@ -207,10 +710,8 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
 
     /**
      * Get list of front names available with access without store code
-     *
-     * @return array
      */
-    public function getDirectFrontNames()
+    public function getDirectFrontNames(): array
     {
         if (is_null($this->_directFrontNames)) {
             $names = Mage::getConfig()->getNode(self::XML_NODE_DIRECT_FRONT_NAMES);
@@ -223,56 +724,19 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
         return $this->_directFrontNames;
     }
 
-    /**
-     * @return Zend_Controller_Request_Http
-     */
-    public function getOriginalRequest()
+    public function getOriginalRequest(): self
     {
-        $request = new Zend_Controller_Request_Http();
+        $request = new self();
         $request->setPathInfo($this->getOriginalPathInfo());
         return $request;
     }
 
-    /**
-     * @return string
-     */
-    public function getRequestString()
+    public function getRequestString(): string
     {
         return $this->_requestString;
     }
 
-    /**
-     * @return string
-     */
-    #[\Override]
-    public function getBasePath()
-    {
-        $path = parent::getBasePath();
-        if (empty($path)) {
-            $path = '/';
-        } else {
-            $path = str_replace('\\', '/', $path);
-        }
-        return $path;
-    }
-
-    /**
-     * @param bool $raw
-     * @return string
-     */
-    #[\Override]
-    public function getBaseUrl($raw = false)
-    {
-        $url = parent::getBaseUrl($raw);
-        $url = str_replace('\\', '/', $url);
-        return $url;
-    }
-
-    /**
-     * @param string $route
-     * @return $this
-     */
-    public function setRouteName($route)
+    public function setRouteName(string $route): self
     {
         $this->_route = $route;
         $router = Mage::app()->getFrontController()->getRouterByRoute($route);
@@ -286,81 +750,15 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getRouteName()
+    public function getRouteName(): ?string
     {
         return $this->_route;
     }
 
     /**
-     * Get the request URI scheme
-     *
-     * @return string
-     */
-    #[\Override]
-    public function getScheme()
-    {
-        return $this->getServer('HTTPS') == 'on'
-          || $this->getServer('HTTP_X_FORWARDED_PROTO') == 'https'
-          || (Mage::isInstalled() && Mage::app()->isCurrentlySecure()) ?
-            self::SCHEME_HTTPS :
-            self::SCHEME_HTTP;
-    }
-
-    /**
-     * Retrieve HTTP HOST
-     *
-     * @param bool $trimPort
-     * @return false|string
-     */
-    #[\Override]
-    public function getHttpHost($trimPort = true)
-    {
-        if (!isset($_SERVER['HTTP_HOST'])) {
-            return false;
-        }
-        $host = $_SERVER['HTTP_HOST'];
-        if ($trimPort) {
-            $hostParts = explode(':', $_SERVER['HTTP_HOST']);
-            $host =  $hostParts[0];
-        }
-
-        if (str_contains($host, ',') || str_contains($host, ';')) {
-            $response = new Zend_Controller_Response_Http();
-            $response->setHttpResponseCode(400)->sendHeaders();
-            exit();
-        }
-
-        return $host;
-    }
-
-    /**
-     * Set a member of the $_POST superglobal
-     *
-     * @param string|array $key
-     * @param mixed $value
-     * @return $this
-     */
-    #[\Override]
-    public function setPost($key, $value = null)
-    {
-        if (is_array($key)) {
-            $_POST = $key;
-        } else {
-            $_POST[$key] = $value;
-        }
-        return $this;
-    }
-
-    /**
      * Specify module name where was found currently used controller
-     *
-     * @param   string $module
-     * @return  Mage_Core_Controller_Request_Http
      */
-    public function setControllerModule($module)
+    public function setControllerModule(string $module): self
     {
         $this->_controllerModule = $module;
         return $this;
@@ -368,77 +766,16 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
 
     /**
      * Get module name of currently used controller
-     *
-     * @return  string
      */
-    public function getControllerModule()
+    public function getControllerModule(): ?string
     {
         return $this->_controllerModule;
     }
 
     /**
-     * Retrieve the module name
-     *
-     * @return string
-     */
-    #[\Override]
-    public function getModuleName()
-    {
-        return $this->_module;
-    }
-    /**
-     * Retrieve the controller name
-     *
-     * @return string
-     */
-    #[\Override]
-    public function getControllerName()
-    {
-        return $this->_controller;
-    }
-    /**
-     * Retrieve the action name
-     *
-     * @return string
-     */
-    #[\Override]
-    public function getActionName()
-    {
-        return $this->_action;
-    }
-
-    /**
-     * Retrieve an alias
-     *
-     * Retrieve the actual key represented by the alias $name.
-     *
-     * @param string $name
-     * @return string|null Returns null when no alias exists
-     */
-    #[\Override]
-    public function getAlias($name)
-    {
-        $aliases = $this->getAliases();
-        return $aliases[$name] ?? null;
-    }
-
-    /**
-     * Retrieve the list of all aliases
-     *
-     * @return array
-     */
-    #[\Override]
-    public function getAliases()
-    {
-        return $this->_routingInfo['aliases'] ?? parent::getAliases();
-    }
-
-    /**
      * Get route name used in request (ignore rewrite)
-     *
-     * @return string
      */
-    public function getRequestedRouteName()
+    public function getRequestedRouteName(): ?string
     {
         if (isset($this->_routingInfo['requested_route'])) {
             return $this->_routingInfo['requested_route'];
@@ -458,10 +795,8 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
 
     /**
      * Get controller name used in request (ignore rewrite)
-     *
-     * @return string
      */
-    public function getRequestedControllerName()
+    public function getRequestedControllerName(): ?string
     {
         if (isset($this->_routingInfo['requested_controller'])) {
             return $this->_routingInfo['requested_controller'];
@@ -474,10 +809,8 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
 
     /**
      * Get action name used in request (ignore rewrite)
-     *
-     * @return string
      */
-    public function getRequestedActionName()
+    public function getRequestedActionName(): ?string
     {
         if (isset($this->_routingInfo['requested_action'])) {
             return $this->_routingInfo['requested_action'];
@@ -490,25 +823,18 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
 
     /**
      * Set routing info data
-     *
-     * @param array $data
-     * @return $this
      */
-    public function setRoutingInfo($data)
+    public function setRoutingInfo(array $data): self
     {
-        if (is_array($data)) {
-            $this->_routingInfo = $data;
-        }
+        $this->_routingInfo = $data;
         return $this;
     }
 
     /**
      * Collect properties changed by _forward in protected storage
      * before _forward was called first time.
-     *
-     * @return $this
      */
-    public function initForward()
+    public function initForward(): self
     {
         if (empty($this->_beforeForwardInfo)) {
             $this->_beforeForwardInfo = [
@@ -526,11 +852,8 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
      * Retrieve property's value which was before _forward call.
      * If property was not changed during _forward call null will be returned.
      * If passed name will be null whole state array will be returned.
-     *
-     * @param string $name
-     * @return array|string|null
      */
-    public function getBeforeForwardInfo($name = null)
+    public function getBeforeForwardInfo(string|null $name = null): array|string|null
     {
         if (is_null($name)) {
             return $this->_beforeForwardInfo;
@@ -543,11 +866,8 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
 
     /**
      * Specify/get _isStraight flag value
-     *
-     * @param bool $flag
-     * @return bool
      */
-    public function isStraight($flag = null)
+    public function isStraight(bool|null $flag = null): bool
     {
         if ($flag !== null) {
             $this->_isStraight = $flag;
@@ -557,10 +877,8 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
 
     /**
      * Check is Request from AJAX
-     *
-     * @return bool
      */
-    public function isAjax()
+    public function isAjax(): bool
     {
         if ($this->isXmlHttpRequest()) {
             return true;
@@ -573,11 +891,8 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
 
     /**
      * Define that request was forwarded internally
-     *
-     * @param bool $flag
-     * @return $this
      */
-    public function setInternallyForwarded($flag = true)
+    public function setInternallyForwarded(bool $flag = true): self
     {
         $this->_internallyForwarded = (bool) $flag;
         return $this;
@@ -585,10 +900,8 @@ class Mage_Core_Controller_Request_Http extends Zend_Controller_Request_Http
 
     /**
      * Checks if request was forwarded internally
-     *
-     * @return bool
      */
-    public function getInternallyForwarded()
+    public function getInternallyForwarded(): bool
     {
         return $this->_internallyForwarded;
     }

--- a/app/code/core/Mage/Core/Controller/Response/Http.php
+++ b/app/code/core/Mage/Core/Controller/Response/Http.php
@@ -10,20 +10,267 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Mage_Core_Controller_Response_Http extends Zend_Controller_Response_Http
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+/**
+ * HTTP Response class wrapping Symfony Response
+ *
+ * Provides compatibility layer for Mage_Core_Controller_Response_Http while using Symfony HttpFoundation
+ */
+class Mage_Core_Controller_Response_Http
 {
     /**
-     * Transport object for observers to perform
-     * @var Varien_Object
+     * Symfony Response instance
      */
-    protected static $_transportObject = null;
+    protected SymfonyResponse $symfonyResponse;
 
     /**
-     * Fixes CGI only one Status header allowed bug
-     * @link  http://bugs.php.net/bug.php?id=36705
+     * Transport object for observers to perform
      */
-    #[\Override]
-    public function sendHeaders()
+    protected static ?Varien_Object $_transportObject = null;
+
+    /**
+     * Array of headers
+     */
+    protected array $_headers = [];
+
+    /**
+     * Array of raw headers
+     */
+    protected array $_headersRaw = [];
+
+    /**
+     * HTTP response code
+     */
+    protected int $_httpResponseCode = 200;
+
+    /**
+     * Flag; is this response a redirect?
+     */
+    protected bool $_isRedirect = false;
+
+    /**
+     * Whether or not to render exceptions
+     */
+    protected bool $_renderExceptions = false;
+
+    /**
+     * Array of exceptions
+     */
+    protected array $_exceptions = [];
+
+    /**
+     * Body content
+     */
+    protected array $_body = [];
+
+    /**
+     * Exception thrown by action controller
+     */
+    public bool $headersSentThrowsException = true;
+
+    public function __construct()
+    {
+        $this->symfonyResponse = new SymfonyResponse();
+    }
+
+    /**
+     * Get the Symfony Response instance (for internal use)
+     */
+    public function getSymfonyResponse(): SymfonyResponse
+    {
+        return $this->symfonyResponse;
+    }
+
+    /**
+     * Set a header
+     */
+    public function setHeader(string $name, string $value, bool $replace = false): self
+    {
+        $this->canSendHeaders(true);
+        $name = $this->_normalizeHeader($name);
+
+        if ($replace) {
+            foreach ($this->_headers as $key => $header) {
+                if ($name == $header['name']) {
+                    unset($this->_headers[$key]);
+                }
+            }
+        }
+
+        $this->_headers[] = [
+            'name' => $name,
+            'value' => $value,
+            'replace' => $replace,
+        ];
+
+        $this->symfonyResponse->headers->set($name, $value, $replace);
+
+        return $this;
+    }
+
+    /**
+     * Set redirect URL
+     *
+     * Sets Location header and response code. Forces replacement of any prior
+     * redirects.
+     */
+    public function setRedirect(string $url, int $code = 302): self
+    {
+        /**
+         * Use single transport object instance
+         */
+        if (self::$_transportObject === null) {
+            self::$_transportObject = new Varien_Object();
+        }
+        self::$_transportObject->setUrl($url);
+        self::$_transportObject->setCode($code);
+        Mage::dispatchEvent(
+            'controller_response_redirect',
+            ['response' => $this, 'transport' => self::$_transportObject],
+        );
+
+        $this->canSendHeaders(true);
+        $this->setHeader('Location', self::$_transportObject->getUrl(), true)
+             ->setHttpResponseCode(self::$_transportObject->getCode());
+
+        $this->symfonyResponse->setStatusCode(self::$_transportObject->getCode());
+        $this->_isRedirect = true;
+
+        return $this;
+    }
+
+    /**
+     * Is this a redirect?
+     */
+    public function isRedirect(): bool
+    {
+        return $this->_isRedirect;
+    }
+
+    /**
+     * Return array of headers; see {@link $_headers} for format
+     */
+    public function getHeaders(): array
+    {
+        return $this->_headers;
+    }
+
+    /**
+     * Clear headers
+     */
+    public function clearHeaders(): self
+    {
+        $this->_headers = [];
+        $this->symfonyResponse->headers = new \Symfony\Component\HttpFoundation\ResponseHeaderBag();
+        return $this;
+    }
+
+    /**
+     * Clear header by name
+     */
+    public function clearHeader(string $name): self
+    {
+        $name = $this->_normalizeHeader($name);
+        foreach ($this->_headers as $key => $header) {
+            if ($name == $header['name']) {
+                unset($this->_headers[$key]);
+            }
+        }
+        $this->symfonyResponse->headers->remove($name);
+        return $this;
+    }
+
+    /**
+     * Set raw HTTP header
+     */
+    public function setRawHeader(string $value): self
+    {
+        $this->canSendHeaders(true);
+        $this->_headersRaw[] = $value;
+        return $this;
+    }
+
+    /**
+     * Get all header values as an array
+     */
+    public function getRawHeaders(): array
+    {
+        return $this->_headersRaw;
+    }
+
+    /**
+     * Clear all raw headers
+     */
+    public function clearRawHeaders(): self
+    {
+        $this->_headersRaw = [];
+        return $this;
+    }
+
+    /**
+     * Clear a specific raw header
+     */
+    public function clearRawHeader(string $headerRaw): self
+    {
+        $key = array_search($headerRaw, $this->_headersRaw);
+        if ($key !== false) {
+            unset($this->_headersRaw[$key]);
+        }
+        return $this;
+    }
+
+    /**
+     * Clear all headers, normal and raw
+     */
+    public function clearAllHeaders(): self
+    {
+        return $this->clearHeaders()
+                    ->clearRawHeaders();
+    }
+
+    /**
+     * Set HTTP response code to use with headers
+     */
+    public function setHttpResponseCode(int $code): self
+    {
+        if ((100 > $code) || (599 < $code)) {
+            throw new Exception('Invalid HTTP response code');
+        }
+
+        $this->_httpResponseCode = $code;
+        $this->symfonyResponse->setStatusCode($code);
+        return $this;
+    }
+
+    /**
+     * Retrieve HTTP response code
+     */
+    public function getHttpResponseCode(): int
+    {
+        return $this->_httpResponseCode;
+    }
+
+    /**
+     * Can we send headers?
+     */
+    public function canSendHeaders(bool $throw = false): bool
+    {
+        $ok = headers_sent($file, $line);
+        if ($ok && $throw && $this->headersSentThrowsException) {
+            throw new Exception('Cannot send headers; headers already sent in ' . $file . ', line ' . $line);
+        }
+
+        return !$ok;
+    }
+
+    /**
+     * Send all headers
+     *
+     * Sends any headers specified. If an {@link setHttpResponseCode() HTTP response code}
+     * has been specified, it is sent with the first header.
+     */
+    public function sendHeaders(): self
     {
         if (!$this->canSendHeaders()) {
             Mage::log('HEADERS ALREADY SENT: ' . mageDebugBacktrace(true, true, true));
@@ -52,11 +299,305 @@ class Mage_Core_Controller_Response_Http extends Zend_Controller_Response_Http
             }
         }
 
-        return parent::sendHeaders();
+        $httpCodeSent = false;
+
+        foreach ($this->_headersRaw as $header) {
+            if (!$httpCodeSent && $this->_httpResponseCode) {
+                header($header, true, $this->_httpResponseCode);
+                $httpCodeSent = true;
+            } else {
+                header($header);
+            }
+        }
+
+        foreach ($this->_headers as $header) {
+            if (!$httpCodeSent && $this->_httpResponseCode) {
+                header($header['name'] . ': ' . $header['value'], $header['replace'], $this->_httpResponseCode);
+                $httpCodeSent = true;
+            } else {
+                header($header['name'] . ': ' . $header['value'], $header['replace']);
+            }
+        }
+
+        if (!$httpCodeSent) {
+            header('HTTP/1.1 ' . $this->_httpResponseCode);
+        }
+
+        return $this;
     }
 
-    #[\Override]
-    public function sendResponse()
+    /**
+     * Set body content
+     */
+    public function setBody(string $content, string|null $name = null): self
+    {
+        if (is_null($name)) {
+            $name = 'default';
+        }
+
+        $this->_body[$name] = $content;
+        $this->symfonyResponse->setContent($this->outputBody());
+        return $this;
+    }
+
+    /**
+     * Append content to the body content
+     */
+    public function appendBody(string $content, string|null $name = null): self
+    {
+        if (is_null($name)) {
+            $name = 'default';
+        }
+
+        if (isset($this->_body[$name])) {
+            $this->_body[$name] .= $content;
+        } else {
+            $this->_body[$name] = $content;
+        }
+
+        $this->symfonyResponse->setContent($this->outputBody());
+        return $this;
+    }
+
+    /**
+     * Clear body content
+     */
+    public function clearBody(string|null $name = null): self
+    {
+        if (!is_null($name)) {
+            if (isset($this->_body[$name])) {
+                unset($this->_body[$name]);
+            }
+        } else {
+            $this->_body = [];
+        }
+
+        $this->symfonyResponse->setContent($this->outputBody());
+        return $this;
+    }
+
+    /**
+     * Return the body content
+     */
+    public function getBody(bool|string $spec = false): string|array
+    {
+        if (false === $spec) {
+            return $this->outputBody();
+        } elseif (true === $spec) {
+            return $this->_body;
+        } elseif (isset($this->_body[$spec])) {
+            return $this->_body[$spec];
+        }
+
+        return '';
+    }
+
+    /**
+     * Append content to a body segment
+     */
+    public function append(string $name, string $content): self
+    {
+        if (isset($this->_body[$name])) {
+            $this->_body[$name] .= $content;
+        } else {
+            $this->_body[$name] = $content;
+        }
+
+        $this->symfonyResponse->setContent($this->outputBody());
+        return $this;
+    }
+
+    /**
+     * Prepend content to a body segment
+     */
+    public function prepend(string $name, string $content): self
+    {
+        if (isset($this->_body[$name])) {
+            $this->_body[$name] = $content . $this->_body[$name];
+        } else {
+            $this->_body[$name] = $content;
+        }
+
+        $this->symfonyResponse->setContent($this->outputBody());
+        return $this;
+    }
+
+    /**
+     * Insert content before a named segment
+     */
+    public function insert(string $name, string $content, string|null $parent = null, bool $before = false): self
+    {
+        if (isset($this->_body[$name])) {
+            $this->_body[$name] = $content;
+        } else {
+            $tmp = [];
+            $inserted = false;
+
+            foreach ($this->_body as $key => $value) {
+                if ($key == $parent) {
+                    if ($before) {
+                        $tmp[$name] = $content;
+                        $tmp[$key] = $value;
+                    } else {
+                        $tmp[$key] = $value;
+                        $tmp[$name] = $content;
+                    }
+                    $inserted = true;
+                } else {
+                    $tmp[$key] = $value;
+                }
+            }
+
+            if (!$inserted) {
+                $tmp[$name] = $content;
+            }
+
+            $this->_body = $tmp;
+        }
+
+        $this->symfonyResponse->setContent($this->outputBody());
+        return $this;
+    }
+
+    /**
+     * Echo the body segments
+     */
+    public function outputBody(): string
+    {
+        $content = '';
+        foreach ($this->_body as $segment) {
+            $content .= $segment;
+        }
+        return $content;
+    }
+
+    /**
+     * Register an exception with the response
+     */
+    public function setException(Throwable $e): self
+    {
+        $this->_exceptions[] = $e;
+        return $this;
+    }
+
+    /**
+     * Retrieve the exception stack
+     */
+    public function getException(): array
+    {
+        return $this->_exceptions;
+    }
+
+    /**
+     * Has an exception been registered with the response?
+     */
+    public function isException(): bool
+    {
+        return !empty($this->_exceptions);
+    }
+
+    /**
+     * Does the response object contain an exception of a given type?
+     */
+    public function hasExceptionOfType(string $type): bool
+    {
+        foreach ($this->_exceptions as $e) {
+            if ($e instanceof $type) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Does the response object contain an exception with a given message?
+     */
+    public function hasExceptionOfMessage(string $message): bool
+    {
+        foreach ($this->_exceptions as $e) {
+            if ($message == $e->getMessage()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Does the response object contain an exception with a given code?
+     */
+    public function hasExceptionOfCode(int $code): bool
+    {
+        $code = (int) $code;
+        foreach ($this->_exceptions as $e) {
+            if ($code == $e->getCode()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Retrieve first exception of given type
+     */
+    public function getExceptionByType(string $type): false|Throwable
+    {
+        foreach ($this->_exceptions as $e) {
+            if ($e instanceof $type) {
+                return $e;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Retrieve first exception with a given message
+     */
+    public function getExceptionByMessage(string $message): false|Throwable
+    {
+        foreach ($this->_exceptions as $e) {
+            if ($message == $e->getMessage()) {
+                return $e;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Retrieve first exception with a given code
+     */
+    public function getExceptionByCode(int $code): false|Throwable
+    {
+        $code = (int) $code;
+        foreach ($this->_exceptions as $e) {
+            if ($code == $e->getCode()) {
+                return $e;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Flag; are exceptions being rendered?
+     */
+    public function renderExceptions(bool|null $flag = null): bool
+    {
+        if (null !== $flag) {
+            $this->_renderExceptions = (bool) $flag;
+        }
+
+        return $this->_renderExceptions;
+    }
+
+    /**
+     * Send the response, including all headers
+     */
+    public function sendResponse(): void
     {
         Mage::dispatchEvent('http_response_send_before', ['response' => $this]);
 
@@ -68,29 +609,40 @@ class Mage_Core_Controller_Response_Http extends Zend_Controller_Response_Http
             $this->setBody($processedBody);
         }
 
-        parent::sendResponse();
+        $this->sendHeaders();
+
+        if ($this->isException() && $this->renderExceptions()) {
+            $exceptions = '';
+            foreach ($this->getException() as $e) {
+                $exceptions .= $e->__toString() . "\n";
+            }
+            echo $exceptions;
+            return;
+        }
+
+        echo $this->outputBody();
     }
 
     /**
-     * Additionally check for session messages in several domains case
+     * Magic __toString functionality
      */
     #[\Override]
-    public function setRedirect($url, $code = 302)
+    public function __toString(): string
     {
-        /**
-         * Use single transport object instance
-         */
-        if (self::$_transportObject === null) {
-            self::$_transportObject = new Varien_Object();
-        }
-        self::$_transportObject->setUrl($url);
-        self::$_transportObject->setCode($code);
-        Mage::dispatchEvent(
-            'controller_response_redirect',
-            ['response' => $this, 'transport' => self::$_transportObject],
-        );
+        ob_start();
+        $this->sendResponse();
+        return ob_get_clean();
+    }
 
-        return parent::setRedirect(self::$_transportObject->getUrl(), self::$_transportObject->getCode());
+    /**
+     * Normalize a header name
+     */
+    protected function _normalizeHeader(string $name): string
+    {
+        $filtered = str_replace(['-', '_'], ' ', (string) $name);
+        $filtered = ucwords(strtolower($filtered));
+        $filtered = str_replace(' ', '-', $filtered);
+        return $filtered;
     }
 
     /**

--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -109,7 +109,7 @@ abstract class Mage_Core_Controller_Varien_Action
      */
     protected $_removeDefaultTitle = false;
 
-    public function __construct(Zend_Controller_Request_Abstract $request, Zend_Controller_Response_Abstract $response, array $invokeArgs = [])
+    public function __construct(Mage_Core_Controller_Request_Http $request, Mage_Core_Controller_Response_Http $response, array $invokeArgs = [])
     {
         $this->_request = $request;
         $this->_response = $response;
@@ -1058,7 +1058,7 @@ abstract class Mage_Core_Controller_Varien_Action
             ->setHeader('Pragma', 'public', true)
             ->setHeader('Cache-Control', 'must-revalidate, post-check=0, pre-check=0', true)
             ->setHeader('Content-type', $contentType, true)
-            ->setHeader('Content-Length', is_null($contentLength) ? strlen($content) : $contentLength, true)
+            ->setHeader('Content-Length', (string) (is_null($contentLength) ? strlen($content) : $contentLength), true)
             ->setHeader('Content-Disposition', 'attachment; filename="' . $fileName . '"', true)
             ->setHeader('Last-Modified', date('r'), true);
 

--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -11,8 +11,6 @@
  */
 
 /**
- * Custom Zend_Controller_Action class (formally)
- *
  * Allows dispatching before and after events for each controller action
  */
 abstract class Mage_Core_Controller_Varien_Action

--- a/app/code/core/Mage/Core/Controller/Varien/Front.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Front.php
@@ -382,11 +382,8 @@ class Mage_Core_Controller_Varien_Front extends Varien_Object
 
     /**
      * Check if requested path starts with one of the admin front names
-     *
-     * @param Zend_Controller_Request_Http $request
-     * @return bool
      */
-    protected function _isAdminFrontNameMatched($request)
+    protected function _isAdminFrontNameMatched(Mage_Core_Controller_Request_Http $request): bool
     {
         return Mage::helper('adminhtml')->isAdminFrontNameMatched($request->getPathInfo());
     }

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Abstract.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Abstract.php
@@ -50,8 +50,5 @@ abstract class Mage_Core_Controller_Varien_Router_Abstract
         return $frontName;
     }
 
-    /**
-     * @return bool
-     */
-    abstract public function match(Zend_Controller_Request_Http $request);
+    abstract public function match(Mage_Core_Controller_Request_Http $request): bool;
 }

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Default.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Default.php
@@ -16,11 +16,9 @@ class Mage_Core_Controller_Varien_Router_Default extends Mage_Core_Controller_Va
      * Modify request and set to no-route action
      * If store is admin and specified different admin front name,
      * change store to default (Possible when enabled Store Code in URL)
-     *
-     * @return bool
      */
     #[\Override]
-    public function match(Mage_Core_Controller_Request_Http $request)
+    public function match(Mage_Core_Controller_Request_Http $request): bool
     {
         $noRoute        = explode('/', $this->_getNoRouteConfig());
         $moduleName     = isset($noRoute[0]) && $noRoute[0] ? $noRoute[0] : 'core';

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Default.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Default.php
@@ -20,7 +20,7 @@ class Mage_Core_Controller_Varien_Router_Default extends Mage_Core_Controller_Va
      * @return bool
      */
     #[\Override]
-    public function match(Zend_Controller_Request_Http $request)
+    public function match(Mage_Core_Controller_Request_Http $request)
     {
         $noRoute        = explode('/', $this->_getNoRouteConfig());
         $moduleName     = isset($noRoute[0]) && $noRoute[0] ? $noRoute[0] : 'core';

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php
@@ -96,7 +96,7 @@ class Mage_Core_Controller_Varien_Router_Standard extends Mage_Core_Controller_V
      * Match the request
      */
     #[\Override]
-    public function match(Mage_Core_Controller_Request_Http $request)
+    public function match(Mage_Core_Controller_Request_Http $request): bool
     {
         //checking before even try to find out that current module
         //should use this router

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php
@@ -94,11 +94,9 @@ class Mage_Core_Controller_Varien_Router_Standard extends Mage_Core_Controller_V
 
     /**
      * Match the request
-     *
-     * @param Mage_Core_Controller_Request_Http $request
      */
     #[\Override]
-    public function match(Zend_Controller_Request_Http $request)
+    public function match(Mage_Core_Controller_Request_Http $request)
     {
         //checking before even try to find out that current module
         //should use this router

--- a/app/code/core/Mage/Core/Model/Url.php
+++ b/app/code/core/Mage/Core/Model/Url.php
@@ -131,7 +131,7 @@ class Mage_Core_Model_Url extends Varien_Object
     /**
      * Controller request object
      *
-     * @var Zend_Controller_Request_Http
+     * @var Mage_Core_Controller_Request_Http
      */
     protected $_request;
 
@@ -275,7 +275,7 @@ class Mage_Core_Model_Url extends Varien_Object
      *
      * @return $this
      */
-    public function setRequest(Zend_Controller_Request_Http $request)
+    public function setRequest(Mage_Core_Controller_Request_Http $request)
     {
         $this->_request = $request;
         return $this;

--- a/app/code/core/Mage/Core/Model/Url/Rewrite/Request.php
+++ b/app/code/core/Mage/Core/Model/Url/Rewrite/Request.php
@@ -57,7 +57,7 @@ class Mage_Core_Model_Url_Rewrite_Request
     /**
      * Constructor
      * Arguments:
-     *   request  - Zend_Controller_Request_Http
+     *   request  - Mage_Core_Controller_Request_Http
      *   config   - Mage_Core_Model_Config
      *   factory  - Mage_Core_Model_Factory
      *   routers  - array

--- a/app/code/core/Mage/Customer/Model/Session.php
+++ b/app/code/core/Mage/Customer/Model/Session.php
@@ -271,11 +271,8 @@ class Mage_Customer_Model_Session extends Mage_Core_Model_Session_Abstract
 
     /**
      * Authenticate controller action by login customer
-     *
-     * @param   bool $loginUrl
-     * @return  bool
      */
-    public function authenticate(Mage_Core_Controller_Varien_Action $action, $loginUrl = null)
+    public function authenticate(Mage_Core_Controller_Varien_Action $action, string|null $loginUrl = null): bool
     {
         if ($this->isLoggedIn()) {
             return true;

--- a/app/code/core/Mage/Downloadable/controllers/DownloadController.php
+++ b/app/code/core/Mage/Downloadable/controllers/DownloadController.php
@@ -34,7 +34,7 @@ class Mage_Downloadable_DownloadController extends Mage_Core_Controller_Front_Ac
     /**
      * @param string $resource
      * @param string $resourceType
-     * @throws Zend_Controller_Response_Exception
+     * @throws Exception
      */
     protected function _processDownload($resource, $resourceType)
     {

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Abstract.php
@@ -342,7 +342,7 @@ abstract class Mage_Eav_Model_Attribute_Data_Abstract
      *
      * @return mixed
      */
-    protected function _getRequestValue(Zend_Controller_Request_Http $request)
+    protected function _getRequestValue(Mage_Core_Controller_Request_Http $request)
     {
         $attrCode  = $this->getAttribute()->getAttributeCode();
         if ($this->_requestScope) {
@@ -372,7 +372,7 @@ abstract class Mage_Eav_Model_Attribute_Data_Abstract
      *
      * @return array|string
      */
-    abstract public function extractValue(Zend_Controller_Request_Http $request);
+    abstract public function extractValue(Mage_Core_Controller_Request_Http $request);
 
     /**
      * Validate data

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Date.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Date.php
@@ -18,7 +18,7 @@ class Mage_Eav_Model_Attribute_Data_Date extends Mage_Eav_Model_Attribute_Data_A
      * @return array|string|false
      */
     #[\Override]
-    public function extractValue(Zend_Controller_Request_Http $request)
+    public function extractValue(Mage_Core_Controller_Request_Http $request)
     {
         $value = $this->_getRequestValue($request);
         return $value ? $this->_applyInputFilter($value) : false;

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/File.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/File.php
@@ -25,7 +25,7 @@ class Mage_Eav_Model_Attribute_Data_File extends Mage_Eav_Model_Attribute_Data_A
      * @return false|array|string
      */
     #[\Override]
-    public function extractValue(Zend_Controller_Request_Http $request)
+    public function extractValue(Mage_Core_Controller_Request_Http $request)
     {
         if ($this->getIsAjaxRequest()) {
             return false;

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
@@ -18,7 +18,7 @@ class Mage_Eav_Model_Attribute_Data_Multiline extends Mage_Eav_Model_Attribute_D
      * @return array|string
      */
     #[\Override]
-    public function extractValue(Zend_Controller_Request_Http $request)
+    public function extractValue(Mage_Core_Controller_Request_Http $request)
     {
         $value = $this->_getRequestValue($request);
         if (!is_array($value)) {

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Multiselect.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Multiselect.php
@@ -18,7 +18,7 @@ class Mage_Eav_Model_Attribute_Data_Multiselect extends Mage_Eav_Model_Attribute
      * @return array|string
      */
     #[\Override]
-    public function extractValue(Zend_Controller_Request_Http $request)
+    public function extractValue(Mage_Core_Controller_Request_Http $request)
     {
         $values = $this->_getRequestValue($request);
         if ($values !== false && !is_array($values)) {

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Select.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Select.php
@@ -18,7 +18,7 @@ class Mage_Eav_Model_Attribute_Data_Select extends Mage_Eav_Model_Attribute_Data
      * @return array|string
      */
     #[\Override]
-    public function extractValue(Zend_Controller_Request_Http $request)
+    public function extractValue(Mage_Core_Controller_Request_Http $request)
     {
         return $this->_getRequestValue($request);
     }

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Text.php
@@ -18,7 +18,7 @@ class Mage_Eav_Model_Attribute_Data_Text extends Mage_Eav_Model_Attribute_Data_A
      * @return array|string
      */
     #[\Override]
-    public function extractValue(Zend_Controller_Request_Http $request)
+    public function extractValue(Mage_Core_Controller_Request_Http $request)
     {
         $value = $this->_getRequestValue($request);
         return $this->_applyInputFilter($value);

--- a/app/code/core/Mage/Eav/Model/Form.php
+++ b/app/code/core/Mage/Eav/Model/Form.php
@@ -305,10 +305,8 @@ abstract class Mage_Eav_Model_Form
 
     /**
      * Prepare request with data and returns it
-     *
-     * @return Zend_Controller_Request_Http
      */
-    public function prepareRequest(array $data)
+    public function prepareRequest(array $data): Mage_Core_Controller_Request_Http
     {
         $request = clone Mage::app()->getRequest();
         $request->setParamSources();
@@ -323,9 +321,8 @@ abstract class Mage_Eav_Model_Form
      *
      * @param string $scope the request scope
      * @param bool $scopeOnly search value only in scope or search value in global too
-     * @return array
      */
-    public function extractData(Zend_Controller_Request_Http $request, $scope = null, $scopeOnly = true)
+    public function extractData(Mage_Core_Controller_Request_Http $request, $scope = null, $scopeOnly = true): array
     {
         $data = [];
         foreach ($this->getAttributes() as $attribute) {

--- a/app/code/core/Mage/Install/Model/Wizard.php
+++ b/app/code/core/Mage/Install/Model/Wizard.php
@@ -52,7 +52,7 @@ class Mage_Install_Model_Wizard
      *
      * @return  Varien_Object | false
      */
-    public function getStepByRequest(Zend_Controller_Request_Abstract $request)
+    public function getStepByRequest(Mage_Core_Controller_Request_Http $request)
     {
         foreach ($this->_steps as $step) {
             if ($step->getController() == $request->getControllerName()

--- a/app/code/core/Mage/Oauth/Model/Server.php
+++ b/app/code/core/Mage/Oauth/Model/Server.php
@@ -137,7 +137,7 @@ class Mage_Oauth_Model_Server
     /**
      * Request object
      *
-     * @var Mage_Core_Controller_Request_Http|Zend_Controller_Request_Http
+     * @var Mage_Core_Controller_Request_Http|Mage_Core_Controller_Request_Http
      */
     protected $_request;
 
@@ -151,7 +151,7 @@ class Mage_Oauth_Model_Server
     /**
      * Response object
      *
-     * @var Zend_Controller_Response_Http
+     * @var Mage_Core_Controller_Response_Http
      */
     protected $_response = null;
 
@@ -165,13 +165,13 @@ class Mage_Oauth_Model_Server
     /**
      * Internal constructor not depended on params
      *
-     * @param Zend_Controller_Request_Http $request OPTIONAL Request object (If not specified - use singleton)
+     * @param Mage_Core_Controller_Request_Http $request OPTIONAL Request object (If not specified - use singleton)
      * @throws Exception
      */
     public function __construct($request = null)
     {
         if (is_object($request)) {
-            if (!$request instanceof Zend_Controller_Request_Http) {
+            if (!$request instanceof Mage_Core_Controller_Request_Http) {
                 throw new Exception('Invalid request object passed');
             }
             $this->_request = $request;
@@ -256,7 +256,7 @@ class Mage_Oauth_Model_Server
     /**
      * Retrieve response object
      *
-     * @return Zend_Controller_Response_Http
+     * @return Mage_Core_Controller_Response_Http
      */
     protected function _getResponse()
     {
@@ -868,11 +868,11 @@ class Mage_Oauth_Model_Server
     /**
      * Create response string for problem during request and set HTTP error code
      *
-     * @param Zend_Controller_Response_Http|null $response OPTIONAL If NULL - will use internal getter
+     * @param Mage_Core_Controller_Response_Http|null $response OPTIONAL If NULL - will use internal getter
      * @return string
      * @throws Zend_Controller_Response_Exception
      */
-    public function reportProblem(Exception $e, ?Zend_Controller_Response_Http $response = null)
+    public function reportProblem(Exception $e, ?Mage_Core_Controller_Response_Http $response = null)
     {
         $eMsg = $e->getMessage();
 
@@ -908,7 +908,7 @@ class Mage_Oauth_Model_Server
      *
      * @return $this
      */
-    public function setResponse(Zend_Controller_Response_Http $response)
+    public function setResponse(Mage_Core_Controller_Response_Http $response)
     {
         $this->_response = $response;
 

--- a/app/code/core/Mage/Oauth/Model/Server.php
+++ b/app/code/core/Mage/Oauth/Model/Server.php
@@ -870,7 +870,7 @@ class Mage_Oauth_Model_Server
      *
      * @param Mage_Core_Controller_Response_Http|null $response OPTIONAL If NULL - will use internal getter
      * @return string
-     * @throws Zend_Controller_Response_Exception
+     * @throws Exception
      */
     public function reportProblem(Exception $e, ?Mage_Core_Controller_Response_Http $response = null)
     {

--- a/app/code/core/Maho/Blog/Controller/Router.php
+++ b/app/code/core/Maho/Blog/Controller/Router.php
@@ -18,7 +18,7 @@ class Maho_Blog_Controller_Router extends Mage_Core_Controller_Varien_Router_Abs
     }
 
     #[\Override]
-    public function match(Zend_Controller_Request_Http $request): bool
+    public function match(Mage_Core_Controller_Request_Http $request): bool
     {
         if (!Mage::isInstalled() || !Mage::helper('blog')->isEnabled()) {
             return false;


### PR DESCRIPTION
  - Custom Request/Response classes: Introduced Mage_Core_Controller_Request_Http and Mage_Core_Controller_Response_Http to replace Zend equivalents, with Symfony HttpFoundation integration
  - API2 routing rewrite: Created Mage_Api2_Model_Route_Base and Mage_Api2_Model_Route_Chain for pattern matching and route chaining without Zend dependencies
  - Type safety improvements: Added strict typing and proper type declarations throughout controller layer
  - PHPStan baseline cleanup: Resolved 40+ type-related errors from the baseline

