### PR TITLE
Fixed PHPStan `reportWrongPhpDocTypeInVarTag` errors

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -6583,12 +6583,6 @@ parameters:
 			path: app/code/core/Mage/Bundle/Model/Product/Price.php
 
 		-
-			rawMessage: 'Parameter #2 $selectionProduct of method Mage_Bundle_Model_Product_Price::getSelectionFinalTotalPrice() expects Mage_Catalog_Model_Product, Mage_Bundle_Model_Selection given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Bundle/Model/Product/Price.php
-
-		-
 			rawMessage: 'Parameter #3 $bundleQty of method Mage_Bundle_Model_Product_Price::getLowestPrice() expects int, float given.'
 			identifier: argument.type
 			count: 1
@@ -7669,12 +7663,6 @@ parameters:
 			path: app/code/core/Mage/Catalog/Model/Index.php
 
 		-
-			rawMessage: 'Call to an undefined method Mage_Core_Model_Store|Mage_Core_Model_Store_Group::isValueChanged().'
-			identifier: method.notFound
-			count: 1
-			path: app/code/core/Mage/Catalog/Model/Indexer/Url.php
-
-		-
 			rawMessage: 'Method Mage_Catalog_Model_Indexer_Url::_processEvent() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -8117,12 +8105,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: app/code/core/Mage/Catalog/Model/Product/Indexer/Flat.php
-
-		-
-			rawMessage: 'Call to an undefined method Mage_Core_Model_Store|Mage_Core_Model_Store_Group::isValueChanged().'
-			identifier: method.notFound
-			count: 1
-			path: app/code/core/Mage/Catalog/Model/Product/Indexer/Price.php
 
 		-
 			rawMessage: 'Method Mage_Catalog_Model_Product_Indexer_Price::_processEvent() has no return type specified.'
@@ -9253,12 +9235,6 @@ parameters:
 			path: app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest.php
 
 		-
-			rawMessage: 'Call to an undefined method Mage_Core_Model_Store|Mage_Core_Model_Store_Group::isValueChanged().'
-			identifier: method.notFound
-			count: 1
-			path: app/code/core/Mage/CatalogInventory/Model/Indexer/Stock.php
-
-		-
 			rawMessage: 'Method Mage_CatalogInventory_Model_Indexer_Stock::_processEvent() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -9721,12 +9697,6 @@ parameters:
 			path: app/code/core/Mage/CatalogSearch/Model/Advanced.php
 
 		-
-			rawMessage: 'Call to an undefined method Mage_Core_Model_Store|Mage_Core_Model_Store_Group::isValueChanged().'
-			identifier: method.notFound
-			count: 1
-			path: app/code/core/Mage/CatalogSearch/Model/Indexer/Fulltext.php
-
-		-
 			rawMessage: 'Method Mage_CatalogSearch_Model_Indexer_Fulltext::_processEvent() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -9815,12 +9785,6 @@ parameters:
 			identifier: arguments.count
 			count: 1
 			path: app/code/core/Mage/Checkout/Block/Cart.php
-
-		-
-			rawMessage: 'Cannot call method setItem() on array.'
-			identifier: method.nonObject
-			count: 1
-			path: app/code/core/Mage/Checkout/Block/Cart/Abstract.php
 
 		-
 			rawMessage: Property Mage_Checkout_Block_Cart_Abstract::$_checkout has no type specified.
@@ -10427,12 +10391,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: app/code/core/Mage/Checkout/controllers/MultishippingController.php
-
-		-
-			rawMessage: 'Call to an undefined method Mage_Sales_Model_Service_Order::register().'
-			identifier: method.notFound
-			count: 1
-			path: app/code/core/Mage/Checkout/controllers/OnepageController.php
 
 		-
 			rawMessage: 'Method Mage_Checkout_Model_Session::getCartWasUpdated() invoked with 1 parameter, 0 required.'
@@ -15895,12 +15853,6 @@ parameters:
 			path: app/code/core/Mage/Payment/Helper/Data.php
 
 		-
-			rawMessage: 'Method Maho\DataObject::getConfigData() invoked with 2 parameters, 0-1 required.'
-			identifier: arguments.count
-			count: 1
-			path: app/code/core/Mage/Payment/Helper/Data.php
-
-		-
 			rawMessage: 'Method Mage_Payment_Model_Billing_Agreement_MethodInterface::getBillingAgreementTokenInfo() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -20958,12 +20910,6 @@ parameters:
 		-
 			rawMessage: 'Method Mage_Tax_Block_Sales_Order_Tax::_initDiscount() has no return type specified.'
 			identifier: missingType.return
-			count: 1
-			path: app/code/core/Mage/Tax/Block/Sales/Order/Tax.php
-
-		-
-			rawMessage: 'Property Mage_Tax_Block_Sales_Order_Tax::$_source (Mage_Sales_Model_Order_Invoice) does not accept Mage_Sales_Model_Order.'
-			identifier: assign.propertyType
 			count: 1
 			path: app/code/core/Mage/Tax/Block/Sales/Order/Tax.php
 

--- a/.phpstan.dist.neon
+++ b/.phpstan.dist.neon
@@ -22,7 +22,6 @@ parameters:
     # Disable strict-rules parameters that aren't controlled by allRules
     reportMaybesInMethodSignatures: false
     reportMaybesInPropertyPhpDocTypes: false
