### PR TITLE
Improved gift message display in customer order view

### DIFF
--- a/app/design/frontend/base/default/template/bundle/sales/order/items/renderer.phtml
+++ b/app/design/frontend/base/default/template/bundle/sales/order/items/renderer.phtml
@@ -356,7 +356,20 @@
         <?php endif ?>
         <?= $this->escapeHtml($_item->getDescription()) ?>
         <?php if($this->canDisplayGiftmessage()): ?>
-            <a href="#" id="order-item-gift-message-link-<?= $parentItem->getId() ?>" class="gift-message-link" onclick="return giftMessageToogle('<?= $parentItem->getId() ?>')"><?= Mage::helper('sales')->__('Gift Message') ?></a>
+            <?php $_giftMessage = $this->helper('giftmessage/message')->getGiftMessageForEntity($parentItem); ?>
+            <details class="gift-message">
+                <summary class="toggle">
+                    <?= $this->getIconSvg('gift') ?>
+                    <?= Mage::helper('sales')->__('Gift Message') ?>
+                </summary>
+                <div class="content">
+                    <div class="header">
+                        <span><strong><?= $this->__('From:') ?></strong> <?= $this->escapeHtml($_giftMessage->getSender()) ?></span>
+                        <span><strong><?= $this->__('To:') ?></strong> <?= $this->escapeHtml($_giftMessage->getRecipient()) ?></span>
+                    </div>
+                    <blockquote class="text"><?= $this->helper('giftmessage/message')->getEscapedGiftMessage($parentItem) ?></blockquote>
+                </div>
+            </details>
         <?php endif ?>
     </td>
     <td data-rwd-label="SKU">&nbsp;</td>

--- a/app/design/frontend/base/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
+++ b/app/design/frontend/base/default/template/downloadable/sales/order/items/renderer/downloadable.phtml
@@ -51,9 +51,20 @@
 
     <?= $this->escapeHtml($_item->getDescription()) ?>
     <?php if ($this->canDisplayGiftmessage()): ?>
-        <br/><a href="#" id="order-item-gift-message-link-<?= $_item->getId() ?>"
-                class="giftmessage-preview-link expand"
-                onclick="return giftMessageToogle('<?= $_item->getId() ?>')"><?= $this->__('Gift Message') ?></a>
+        <?php $_giftMessage = $this->helper('giftmessage/message')->getGiftMessageForEntity($_item); ?>
+        <details class="gift-message">
+            <summary class="toggle">
+                <?= $this->getIconSvg('gift') ?>
+                <?= $this->__('Gift Message') ?>
+            </summary>
+            <div class="content">
+                <div class="header">
+                    <span><strong><?= $this->__('From:') ?></strong> <?= $this->escapeHtml($_giftMessage->getSender()) ?></span>
+                    <span><strong><?= $this->__('To:') ?></strong> <?= $this->escapeHtml($_giftMessage->getRecipient()) ?></span>
+                </div>
+                <blockquote class="text"><?= $this->helper('giftmessage/message')->getEscapedGiftMessage($_item) ?></blockquote>
+            </div>
+        </details>
     <?php endif ?>
 </td>
 <td data-rwd-label="<?= $this->__('SKU') ?>"><?= $this->escapeHtml(Mage::helper('core/string')->splitInjection($this->getSku())) ?></td>

--- a/app/design/frontend/base/default/template/sales/order/items.phtml
+++ b/app/design/frontend/base/default/template/sales/order/items.phtml
@@ -37,19 +37,6 @@
         <?php if ($_item->getParentItem()) continue; ?>
         <tbody>
             <?= $this->getItemHtml($_item) ?>
