### PR TITLE
Removed redundant My Account menu from System menu

### DIFF
--- a/app/code/core/Mage/Adminhtml/etc/adminhtml.xml
+++ b/app/code/core/Mage/Adminhtml/etc/adminhtml.xml
@@ -22,11 +22,6 @@
             <sort_order>90</sort_order>
             <!-- action>adminhtml/system</action -->
             <children>
-                <myaccount translate="title">
-                    <title>My Account</title>
-                    <action>adminhtml/system_account</action>
-                    <sort_order>10</sort_order>
-                </myaccount>
                 <tools translate="title">
                     <title>Tools</title>
                     <sort_order>20</sort_order>

--- a/app/design/adminhtml/default/default/template/page/header.phtml
+++ b/app/design/adminhtml/default/default/template/page/header.phtml
@@ -66,7 +66,7 @@
         </fieldset>
         <?php endif ?>
         <div class="user-menu-icons">
-            <a href="<?= Mage::helper("adminhtml")->getUrl("adminhtml/system_account") ?>" class="user-icon" title="<?= $this->__("Logged in as %s", $this->escapeHtml($this->getUser()->getUsername())) ?>">
+            <a href="<?= Mage::helper("adminhtml")->getUrl("adminhtml/system_account") ?>" class="user-icon" title="<?= $this->__("My Account") ?>">
                 <?= $this->getIconSvg('user') ?>
             </a>
             <a href="<?= $this->getLogoutLink() ?>" class="logout-icon" title="<?= $this->__('Log Out') ?>">

--- a/app/locale/en_US/Mage_Adminhtml.csv
+++ b/app/locale/en_US/Mage_Adminhtml.csv
@@ -514,7 +514,6 @@
 "Local/Remote Server","Local/Remote Server"
 "Locale","Locale"
 "Local Server","Local Server"
-"Logged in as %s","Logged in as %s"
 "Log In","Log In"
 "Login","Login"
 "Log in to Admin Panel","Log in to Admin Panel"


### PR DESCRIPTION
## Summary
- Removed "My Account" menu item from System sidebar (already accessible via user icon in header)
- Updated user icon tooltip from "Logged in as %s" to "My Account" for clarity
- Removed unused translation string