### PR TITLE
Removed unneeded Zend Framework patches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,8 +110,6 @@
     "extra": {
         "patches": {
             "shardj/zf1-future": {
-                "MAG-1.9.3.7 - SUPEE-10415": "https://raw.githubusercontent.com/MahoCommerce/maho-composer-patches/cff368fa23f790288f6913ffae20120b6fec45db/MAG-1.9.3.7.patch",
-                "OM-1081 - Not detecting HTTPS behind a proxy": "https://raw.githubusercontent.com/MahoCommerce/maho-composer-patches/cff368fa23f790288f6913ffae20120b6fec45db/OM-1081.patch",
                 "OM-2047 - Pass delimiter char to preg_quote": "https://raw.githubusercontent.com/MahoCommerce/maho-composer-patches/cff368fa23f790288f6913ffae20120b6fec45db/OM-2047.patch"
             }
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e648f60f02c6552804f2bbd9765d0526",
+    "content-hash": "685f64217b228dcf3c9edad3a84e1944",
     "packages": [
         {
             "name": "altcha-org/altcha",


### PR DESCRIPTION
 - Removed SUPEE-10415 patch for `Zend_Form`
 - Removed OM-1081 patch for `Zend_Controller_Request_Http`

  These patches are no longer necessary as Maho has removed dependencies on those Zend Framework modules.
