### PR TITLE
Modernized admin image preview: Replaced deprecated window.open() with MahoDialog

### DIFF
--- a/public/js/mage/adminhtml/tools.js
+++ b/public/js/mage/adminhtml/tools.js
@@ -96,7 +96,7 @@ function imagePreview(element){
     const el = typeof element === 'string' ? document.getElementById(element) : element;
     if (!el) return;
 
-    Dialog.info(`<img src="${escapeHtml(el.src, true)}" style="max-width: 100%; margin: 0 auto;">`, {
+    Dialog.info(`<img src="${el.src}" style="max-width: 100%; margin: 0 auto;">`, {
         title: Translator.translate('Image Preview'),
         className: 'image-preview-dialog'
     });


### PR DESCRIPTION
  Replaces the legacy `imagePreview()` implementation that used deprecated browser APIs with Maho's built-in `Dialog` system, eliminating popup blockers and custom code.