-            <?php if($this->canDisplayGiftmessage($_item)): ?>
-            <tr class="border<?= ($_index++ > $_count ?' last':'') ?>" id="order-item-gift-message-<?= $_item->getId() ?>" style="display:none;">
-                <?php $_giftMessage=$this->helper('giftmessage/message')->getGiftMessageForEntity($_item); ?>
-                <td class="gift-message-row" colspan="7">
-                    <a href="#" title="<?= $this->quoteEscape($this->__('Close')) ?>" onclick="return giftMessageToogle('<?= $_item->getId() ?>');" class="btn-close"><?= $this->__('Close') ?></a>
-                    <dl class="gift-message">
-                        <dt><strong><?= $this->__('From:') ?></strong> <?= $this->escapeHtml($_giftMessage->getSender()) ?></dt>
-                        <dt><strong><?= $this->__('To:') ?></strong> <?= $this->escapeHtml($_giftMessage->getRecipient()) ?></dt>
-                        <dd><?= $this->helper('giftmessage/message')->getEscapedGiftMessage($_item) ?></dd>
-                    </dl>
-                </td>
-            </tr>
-            <?php endif ?>
         </tbody>
         <?php endforeach ?>
 </table>

--- a/app/design/frontend/base/default/template/sales/order/items/renderer/default.phtml
+++ b/app/design/frontend/base/default/template/sales/order/items/renderer/default.phtml
@@ -45,7 +45,20 @@
         <?php endif ?>
         <?= $this->escapeHtml($_item->getDescription()) ?>
         <?php if($this->canDisplayGiftmessage()): ?>
-            <a href="#" id="order-item-gift-message-link-<?= $_item->getId() ?>" class="gift-message-link" onclick="return giftMessageToogle('<?= $_item->getId() ?>')"><?= $this->__('Gift Message') ?></a>
+            <?php $_giftMessage = $this->helper('giftmessage/message')->getGiftMessageForEntity($_item); ?>
+            <details class="gift-message">
+                <summary class="toggle">
+                    <?= $this->getIconSvg('gift') ?>
+                    <?= $this->__('Gift Message') ?>
+                </summary>
+                <div class="content">
+                    <div class="header">
+                        <span><strong><?= $this->__('From:') ?></strong> <?= $this->escapeHtml($_giftMessage->getSender()) ?></span>
+                        <span><strong><?= $this->__('To:') ?></strong> <?= $this->escapeHtml($_giftMessage->getRecipient()) ?></span>
+                    </div>
+                    <blockquote class="text"><?= $this->helper('giftmessage/message')->getEscapedGiftMessage($_item) ?></blockquote>
+                </div>
+            </details>
         <?php endif ?>
     </td>
     <td data-rwd-label="<?= $this->__('SKU') ?>"><?= $this->escapeHtml(Mage::helper('core/string')->splitInjection($this->getSku())) ?></td>

--- a/app/design/frontend/base/default/template/sales/order/view.phtml
+++ b/app/design/frontend/base/default/template/sales/order/view.phtml
@@ -12,32 +12,6 @@
 /** @var Mage_Sales_Block_Order_View $this */
 ?>
 <div class="order-items order-details">
-    <?php if ($this->canDisplayGiftmessageItems()): ?>
-    <script type="text/javascript">
-        function giftMessageToogle(giftMessageIdentifier) {
-            const link = document.getElementById('order-item-gift-message-link-' + giftMessageIdentifier);
-            const container = document.getElementById('order-item-gift-message-' + giftMessageIdentifier);
-            const row = document.getElementById('order-item-row-' + giftMessageIdentifier);
-
-            if (link.expanded) {
-                link.expanded = false;
-                link.classList.remove('expanded');
-                if (container.classList.contains('last')) {
-                    row.classList.add('last');
-                }
-                container.style.display = 'none';
-            } else {
-                link.expanded = true;
-                link.classList.add('expanded');
-                if (container.classList.contains('last')) {
-                    row.classList.remove('last');
-                }
-                container.style.display = 'block';
-            }
-            return false;
-        }
-    </script>
-    <?php endif ?>
     <?php $_order = $this->getOrder() ?>
     <h2 class="table-caption"><?= $this->__('Items Ordered') ?>
         <?php if ($_order->getTracksCollection()->count()) : ?>
@@ -48,15 +22,20 @@
     <?= $this->getChildHtml('order_items') ?>
 
     <?php if($this->canDisplayGiftmessageOrder()): ?>
