### PR TITLE
Disabled slideshow insertion in newsletter template editor

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Edit/Form.php
@@ -108,6 +108,7 @@ class Mage_Adminhtml_Block_Newsletter_Template_Edit_Form extends Mage_Adminhtml_
         $wysiwygConfig = Mage::getSingleton('cms/wysiwyg_config')->getConfig([
             'widget_filters' => $widgetFilters,
             'add_variables' => true,
+            'add_slideshows' => false,
             'variable_window_url' => Mage::getSingleton('adminhtml/url')->getUrl('*/newsletter_template/wysiwygVariable'),
         ]);
         if ($model->isPlain()) {

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
@@ -258,13 +258,13 @@ class tiptapWysiwygSetup {
                         variable_target_id: this.id,
                     }),
                 }),
-                TiptapModules.MahoSlideshow.configure({
+                ...(this.config.add_slideshows !== false ? [TiptapModules.MahoSlideshow.configure({
                     directivesUrl: this.config.directives_url,
                     browserUrl: setRouteParams(this.config.files_browser_window_url, {
                         store: this.storeId,
                         filetype: 'image',
                     }),
-                }),
+                })] : []),
                 TiptapModules.Table.configure({
                     resizable: true
                 }),
@@ -371,7 +371,7 @@ class tiptapWysiwygSetup {
             { type: 'button', title: 'Link', icon: 'link', onClick: this.linkHandler.bind(this) },
             { type: 'button', title: 'Insert Table', icon: 'table', command: 'insertTable', args: [{rows:3, cols:3, withHeaderRow:true}] },
             { type: 'button', title: 'Insert Image', icon: 'image', command: 'insertMahoImage', enabled: this.config.add_images },
-            { type: 'button', title: 'Insert Slideshow', icon: 'slideshow', command: 'insertMahoSlideshow', enabled: this.config.add_images },
+            { type: 'button', title: 'Insert Slideshow', icon: 'slideshow', command: 'insertMahoSlideshow', enabled: this.config.add_images && this.config.add_slideshows !== false },
             { type: 'button', title: 'Insert Widget', icon: 'widget', command: 'insertMahoWidget', enabled: this.config.add_widgets },
             { type: 'button', title: 'Insert Variable', icon: 'variable', command: 'insertMahoVariable', enabled: this.config.add_variables},
             { type: 'spacer' },


### PR DESCRIPTION
 Adds `add_slideshows` config option to WYSIWYG editor, allowing contexts to disable the slideshow feature. Newsletter templates now use this to hide the slideshow button and extension, since slideshows aren't suitable for email content.
