### PR TITLE
Fixed symlink "File exists" warning from Symfony cache

### DIFF
--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -67,6 +67,15 @@ function mageCoreErrorHandler($errno, $errstr, $errfile, $errline)
         return false;
     }
 
+    // Ignore symlink "File exists" warnings from Symfony cache
+    // @see https://github.com/MahoCommerce/maho/issues/269
+    if ($errno === E_WARNING
+        && str_contains($errstr, 'symlink(): File exists')
+        && str_contains($errfile, 'FilesystemTagAwareAdapter.php')
+    ) {
+        return false;
+    }
+
     $errno = $errno & error_reporting();
     if ($errno == 0) {
         return false;


### PR DESCRIPTION
## Summary

Fixes #269

When using `FilesystemTagAwareAdapter` for caching, a `symlink(): File exists` warning can occur after session/cache expiration. This happens because:

1. Cache items are saved with tags, creating symlinks in the tags directory
2. When cache expires and regenerates, the old symlinks may still exist
3. Symfony's code at `FilesystemTagAwareAdapter:149` uses `@symlink()` with a fallback check:
   ```php
   if (!@symlink($file, $tagLink) && !is_link($tagLink)) {
   ```
4. The `@` operator should suppress the warning, but Maho's error handler intercepts it before suppression can work
5. In developer mode, this throws an `ErrorException`

This fix adds an early return in `mageCoreErrorHandler` to ignore this specific warning from `FilesystemTagAwareAdapter`, following the same pattern already used for `DateTimeZone` warnings.

## Technical Details

- The issue is a known limitation in Symfony's FilesystemTagAwareAdapter when used with custom error handlers
- The Symfony code correctly handles the case where a symlink already exists (the `&& !is_link($tagLink)` fallback)
- But the error handler catches the warning before `symlink()` returns, preventing the fallback from executing