### PR TITLE
Added CLI commands for maintenance mode management

### DIFF
--- a/lib/MahoCLI/Commands/MaintenanceDisable.php
+++ b/lib/MahoCLI/Commands/MaintenanceDisable.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @package    MahoCLI
+ * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Commands;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'maintenance:disable',
+    description: 'Disable maintenance mode',
+)]
+class MaintenanceDisable extends Command
+{
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $maintenanceFile = BP . '/maintenance.flag';
+        $maintenanceIpFile = BP . '/maintenance.ip';
+
+        if (!file_exists($maintenanceFile)) {
+            $output->writeln('<comment>Maintenance mode is not enabled</comment>');
+            return Command::SUCCESS;
+        }
+
+        if (!unlink($maintenanceFile)) {
+            $output->writeln('<error>Failed to remove maintenance.flag file</error>');
+            return Command::FAILURE;
+        }
+
+        if (file_exists($maintenanceIpFile)) {
+            unlink($maintenanceIpFile);
+        }
+
+        $output->writeln('<info>Maintenance mode disabled</info>');
+
+        return Command::SUCCESS;
+    }
+}

--- a/lib/MahoCLI/Commands/MaintenanceEnable.php
+++ b/lib/MahoCLI/Commands/MaintenanceEnable.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @package    MahoCLI
+ * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Commands;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'maintenance:enable',
+    description: 'Enable maintenance mode',
+)]
+class MaintenanceEnable extends Command
+{
+    #[\Override]
+    protected function configure(): void
+    {
+        $this->addOption(
+            'ip',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Comma-separated list of IPs allowed to bypass maintenance mode',
+        );
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $maintenanceFile = BP . '/maintenance.flag';
+        $maintenanceIpFile = BP . '/maintenance.ip';
+
+        if (file_put_contents($maintenanceFile, '') === false) {
+            $output->writeln('<error>Failed to create maintenance.flag file</error>');
+            return Command::FAILURE;
+        }
+
+        $output->writeln('<info>Maintenance mode enabled</info>');
+
+        $ipOption = $input->getOption('ip');
+        if ($ipOption !== null) {
+            $ips = array_filter(array_map('trim', explode(',', $ipOption)));
+            if ($ips) {
+                if (file_put_contents($maintenanceIpFile, implode("\n", $ips)) === false) {
+                    $output->writeln('<error>Failed to create maintenance.ip file</error>');
+                    return Command::FAILURE;
+                }
+                $output->writeln('<info>Allowed IPs: ' . implode(', ', $ips) . '</info>');
+            }
+        } elseif (file_exists($maintenanceIpFile)) {
+            unlink($maintenanceIpFile);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/lib/MahoCLI/Commands/MaintenanceStatus.php
+++ b/lib/MahoCLI/Commands/MaintenanceStatus.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @package    MahoCLI
+ * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Commands;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'maintenance:status',
+    description: 'Show maintenance mode status',
+)]
+class MaintenanceStatus extends Command
+{
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $maintenanceFile = BP . '/maintenance.flag';
+        $maintenanceIpFile = BP . '/maintenance.ip';
+
+        if (!file_exists($maintenanceFile)) {
+            $output->writeln('<info>Maintenance mode is disabled</info>');
+            return Command::SUCCESS;
+        }
+
+        $output->writeln('<comment>Maintenance mode is enabled</comment>');
+
+        if (file_exists($maintenanceIpFile) && is_readable($maintenanceIpFile)) {
+            $contents = file_get_contents($maintenanceIpFile);
+            if ($contents) {
+                $ips = preg_split('/[\s,]+/', $contents, -1, PREG_SPLIT_NO_EMPTY);
+                if ($ips) {
+                    $output->writeln('<info>Allowed IPs:</info>');
+                    foreach ($ips as $ip) {
+                        $output->writeln("  - $ip");
+                    }
+                }
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/maho
+++ b/maho
@@ -56,6 +56,10 @@ $application->addCommand(new \MahoCLI\Commands\CronRun());
 $application->addCommand(new \MahoCLI\Commands\LogClean());
 $application->addCommand(new \MahoCLI\Commands\LogStatus());
 
+$application->addCommand(new \MahoCLI\Commands\MaintenanceEnable());
+$application->addCommand(new \MahoCLI\Commands\MaintenanceDisable());
+$application->addCommand(new \MahoCLI\Commands\MaintenanceStatus());
+
 $application->addCommand(new \MahoCLI\Commands\HealthCheck());
 $application->addCommand(new \MahoCLI\Commands\Install());
 $application->addCommand(new \MahoCLI\Commands\LegacyRenameMysql4Classes());


### PR DESCRIPTION
## Summary

- Added `maintenance:enable` command with optional `--ip` flag for allowed IPs
- Added `maintenance:disable` command to disable maintenance mode and remove IP whitelist
- Added `maintenance:status` command to show current status and allowed IPs

## Usage

```bash
./maho maintenance:enable                          # Enable maintenance mode
./maho maintenance:enable --ip="1.2.3.4,5.6.7.8"   # Enable with allowed IPs
./maho maintenance:disable                         # Disable maintenance mode
./maho maintenance:status                          # Show current status
```

Related to #443