### PR TITLE
Fixed HTML structure in shipment tracking email template

### DIFF
--- a/app/design/frontend/base/default/template/email/order/shipment/track.phtml
+++ b/app/design/frontend/base/default/template/email/order/shipment/track.phtml
@@ -22,13 +22,13 @@
         </tr>
     </thead>
     <tbody>
-    <?php $i = 0;
-    foreach ($_shipment->getAllTracks() as $_item): $i++ ?>
-    <tbody>
-            <td align="left" valign="top" style="padding:3px 9px"><?= $this->escapeHtml($_item->getTitle()) ?></td>
-            <td align="center" valign="top" style="padding:3px 9px"><?= $this->escapeHtml($_item->getNumber()) ?></td>
-        </tr>
-    <?php endforeach ?>
+        <?php $i = 0;
+        foreach ($_shipment->getAllTracks() as $_item): $i++ ?>
+            <tr>
+                <td align="left" valign="top" style="padding:3px 9px"><?= $this->escapeHtml($_item->getTitle()) ?></td>
+                <td align="center" valign="top" style="padding:3px 9px"><?= $this->escapeHtml($_item->getNumber()) ?></td>
+            </tr>
+        <?php endforeach ?>
     </tbody>
 </table>
 <?php endif ?>


### PR DESCRIPTION
Thanks to @loekvangool at OpenMage for finding this bug, fixed in https://github.com/OpenMage/magento-lts/pull/5108

app/design/frontend/base/default/template/email/order/shipment/track.phtml already has openmage copyright 2021-2025