-    reportWrongPhpDocTypeInVarTag: false
 
     fileExtensions:
         - php

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
@@ -38,7 +38,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_Account extends Mage_Adminhtml_Bloc
 
         $attributes = $customerForm->getAttributes();
         foreach ($attributes as $attribute) {
-            /** @var Mage_Eav_Model_Entity_Attribute $attribute */
+            /** @var Mage_Customer_Model_Attribute $attribute */
             $attribute->setFrontendLabel(Mage::helper('customer')->__($attribute->getFrontend()->getLabel()));
             $attribute->setNote(Mage::helper('customer')->__($attribute->getNote()));
             $attribute->unsIsVisible();

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
@@ -120,7 +120,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_Addresses extends Mage_Adminhtml_Bl
                 ->processStreetAttribute($attributes['street']);
         }
         foreach ($attributes as $attribute) {
-            /** @var Mage_Eav_Model_Entity_Attribute $attribute */
+            /** @var Mage_Customer_Model_Attribute $attribute */
             $attribute->setFrontendLabel(Mage::helper('customer')->__($attribute->getFrontend()->getLabel()));
             $attribute->setNote(Mage::helper('customer')->__($attribute->getNote()));
             $attribute->unsIsVisible();

--- a/app/code/core/Mage/Adminhtml/Block/Report/Filter/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Filter/Form.php
@@ -201,7 +201,6 @@ class Mage_Adminhtml_Block_Report_Filter_Form extends Mage_Adminhtml_Block_Widge
             // apply field options
             foreach ($this->_fieldOptions as $fieldId => $fieldOptions) {
                 $field = $fieldset->getElements()->searchById($fieldId);
-                /** @var Varien_Object $field */
                 if ($field) {
                     foreach ($fieldOptions as $k => $v) {
                         $field->setDataUsingMethod($k, $v);

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
@@ -115,7 +115,6 @@ class Mage_Adminhtml_Block_System_Config_Form extends Mage_Adminhtml_Block_Widge
                 usort($groups, [$this, '_sortForm']);
 
                 foreach ($groups as $group) {
-                    /** @var Varien_Simplexml_Element $group */
                     if (!$this->_canShowField($group)) {
                         continue;
                     }

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Edit/Form.php
@@ -64,7 +64,6 @@ class Mage_Adminhtml_Block_System_Store_Edit_Form extends Mage_Adminhtml_Block_W
             $fieldset = $form->addFieldset('website_fieldset', [
                 'legend' => Mage::helper('core')->__('Website Information'),
             ]);
-            /** @var Varien_Data_Form $fieldset */
 
             $fieldset->addField('website_name', 'text', [
                 'name'      => 'website[name]',

--- a/app/code/core/Mage/Adminhtml/Model/Observer.php
+++ b/app/code/core/Mage/Adminhtml/Model/Observer.php
@@ -57,7 +57,7 @@ class Mage_Adminhtml_Model_Observer
     public function setCookieLifetime(Varien_Event_Observer $observer): void
     {
         if ($observer->getSessionName() === Mage_Adminhtml_Controller_Action::SESSION_NAMESPACE) {
-            /** @var Mage_Core_Model_Session $session */
+            /** @var Mage_Adminhtml_Model_Session $session */
             $session = Mage::getSingleton('adminhtml/session');
 
             $lifetime = Mage::getStoreConfigAsInt('admin/security/session_cookie_lifetime');

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
@@ -185,11 +185,11 @@ class Mage_Adminhtml_Catalog_Product_AttributeController extends Mage_Adminhtml_
     {
         $data = $this->getRequest()->getPost();
         if ($data) {
-            /** @var Mage_Admin_Model_Session $session */
+            /** @var Mage_Adminhtml_Model_Session $session */
             $session = Mage::getSingleton('adminhtml/session');
 
             $redirectBack   = $this->getRequest()->getParam('back', false);
-            /** @var Mage_Catalog_Model_Entity_Attribute $model */
+            /** @var Mage_Catalog_Model_Resource_Eav_Attribute $model */
             $model = Mage::getModel('catalog/resource_eav_attribute');
             /** @var Mage_Catalog_Helper_Product $helper */
             $helper = Mage::helper('catalog/product');

--- a/app/code/core/Mage/Adminhtml/controllers/System/Convert/ProfileController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Convert/ProfileController.php
@@ -225,8 +225,8 @@ class Mage_Adminhtml_System_Convert_ProfileController extends Mage_Adminhtml_Con
             $batchImportModel = $batchModel->getBatchImportModel();
             $importIds = $batchImportModel->getIdCollection();
 
-            /** @var Mage_Catalog_Model_Convert_Adapter_Product $adapter */
             $adapter = Mage::getModel($batchModel->getAdapter());
+            assert($adapter instanceof \Mage_Catalog_Model_Convert_Adapter_Product);
             $adapter->setBatchParams($batchModel->getParams());
 
             $errors = [];
@@ -248,19 +248,17 @@ class Mage_Adminhtml_System_Convert_ProfileController extends Mage_Adminhtml_Con
                 $saved++;
             }
 
-            if (method_exists($adapter, 'getEventPrefix')) {
-                /**
-                 * Event for process rules relations after products import
-                 */
-                Mage::dispatchEvent($adapter->getEventPrefix() . '_finish_before', [
-                    'adapter' => $adapter,
-                ]);
+            /**
+             * Event for process rules relations after products import
+             */
+            Mage::dispatchEvent($adapter->getEventPrefix() . '_finish_before', [
+                'adapter' => $adapter,
+            ]);
 
-                /**
-                 * Clear affected ids for adapter possible reuse
-                 */
-                $adapter->clearAffectedEntityIds();
-            }
+            /**
+             * Clear affected ids for adapter possible reuse
+             */
+            $adapter->clearAffectedEntityIds();
 
             $result = [
                 'savedRows' => $saved,

--- a/app/code/core/Mage/Api/Model/Server.php
+++ b/app/code/core/Mage/Api/Model/Server.php
@@ -79,7 +79,6 @@ class Mage_Api_Model_Server
         $adapters = $helper->getActiveAdapters();
 
         if (isset($adapters[$adapterCode])) {
-            /** @var Mage_Api_Model_Server_Adapter_Interface $adapterModel */
             $adapterModel = Mage::getModel((string) $adapters[$adapterCode]->model);
 
             if (!($adapterModel instanceof Mage_Api_Model_Server_Adapter_Interface)) {

--- a/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/ResourcePermission.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Filter/Attribute/ResourcePermission.php
@@ -89,9 +89,8 @@ class Mage_Api2_Model_Acl_Filter_Attribute_ResourcePermission implements Mage_Ap
                         continue;
                     }
                     try {
-                        /** @var Mage_Api2_Model_Resource $resourceModel */
                         $resourceModel = Mage::getModel($config->getResourceModel($resource));
-                        if ($resourceModel) {
+                        if ($resourceModel instanceof Mage_Api2_Model_Resource) {
                             $resourceModel->setResourceType($resource)
                                 ->setUserType($this->_userType);
 

--- a/app/code/core/Mage/Api2/Model/Auth.php
+++ b/app/code/core/Mage/Api2/Model/Auth.php
@@ -42,7 +42,6 @@ class Mage_Api2_Model_Auth
                 Mage_Api2_Model_Server::HTTP_UNAUTHORIZED,
             );
         }
-        /** @var Mage_Api2_Model_Auth_User_Abstract $userModel */
         $userModel = Mage::getModel($userTypes[$userParamsObj->type]);
 
         if (!$userModel instanceof Mage_Api2_Model_Auth_User_Abstract) {

--- a/app/code/core/Mage/Api2/Model/Auth/User.php
+++ b/app/code/core/Mage/Api2/Model/Auth/User.php
@@ -25,7 +25,6 @@ class Mage_Api2_Model_Auth_User
         $helper = Mage::helper('api2');
 
         foreach ($helper->getUserTypes() as $modelPath) {
-            /** @var Mage_Api2_Model_Auth_User_Abstract $userModel */
             $userModel = Mage::getModel($modelPath);
 
             if ($asOptionArray) {

--- a/app/code/core/Mage/Api2/Model/Dispatcher.php
+++ b/app/code/core/Mage/Api2/Model/Dispatcher.php
@@ -72,7 +72,6 @@ class Mage_Api2_Model_Dispatcher
         );
 
         try {
-            /** @var Mage_Api2_Model_Resource $modelObj */
             $modelObj = Mage::getModel($class);
         } catch (Exception $e) {
             // getModel() throws exception when in application is in development mode - skip it to next check

--- a/app/code/core/Mage/Api2/Model/Request.php
+++ b/app/code/core/Mage/Api2/Model/Request.php
@@ -63,9 +63,9 @@ class Mage_Api2_Model_Request extends Mage_Core_Controller_Request_Http
     protected function _getInterpreter()
     {
         if ($this->_interpreter === null) {
-            /** @var Mage_Api2_Model_Request_Interpreter_Interface $factory */
-            $factory = Mage_Api2_Model_Request_Interpreter::factory($this->getContentType());
-            $this->_interpreter = $factory;
+            $interpreter = Mage_Api2_Model_Request_Interpreter::factory($this->getContentType());
+            assert($interpreter instanceof \Mage_Api2_Model_Request_Interpreter_Interface);
+            $this->_interpreter = $interpreter;
         }
         return $this->_interpreter;
     }

--- a/app/code/core/Mage/Api2/Model/Resource.php
+++ b/app/code/core/Mage/Api2/Model/Resource.php
@@ -985,11 +985,10 @@ abstract class Mage_Api2_Model_Resource
         $workModel = $this->getConfig()->getResourceWorkingModel($this->getResourceType());
 
         if ($workModel) {
-            /** @var Mage_Core_Model_Resource_Db_Abstract $resource */
             $resource = Mage::getResourceModel($workModel);
 
             if (method_exists($resource, 'getMainTable')) {
-                $available = array_keys($resource->getReadConnection()->describeTable($resource->getMainTable()));
+                $available = array_keys($resource->getConnection()->describeTable($resource->getMainTable()));
             }
         }
         return $available;

--- a/app/code/core/Mage/Api2/Model/Server.php
+++ b/app/code/core/Mage/Api2/Model/Server.php
@@ -63,10 +63,9 @@ class Mage_Api2_Model_Server
         }
         // can not render errors case
         try {
-            /** @var Mage_Api2_Model_Request $request */
             $request = Mage::getSingleton('api2/request');
-            /** @var Mage_Api2_Model_Renderer_Interface $renderer */
             $renderer = Mage_Api2_Model_Renderer::factory($request->getAcceptTypes());
+            assert($renderer instanceof \Mage_Api2_Model_Renderer_Interface);
         } catch (Exception $e) {
             Mage::logException($e);
 

--- a/app/code/core/Mage/Bundle/Model/Product/Price.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Price.php
@@ -350,7 +350,6 @@ class Mage_Bundle_Model_Product_Price extends Mage_Catalog_Model_Product_Type_Pr
         }
 
         foreach ($selections as $selection) {
-            /** @var Mage_Bundle_Model_Selection $selection */
             if (!$selection->isSalable()) {
                 /**
                  * @todo CatalogInventory Show out of stock Products

--- a/app/code/core/Mage/Bundle/Model/Product/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Type.php
@@ -933,7 +933,6 @@ class Mage_Bundle_Model_Product_Type extends Mage_Catalog_Model_Product_Type_Abs
 
         $skipSaleableCheck = Mage::helper('catalog/product')->getSkipSaleableCheck();
         foreach ($selectionIds as $selectionId) {
-            /** @var Mage_Bundle_Model_Selection $selection */
             $selection = $productSelections->getItemById($selectionId);
             if (!$selection || (!$selection->isSalable() && !$skipSaleableCheck)) {
                 Mage::throwException(

--- a/app/code/core/Mage/Catalog/Helper/Data.php
+++ b/app/code/core/Mage/Catalog/Helper/Data.php
@@ -261,8 +261,8 @@ class Mage_Catalog_Helper_Data extends Mage_Core_Helper_Abstract
     public function getPageTemplateProcessor()
     {
         $model = (string) Mage::getConfig()->getNode(self::XML_PATH_CONTENT_TEMPLATE_FILTER);
-        /** @var Varien_Filter_Template $model */
         $model = Mage::getModel($model);
+        assert($model instanceof \Maho\Filter\Template);
         return $model;
     }
 

--- a/app/code/core/Mage/Catalog/Model/Category/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Url.php
@@ -112,8 +112,8 @@ class Mage_Catalog_Model_Category_Url
     public function getUrlInstance()
     {
         if ($this->_url === null) {
-            /** @var Mage_Core_Model_Url $model */
             $model = $this->_factory->getModel('core/url');
+            assert($model instanceof \Mage_Core_Model_Url);
             $this->_url = $model;
         }
         return $this->_url;

--- a/app/code/core/Mage/Catalog/Model/Factory.php
+++ b/app/code/core/Mage/Catalog/Model/Factory.php
@@ -38,10 +38,12 @@ class Mage_Catalog_Model_Factory extends Mage_Core_Model_Factory
      */
     public function getCategoryUrlRewriteHelper()
     {
-        /** @var Mage_Catalog_Helper_Category_Url_Rewrite_Interface $model */
         $model = $this->getHelper(
             (string) $this->_config->getNode(self::XML_PATH_CATEGORY_URL_REWRITE_HELPER_CLASS),
         );
+        if (!$model instanceof Mage_Catalog_Helper_Category_Url_Rewrite_Interface) {
+            throw new Mage_Core_Exception('Invalid category URL rewrite helper configured');
+        }
         return $model;
     }
 
@@ -52,10 +54,12 @@ class Mage_Catalog_Model_Factory extends Mage_Core_Model_Factory
      */
     public function getProductUrlRewriteHelper()
     {
-        /** @var Mage_Catalog_Helper_Product_Url_Rewrite_Interface $model */
         $model = $this->getHelper(
             (string) $this->_config->getNode(self::XML_PATH_PRODUCT_URL_REWRITE_HELPER_CLASS),
         );
+        if (!$model instanceof Mage_Catalog_Helper_Product_Url_Rewrite_Interface) {
+            throw new Mage_Core_Exception('Invalid product URL rewrite helper configured');
+        }
         return $model;
     }
 
@@ -66,10 +70,10 @@ class Mage_Catalog_Model_Factory extends Mage_Core_Model_Factory
      */
     public function getProductUrlInstance()
     {
-        /** @var Mage_Catalog_Model_Product_Url $model */
         $model = $this->getModel(
             (string) $this->_config->getNode(self::XML_PATH_PRODUCT_URL_MODEL),
         );
+        assert($model instanceof \Mage_Catalog_Model_Product_Url);
         return $model;
     }
 
@@ -80,10 +84,10 @@ class Mage_Catalog_Model_Factory extends Mage_Core_Model_Factory
      */
     public function getCategoryUrlInstance()
     {
-        /** @var Mage_Catalog_Model_Category_Url $model */
         $model = $this->getModel(
             (string) $this->_config->getNode(self::XML_PATH_CATEGORY_URL_MODEL),
         );
+        assert($model instanceof \Mage_Catalog_Model_Category_Url);
         return $model;
     }
 }

--- a/app/code/core/Mage/Catalog/Model/Indexer/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Indexer/Url.php
@@ -115,6 +115,7 @@ class Mage_Catalog_Model_Indexer_Url extends Mage_Index_Model_Indexer_Abstract
                 $result = false;
             }
         } elseif ($entity == Mage_Core_Model_Config_Data::ENTITY) {
+            /** @var Mage_Core_Model_Config_Data $configData */
             $configData = $event->getDataObject();
             if ($configData && in_array($configData->getPath(), $this->_relatedConfigSettings)) {
                 $result = $configData->isValueChanged();

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -379,8 +379,10 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
         if (empty($this->_resourceCollectionName)) {
             Mage::throwException(Mage::helper('catalog')->__('The model collection resource name is not defined.'));
         }
-        /** @var Mage_Catalog_Model_Resource_Product_Collection $collection */
         $collection = Mage::getResourceModel($this->_resourceCollectionName);
+        if (!$collection instanceof Mage_Catalog_Model_Resource_Product_Collection) {
+            Mage::throwException(Mage::helper('catalog')->__('Invalid product collection resource.'));
+        }
         $collection->setStoreId($this->getStoreId());
         return $collection;
     }

--- a/app/code/core/Mage/Catalog/Model/Product/Indexer/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Indexer/Flat.php
@@ -220,7 +220,6 @@ class Mage_Catalog_Model_Product_Indexer_Flat extends Mage_Index_Model_Indexer_A
                 break;
 
             case Mage_Index_Model_Event::TYPE_MASS_ACTION:
-                /** @var Varien_Object $actionObject */
                 $actionObject = $event->getDataObject();
 
                 $reindexData  = [];

--- a/app/code/core/Mage/Catalog/Model/Product/Indexer/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Indexer/Price.php
@@ -134,6 +134,7 @@ class Mage_Catalog_Model_Product_Indexer_Price extends Mage_Index_Model_Indexer_
         }
 
         if ($event->getEntity() == Mage_Core_Model_Config_Data::ENTITY) {
+            /** @var Mage_Core_Model_Config_Data $data */
             $data = $event->getDataObject();
             if ($data && in_array($data->getPath(), $this->_relatedConfigSettings)) {
                 $result = $data->isValueChanged();

--- a/app/code/core/Mage/Catalog/Model/Product/Option.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option.php
@@ -317,8 +317,8 @@ class Mage_Catalog_Model_Product_Option extends Mage_Core_Model_Abstract
     {
         $group = $this->getGroupByType($type);
         if (!empty($group)) {
-            /** @var Mage_Catalog_Model_Product_Option_Type_Default $model */
             $model = Mage::getModel('catalog/product_option_type_' . $group);
+            assert($model instanceof \Mage_Catalog_Model_Product_Option_Type_Default);
             return $model;
         }
         Mage::throwException(Mage::helper('catalog')->__('Wrong option type to get group instance.'));

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
@@ -706,7 +706,6 @@ class Mage_Catalog_Model_Product_Type_Configurable extends Mage_Catalog_Model_Pr
     {
         $options = parent::getOrderOptions($product);
         $options['attributes_info'] = $this->getSelectedAttributesInfo($product);
-        /** @var Mage_Sales_Model_Quote_Item_Option|Mage_Catalog_Model_Product_Configuration_Item_Option $simpleOption */
         $simpleOption = $this->getProduct($product)->getCustomOption('simple_product');
         if ($simpleOption) {
             $options['simple_name'] = $simpleOption->getProduct()->getName();
@@ -774,7 +773,6 @@ class Mage_Catalog_Model_Product_Type_Configurable extends Mage_Catalog_Model_Pr
         if ($this->getProduct($product)->hasCustomOptions() &&
             ($simpleProductOption = $this->getProduct($product)->getCustomOption('simple_product'))
         ) {
-            /** @var Mage_Sales_Model_Quote_Item_Option|Mage_Catalog_Model_Product_Configuration_Item_Option $simpleProductOption */
             $simpleProduct = $simpleProductOption->getProduct();
             if ($simpleProduct) {
                 return $simpleProduct->getWeight();

--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -138,7 +138,6 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
     #[\Override]
     protected function _addLoadAttributesSelectFields($select, $table, $type)
     {
-        /** @var Mage_Catalog_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('catalog');
         $select->columns(
             $helper->attributeSelectFields('attr_table', $type),
@@ -586,7 +585,6 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
 
             $store = (int) $store;
 
-            /** @var Mage_Eav_Model_Resource_Helper_Mysql|Mage_Eav_Model_Resource_Helper_Pgsql $helper */
             $helper = Mage::getResourceHelper('eav');
 
             foreach ($typedAttributes as $table => $attributes) {

--- a/app/code/core/Mage/Catalog/Model/Resource/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Attribute.php
@@ -128,7 +128,6 @@ class Mage_Catalog_Model_Resource_Attribute extends Mage_Eav_Model_Resource_Enti
             $select->where('entity.attribute_set_id = :attribute_set_id');
         }
 
-        /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('core');
         $query  = $helper->getQueryUsingAnalyticFunction($select);
         return $adapter->fetchOne($query, $bind);

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -628,7 +628,6 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
      */
     protected function _getStaticColumns()
     {
-        /** @var Mage_Eav_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('catalog');
         $columns = [];
         $columnsToSkip = ['entity_type_id', 'attribute_set_id'];

--- a/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Collection/Abstract.php
@@ -94,8 +94,6 @@ class Mage_Catalog_Model_Resource_Collection_Abstract extends Mage_Eav_Model_Ent
         if ($storeId) {
             $adapter = $this->getConnection();
             $entity  = $this->getEntity();
-
-            /** @var Mage_Eav_Model_Resource_Helper_Mysql|Mage_Eav_Model_Resource_Helper_Pgsql $helper */
             $helper = Mage::getResourceHelper('eav');
 
             // see also Mage_Catalog_Model_Resource_Abstract::getAttributeRawValue()
@@ -158,7 +156,6 @@ class Mage_Catalog_Model_Resource_Collection_Abstract extends Mage_Eav_Model_Ent
     {
         $storeId = $this->getStoreId();
         if ($storeId) {
-            /** @var Mage_Eav_Model_Resource_Helper_Mysql|Mage_Eav_Model_Resource_Helper_Pgsql $helper */
             $helper = Mage::getResourceHelper('eav');
             $adapter = $this->getConnection();
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Attribute/Collection.php
@@ -33,7 +33,6 @@ class Mage_Catalog_Model_Resource_Product_Attribute_Collection extends Mage_Eav_
         $columns = $this->getConnection()->describeTable($this->getResource()->getMainTable());
         unset($columns['attribute_id']);
         $retColumns = [];
-        /** @var Mage_Core_Model_Resource_Helper_Abstract|false $helper */
         $helper = Mage::getResourceHelper('core');
         foreach ($columns as $labelColumn => $columnData) {
             $retColumns[$labelColumn] = $labelColumn;

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -1545,7 +1545,6 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
             );
         }
         // Avoid column duplication problems
-        /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('core');
         $helper->prepareColumnsList($this->getSelect());
 
@@ -1594,7 +1593,6 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
             return $this;
         }
 
-        /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
         $helper     = Mage::getResourceHelper('core');
         $connection = $this->getConnection();
         $select     = $this->getSelect();

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Flat/Indexer.php
@@ -437,7 +437,6 @@ class Mage_Catalog_Model_Resource_Product_Flat_Indexer extends Mage_Index_Model_
      */
     protected function _compareColumnProperties($column, $describe)
     {
-        /** @var Mage_Catalog_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('catalog');
         return $helper->compareIndexColumnProperties($column, $describe);
     }

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
@@ -123,7 +123,6 @@ class Mage_Catalog_Model_Resource_Product_Indexer_Eav_Source extends Mage_Catalo
             )
             ->where('pid.attribute_id IN(?)', $attrIds);
 
-        /** @var Mage_Catalog_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('catalog');
         $select->where($helper->getIsNullNotNullCondition('pis.value', 'pid.value'));
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Url.php
@@ -163,7 +163,6 @@ class Mage_Catalog_Model_Resource_Url extends Mage_Core_Model_Resource_Db_Abstra
     {
         $adapter = $this->_getWriteAdapter();
         $requestPathField = new Maho\Db\Expr($adapter->quoteIdentifier('request_path'));
-        /** @var Mage_Eav_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('eav');
         //select increment part of request path and cast expression to integer
         $urlIncrementPartExpression = $helper

--- a/app/code/core/Mage/CatalogInventory/Model/Indexer/Stock.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Indexer/Stock.php
@@ -131,6 +131,7 @@ class Mage_CatalogInventory_Model_Indexer_Stock extends Mage_Index_Model_Indexer
                 $result = false;
             }
         } elseif ($entity == Mage_Core_Model_Config_Data::ENTITY) {
+            /** @var Mage_Core_Model_Config_Data $configData */
             $configData = $event->getDataObject();
             if ($configData && in_array($configData->getPath(), $this->_relatedConfigSettings)) {
                 $result = $configData->isValueChanged();

--- a/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
+++ b/app/code/core/Mage/CatalogRule/Model/Action/Index/Refresh.php
@@ -87,8 +87,10 @@ class Mage_CatalogRule_Model_Action_Index_Refresh
     {
         $this->_app->dispatchEvent('catalogrule_before_apply', ['resource' => $this->_resource]);
 
-        /** @var Mage_Core_Model_Date $coreDate */
-        $coreDate  = $this->_factory->getModel('core/date');
+        $coreDate = $this->_factory->getModel('core/date');
+        if (!$coreDate instanceof Mage_Core_Model_Date) {
+            throw new Mage_Core_Exception('Invalid core/date model');
+        }
         $timestamp = $coreDate->gmtTimestamp();
 
         foreach ($this->_app->getWebsites(false) as $website) {
@@ -240,11 +242,15 @@ class Mage_CatalogRule_Model_Action_Index_Refresh
      */
     protected function _prepareTemporarySelect(Mage_Core_Model_Website $website)
     {
-        /** @var Mage_Catalog_Helper_Product_Flat $catalogFlatHelper */
         $catalogFlatHelper = $this->_factory->getHelper('catalog/product_flat');
+        if (!$catalogFlatHelper instanceof Mage_Catalog_Helper_Product_Flat) {
+            throw new Mage_Core_Exception('Invalid catalog product flat helper');
+        }
 
-        /** @var Mage_Eav_Model_Config $eavConfig */
         $eavConfig = $this->_factory->getSingleton('eav/config');
+        if (!$eavConfig instanceof Mage_Eav_Model_Config) {
+            throw new Mage_Core_Exception('Invalid eav config model');
+        }
         $priceAttribute = $eavConfig->getAttribute(Mage_Catalog_Model_Product::ENTITY, 'price');
 
         $select = $this->_connection->select()
@@ -616,7 +622,6 @@ class Mage_CatalogRule_Model_Action_Index_Refresh
      */
     protected function _prepareAffectedProduct()
     {
-        /** @var Mage_Catalog_Model_Product_Condition $modelCondition */
         $modelCondition = $this->_factory->getModel('catalog/product_condition');
 
         $productCondition = $modelCondition->setTable($this->_resource->getTable('catalogrule/affected_product'))

--- a/app/code/core/Mage/CatalogSearch/Model/Indexer/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Indexer/Fulltext.php
@@ -159,6 +159,7 @@ class Mage_CatalogSearch_Model_Indexer_Fulltext extends Mage_Index_Model_Indexer
                 $result = false;
             }
         } elseif ($entity == Mage_Core_Model_Config_Data::ENTITY) {
+            /** @var Mage_Core_Model_Config_Data $data */
             $data = $event->getDataObject();
             if ($data && in_array($data->getPath(), $this->_relatedConfigSettings)) {
                 $result = $data->isValueChanged();
@@ -249,7 +250,6 @@ class Mage_CatalogSearch_Model_Indexer_Fulltext extends Mage_Index_Model_Indexer
                 $event->addNewData('catalogsearch_delete_product_id', $product->getId());
                 break;
             case Mage_Index_Model_Event::TYPE_MASS_ACTION:
-                /** @var Varien_Object $actionObject */
                 $actionObject = $event->getDataObject();
                 $attrData     = $actionObject->getAttributesData();
                 $rebuildIndex = false;

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext.php
@@ -303,7 +303,6 @@ class Mage_CatalogSearch_Model_Resource_Fulltext extends Mage_Core_Model_Resourc
      */
     public function prepareResult($object, $queryText, $query)
     {
-        /** @var Mage_CatalogSearch_Model_Resource_Helper_Mysql $searchHelper */
         $searchHelper = Mage::getResourceHelper('catalogsearch');
 
         $adapter = $this->_getWriteAdapter();
@@ -467,7 +466,6 @@ class Mage_CatalogSearch_Model_Resource_Fulltext extends Mage_Core_Model_Resourc
      */
     protected function _unifyField($field, $backendType = 'varchar')
     {
-        /** @var Mage_Core_Model_Resource_Helper_Abstract|false $helper */
         $helper = Mage::getResourceHelper('catalogsearch');
 
         if ($backendType === 'datetime') {

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Collection.php
@@ -189,7 +189,6 @@ class Mage_CatalogSearch_Model_Resource_Fulltext_Collection extends Mage_Catalog
             return $this;
         }
 
-        /** @var Mage_CatalogSearch_Model_Resource_Helper_Mysql $resourceHelper */
         $resourceHelper = Mage::getResourceHelper('catalogsearch');
         $this->_select->order(
             new Maho\Db\Expr(

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Engine.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Engine.php
@@ -61,7 +61,6 @@ class Mage_CatalogSearch_Model_Resource_Fulltext_Engine extends Mage_Core_Model_
         }
 
         if ($data) {
-            /** @var Mage_CatalogSearch_Model_Resource_Helper_Mysql $helper */
             $helper = Mage::getResourceHelper('catalogsearch');
             $helper->insertOnDuplicate($this->getMainTable(), $data, ['data_index']);
         }

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Query/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Query/Collection.php
@@ -61,7 +61,6 @@ class Mage_CatalogSearch_Model_Resource_Query_Collection extends Mage_Core_Model
      */
     public function setQueryFilter($query)
     {
-        /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('core');
 
         $ifSynonymFor = $this->getConnection()

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Search/Collection.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Search/Collection.php
@@ -111,7 +111,6 @@ class Mage_CatalogSearch_Model_Resource_Search_Collection extends Mage_Catalog_M
         $tables = [];
         $selects = [];
 
-        /** @var Mage_Core_Model_Resource_Helper_Abstract $resHelper */
         $resHelper = Mage::getResourceHelper('core');
         $likeOptions = ['position' => 'start'];
 

--- a/app/code/core/Mage/Checkout/Block/Cart/Abstract.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Abstract.php
@@ -58,7 +58,7 @@ abstract class Mage_Checkout_Block_Cart_Abstract extends Mage_Core_Block_Templat
      * Get renderer block instance by product type code
      *
      * @param   string $type
-     * @return  array
+     * @return  Mage_Checkout_Block_Cart_Item_Renderer
      */
     public function getItemRenderer($type)
     {

--- a/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Grouped.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Item/Renderer/Grouped.php
@@ -67,7 +67,6 @@ class Mage_Checkout_Block_Cart_Item_Renderer_Grouped extends Mage_Checkout_Block
     #[\Override]
     protected function _toHtml()
     {
-        /** @var Mage_Checkout_Block_Cart_Item_Renderer $renderer */
         $renderer = $this->getRenderedBlock()->getItemRenderer($this->getItem()->getRealProductType());
         $renderer->setItem($this->getItem());
         $renderer->overrideProductThumbnail($this->getProductThumbnail());

--- a/app/code/core/Mage/Checkout/controllers/OnepageController.php
+++ b/app/code/core/Mage/Checkout/controllers/OnepageController.php
@@ -524,7 +524,7 @@ class Mage_Checkout_OnepageController extends Mage_Checkout_Controller_Action
     /**
      * Create invoice
      *
-     * @return Mage_Sales_Model_Service_Order
+     * @return Mage_Sales_Model_Order_Invoice
      * @throws Mage_Core_Exception
      * @throws Mage_Payment_Model_Info_Exception
      */
@@ -534,9 +534,8 @@ class Mage_Checkout_OnepageController extends Mage_Checkout_Controller_Action
         foreach ($this->_getOrder()->getAllItems() as $item) {
             $items[$item->getId()] = $item->getQtyOrdered();
         }
-        /** @var Mage_Sales_Model_Service_Order $invoice */
         $invoice = Mage::getModel('sales/service_order', $this->_getOrder())->prepareInvoice($items);
-        $invoice->setEmailSent(true)->register();
+        $invoice->setEmailSent(1)->register();
 
         Mage::register('current_invoice', $invoice);
         return $invoice;

--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -983,8 +983,8 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
      */
     protected function _getUrlModel()
     {
-        /** @var Mage_Core_Model_Url $model */
         $model = Mage::getModel($this->_getUrlModelClass());
+        assert($model instanceof \Mage_Core_Model_Url);
         return $model;
     }
 
@@ -1381,8 +1381,8 @@ abstract class Mage_Core_Block_Abstract extends Varien_Object
         if ($this->_getApp()->useCache(self::CACHE_GROUP)) {
             $this->_getApp()->setUseSessionVar(false);
             \Maho\Profiler::start('CACHE_URL');
-            /** @var Mage_Core_Model_Url $model */
             $model = Mage::getSingleton($this->_getUrlModelClass());
+            assert($model instanceof \Mage_Core_Model_Url);
             $html = $model->sessionUrlVar($html);
             \Maho\Profiler::stop('CACHE_URL');
         }

--- a/app/code/core/Mage/Core/Controller/Varien/Front.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Front.php
@@ -198,10 +198,10 @@ class Mage_Core_Controller_Varien_Front extends Varien_Object
     protected function _getRequestRewriteController()
     {
         $className = (string) Mage::getConfig()->getNode('global/request_rewrite/model');
-        /** @var Mage_Core_Model_Url_Rewrite_Request $model */
         $model = Mage::getSingleton('core/factory')->getModel($className, [
             'routers' => $this->getRouters(),
         ]);
+        assert($model instanceof \Mage_Core_Model_Url_Rewrite_Request);
         return $model;
     }
 

--- a/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php
@@ -32,7 +32,7 @@ class Mage_Core_Controller_Varien_Router_Standard extends Mage_Core_Controller_V
             if ($use == $useRouterName) {
                 $modules = [(string) $routerConfig->args->module];
                 if ($routerConfig->args->modules) {
-                    /** @var Varien_Simplexml_Element $customModule */
+                    /** @var Mage_Core_Model_Config_Element $customModule */
                     foreach ($routerConfig->args->modules->children() as $customModule) {
                         if ((string) $customModule) {
                             if ($before = $customModule->getAttribute('before')) {

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1529,7 +1529,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         $stores = $this->getNode('stores');
         /**
          * @var string $code
-         * @var Varien_Simplexml_Element $store
+         * @var Mage_Core_Model_Config_Element $store
          */
         foreach ($stores->children() as $code => $store) {
             switch ($useAsKey) {

--- a/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
@@ -509,7 +509,6 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends Varien_Da
      */
     protected function _prepareSelect(\Maho\Db\Select $select)
     {
-        /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('core');
 
         $unionParts = $select->getPart(Maho\Db\Select::UNION);

--- a/app/code/core/Mage/CurrencySymbol/Block/Adminhtml/System/Currencysymbol.php
+++ b/app/code/core/Mage/CurrencySymbol/Block/Adminhtml/System/Currencysymbol.php
@@ -47,7 +47,6 @@ class Mage_CurrencySymbol_Block_Adminhtml_System_Currencysymbol extends Mage_Adm
      */
     public function getSaveButtonHtml()
     {
-        /** @var Mage_Core_Block_Abstract $block */
         $block = $this->getLayout()->createBlock('adminhtml/widget_button');
         $block->setData([
             'label'     => Mage::helper('currencysymbol')->__('Save Currency Symbols'),

--- a/app/code/core/Mage/Customer/Model/Observer.php
+++ b/app/code/core/Mage/Customer/Model/Observer.php
@@ -251,7 +251,7 @@ class Mage_Customer_Model_Observer
     public function setCookieLifetime(Varien_Event_Observer $observer)
     {
         if ($observer->getSessionName() === Mage_Core_Controller_Front_Action::SESSION_NAMESPACE) {
-            /** @var Mage_Core_Model_Session $session */
+            /** @var Mage_Customer_Model_Session $session */
             $session = Mage::getSingleton('customer/session');
 
             if ($session->getRememberMe() && Mage::getStoreConfigFlag('web/cookie/remember_enabled')) {

--- a/app/code/core/Mage/Directory/Model/Observer.php
+++ b/app/code/core/Mage/Directory/Model/Observer.php
@@ -36,7 +36,6 @@ class Mage_Directory_Model_Observer
         }
 
         try {
-            /** @var Mage_Directory_Model_Currency_Import_Abstract $importModel */
             $importModel = Mage::getModel(Mage::getConfig()->getNode('global/currency/import/services/' . $service . '/model')->asArray());
         } catch (Exception $e) {
             $importWarnings[] = Mage::helper('directory')->__('FATAL ERROR:') . ' ' . Mage::throwException(Mage::helper('directory')->__('Unable to initialize the import model.'));
@@ -45,6 +44,7 @@ class Mage_Directory_Model_Observer
         if (!isset($importModel)) {
             return;
         }
+        assert($importModel instanceof \Mage_Directory_Model_Currency_Import_Abstract);
 
         $rates = $importModel->fetchRates();
         $errors = $importModel->getMessages();

--- a/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/app/code/core/Mage/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -67,7 +67,6 @@ class Mage_Downloadable_Block_Adminhtml_Catalog_Product_Edit_Tab_Downloadable_Sa
         $samplesArr = [];
         /** @var Mage_Downloadable_Model_Product_Type $productType */
         $productType = $this->getProduct()->getTypeInstance(true);
-        /** @var Mage_Downloadable_Model_Sample[] $samples */
         $samples = $productType->getSamples($this->getProduct());
         foreach ($samples as $item) {
             $tmpSampleItem = [

--- a/app/code/core/Mage/Eav/Model/Attribute/Data.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data.php
@@ -37,7 +37,6 @@ class Mage_Eav_Model_Attribute_Data
         $dataModelClass = $attribute->getDataModel();
         if (!empty($dataModelClass)) {
             if (empty(self::$_dataModels[$dataModelClass])) {
-                /** @var Mage_Eav_Model_Attribute_Data_Abstract $dataModel */
                 $dataModel = Mage::getModel($dataModelClass);
                 self::$_dataModels[$dataModelClass] = $dataModel;
             } else {
@@ -46,7 +45,6 @@ class Mage_Eav_Model_Attribute_Data
         } else {
             if (empty(self::$_dataModels[$attribute->getFrontendInput()])) {
                 $dataModelClass = sprintf('eav/attribute_data_%s', $attribute->getFrontendInput());
-                /** @var Mage_Eav_Model_Attribute_Data_Abstract $dataModel */
                 $dataModel      = Mage::getModel($dataModelClass);
                 self::$_dataModels[$attribute->getFrontendInput()] = $dataModel;
             } else {

--- a/app/code/core/Mage/Eav/Model/Entity/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Abstract.php
@@ -957,7 +957,6 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
             $select = $this->_getLoadAttributesSelect($object, $table);
             $selects[$eavType][] = $this->_addLoadAttributesSelectFields($select, $table, $eavType);
         }
-        /** @var Mage_Eav_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('eav');
         $selectGroups = $helper->getLoadAttributesSelectGroups($selects);
         foreach ($selectGroups as $selects) {
@@ -1028,7 +1027,6 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
      */
     protected function _addLoadAttributesSelectFields($select, $table, $type)
     {
-        /** @var Mage_Eav_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('eav');
         $select->columns($helper->attributeSelectFields($table, $type));
         return $select;

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
@@ -643,7 +643,6 @@ abstract class Mage_Eav_Model_Entity_Attribute_Abstract extends Mage_Core_Model_
      */
     public function _getFlatColumnsDdlDefinition()
     {
-        /** @var Mage_Eav_Model_Resource_Helper_Mysql $helper */
         $helper  = Mage::getResourceHelper('eav');
         $columns = [];
         switch ($this->getBackendType()) {

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -354,7 +354,6 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
             }
 
             if (in_array($attrInstance->getFrontendClass(), $this->_castToIntMap)) {
-                /** @var Mage_Eav_Model_Resource_Helper_Mysql $helper */
                 $helper = Mage::getResourceHelper('eav');
                 $orderExpr = $helper->getCastToIntExpression($this->_prepareOrderExpression($orderExpr));
             }
@@ -1075,7 +1074,6 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
             );
         }
 
-        /** @var Mage_Eav_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('eav');
         $selectGroups = $helper->getLoadAttributesSelectGroups($selects);
         foreach ($selectGroups as $selects) {
@@ -1133,7 +1131,6 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
      */
     protected function _addLoadAttributesSelectValues($select, $table, $type)
     {
-        /** @var Mage_Eav_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('eav');
         $select->columns([
             'value' => $helper->prepareEavAttributeValue($table . '.value', $type),
@@ -1472,7 +1469,6 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends Varien_Data_Col
     public function _prepareSelect(\Maho\Db\Select $select)
     {
         if ($this->_useAnalyticFunction) {
-            /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
             $helper = Mage::getResourceHelper('core');
             return $helper->getQueryUsingAnalyticFunction($select);
         }

--- a/app/code/core/Mage/Eav/Model/Entity/Type.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Type.php
@@ -193,7 +193,6 @@ class Mage_Eav_Model_Entity_Type extends Mage_Core_Model_Abstract
                     ->save();
             }
 
-            /** @var Mage_Eav_Model_Entity_Increment_Abstract $incrementInstance */
             $incrementInstance = Mage::getModel($this->getIncrementModel())
                 ->setPrefix($entityStoreConfig->getIncrementPrefix())
                 ->setPadLength($this->getIncrementPadLength())
@@ -332,8 +331,10 @@ class Mage_Eav_Model_Entity_Type extends Mage_Core_Model_Abstract
      */
     public function getEntity()
     {
-        /** @var Mage_Eav_Model_Entity_Abstract $entity */
         $entity = Mage::getResourceSingleton($this->_data['entity_model']);
+        if (!$entity instanceof Mage_Eav_Model_Entity_Abstract) {
+            throw new Mage_Core_Exception('Invalid entity model');
+        }
         return $entity;
     }
 

--- a/app/code/core/Mage/ImportExport/Model/Export.php
+++ b/app/code/core/Mage/ImportExport/Model/Export.php
@@ -56,18 +56,17 @@ class Mage_ImportExport_Model_Export extends Mage_ImportExport_Model_Abstract
 
             if (isset($validTypes[$this->getEntity()])) {
                 try {
-                    /** @var Mage_ImportExport_Model_Export_Entity_Abstract $_entityAdapter */
                     $_entityAdapter = Mage::getModel($validTypes[$this->getEntity()]['model']);
+                    if (!$_entityAdapter instanceof Mage_ImportExport_Model_Export_Entity_Abstract) {
+                        Mage::throwException(
+                            Mage::helper('importexport')->__('Entity adapter object must be an instance of Mage_ImportExport_Model_Export_Entity_Abstract'),
+                        );
+                    }
                     $this->_entityAdapter = $_entityAdapter;
                 } catch (Exception $e) {
                     Mage::logException($e);
                     Mage::throwException(
                         Mage::helper('importexport')->__('Invalid entity model'),
-                    );
-                }
-                if (!$this->_entityAdapter instanceof Mage_ImportExport_Model_Export_Entity_Abstract) {
-                    Mage::throwException(
-                        Mage::helper('importexport')->__('Entity adapter obejct must be an instance of Mage_ImportExport_Model_Export_Entity_Abstract'),
                     );
                 }
             } else {
@@ -97,18 +96,17 @@ class Mage_ImportExport_Model_Export extends Mage_ImportExport_Model_Abstract
 
             if (isset($validWriters[$this->getFileFormat()])) {
                 try {
-                    /** @var Mage_ImportExport_Model_Export_Adapter_Abstract $_writer */
                     $_writer = Mage::getModel($validWriters[$this->getFileFormat()]['model']);
+                    if (!$_writer instanceof Mage_ImportExport_Model_Export_Adapter_Abstract) {
+                        Mage::throwException(
+                            Mage::helper('importexport')->__('Adapter object must be an instance of %s', 'Mage_ImportExport_Model_Export_Adapter_Abstract'),
+                        );
+                    }
                     $this->_writer = $_writer;
                 } catch (Exception $e) {
                     Mage::logException($e);
                     Mage::throwException(
                         Mage::helper('importexport')->__('Invalid entity model'),
-                    );
-                }
-                if (!$this->_writer instanceof Mage_ImportExport_Model_Export_Adapter_Abstract) {
-                    Mage::throwException(
-                        Mage::helper('importexport')->__('Adapter object must be an instance of %s', 'Mage_ImportExport_Model_Export_Adapter_Abstract'),
                     );
                 }
             } else {

--- a/app/code/core/Mage/ImportExport/Model/Import.php
+++ b/app/code/core/Mage/ImportExport/Model/Import.php
@@ -70,18 +70,17 @@ class Mage_ImportExport_Model_Import extends Mage_ImportExport_Model_Abstract
 
             if (isset($validTypes[$this->getEntity()])) {
                 try {
-                    /** @var Mage_ImportExport_Model_Import_Entity_Abstract $_entityAdapter */
                     $_entityAdapter = Mage::getModel($validTypes[$this->getEntity()]['model']);
+                    if (!$_entityAdapter instanceof Mage_ImportExport_Model_Import_Entity_Abstract) {
+                        Mage::throwException(
+                            Mage::helper('importexport')->__('Entity adapter object must be an instance of Mage_ImportExport_Model_Import_Entity_Abstract'),
+                        );
+                    }
                     $this->_entityAdapter = $_entityAdapter;
                 } catch (Exception $e) {
                     Mage::logException($e);
                     Mage::throwException(
                         Mage::helper('importexport')->__('Invalid entity model'),
-                    );
-                }
-                if (!($this->_entityAdapter instanceof Mage_ImportExport_Model_Import_Entity_Abstract)) {
-                    Mage::throwException(
-                        Mage::helper('importexport')->__('Entity adapter object must be an instance of Mage_ImportExport_Model_Import_Entity_Abstract'),
                     );
                 }
             } else {

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Abstract.php
@@ -245,7 +245,6 @@ abstract class Mage_ImportExport_Model_Import_Entity_Abstract
         $bunchRows       = [];
         $startNewBunch   = false;
         $nextRowBackup   = [];
-        /** @var Mage_ImportExport_Model_Resource_Helper_Mysql $helper */
         $helper          = Mage::getResourceHelper('importexport');
         $maxDataSize     = $helper->getMaxDataSize();
         $bunchSize       = Mage::helper('importexport')->getBunchSize();

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer.php
@@ -349,7 +349,6 @@ class Mage_ImportExport_Model_Import_Entity_Customer extends Mage_ImportExport_M
         /** @var Mage_Customer_Model_Customer $resource */
         $resource       = Mage::getModel('customer/customer');
         $table = $resource->getResource()->getEntityTable();
-        /** @var Mage_ImportExport_Model_Resource_Helper_Mysql $helper */
         $helper         = Mage::getResourceHelper('importexport');
         $nextEntityId   = $helper->getNextAutoincrement($table);
         $passId         = $resource->getAttribute('password_hash')->getId();
@@ -400,7 +399,6 @@ class Mage_ImportExport_Model_Import_Entity_Customer extends Mage_ImportExport_M
                     // attribute values
                     foreach (array_intersect_key($rowData, $this->_attributes) as $attrCode => $value) {
                         if (!$this->_attributes[$attrCode]['is_static'] && strlen($value)) {
-                            /** @var Mage_Customer_Model_Attribute $attribute */
                             $attribute  = $resource->getAttribute($attrCode);
                             $backModel  = $attribute->getBackendModel();
                             $attrParams = $this->_attributes[$attrCode];

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer/Address.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer/Address.php
@@ -139,7 +139,6 @@ class Mage_ImportExport_Model_Import_Entity_Customer_Address extends Mage_Import
         /** @var Mage_Customer_Model_Address $resource */
         $resource       = Mage::getModel('customer/address');
         $table          = $resource->getResource()->getEntityTable();
-        /** @var Mage_ImportExport_Model_Resource_Helper_Mysql $helper */
         $helper         = Mage::getResourceHelper('importexport');
         $nextEntityId   = $helper->getNextAutoincrement($table);
         $customerId     = null;

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
@@ -816,7 +816,6 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
         $typePriceTable = $coreResource->getTableName('catalog/product_option_type_price');
         $typeTitleTable = $coreResource->getTableName('catalog/product_option_type_title');
         $typeValueTable = $coreResource->getTableName('catalog/product_option_type_value');
-        /** @var Mage_ImportExport_Model_Resource_Helper_Mysql $helper */
         $helper         = Mage::getResourceHelper('importexport');
         $nextOptionId   = $helper->getNextAutoincrement($optionTable);
         $nextValueId    = $helper->getNextAutoincrement($typeValueTable);
@@ -1124,7 +1123,6 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
         $resource       = Mage::getResourceModel('catalog/product_link');
         $mainTable      = $resource->getMainTable();
         $positionAttrId = [];
-        /** @var Maho\Db\Adapter\AdapterInterface $adapter */
         $adapter = $this->_connection;
 
         // pre-load 'position' attributes ID for each link type once
@@ -1142,7 +1140,6 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
             $positionAttrId[$linkId] = $adapter->fetchOne($select, $bind);
         }
 
-        /** @var Mage_ImportExport_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('importexport');
         $nextLinkId = $helper->getNextAutoincrement($mainTable);
         while ($bunch = $this->_dataSourceModel->getNextBunch()) {

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Configurable.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Configurable.php
@@ -353,7 +353,6 @@ class Mage_ImportExport_Model_Import_Entity_Product_Type_Configurable extends Ma
         $productSuperAttrId = null;
         $productId       = null;
         $productData     = null;
-        /** @var Mage_ImportExport_Model_Resource_Helper_Mysql $helper */
         $helper          = Mage::getResourceHelper('importexport');
         $nextAttrId      = $helper->getNextAutoincrement($mainTable);
 

--- a/app/code/core/Mage/Index/Model/Event.php
+++ b/app/code/core/Mage/Index/Model/Event.php
@@ -22,7 +22,7 @@
  * @method $this setCreatedAt(string $value)
  * @method $this setOldData(string|array $value)
  * @method $this setNewData(string|array $value)
- * @method Mage_Core_Model_Store|Mage_Core_Model_Store_Group getDataObject()
+ * @method Mage_Core_Model_Abstract getDataObject()
  * @method $this setDataObject(Varien_Object $value)
  * @method bool hasCreatedAt()
  */

--- a/app/code/core/Mage/Index/Model/Lock.php
+++ b/app/code/core/Mage/Index/Model/Lock.php
@@ -253,8 +253,8 @@ class Mage_Index_Model_Lock
     {
         if (!$this->_storage instanceof Mage_Index_Model_Lock_Storage_Interface) {
             $config = Mage::getConfig()->getNode(self::STORAGE_CONFIG_PATH);
-            /** @var Mage_Index_Model_Lock_Storage_Interface $model */
             $model = Mage::getModel($config->model);
+            assert($model instanceof \Mage_Index_Model_Lock_Storage_Interface);
             $this->_storage = $model;
         }
         return $this->_storage;

--- a/app/code/core/Mage/Index/Model/Lock/Storage/Db.php
+++ b/app/code/core/Mage/Index/Model/Lock/Storage/Db.php
@@ -13,7 +13,7 @@
 class Mage_Index_Model_Lock_Storage_Db implements Mage_Index_Model_Lock_Storage_Interface
 {
     /**
-     * @var Mage_Index_Model_Resource_Helper_Mysql
+     * @var Mage_Index_Model_Resource_Helper_Lock_Interface
      */
     protected $_helper;
 
@@ -27,8 +27,10 @@ class Mage_Index_Model_Lock_Storage_Db implements Mage_Index_Model_Lock_Storage_
         /** @var Mage_Index_Model_Resource_Lock_Resource $resource */
         $resource = Mage::getSingleton('index/resource_lock_resource');
         $this->_connection = $resource->getConnection('index_write', 'default_lock');
-        /** @var Mage_Index_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('index');
+        if (!$helper instanceof Mage_Index_Model_Resource_Helper_Lock_Interface) {
+            throw new Mage_Core_Exception('Index resource helper must implement Lock interface');
+        }
         $this->_helper = $helper;
     }
 

--- a/app/code/core/Mage/Index/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Resource/Abstract.php
@@ -109,7 +109,6 @@ abstract class Mage_Index_Model_Resource_Abstract extends Mage_Core_Model_Resour
         }
         $select = $this->_getIndexAdapter()->select()->from($sourceTable, $sourceColumns);
 
-        /** @var Mage_Index_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('index');
         $helper->insertData($this, $select, $destTable, $targetColumns, $readToIndex);
         return $this;

--- a/app/code/core/Mage/Install/Model/Installer/Db.php
+++ b/app/code/core/Mage/Install/Model/Installer/Db.php
@@ -112,13 +112,13 @@ class Mage_Install_Model_Installer_Db extends Mage_Install_Model_Installer_Abstr
     protected function _getDbResource(string $engine): Mage_Install_Model_Installer_Db_Abstract
     {
         if (!isset($this->_dbResource)) {
-            /** @var Mage_Install_Model_Installer_Db_Abstract $resource */
             $resource = Mage::getSingleton(sprintf('install/installer_db_%s', $engine));
             if (!$resource) {
                 Mage::throwException(
                     Mage::helper('install')->__('Installer does not exist for %s database engine', $engine),
                 );
             }
+            assert($resource instanceof \Mage_Install_Model_Installer_Db_Abstract);
             $this->_dbResource = $resource;
         }
         return $this->_dbResource;

--- a/app/code/core/Mage/Log/Model/Resource/Visitor/Online/Collection.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor/Online/Collection.php
@@ -46,7 +46,6 @@ class Mage_Log_Model_Resource_Visitor_Online_Collection extends Mage_Core_Model_
 
         foreach ($attributes as $alias => $attributeCode) {
             $attribute = $customer->getAttribute($attributeCode);
-            /** @var Mage_Eav_Model_Entity_Attribute_Abstract $attribute */
 
             if ($attribute->getBackendType() == 'static') {
                 $tableAlias = 'customer_' . $attribute->getAttributeCode();

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizeController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizeController.php
@@ -85,10 +85,9 @@ class Mage_Oauth_Adminhtml_Oauth_AuthorizeController extends Mage_Adminhtml_Cont
      */
     protected function _initForm($simple = false)
     {
-        /** @var Mage_Oauth_Model_Server $server */
         $server = Mage::getModel('oauth/server');
-        /** @var Mage_Admin_Model_Session $session */
         $session = Mage::getSingleton($this->_sessionName);
+        assert($session instanceof \Mage_Admin_Model_Session);
 
         $isException = false;
         try {
@@ -132,11 +131,10 @@ class Mage_Oauth_Adminhtml_Oauth_AuthorizeController extends Mage_Adminhtml_Cont
      */
     protected function _initConfirmPage($simple = false)
     {
-        /** @var Mage_Oauth_Helper_Data $helper */
         $helper = Mage::helper('oauth');
 
-        /** @var Mage_Admin_Model_Session $session */
         $session = Mage::getSingleton($this->_sessionName);
+        assert($session instanceof \Mage_Admin_Model_Session);
 
         /** @var Mage_Admin_Model_User $user */
         $user = $session->getData('user');
@@ -187,11 +185,10 @@ class Mage_Oauth_Adminhtml_Oauth_AuthorizeController extends Mage_Adminhtml_Cont
      */
     protected function _initRejectPage($simple = false)
     {
-        /** @var Mage_Oauth_Model_Server $server */
         $server = Mage::getModel('oauth/server');
 
-        /** @var Mage_Admin_Model_Session $session */
         $session = Mage::getSingleton($this->_sessionName);
+        assert($session instanceof \Mage_Admin_Model_Session);
 
         $this->loadLayout();
 

--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -63,9 +63,8 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
             if (!$model = Mage::getStoreConfig($prefix . 'model', $store)) {
                 continue;
             }
-            /** @var Mage_Payment_Model_Method_Abstract|false $methodInstance */
             $methodInstance = Mage::getModel($model);
-            if (!$methodInstance) {
+            if (!$methodInstance instanceof Mage_Payment_Model_Method_Abstract) {
                 continue;
             }
             $methodInstance->setStore($store);
@@ -173,9 +172,8 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
                 continue;
             }
 
-            /** @var Mage_Payment_Model_Method_Abstract $method */
             $method = Mage::getModel($paymentMethodModelClassName);
-            if ($method && $method->canManageRecurringProfiles()) {
+            if ($method instanceof Mage_Payment_Model_Method_Abstract && $method->canManageRecurringProfiles()) {
                 $result[] = $method;
             }
         }
@@ -227,7 +225,10 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
             } else {
                 $paymentMethodModelClassName = $this->getMethodModelClassName($code);
                 if ($paymentMethodModelClassName) {
-                    $methods[$code] = Mage::getModel($paymentMethodModelClassName)->getConfigData('title', $store);
+                    $paymentMethod = Mage::getModel($paymentMethodModelClassName);
+                    if ($paymentMethod instanceof Mage_Payment_Model_Method_Abstract) {
+                        $methods[$code] = $paymentMethod->getConfigData('title', $store);
+                    }
                 }
             }
             if ($asLabelValue && $withGroups && isset($data['group'])) {

--- a/app/code/core/Mage/Payment/controllers/Adminhtml/Payment/RestrictionController.php
+++ b/app/code/core/Mage/Payment/controllers/Adminhtml/Payment/RestrictionController.php
@@ -261,14 +261,13 @@ class Mage_Payment_Adminhtml_Payment_RestrictionController extends Mage_Adminhtm
         // Ensure the rule has a form (should auto-create if null)
         $rule->getForm();
 
-        /** @var Mage_Rule_Model_Condition_Abstract $model */
         $model = Mage::getModel($type)
             ->setId($id)
             ->setType($type)
             ->setRule($rule)
             ->setPrefix('conditions');
         if (!empty($typeArr[1])) {
-            $model->setAttribute($typeArr[1]);
+            $model->setData('attribute', $typeArr[1]);
         }
 
         if ($model instanceof Mage_Rule_Model_Condition_Abstract) {

--- a/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
+++ b/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
@@ -49,8 +49,8 @@ abstract class Mage_Paypal_Controller_Express_Abstract extends Mage_Core_Control
     protected function _construct()
     {
         parent::_construct();
-        /** @var Mage_Paypal_Model_Config $classInstance */
         $classInstance = Mage::getModel($this->_configType, [$this->_configMethod]);
+        assert($classInstance instanceof \Mage_Paypal_Model_Config);
         $this->_config = $classInstance;
     }
 
@@ -445,11 +445,11 @@ abstract class Mage_Paypal_Controller_Express_Abstract extends Mage_Core_Control
             Mage::throwException(Mage::helper('paypal')->__('Unable to initialize Express Checkout.'));
         }
 
-        /** @var Mage_Paypal_Model_Express_Checkout $classInstance */
         $classInstance = Mage::getSingleton($this->_checkoutType, [
             'config' => $this->_config,
             'quote'  => $quote,
         ]);
+        assert($classInstance instanceof \Mage_Paypal_Model_Express_Checkout);
         $this->_checkout = $classInstance;
         return $this->_checkout;
     }

--- a/app/code/core/Mage/Paypal/Model/Direct.php
+++ b/app/code/core/Mage/Paypal/Model/Direct.php
@@ -52,8 +52,8 @@ class Mage_Paypal_Model_Direct extends Mage_Payment_Model_Method_Cc
         if ($proInstance instanceof Mage_Paypal_Model_Pro) {
             $this->_pro = $proInstance;
         } else {
-            /** @var Mage_Paypal_Model_Pro $model */
             $model = Mage::getModel($this->_proType);
+            assert($model instanceof \Mage_Paypal_Model_Pro);
             $this->_pro = $model;
         }
         $this->_pro->setMethod($this->_code);

--- a/app/code/core/Mage/Paypal/Model/Express.php
+++ b/app/code/core/Mage/Paypal/Model/Express.php
@@ -66,8 +66,8 @@ class Mage_Paypal_Model_Express extends Mage_Payment_Model_Method_Abstract imple
         if ($proInstance instanceof Mage_Paypal_Model_Pro) {
             $this->_pro = $proInstance;
         } else {
-            /** @var Mage_Paypal_Model_Pro $model */
             $model = Mage::getModel($this->_proType);
+            assert($model instanceof \Mage_Paypal_Model_Pro);
             $this->_pro = $model;
         }
         $this->_pro->setMethod($this->_code);

--- a/app/code/core/Mage/Paypal/Model/Pro.php
+++ b/app/code/core/Mage/Paypal/Model/Pro.php
@@ -74,8 +74,8 @@ class Mage_Paypal_Model_Pro
                 $params[] = $storeId;
             }
 
-            /** @var Mage_Paypal_Model_Config $model */
             $model = Mage::getModel($this->_configType, $params);
+            assert($model instanceof \Mage_Paypal_Model_Config);
             $this->_config = $model;
         } else {
             $this->_config->setMethod($code);

--- a/app/code/core/Mage/Reports/Model/Resource/Customer/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Customer/Collection.php
@@ -209,7 +209,6 @@ class Mage_Reports_Model_Resource_Customer_Collection extends Mage_Customer_Mode
               ->where('orders.customer_id IN(?)', $customerIds)
               ->group('orders.customer_id');
 
-            /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
             $helper = Mage::getResourceHelper('core');
 
             /*

--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Abstract.php
@@ -111,7 +111,6 @@ abstract class Mage_Reports_Model_Resource_Product_Index_Abstract extends Mage_C
 
         $matchFields = ['product_id', 'store_id'];
 
-        /** @var Mage_Reports_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('reports');
         $helper->mergeVisitorProductIndex(
             $this->getMainTable(),
@@ -184,7 +183,6 @@ abstract class Mage_Reports_Model_Resource_Product_Index_Abstract extends Mage_C
 
         $matchFields = ['product_id', 'store_id'];
 
-        /** @var Mage_Reports_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('reports');
         foreach ($data as $row) {
             $helper->mergeVisitorProductIndex(

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed.php
@@ -63,7 +63,6 @@ class Mage_Reports_Model_Resource_Report_Product_Viewed extends Mage_Sales_Model
             ),
         );
 
-        /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('core');
         $select = $adapter->select();
 
@@ -189,7 +188,6 @@ class Mage_Reports_Model_Resource_Report_Product_Viewed extends Mage_Sales_Model
         );
         $adapter->query($insertQuery);
 
-        /** @var Mage_Reports_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('reports');
         $helper
             ->updateReportRatingPos('day', 'views_num', $mainTable, $this->getTable(self::AGGREGATION_DAILY));

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Product/Viewed/Collection.php
@@ -281,7 +281,6 @@ class Mage_Reports_Model_Resource_Report_Product_Viewed_Collection extends Mage_
             if ($selectUnions) {
                 $unionParts = [];
                 $cloneSelect = clone $this->getSelect();
-                /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
                 $helper = Mage::getResourceHelper('core');
                 $unionParts[] = '(' . $cloneSelect . ')';
                 foreach ($selectUnions as $union) {

--- a/app/code/core/Mage/Reports/Model/Resource/Review/Product/Collection.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Review/Product/Collection.php
@@ -25,7 +25,6 @@ class Mage_Reports_Model_Resource_Review_Product_Collection extends Mage_Catalog
      */
     public function joinReview()
     {
-        /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
         $helper    = Mage::getResourceHelper('core');
 
         $subSelect = clone $this->getSelect();

--- a/app/code/core/Mage/Rss/Block/Catalog/Tag.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Tag.php
@@ -56,7 +56,6 @@ class Mage_Rss_Block_Catalog_Tag extends Mage_Rss_Block_Catalog_Abstract
 
         $product = Mage::getModel('catalog/product');
 
-        /** @var Mage_Core_Model_Resource_Helper_Mysql $resourceHelper */
         $resourceHelper = Mage::getResourceHelper('core');
         Mage::getSingleton('core/resource_iterator')->walk(
             $resourceHelper->getQueryUsingAnalyticFunction($collection->getSelect()),

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -38,7 +38,7 @@ class Mage_Sales_Model_Order_Creditmemo_Total_Discount extends Mage_Sales_Model_
             $baseTotalDiscountAmount = $baseTotalDiscountAmount + $baseShippingDiscount;
         }
 
-        /** @var Mage_Sales_Model_Order_Invoice_Item $item */
+        /** @var Mage_Sales_Model_Order_Creditmemo_Item $item */
         foreach ($creditmemo->getAllItems() as $item) {
             $orderItem = $item->getOrderItem();
 

--- a/app/code/core/Mage/Sales/Model/Resource/Helper/Mysql.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Helper/Mysql.php
@@ -28,7 +28,6 @@ class Mage_Sales_Model_Resource_Helper_Mysql extends Mage_Core_Model_Resource_He
         $mainTable,
         $aggregationTable,
     ) {
-        /** @var Mage_Reports_Model_Resource_Helper_Interface $reportsResourceHelper */
         $reportsResourceHelper = Mage::getResourceHelper('reports');
 
         if ($aggregation == $aggregationAliases['monthly']) {

--- a/app/code/core/Mage/Sales/Model/Resource/Helper/Pgsql.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Helper/Pgsql.php
@@ -26,7 +26,6 @@ class Mage_Sales_Model_Resource_Helper_Pgsql extends Mage_Core_Model_Resource_He
         $mainTable,
         $aggregationTable,
     ) {
-        /** @var Mage_Reports_Model_Resource_Helper_Interface $reportsResourceHelper */
         $reportsResourceHelper = Mage::getResourceHelper('reports');
 
         if ($aggregation == $aggregationAliases['monthly']) {

--- a/app/code/core/Mage/Sales/Model/Resource/Helper/Sqlite.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Helper/Sqlite.php
@@ -26,7 +26,6 @@ class Mage_Sales_Model_Resource_Helper_Sqlite extends Mage_Core_Model_Resource_H
         $mainTable,
         $aggregationTable,
     ) {
-        /** @var Mage_Reports_Model_Resource_Helper_Interface $reportsResourceHelper */
         $reportsResourceHelper = Mage::getResourceHelper('reports');
 
         if ($aggregation == $aggregationAliases['monthly']) {

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Collection.php
@@ -131,7 +131,6 @@ class Mage_Sales_Model_Resource_Order_Collection extends Mage_Sales_Model_Resour
                 ],
             );
 
-        /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('core');
         $helper->prepareColumnsList($this->getSelect());
         return $this;

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers.php
@@ -66,7 +66,6 @@ class Mage_Sales_Model_Resource_Report_Bestsellers extends Mage_Sales_Model_Reso
                 ),
             );
 
-            /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
             $helper = Mage::getResourceHelper('core');
             $select = $adapter->select();
 
@@ -232,7 +231,6 @@ class Mage_Sales_Model_Resource_Report_Bestsellers extends Mage_Sales_Model_Reso
         /** @var Mage_Catalog_Model_Resource_Product $product */
         $product    = Mage::getResourceSingleton('catalog/product');
         $attr       = $product->getAttribute('price');
-        /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
         $helper     = Mage::getResourceHelper('core');
 
         $columns = [
@@ -306,7 +304,6 @@ class Mage_Sales_Model_Resource_Report_Bestsellers extends Mage_Sales_Model_Reso
             'yearly'  => self::AGGREGATION_YEARLY,
         ];
 
-        /** @var Mage_Sales_Model_Resource_Helper_Mysql $helper */
         $helper = Mage::getResourceHelper('sales');
         $helper->getBestsellersReportUpdateRatingPos(
             $aggregation,

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers/Collection.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Bestsellers/Collection.php
@@ -295,7 +295,6 @@ class Mage_Sales_Model_Resource_Report_Bestsellers_Collection extends Mage_Sales
             if ($selectUnions) {
                 $unionParts = [];
                 $cloneSelect = clone $this->getSelect();
-                /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
                 $helper = Mage::getResourceHelper('core');
                 $unionParts[] = '(' . $cloneSelect . ')';
                 foreach ($selectUnions as $union) {

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Invoiced.php
@@ -51,7 +51,6 @@ class Mage_Sales_Model_Resource_Report_Invoiced extends Mage_Sales_Model_Resourc
         $table       = $this->getTable('sales/invoiced_aggregated');
         $sourceTable = $this->getTable('sales/invoice');
         $orderTable  = $this->getTable('sales/order');
-        /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
         $helper      = Mage::getResourceHelper('core');
         $adapter     = $this->_getWriteAdapter();
 
@@ -248,7 +247,6 @@ class Mage_Sales_Model_Resource_Report_Invoiced extends Mage_Sales_Model_Resourc
 
         $select->having('orders_count > 0');
 
-        /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
         $helper      = Mage::getResourceHelper('core');
         $insertQuery = $helper->getInsertFromSelectUsingAnalytic($select, $table, array_keys($columns));
         $adapter->query($insertQuery);
@@ -277,7 +275,6 @@ class Mage_Sales_Model_Resource_Report_Invoiced extends Mage_Sales_Model_Resourc
             'order_status',
         ]);
 
-        /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
         $helper      = Mage::getResourceHelper('core');
         $insertQuery = $helper->getInsertFromSelectUsingAnalytic($select, $table, array_keys($columns));
         $adapter->query($insertQuery);

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Refunded.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Refunded.php
@@ -95,7 +95,6 @@ class Mage_Sales_Model_Resource_Report_Refunded extends Mage_Sales_Model_Resourc
 
             $select->having('orders_count > 0');
 
-            /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
             $helper      = Mage::getResourceHelper('core');
             $insertQuery = $helper->getInsertFromSelectUsingAnalytic($select, $table, array_keys($columns));
             $adapter->query($insertQuery);
@@ -226,7 +225,6 @@ class Mage_Sales_Model_Resource_Report_Refunded extends Mage_Sales_Model_Resourc
 
             $select->having('orders_count > 0');
 
-            /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
             $helper        = Mage::getResourceHelper('core');
             $insertQuery   = $helper->getInsertFromSelectUsingAnalytic($select, $table, array_keys($columns));
             $adapter->query($insertQuery);

--- a/app/code/core/Mage/Sales/Model/Resource/Report/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Report/Shipping.php
@@ -101,7 +101,6 @@ class Mage_Sales_Model_Resource_Report_Shipping extends Mage_Sales_Model_Resourc
 
             $select->having('orders_count > 0');
 
-            /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
             $helper        = Mage::getResourceHelper('core');
             $insertQuery   = $helper->getInsertFromSelectUsingAnalytic($select, $table, array_keys($columns));
             $adapter->query($insertQuery);
@@ -226,7 +225,6 @@ class Mage_Sales_Model_Resource_Report_Shipping extends Mage_Sales_Model_Resourc
                 'order_table.shipping_description',
             ]);
 
-            /** @var Mage_Core_Model_Resource_Helper_Mysql $helper */
             $helper        = Mage::getResourceHelper('core');
             $insertQuery   = $helper->getInsertFromSelectUsingAnalytic($select, $table, array_keys($columns));
             $adapter->query($insertQuery);

--- a/app/code/core/Mage/Shipping/Model/Config.php
+++ b/app/code/core/Mage/Shipping/Model/Config.php
@@ -91,9 +91,8 @@ class Mage_Shipping_Model_Config extends Varien_Object
             return false;
         }
         $modelName = $config['model'];
-        /** @var Mage_Shipping_Model_Carrier_Abstract $carrier */
         $carrier = Mage::getModel($modelName);
-        if (!$carrier) {
+        if (!$carrier instanceof Mage_Shipping_Model_Carrier_Abstract) {
             return false;
         }
         $carrier->setId($code)->setStore($store);

--- a/app/code/core/Mage/Shipping/Model/Shipping.php
+++ b/app/code/core/Mage/Shipping/Model/Shipping.php
@@ -136,7 +136,6 @@ class Mage_Shipping_Model_Shipping
      */
     public function collectCarrierRates($carrierCode, $request)
     {
-        /** @var Mage_Shipping_Model_Carrier_Abstract $carrier */
         $carrier = $this->getCarrierByCode($carrierCode, $request->getStoreId());
         if (!$carrier) {
             return $this;
@@ -390,7 +389,7 @@ class Mage_Shipping_Model_Shipping
      *
      * @param string $carrierCode
      * @param null|int $storeId
-     * @return bool|Mage_Core_Model_Abstract
+     * @return Mage_Shipping_Model_Carrier_Abstract|false
      */
     public function getCarrierByCode($carrierCode, $storeId = null)
     {
@@ -402,6 +401,9 @@ class Mage_Shipping_Model_Shipping
             return false;
         }
         $obj = Mage::getModel($className);
+        if (!$obj instanceof Mage_Shipping_Model_Carrier_Abstract) {
+            return false;
+        }
         if ($storeId) {
             $obj->setStore($storeId);
         }

--- a/app/code/core/Mage/Tax/Block/Adminhtml/Notifications.php
+++ b/app/code/core/Mage/Tax/Block/Adminhtml/Notifications.php
@@ -47,8 +47,10 @@ class Mage_Tax_Block_Adminhtml_Notifications extends Mage_Adminhtml_Block_Templa
     {
         $defaultStoreId = Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID;
         //check default store first
-        /** @var Mage_Tax_Model_Config $model */
         $model = $this->_factory->getSingleton('tax/config');
+        if (!$model instanceof Mage_Tax_Model_Config) {
+            return [];
+        }
         if (!$model->checkDisplaySettings($defaultStoreId)) {
             return true;
         }
@@ -108,8 +110,10 @@ class Mage_Tax_Block_Adminhtml_Notifications extends Mage_Adminhtml_Block_Templa
      */
     public function checkDisplaySettings($store = null)
     {
-        /** @var Mage_Tax_Model_Config $model */
         $model = $this->_factory->getSingleton('tax/config');
+        if (!$model instanceof Mage_Tax_Model_Config) {
+            return false;
+        }
         return $model->checkDisplaySettings($store);
     }
 
@@ -121,8 +125,10 @@ class Mage_Tax_Block_Adminhtml_Notifications extends Mage_Adminhtml_Block_Templa
      */
     public function getWebsitesWithWrongDiscountSettings()
     {
-        /** @var Mage_Tax_Model_Config $model */
         $model = $this->_factory->getSingleton('tax/config');
+        if (!$model instanceof Mage_Tax_Model_Config) {
+            return [];
+        }
 
         $defaultStoreId = Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID;
         //check default store first
@@ -180,9 +186,8 @@ class Mage_Tax_Block_Adminhtml_Notifications extends Mage_Adminhtml_Block_Templa
     #[\Override]
     protected function _toHtml()
     {
-        /** @var Mage_Admin_Model_Session $model */
         $model = $this->_factory->getSingleton('admin/session');
-        if ($model->isAllowed('system/config/tax')) {
+        if ($model instanceof Mage_Admin_Model_Session && $model->isAllowed('system/config/tax')) {
             return parent::_toHtml();
         }
         return '';

--- a/app/code/core/Mage/Tax/Block/Sales/Order/Tax.php
+++ b/app/code/core/Mage/Tax/Block/Sales/Order/Tax.php
@@ -28,7 +28,7 @@ class Mage_Tax_Block_Sales_Order_Tax extends Mage_Core_Block_Template
     protected $_order;
 
     /**
-     * @var Mage_Sales_Model_Order_Invoice
+     * @var Mage_Sales_Model_Order|Mage_Sales_Model_Order_Invoice|Mage_Sales_Model_Order_Creditmemo|Maho\DataObject
      */
     protected $_source;
 
@@ -68,7 +68,6 @@ class Mage_Tax_Block_Sales_Order_Tax extends Mage_Core_Block_Template
      */
     public function initTotals()
     {
-        /** @var Mage_Adminhtml_Block_Sales_Order_Invoice_Totals $parent */
         $parent = $this->getParentBlock();
         $this->_order   = $parent->getOrder();
         $this->_source  = $parent->getSource();

--- a/app/code/core/Mage/Weee/Model/Attribute/Backend/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Attribute/Backend/Weee/Tax.php
@@ -26,8 +26,11 @@ class Mage_Weee_Model_Attribute_Backend_Weee_Tax extends Mage_Catalog_Model_Prod
      */
     protected function _getResource()
     {
-        /** @var Mage_Weee_Model_Resource_Attribute_Backend_Weee_Tax */
-        return Mage::getResourceSingleton(self::getBackendModelName());
+        $resource = Mage::getResourceSingleton(self::getBackendModelName());
+        if (!$resource instanceof Mage_Weee_Model_Resource_Attribute_Backend_Weee_Tax) {
+            throw new Mage_Core_Exception('Invalid Weee tax resource model');
+        }
+        return $resource;
     }
 
     /**

--- a/app/code/core/Maho/Blog/Block/Adminhtml/Post/Grid.php
+++ b/app/code/core/Maho/Blog/Block/Adminhtml/Post/Grid.php
@@ -23,8 +23,10 @@ class Maho_Blog_Block_Adminhtml_Post_Grid extends Mage_Adminhtml_Block_Widget_Gr
     #[\Override]
     protected function _prepareCollection()
     {
-        /** @var Maho_Blog_Model_Resource_Post_Collection $collection */
         $collection = Mage::getModel('blog/post')->getCollection();
+        if (!$collection instanceof Maho_Blog_Model_Resource_Post_Collection) {
+            return $this;
+        }
 
         // Static attributes are automatically selected from main table
         // Only need to select EAV attributes explicitly

--- a/app/code/core/Maho/Blog/Block/Autocomplete.php
+++ b/app/code/core/Maho/Blog/Block/Autocomplete.php
@@ -15,15 +15,17 @@ class Maho_Blog_Block_Autocomplete extends Mage_Core_Block_Template
 {
     protected ?Maho_Blog_Model_Resource_Post_Collection $_blogCollection = null;
 
-    public function getBlogCollection(): Maho_Blog_Model_Resource_Post_Collection
+    public function getBlogCollection(): ?Maho_Blog_Model_Resource_Post_Collection
     {
         if ($this->_blogCollection === null) {
             /** @var Mage_CatalogSearch_Helper_Data $helper */
             $helper = Mage::helper('catalogsearch');
             $query = $helper->getQueryText();
 
-            /** @var Maho_Blog_Model_Resource_Post_Collection $collection */
             $collection = Mage::getModel('blog/post')->getCollection();
+            if (!$collection instanceof Maho_Blog_Model_Resource_Post_Collection) {
+                return null;
+            }
 
             // Apply search filter based on configured search type
             $searchType = (int) Mage::getStoreConfig(Mage_CatalogSearch_Model_Fulltext::XML_PATH_CATALOG_SEARCH_TYPE);

--- a/app/code/core/Maho/Blog/Model/Post/Api.php
+++ b/app/code/core/Maho/Blog/Model/Post/Api.php
@@ -14,8 +14,10 @@ class Maho_Blog_Model_Post_Api extends Mage_Api_Model_Resource_Abstract
     public function items(?array $filters = null): array
     {
         try {
-            /** @var Maho_Blog_Model_Resource_Post_Collection $collection */
             $collection = Mage::getModel('blog/post')->getCollection();
+            if (!$collection instanceof Maho_Blog_Model_Resource_Post_Collection) {
+                return [];
+            }
             $collection->addAttributeToSelect('*');
 
             if (is_array($filters)) {

--- a/app/code/core/Maho/CatalogLinkRule/Model/Rule.php
+++ b/app/code/core/Maho/CatalogLinkRule/Model/Rule.php
@@ -87,8 +87,11 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
 
     public function getTargetConditions(): Mage_Rule_Model_Condition_Combine
     {
-        /** @var Maho_CatalogLinkRule_Model_Rule_Target_Combine */
-        return $this->getActions();
+        $actions = $this->getActions();
+        if (!$actions instanceof Mage_Rule_Model_Condition_Combine) {
+            throw new Mage_Core_Exception('Target conditions must be a Mage_Rule_Model_Condition_Combine');
+        }
+        return $actions;
     }
 
     /**

--- a/app/code/core/Maho/SpeculationRules/Helper/Data.php
+++ b/app/code/core/Maho/SpeculationRules/Helper/Data.php
@@ -67,7 +67,6 @@ class Maho_SpeculationRules_Helper_Data extends Mage_Core_Helper_Abstract
             }
 
             // Parse selectors (one per line)
-            /** @var string[] $selectors */
             $selectors = array_filter(array_map('trim', explode("\n", $selectorsConfig)));
 
             if (empty($selectors)) {


### PR DESCRIPTION
## Summary

- Enabled the PHPStan rule `reportWrongPhpDocTypeInVarTag` which validates that `@var` PHPDoc annotations are proper subtypes of inferred types
- Replaced `@var` annotations with `instanceof` checks where factory methods return union types (e.g., `Mage_Core_Model_Abstract|false`)
- Removed redundant `@var` annotations where PHPStan already knows the type
- Fixed incorrect `@return` type annotations in several methods
- Added proper type narrowing for classes that don't extend expected base classes (`Mage_Tax_Model_Config`, `Mage_Eav_Model_Config`, etc.)