### PR TITLE
Disabled flat catalog for SQLite and PostgreSQL

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatcatalog.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatcatalog.php
@@ -15,7 +15,13 @@ class Mage_Adminhtml_Block_System_Config_Form_Field_Select_Flatcatalog extends M
     #[\Override]
     protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
     {
-        if (!Mage::helper('catalog/category_flat')->isBuilt()) {
+        // Flat catalog is only supported on MySQL
+        $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+        if (!($adapter instanceof Maho\Db\Adapter\Pdo\Mysql)) {
+            $element->setDisabled(true)
+                ->setValue(0)
+                ->setComment('Flat catalog is only supported with MySQL database engine.');
+        } elseif (!Mage::helper('catalog/category_flat')->isBuilt()) {
             $element->setDisabled(true)
                 ->setValue(0);
         }

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatproduct.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatproduct.php
@@ -20,7 +20,13 @@ class Mage_Adminhtml_Block_System_Config_Form_Field_Select_Flatproduct extends M
     #[\Override]
     protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
     {
-        if (!Mage::helper('catalog/product_flat')->isBuilt()) {
+        // Flat catalog is only supported on MySQL
+        $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+        if (!($adapter instanceof Maho\Db\Adapter\Pdo\Mysql)) {
+            $element->setDisabled(true)
+                ->setValue(0)
+                ->setComment('Flat catalog is only supported with MySQL database engine.');
+        } elseif (!Mage::helper('catalog/product_flat')->isBuilt()) {
             $element->setDisabled(true)
                 ->setValue(0);
         }

--- a/app/code/core/Mage/Catalog/Helper/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Helper/Category/Flat.php
@@ -46,6 +46,11 @@ class Mage_Catalog_Helper_Category_Flat extends Mage_Catalog_Helper_Flat_Abstrac
     #[\Override]
     public function isEnabled($skipAdminCheck = false)
     {
+        // Flat catalog is only supported on MySQL
+        $adapter = Mage::getSingleton('core/resource')->getConnection('core_read');
+        if (!($adapter instanceof Maho\Db\Adapter\Pdo\Mysql)) {
+            return false;
+        }
         return Mage::getStoreConfigFlag(self::XML_PATH_IS_ENABLED_FLAT_CATALOG_CATEGORY);
     }
 

--- a/app/code/core/Mage/Catalog/Helper/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Flat.php
@@ -96,6 +96,11 @@ class Mage_Catalog_Helper_Product_Flat extends Mage_Catalog_Helper_Flat_Abstract
     #[\Override]
     public function isEnabled($store = null)
     {
+        // Flat catalog is only supported on MySQL
+        $adapter = Mage::getSingleton('core/resource')->getConnection('core_read');
+        if (!($adapter instanceof Maho\Db\Adapter\Pdo\Mysql)) {
+            return false;
+        }
         return Mage::getStoreConfigFlag(self::XML_PATH_USE_PRODUCT_FLAT);
     }
 


### PR DESCRIPTION
## Summary
Disables flat catalog functionality for SQLite and PostgreSQL database engines, as it is only fully supported on MySQL.

## Problem
Flat catalog has various compatibility issues with SQLite and PostgreSQL due to differences in SQL syntax, DDL operations, and query optimization approaches. Rather than maintaining multiple database-specific workarounds, it's more practical to restrict this feature to MySQL where it's fully tested and supported.

## Solution
- Modified admin configuration form fields to disable and display a notice when using non-MySQL databases
- Updated helper methods `isEnabled()` to return false for non-MySQL databases
- Ensures flat catalog cannot be enabled through backend or code when using SQLite/PostgreSQL

## Changed Files
- `app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatcatalog.php`
- `app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Flatproduct.php`
- `app/code/core/Mage/Catalog/Helper/Category/Flat.php`
- `app/code/core/Mage/Catalog/Helper/Product/Flat.php`

## Impact
- **MySQL**: No change - flat catalog continues to work as before
- **SQLite/PostgreSQL**: Flat catalog options are disabled in admin and `isEnabled()` always returns false