### PR TITLE
Added `frontend:theme:create` CLI command

### DIFF
--- a/lib/MahoCLI/Commands/FrontendThemeCreate.php
+++ b/lib/MahoCLI/Commands/FrontendThemeCreate.php
@@ -4,7 +4,7 @@
  * Maho
  *
  * @package    MahoCLI
- * @copyright  Copyright (c) 2025 Maho (https://mahocommerce.com)
+ * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 


### PR DESCRIPTION
## Summary

- New CLI command to scaffold frontend themes with proper directory structure
- Interactive mode with smart defaults and validation
- Suggests package's own default theme as parent for sub-themes
- Warns if creating sub-theme without package's default theme first
- Detects CSS file collisions with base theme to prevent accidental overrides
- Generates `theme.xml`, `local.xml`, and themed CSS file with helpful comments

## Usage

```bash
# Interactive mode
./maho frontend:theme:create

# Non-interactive mode
./maho frontend:theme:create -p mystore -t holiday --parent=base/default
```

## Generated files

```
app/design/frontend/{package}/{theme}/
├── etc/theme.xml
└── layout/local.xml

public/skin/frontend/{package}/{theme}/
└── css/{theme}.css
```

## Test plan

- [x] Create default theme for new package
- [x] Create sub-theme with package's default as parent
- [x] Test validation: theme already exists
- [x] Test validation: parent theme doesn't exist
- [x] Test CSS collision detection (try creating theme named "checkout")
- [x] Test warning when creating sub-theme without package's default
- [x] Verify generated files have correct content
- [x] PHPStan passes
- [x] PHP-CS-Fixer passes

Closes #413