### PR TITLE
Renamed all `@package` tags to `MahoLib` in `lib/Maho`

### DIFF
--- a/lib/Maho/Convert.php
+++ b/lib/Maho/Convert.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Action.php
+++ b/lib/Maho/Convert/Action.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Action/AbstractAction.php
+++ b/lib/Maho/Convert/Action/AbstractAction.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Action/ActionInterface.php
+++ b/lib/Maho/Convert/Action/ActionInterface.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Container/AbstractContainer.php
+++ b/lib/Maho/Convert/Container/AbstractContainer.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Container/Collection.php
+++ b/lib/Maho/Convert/Container/Collection.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Container/ContainerInterface.php
+++ b/lib/Maho/Convert/Container/ContainerInterface.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Container/Generic.php
+++ b/lib/Maho/Convert/Container/Generic.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Exception.php
+++ b/lib/Maho/Convert/Exception.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Mapper/AbstractMapper.php
+++ b/lib/Maho/Convert/Mapper/AbstractMapper.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Mapper/Column.php
+++ b/lib/Maho/Convert/Mapper/Column.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Mapper/MapperInterface.php
+++ b/lib/Maho/Convert/Mapper/MapperInterface.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Parser/AbstractParser.php
+++ b/lib/Maho/Convert/Parser/AbstractParser.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Parser/Csv.php
+++ b/lib/Maho/Convert/Parser/Csv.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Parser/ParserInterface.php
+++ b/lib/Maho/Convert/Parser/ParserInterface.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Parser/Serialize.php
+++ b/lib/Maho/Convert/Parser/Serialize.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Parser/Xml/Excel.php
+++ b/lib/Maho/Convert/Parser/Xml/Excel.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Profile.php
+++ b/lib/Maho/Convert/Profile.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Profile/AbstractProfile.php
+++ b/lib/Maho/Convert/Profile/AbstractProfile.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Convert/Profile/Collection.php
+++ b/lib/Maho/Convert/Profile/Collection.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Convert
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Collection.php
+++ b/lib/Maho/Data/Collection.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Collection/Db.php
+++ b/lib/Maho/Data/Collection/Db.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Collection/Filesystem.php
+++ b/lib/Maho/Data/Collection/Filesystem.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form.php
+++ b/lib/Maho/Data/Form.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/AbstractForm.php
+++ b/lib/Maho/Data/Form/AbstractForm.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/AbstractElement.php
+++ b/lib/Maho/Data/Form/Element/AbstractElement.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Boolean.php
+++ b/lib/Maho/Data/Form/Element/Boolean.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @category   Maho
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */

--- a/lib/Maho/Data/Form/Element/Button.php
+++ b/lib/Maho/Data/Form/Element/Button.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Checkbox.php
+++ b/lib/Maho/Data/Form/Element/Checkbox.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Checkboxes.php
+++ b/lib/Maho/Data/Form/Element/Checkboxes.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Collection.php
+++ b/lib/Maho/Data/Form/Element/Collection.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2019-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Color.php
+++ b/lib/Maho/Data/Form/Element/Color.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)

--- a/lib/Maho/Data/Form/Element/Column.php
+++ b/lib/Maho/Data/Form/Element/Column.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Date.php
+++ b/lib/Maho/Data/Form/Element/Date.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2017-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Datetime.php
+++ b/lib/Maho/Data/Form/Element/Datetime.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Editor.php
+++ b/lib/Maho/Data/Form/Element/Editor.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Fieldset.php
+++ b/lib/Maho/Data/Form/Element/Fieldset.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/File.php
+++ b/lib/Maho/Data/Form/Element/File.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Gallery.php
+++ b/lib/Maho/Data/Form/Element/Gallery.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Hidden.php
+++ b/lib/Maho/Data/Form/Element/Hidden.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Image.php
+++ b/lib/Maho/Data/Form/Element/Image.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Imagefile.php
+++ b/lib/Maho/Data/Form/Element/Imagefile.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Info.php
+++ b/lib/Maho/Data/Form/Element/Info.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)

--- a/lib/Maho/Data/Form/Element/Label.php
+++ b/lib/Maho/Data/Form/Element/Label.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Link.php
+++ b/lib/Maho/Data/Form/Element/Link.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Multiline.php
+++ b/lib/Maho/Data/Form/Element/Multiline.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Multiselect.php
+++ b/lib/Maho/Data/Form/Element/Multiselect.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Note.php
+++ b/lib/Maho/Data/Form/Element/Note.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Obscure.php
+++ b/lib/Maho/Data/Form/Element/Obscure.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Password.php
+++ b/lib/Maho/Data/Form/Element/Password.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Radio.php
+++ b/lib/Maho/Data/Form/Element/Radio.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Radios.php
+++ b/lib/Maho/Data/Form/Element/Radios.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Renderer/RendererInterface.php
+++ b/lib/Maho/Data/Form/Element/Renderer/RendererInterface.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Reset.php
+++ b/lib/Maho/Data/Form/Element/Reset.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Select.php
+++ b/lib/Maho/Data/Form/Element/Select.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Submit.php
+++ b/lib/Maho/Data/Form/Element/Submit.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Text.php
+++ b/lib/Maho/Data/Form/Element/Text.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Textarea.php
+++ b/lib/Maho/Data/Form/Element/Textarea.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Element/Time.php
+++ b/lib/Maho/Data/Form/Element/Time.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Filter/Date.php
+++ b/lib/Maho/Data/Form/Filter/Date.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Filter/Datetime.php
+++ b/lib/Maho/Data/Form/Filter/Datetime.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Filter/Escapehtml.php
+++ b/lib/Maho/Data/Form/Filter/Escapehtml.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Filter/FilterInterface.php
+++ b/lib/Maho/Data/Form/Filter/FilterInterface.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Form/Filter/Striptags.php
+++ b/lib/Maho/Data/Form/Filter/Striptags.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Tree.php
+++ b/lib/Maho/Data/Tree.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Tree/Dbp.php
+++ b/lib/Maho/Data/Tree/Dbp.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Tree/Node.php
+++ b/lib/Maho/Data/Tree/Node.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Data/Tree/Node/Collection.php
+++ b/lib/Maho/Data/Tree/Node/Collection.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Data
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2019-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/DataObject/Cache.php
+++ b/lib/Maho/DataObject/Cache.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_DataObject
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/DataObject/Mapper.php
+++ b/lib/Maho/DataObject/Mapper.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_DataObject
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Db/Adapter/AdapterInterface.php
+++ b/lib/Maho/Db/Adapter/AdapterInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * Maho
  *
