### PR TITLE
Removed unused filesystem token configuration system

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Logo.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Email/Logo.php
@@ -6,7 +6,7 @@
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -15,19 +15,14 @@ class Mage_Adminhtml_Model_System_Config_Backend_Email_Logo extends Mage_Adminht
     /**
      * The tail part of directory path for uploading
      */
-    public const UPLOAD_DIR                = 'email/logo';
-
-    /**
-     * Token for the root part of directory path for uploading
-     */
-    public const UPLOAD_ROOT_TOKEN         = 'system/filesystem/media';
+    public const UPLOAD_DIR = 'email/logo';
 
     /**
      * Upload max file size in kilobytes
      *
      * @var int
      */
-    protected $_maxFileSize         = 2048;
+    protected $_maxFileSize = 2048;
 
     /**
      * Return path to directory for upload file
@@ -37,9 +32,9 @@ class Mage_Adminhtml_Model_System_Config_Backend_Email_Logo extends Mage_Adminht
     #[\Override]
     protected function _getUploadDir()
     {
-        $uploadDir  = $this->_appendScopeInfo(self::UPLOAD_DIR);
-        $uploadRoot = $this->_getUploadRoot(self::UPLOAD_ROOT_TOKEN);
-        $uploadDir  = $uploadRoot . DS . $uploadDir;
+        $uploadDir = $this->_appendScopeInfo(self::UPLOAD_DIR);
+        $uploadRoot = Mage::getBaseDir('media');
+        $uploadDir = $uploadRoot . DS . $uploadDir;
         return $uploadDir;
     }
 

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/File.php
@@ -12,8 +12,6 @@
 
 class Mage_Adminhtml_Model_System_Config_Backend_File extends Mage_Core_Model_Config_Data
 {
-    public const SYSTEM_FILESYSTEM_REGEX = '/{{([a-z_]+)}}(.*)/';
-
     /**
      * Upload max file size in kilobytes
      *
@@ -120,31 +118,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_File extends Mage_Core_Model_Co
             $uploadDir = $this->_appendScopeInfo($uploadDir);
         }
 
-        /**
-         * Take root from config
-         */
-        if (!empty($el['config'])) {
-            $uploadRoot = $this->_getUploadRoot((string) $el['config']);
-            $uploadDir = $uploadRoot . '/' . $uploadDir;
-        }
         return $uploadDir;
-    }
-
-    /**
-     * Return the root part of directory path for uploading
-     *
-     * @param string $token
-     * @return string
-     */
-    protected function _getUploadRoot($token)
-    {
-        $value = Mage::getStoreConfig($token) ?? '';
-        if (strlen($value) && preg_match(self::SYSTEM_FILESYSTEM_REGEX, $value, $matches) !== false) {
-            $dir = str_replace('root_dir', 'public_dir', $matches[1]);
-            $path = str_replace('/', DS, $matches[2]);
-            return Mage::getConfig()->getOptions()->getData($dir) . $path;
-        }
-        return Mage::getBaseDir('media');
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Favicon.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Favicon.php
@@ -6,7 +6,7 @@
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -19,12 +19,6 @@ class Mage_Adminhtml_Model_System_Config_Backend_Image_Favicon extends Mage_Admi
     public const UPLOAD_DIR = 'favicon';
 
     /**
-     * Token for the root part of directory path for uploading
-     *
-     */
-    public const UPLOAD_ROOT = 'media';
-
-    /**
      * Return path to directory for upload file
      *
      * @return string
@@ -34,7 +28,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_Image_Favicon extends Mage_Admi
     protected function _getUploadDir()
     {
         $uploadDir = $this->_appendScopeInfo(self::UPLOAD_DIR);
-        $uploadRoot = $this->_getUploadRoot(self::UPLOAD_ROOT);
+        $uploadRoot = Mage::getBaseDir('media');
         $uploadDir = $uploadRoot . '/' . $uploadDir;
         return $uploadDir;
     }
@@ -59,17 +53,5 @@ class Mage_Adminhtml_Model_System_Config_Backend_Image_Favicon extends Mage_Admi
     protected function _getAllowedExtensions()
     {
         return ['ico', 'png', 'gif', 'jpg', 'jpeg', 'apng'];
-    }
-
-    /**
-     * Get real media dir path
-     *
-     * @param string $token
-     * @return string
-     */
-    #[\Override]
-    protected function _getUploadRoot($token)
-    {
-        return Mage::getBaseDir($token);
     }
 }

--- a/app/code/core/Mage/Catalog/etc/system.xml
+++ b/app/code/core/Mage/Catalog/etc/system.xml
@@ -229,7 +229,7 @@
                             <label></label>
                             <frontend_type>image</frontend_type>
                             <backend_model>adminhtml/system_config_backend_image</backend_model>