-    <div class="order-additional order-gift-message">
-        <h2 class="sub-title"><?= $this->__('Gift Message for This Order') ?></h2>
-        <?php $_giftMessage=$this->helper('giftmessage/message')->getGiftMessageForEntity($_order); ?>
-        <dl class="gift-message">
-            <dt><strong><?= $this->__('From:') ?></strong> <?= $this->escapeHtml($_giftMessage->getSender()) ?></dt>
-            <dt><strong><?= $this->__('To:') ?></strong> <?= $this->escapeHtml($_giftMessage->getRecipient()) ?></dt>
-            <dd><?= $this->helper('giftmessage/message')->getEscapedGiftMessage($_order) ?></dd>
-        </dl>
-    </div>
+        <?php $_giftMessage = $this->helper('giftmessage/message')->getGiftMessageForEntity($_order); ?>
+        <details class="gift-message order-level">
+            <summary class="toggle">
+                <?= $this->getIconSvg('gift') ?>
+                <?= $this->__('Gift Message for This Order') ?>
+            </summary>
+            <div class="content">
+                <div class="header">
+                    <span><strong><?= $this->__('From:') ?></strong> <?= $this->escapeHtml($_giftMessage->getSender()) ?></span>
+                    <span><strong><?= $this->__('To:') ?></strong> <?= $this->escapeHtml($_giftMessage->getRecipient()) ?></span>
+                </div>
+                <blockquote class="text"><?= $this->helper('giftmessage/message')->getEscapedGiftMessage($_order) ?></blockquote>
+            </div>
+        </details>
     <?php endif ?>
     <?php $_history = $this->getOrder()->getVisibleStatusHistory() ?>
     <?php if (count($_history)): ?>

--- a/public/skin/frontend/base/default/css/styles.css
+++ b/public/skin/frontend/base/default/css/styles.css
@@ -5687,6 +5687,83 @@ ol#cart-sidebar-reorder p.product-name {
   margin-top: 10px;
 }
 
+/* Gift Message Card */
+.customer-account .gift-message {
+  margin-top: 12px;
+  border: 1px solid var(--maho-color-border-light);
+  border-radius: 6px;
+  background: var(--maho-color-background-alt);
+
+  .toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--maho-color-text-primary);
+    cursor: pointer;
+    list-style: none;
+
+    &::after {
+      content: "";
+      margin-left: auto;
+      width: 0;
+      height: 0;
+      border-left: 5px solid transparent;
+      border-right: 5px solid transparent;
+      border-top: 5px solid var(--maho-color-text-secondary);
+      transition: transform 0.2s ease;
+    }
+
+    svg {
+      flex-shrink: 0;
+      width: 18px;
+      height: 18px;
+      color: var(--maho-color-text-secondary);
+    }
+  }
+
+  &[open] .toggle::after {
+    transform: rotate(180deg);
+  }
+
+  .content {
+    padding: 0 14px 14px;
+    border-top: 1px solid var(--maho-color-border-light);
+    background: var(--maho-color-background);
+    border-radius: 0 0 6px 6px;
+  }
+
+  .header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 20px;
+    padding-top: 12px;
+    font-size: 13px;
+    color: var(--maho-color-text-secondary);
+  }
+
+  .text {
+    margin: 12px 0 0;
+    padding: 10px 14px;
+    border-left: 3px solid var(--maho-color-border);
+    color: var(--maho-color-text-primary);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  &.order-level {
+    margin: 30px 0;
+    width: fit-content;
+    min-width: 380px;
+
+    @media (max-width: 767px) {
+      width: 100%;
+    }
+  }
+}
+
 @media only screen and (max-width: 1199px) {
   .dashboard .col2-set .col-1,
   .dashboard .col2-set .col-2 {


### PR DESCRIPTION
## Summary
- Replace ugly hidden table row approach with modern collapsible card using native `<details>` element
- Add gift icon using `getIconSvg('gift')` with chevron indicator for expand/collapse
- Display From/To header with message text in clean card layout
- Remove unused `giftMessageToogle` JavaScript function (no longer needed)
- Update all item renderers (default, bundle, downloadable) and order-level gift message
- Use CSS variables for consistent theming with Maho design system
- Scope styles under `.customer-account` to avoid conflicts
- Add responsive styles for mobile (100% width on order-level)