### PR TITLE
Unified cart item options styling with SKU display

### DIFF
--- a/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
@@ -43,22 +43,19 @@ $_deleteUrl = $this->getDeleteUrlCustom(false);
         </div>
 
         <?php if ($_options = $this->getOptionList()):?>
-        <dl class="item-options">
             <?php foreach ($_options as $_option) : ?>
             <?php $_formatedOptionValue = $this->getFormatedOptionValue($_option) ?>
-                <dt><?= $this->escapeHtml($_option['label']) ?></dt>
-                <dd<?php if (isset($_formatedOptionValue['full_view'])): ?> class="truncated"<?php endif ?>><?= $_formatedOptionValue['value'] ?>
+            <div class="product-cart-sku<?php if (isset($_formatedOptionValue['full_view'])): ?> truncated<?php endif ?>">
+                <span class="label"><?= $this->escapeHtml($_option['label']) ?>:</span>
+                <?= $_formatedOptionValue['value'] ?>
                 <?php if (isset($_formatedOptionValue['full_view'])): ?>
                 <div class="truncated_full_value">
-                    <dl class="item-options">
-                        <dt><?= $this->escapeHtml($_option['label']) ?></dt>
-                        <dd><?= $_formatedOptionValue['full_view'] ?></dd>
-                    </dl>
+                    <span class="label"><?= $this->escapeHtml($_option['label']) ?>:</span>
+                    <?= $_formatedOptionValue['full_view'] ?>
                 </div>
                 <?php endif ?>
-            </dd>
+            </div>
             <?php endforeach ?>
-        </dl>
         <?php endif ?>
 
         <?php if ($messages = $this->getMessages()): ?>

--- a/app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
@@ -34,31 +34,26 @@ $_deleteUrl = $this->getDeleteUrlCustom(false);
     </div>
 
     <?php if ($_options = $this->getOptionList()): ?>
-        <dl class="item-options">
-            <?php foreach ($_options as $_option) : ?>
-                <?php $_formatedOptionValue = $this->getFormatedOptionValue($_option) ?>
-                <dt><?= $this->escapeHtml($_option['label']) ?></dt>
-                <dd<?php if (isset($_formatedOptionValue['full_view'])): ?> class="truncated"<?php endif ?>><?= $_formatedOptionValue['value'] ?>
-                    <?php if (isset($_formatedOptionValue['full_view'])): ?>
-                        <div class="truncated_full_value">
-                            <dl class="item-options">
-                                <dt><?= $this->escapeHtml($_option['label']) ?></dt>
-                                <dd><?= $_formatedOptionValue['full_view'] ?></dd>
-                            </dl>
-                        </div>
-                    <?php endif ?>
-                </dd>
-            <?php endforeach ?>
-        </dl>
+        <?php foreach ($_options as $_option) : ?>
+            <?php $_formatedOptionValue = $this->getFormatedOptionValue($_option) ?>
+            <div class="product-cart-sku<?php if (isset($_formatedOptionValue['full_view'])): ?> truncated<?php endif ?>">
+                <span class="label"><?= $this->escapeHtml($_option['label']) ?>:</span>
+                <?= $_formatedOptionValue['value'] ?>
+                <?php if (isset($_formatedOptionValue['full_view'])): ?>
+                <div class="truncated_full_value">
+                    <span class="label"><?= $this->escapeHtml($_option['label']) ?>:</span>
+                    <?= $_formatedOptionValue['full_view'] ?>
+                </div>
+                <?php endif ?>
+            </div>
+        <?php endforeach ?>
     <?php endif ?>
     <!-- downloadable -->
     <?php if ($links = $this->getLinks()): ?>
-        <dl class="item-options">
-            <dt><?= $this->escapeHtml($this->getLinksTitle()) ?></dt>
-            <?php foreach ($links as $link): ?>
-                <dd><?= $this->escapeHtml($link->getTitle()) ?></dd>
-            <?php endforeach ?>
-        </dl>
+        <div class="product-cart-sku">
+            <span class="label"><?= $this->escapeHtml($this->getLinksTitle()) ?>:</span>
+            <?= implode(', ', array_map(fn($link) => $this->escapeHtml($link->getTitle()), $links)) ?>
+        </div>
     <?php endif ?>
     <!-- EOF downloadable -->
 

--- a/public/skin/frontend/base/default/css/checkout.css
+++ b/public/skin/frontend/base/default/css/checkout.css
@@ -224,7 +224,7 @@ td.product-cart-remove a {
 .cart-table .product-cart-sku {
     font-style: italic;
     font-size: 0.75rem;
-    margin: 5px 0 12px;
+    margin-block: 5px;
 }
 .cart-table .product-cart-sku .label {
     font-weight: 600;


### PR DESCRIPTION
## Summary
- Changed custom options in cart to use the same HTML structure as the SKU field
- Replaced `<dl class="item-options">` with `<div class="product-cart-sku">` structure
- Updated both regular and downloadable product cart item templates
- Provides consistent visual appearance for all product metadata in the cart