### PR TITLE
Added missing license texts in Maho modules files

### DIFF
--- a/app/code/core/Maho/AdminActivityLog/etc/adminhtml.xml
+++ b/app/code/core/Maho/AdminActivityLog/etc/adminhtml.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_AdminActivityLog
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/AdminActivityLog/etc/config.xml
+++ b/app/code/core/Maho/AdminActivityLog/etc/config.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_AdminActivityLog
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/AdminActivityLog/etc/system.xml
+++ b/app/code/core/Maho/AdminActivityLog/etc/system.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_AdminActivityLog
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/Blog/etc/adminhtml.xml
+++ b/app/code/core/Maho/Blog/etc/adminhtml.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_Blog
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/Blog/etc/api.xml
+++ b/app/code/core/Maho/Blog/etc/api.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_Blog
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/Blog/etc/api2.xml
+++ b/app/code/core/Maho/Blog/etc/api2.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_Blog
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/Blog/etc/config.xml
+++ b/app/code/core/Maho/Blog/etc/config.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_Blog
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/Blog/etc/system.xml
+++ b/app/code/core/Maho/Blog/etc/system.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_Blog
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/Captcha/etc/config.xml
+++ b/app/code/core/Maho/Captcha/etc/config.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_Captcha
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/Captcha/etc/system.xml
+++ b/app/code/core/Maho/Captcha/etc/system.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_Captcha
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/CatalogLinkRule/etc/adminhtml.xml
+++ b/app/code/core/Maho/CatalogLinkRule/etc/adminhtml.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_CatalogLinkRule
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/CatalogLinkRule/etc/config.xml
+++ b/app/code/core/Maho/CatalogLinkRule/etc/config.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_CatalogLinkRule
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/CatalogLinkRule/etc/system.xml
+++ b/app/code/core/Maho/CatalogLinkRule/etc/system.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_CatalogLinkRule
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/CustomerSegmentation/etc/adminhtml.xml
+++ b/app/code/core/Maho/CustomerSegmentation/etc/adminhtml.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_CustomerSegmentation
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/CustomerSegmentation/etc/config.xml
+++ b/app/code/core/Maho/CustomerSegmentation/etc/config.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_CustomerSegmentation
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/CustomerSegmentation/etc/system.xml
+++ b/app/code/core/Maho/CustomerSegmentation/etc/system.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_CustomerSegmentation
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/SpeculationRules/etc/config.xml
+++ b/app/code/core/Maho/SpeculationRules/etc/config.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_SpeculationRules
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/code/core/Maho/SpeculationRules/etc/system.xml
+++ b/app/code/core/Maho/SpeculationRules/etc/system.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_SpeculationRules
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/design/adminhtml/default/default/layout/cataloglinkrule.xml
+++ b/app/design/adminhtml/default/default/layout/cataloglinkrule.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_CatalogLinkRule
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <layout>

--- a/app/design/adminhtml/default/default/layout/customersegmentation.xml
+++ b/app/design/adminhtml/default/default/layout/customersegmentation.xml
@@ -8,7 +8,7 @@
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <layout>

--- a/app/design/adminhtml/default/default/layout/sales_pdf.xml
+++ b/app/design/adminhtml/default/default/layout/sales_pdf.xml
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Sales
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <layout version="0.1.0">

--- a/app/etc/modules/Maho_AdminActivityLog.xml
+++ b/app/etc/modules/Maho_AdminActivityLog.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_AdminActivityLog
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/etc/modules/Maho_Blog.xml
+++ b/app/etc/modules/Maho_Blog.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_Blog
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/etc/modules/Maho_Captcha.xml
+++ b/app/etc/modules/Maho_Captcha.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_Captcha
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/etc/modules/Maho_CatalogLinkRule.xml
+++ b/app/etc/modules/Maho_CatalogLinkRule.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_CatalogLinkRule
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/etc/modules/Maho_CustomerSegmentation.xml
+++ b/app/etc/modules/Maho_CustomerSegmentation.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_CustomerSegmentation
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/etc/modules/Maho_SpeculationRules.xml
+++ b/app/etc/modules/Maho_SpeculationRules.xml
@@ -6,7 +6,7 @@
  * @category   Maho
  * @package    Maho_SpeculationRules
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
- * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license    https://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
  */
 -->
 <config>

--- a/app/locale/en_US/Maho_Captcha.csv
+++ b/app/locale/en_US/Maho_Captcha.csv
@@ -1,5 +1,8 @@
+"Captcha","Captcha"
 "Captcha is disabled","Captcha is disabled"
 "CSS Selectors","CSS Selectors"
 "Enable","Enable"
+"Enable Captcha","Enable Captcha"
 "Incorrect CAPTCHA.","Incorrect CAPTCHA."
 "Internal Error","Internal Error"
+"These CSS selectors are used to identify the forms for which captcha will be activated.<br />One selector per line.<br />To disable a selector, type // at the beginning of the line.","These CSS selectors are used to identify the forms for which captcha will be activated.<br />One selector per line.<br />To disable a selector, type // at the beginning of the line."


### PR DESCRIPTION
## Description

This PR adds missing license texts to Maho module XML files to ensure consistency. Only the `wsdl.xml` and `wsi.xml` of the `Maho_Blog` module still do not have a license text, as these files do not contain a license text anywhere else (including in all `Mage` modules).

### Disclaimer

The changes in this PR are just my suggestions as usual. If you prefer to do it differently, that's perfectly fine, and you can adjust the code of this PR directly. :)
