### PR TITLE
Added debounce and request cancellation to MahoAutocomplete

### DIFF
--- a/public/js/maho-autocomplete.js
+++ b/public/js/maho-autocomplete.js
@@ -14,8 +14,12 @@ class MahoAutocomplete {
         this.options = Object.assign({
             paramName: this.field.name,
             method: 'GET',
-            minChars: 3
+            minChars: 3,
+            debounceDelay: 200
         }, options);
+
+        this.debounceTimer = null;
+        this.abortController = null;
 
         this.setupEventListeners();
     }
@@ -27,8 +31,12 @@ class MahoAutocomplete {
 
     onInput() {
         const value = this.field.value;
+
+        clearTimeout(this.debounceTimer);
+        this.abortController?.abort();
+
         if (value.length >= this.options.minChars) {
-            this.fetchSuggestions(value);
+            this.debounceTimer = setTimeout(() => this.fetchSuggestions(value), this.options.debounceDelay);
         } else {
             this.hideSuggestions();
         }
@@ -41,13 +49,14 @@ class MahoAutocomplete {
     }
 
     fetchSuggestions(query) {
+        this.abortController = new AbortController();
+
         const params = new URLSearchParams({ [this.options.paramName]: query });
         const url = `${this.url}?${params}`;
 
-        fetch(url, { method: this.options.method })
-            .then(response => response.text())
+        mahoFetch(url, { method: this.options.method, signal: this.abortController.signal, loaderArea: false })
             .then(html => this.showSuggestions(html))
-            .catch(error => console.error('Error fetching suggestions:', error));
+            .catch(() => {});
     }
 
     showSuggestions(html) {


### PR DESCRIPTION
## Summary

- Add 200ms debounce delay to prevent excessive API requests on each keystroke
- Use AbortController to cancel in-flight requests when new input arrives
- Switch from `fetch()` to `mahoFetch()` for consistency
- Add configurable `debounceDelay` option (default: 200ms)

## Problem

Typing "bluetooth speaker" generated 15 separate backend requests—one per character after the minimum threshold—when only the final complete query serves practical value.

## Solution

**Debouncing**: Waits 200ms after the user stops typing before making a request.

**Request cancellation**: Uses `AbortController` to abort any in-flight request when new input arrives, preventing race conditions where slow responses could overwrite newer results.

Fixes #407