-                            <upload_dir config="system/filesystem/media" scope_info="1">catalog/product/placeholder</upload_dir>
+                            <upload_dir scope_info="1">catalog/product/placeholder</upload_dir>
                             <base_url type="media" scope_info="1">catalog/product/placeholder</base_url>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
@@ -465,7 +465,7 @@
                             <label>Watermark</label>
                             <frontend_type>image</frontend_type>
                             <backend_model>adminhtml/system_config_backend_image</backend_model>
-                            <upload_dir config="system/filesystem/media" scope_info="1">catalog/product/watermark</upload_dir>
+                            <upload_dir scope_info="1">catalog/product/watermark</upload_dir>
                             <base_url type="media" scope_info="1">catalog/product/watermark</base_url>
                             <sort_order>200</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/code/core/Mage/Sales/etc/system.xml
+++ b/app/code/core/Mage/Sales/etc/system.xml
@@ -121,7 +121,7 @@
                             <label>Logo for PDF Print-outs (200x50)</label>
                             <frontend_type>image</frontend_type>
                             <backend_model>adminhtml/system_config_backend_image_pdf</backend_model>
-                            <upload_dir config="system/filesystem/media" scope_info="1">sales/store/logo</upload_dir>
+                            <upload_dir scope_info="1">sales/store/logo</upload_dir>
                             <base_url type="media" scope_info="1">sales/store/logo</base_url>
                             <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
@@ -133,7 +133,7 @@
                             <label>Logo for HTML Print View</label>
                             <frontend_type>image</frontend_type>
                             <backend_model>adminhtml/system_config_backend_image</backend_model>
-                            <upload_dir config="system/filesystem/media" scope_info="1">sales/store/logo_html</upload_dir>
+                            <upload_dir scope_info="1">sales/store/logo_html</upload_dir>
                             <base_url type="media" scope_info="1">sales/store/logo_html</base_url>
                             <sort_order>150</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/etc/config.xml
+++ b/app/etc/config.xml
@@ -6,7 +6,7 @@
  * @package    Mage_Core
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2022 The OpenMage Contributors (https://openmage.org)
- * @copyright  Copyright (c) 2024 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2024-2025 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
@@ -106,25 +106,6 @@
         </models>
     </global>
     <default>
-        <system>
-            <filesystem>
-                <base>{{root_dir}}</base>
-                <app>{{root_dir}}/app</app>
-                <code>{{app_dir}}/code</code>
-                <design>{{app_dir}}/design</design>
-                <locale>{{app_dir}}/locale</locale>
-                <etc>{{app_dir}}/etc</etc>
-                <media>{{root_dir}}/media</media>
-                <upload>{{root_dir}}/media/upload</upload>
-                <skin>{{root_dir}}/skin</skin>
-                <var>{{var_dir}}</var>
-                <cache>{{var_dir}}/cache</cache>
-                <session>{{var_dir}}/session</session>
-                <tmp>{{var_dir}}/tmp</tmp>
-                <pear>{{var_dir}}/pear</pear>
-                <export>{{var_dir}}/export</export>
-            </filesystem>
-        </system>
         <dev>
             <template>
                 <allow_symlink>0</allow_symlink>


### PR DESCRIPTION
Removes the unused and misleading `system/filesystem` token-based configuration system that suggested custom media directories were supported when they were not.

  This addresses the same issue identified in OpenMage: https://github.com/OpenMage/magento-lts/issues/5018

  ## Problem

  The codebase contained a half-implemented legacy feature from Magento 1.x that:
  - Defined a token system (`system/filesystem/media`, etc.) for configurable upload directories
  - Only affected 4 admin file upload fields (logos, favicon, placeholders, watermarks)
  - Was ignored by 27+ hardcoded `Mage::getBaseDir('media')` calls throughout the codebase
  - Had no admin UI to configure it
  - Would create a broken split-brain scenario if anyone tried to use it

  ## Changes Made

  ### Code Changes
  1. **Removed `_getUploadRoot()` method** from `Mage_Adminhtml_Model_System_Config_Backend_File`
  2. **Simplified `_getUploadDir()`** to remove token-based root configuration logic
  3. **Cleaned up child classes**:
     - `Mage_Adminhtml_Model_System_Config_Backend_Email_Logo` - now uses `Mage::getBaseDir('media')` directly
     - `Mage_Adminhtml_Model_System_Config_Backend_Image_Favicon` - removed override and constants

  ### Configuration Changes
  4. **Removed `config="system/filesystem/media"` attributes** from system.xml files:
     - `app/code/core/Mage/Sales/etc/system.xml` (PDF & HTML logos)
     - `app/code/core/Mage/Catalog/etc/system.xml` (placeholders & watermarks)

  5. **Removed entire `<system><filesystem>` configuration block** from `app/etc/config.xml`
