### PR TITLE
Fixed unnecessary `GROUP BY` in Flat Category getProductCount()

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category.php
@@ -522,12 +522,9 @@ class Mage_Catalog_Model_Resource_Category extends Mage_Catalog_Model_Resource_A
                 ['main_table' => $productTable],
                 [new Maho\Db\Expr('COUNT(main_table.product_id)')],
             )
-            ->where('main_table.category_id = :category_id');
+            ->where('main_table.category_id = ?', (int) $category->getId());
 
-        $bind = ['category_id' => (int) $category->getId()];
-        $counts = $this->getReadConnection()->fetchOne($select, $bind);
-
-        return (int) $counts;
+        return (int) $this->getReadConnection()->fetchOne($select);
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -1194,9 +1194,9 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
         $select = $this->_getReadAdapter()->select()
             ->from(
                 ['main_table' => $this->getTable('catalog/category_product')],
-                [new \Maho\Db\Expr('COUNT(main_table.product_id)')],
+                [new Maho\Db\Expr('COUNT(main_table.product_id)')],
             )
-            ->where('main_table.category_id = ?', $category->getId());
+            ->where('main_table.category_id = ?', (int) $category->getId());
 
         return (int) $this->_getReadAdapter()->fetchOne($select);
     }


### PR DESCRIPTION
## Summary

- Removed redundant `GROUP BY` clause from `Mage_Catalog_Model_Resource_Category_Flat::getProductCount()` that was causing unnecessary performance overhead

## Problem

When Catalog Flat Tables are enabled, the `getProductCount()` method included a `GROUP BY category_id` clause on a query that already filters by a single `category_id` via `WHERE`. This forced MySQL to:
- Create temporary tables
- Perform filesort operations
- Use query plan: `"Using where; Using index; Using temporary; Using filesort"`

The non-flat version (`Mage_Catalog_Model_Resource_Category::getProductCount()`) correctly omits the GROUP BY and uses the optimal plan: `"Using index"`

## Solution

Removed the unnecessary `GROUP BY` clause to match the non-flat implementation.

## Thanks

Thanks to @loekvangool for discovering this issue.
See: https://github.com/OpenMage/magento-lts/issues/5206