- * @package    Maho_Db
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * Maho
  *
- * @package    Maho_Db
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2017-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Db/Ddl/Table.php
+++ b/lib/Maho/Db/Ddl/Table.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * Maho
  *
- * @package    Maho_Db
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Db/Exception.php
+++ b/lib/Maho/Db/Exception.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * Maho
  *
- * @package    Maho_Db
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */

--- a/lib/Maho/Db/Expr.php
+++ b/lib/Maho/Db/Expr.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * Maho
  *
- * @package    Maho_Db
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */

--- a/lib/Maho/Db/Helper.php
+++ b/lib/Maho/Db/Helper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * Maho
  *
- * @package    Maho_Db
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Db/Select.php
+++ b/lib/Maho/Db/Select.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * Maho
  *
- * @package    Maho_Db
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2019-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Db/Statement/Parameter.php
+++ b/lib/Maho/Db/Statement/Parameter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * Maho
  *
- * @package    Maho_Db
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Db/Statement/Pdo/Mysql.php
+++ b/lib/Maho/Db/Statement/Pdo/Mysql.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * Maho
  *
- * @package    Maho_Db
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Event.php
+++ b/lib/Maho/Event.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Event
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Event/Collection.php
+++ b/lib/Maho/Event/Collection.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Event
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Event/Observer.php
+++ b/lib/Maho/Event/Observer.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Event
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Event/Observer/Collection.php
+++ b/lib/Maho/Event/Observer/Collection.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Event
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/File/Csv.php
+++ b/lib/Maho/File/Csv.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_File
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/File/Uploader.php
+++ b/lib/Maho/File/Uploader.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_File
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Filter/ArrayFilter.php
+++ b/lib/Maho/Filter/ArrayFilter.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Filter
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2021-2022 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Filter/ArrayFilter/Grid.php
+++ b/lib/Maho/Filter/ArrayFilter/Grid.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Filter
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Filter/Email.php
+++ b/lib/Maho/Filter/Email.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Filter
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Filter/FormElementName.php
+++ b/lib/Maho/Filter/FormElementName.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Filter
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Filter/ObjectFilter.php
+++ b/lib/Maho/Filter/ObjectFilter.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Filter
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2021-2022 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Filter/ObjectFilter/Grid.php
+++ b/lib/Maho/Filter/ObjectFilter/Grid.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Filter
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Filter/Sprintf.php
+++ b/lib/Maho/Filter/Sprintf.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Filter
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Filter/Template.php
+++ b/lib/Maho/Filter/Template.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Filter
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Filter/Template/Simple.php
+++ b/lib/Maho/Filter/Template/Simple.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Filter
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Filter/Template/Tokenizer/AbstractTokenizer.php
+++ b/lib/Maho/Filter/Template/Tokenizer/AbstractTokenizer.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Filter
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Filter/Template/Tokenizer/Parameter.php
+++ b/lib/Maho/Filter/Template/Tokenizer/Parameter.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Filter
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Filter/Template/Tokenizer/Variable.php
+++ b/lib/Maho/Filter/Template/Tokenizer/Variable.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Filter
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Io/AbstractIo.php
+++ b/lib/Maho/Io/AbstractIo.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Io
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Io/Exception.php
+++ b/lib/Maho/Io/Exception.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Io
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Io/File.php
+++ b/lib/Maho/Io/File.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Io
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2016-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Io/Ftp.php
+++ b/lib/Maho/Io/Ftp.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Io
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Io/IoInterface.php
+++ b/lib/Maho/Io/IoInterface.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Io
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Io/Sftp.php
+++ b/lib/Maho/Io/Sftp.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Io
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2019-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Simplexml/Config.php
+++ b/lib/Maho/Simplexml/Config.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Simplexml
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/lib/Maho/Simplexml/Element.php
+++ b/lib/Maho/Simplexml/Element.php
@@ -3,7 +3,7 @@
 /**
  * Maho
  *
- * @package    Maho_Simplexml
+ * @package    Maho_Lib
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)


### PR DESCRIPTION
This should fix https://phpdoc.mahocommerce.com confusion in the sidebar