### PR TITLE
Added global AJAX loader for frontend

### DIFF
--- a/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
@@ -10,7 +10,7 @@
  */
 ?>
 <?php /** @var Mage_Checkout_Block_Cart_Shipping $this */ ?>
-<div class="shipping">
+<div class="shipping" id="shipping-container">
     <h2><?= $this->__('Estimate Shipping and Tax') ?></h2>
     <div class="shipping-form">
        <form action="<?= $this->getFormActionUrl() ?>" method="post" id="shipping-zip-form">
@@ -59,6 +59,7 @@
             const countriesWithOptionalZip = <?= $this->helper('directory')->getCountriesWithOptionalZip(true) ?>;
             const form = document.getElementById('shipping-zip-form');
             const container = document.getElementById('co-shipping-method-form-container');
+            const shippingContainer = document.getElementById('shipping-container');
 
             function validate() {
                 const country = document.getElementById('country').value;
@@ -92,7 +93,7 @@
                     const result = await mahoFetch(form.action, {
                         method: 'POST',
                         body: new URLSearchParams(new FormData(form)),
-                        loaderArea: container
+                        loaderArea: shippingContainer
                     });
                     if (result.rates_html) container.innerHTML = result.rates_html;
                 } catch (error) {
@@ -108,7 +109,7 @@
                     const result = await mahoFetch(e.target.action, {
                         method: 'POST',
                         body: new URLSearchParams(new FormData(e.target)),
-                        loaderArea: container
+                        loaderArea: shippingContainer
                     });
                     updateTotals(result.totals_html);
                 } catch (error) {

--- a/public/js/varien/js.js
+++ b/public/js/varien/js.js
@@ -89,6 +89,30 @@ function mahoOnReady(callback) {
     }
 }
 
+let mahoLoaderTimeout, mahoLoaderElement;
+function showLoader(loaderArea) {
+    loaderArea = (typeof loaderArea === 'string' ? document.getElementById(loaderArea) : loaderArea) || document.body;
+    hideLoader();
+
+    const overlay = document.createElement('div');
+    overlay.className = 'maho-loader-overlay';
+    overlay.innerHTML = '<div class="maho-loader-spinner"></div>';
+    overlay.style.opacity = '0';
+
+    if (getComputedStyle(loaderArea).position === 'static') {
+        loaderArea.style.position = 'relative';
+    }
+
+    loaderArea.appendChild(mahoLoaderElement = overlay);
+    mahoLoaderTimeout = setTimeout(() => overlay.style.opacity = '', 150);
+}
+
+function hideLoader() {
+    clearTimeout(mahoLoaderTimeout);
+    mahoLoaderElement?.remove();
+    mahoLoaderTimeout = mahoLoaderElement = null;
+}
+
 function popWin(url,win,para) {
     var win = window.open(url,win,para);
     win.focus();

--- a/public/skin/frontend/base/default/css/styles.css
+++ b/public/skin/frontend/base/default/css/styles.css
@@ -7886,3 +7886,25 @@ input[type="datetime-local"]:focus {
 #offcanvas #minicart-error-message {
     border-left: 5px solid var(--maho-color-error);
 }
+
+/* ============================================ *
+ * AJAX Loader Overlay
+ * ============================================ */
+
+.maho-loader-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 255, 255, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    transition: opacity 0.2s ease;
+}
+
+.maho-loader-spinner {
+    width: 32px;
+    height: 32px;
+    background: url('../images/loading.svg') no-repeat center;
+    background-size: contain;
+}


### PR DESCRIPTION
## Summary

- Implements `showLoader()` and `hideLoader()` functions for the frontend
- Enables the `loaderArea` option in `mahoFetch()` to display loading indicators during AJAX operations
- Uses existing `loading.svg` spinner with a semi-transparent overlay
- Includes 150ms delay before showing to avoid flash on fast requests

## Changes

- **public/js/varien/js.js**: Added `showLoader()` and `hideLoader()` functions
- **public/skin/frontend/base/default/css/styles.css**: Added `.maho-loader-overlay` and `.maho-loader-spinner` styles
- **shipping.phtml**: Updated to use the loader on the shipping container

## Test plan

- [x] Go to cart page with items
- [x] Fill in shipping estimate form and click "Estimate"
- [x] Verify the shipping section dims with a spinner during AJAX request
- [x] Select a shipping method and verify the loader appears again

Closes #427