### PR TITLE
Applied `ChangeNestedIfsToEarlyReturnRector`

### DIFF
--- a/.rector.php
+++ b/.rector.php
@@ -35,6 +35,7 @@ return RectorConfig::configure()
         DeadCode\ClassMethod\RemoveUselessReturnTagRector::class,
         DeadCode\MethodCall\RemoveNullArgOnNullDefaultParamRector::class,
         DeadCode\Property\RemoveUselessVarTagRector::class,
+        EarlyReturn\If_\ChangeNestedIfsToEarlyReturnRector::class,
         EarlyReturn\If_\RemoveAlwaysElseRector::class,
         Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector::class,
         Rector\Php71\Rector\List_\ListToArrayDestructRector::class,

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
@@ -58,15 +58,18 @@ class Mage_Adminhtml_Block_Catalog_Form_Renderer_Fieldset_Element extends Mage_A
      */
     public function canDisplayUseDefault()
     {
-        if ($attribute = $this->getAttribute()) {
-            if (!$attribute->isScopeGlobal()
-                && $this->getDataObject()
-                && $this->getDataObject()->getId()
-                && $this->getDataObject()->getStoreId()
-            ) {
-                return true;
-            }
+        if (!$attribute = $this->getAttribute()) {
+            return false;
         }
+
+        if (!$attribute->isScopeGlobal()
+            && $this->getDataObject()
+            && $this->getDataObject()->getId()
+            && $this->getDataObject()->getStoreId()
+        ) {
+            return true;
+        }
+
         return false;
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Inventory.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Inventory.php
@@ -81,10 +81,12 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Inventory extends Mage_Admin
 
     public function getConfigFieldValue($field)
     {
-        if ($this->getStockItem()) {
-            if ($this->getStockItem()->getData('use_config_' . $field) == 0) {
-                return $this->getStockItem()->getData($field);
-            }
+        if (!$this->getStockItem()) {
+            return Mage::getStoreConfig(Mage_CatalogInventory_Model_Stock_Item::XML_PATH_ITEM . $field);
+        }
+
+        if ($this->getStockItem()->getData('use_config_' . $field) == 0) {
+            return $this->getStockItem()->getData($field);
         }
 
         return Mage::getStoreConfig(Mage_CatalogInventory_Model_Stock_Item::XML_PATH_ITEM . $field);

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Abstract.php
@@ -147,12 +147,11 @@ abstract class Mage_Bundle_Model_Sales_Order_Pdf_Items_Abstract extends Mage_Sal
     public function getBundleOptions($item = null): array
     {
         $options = $this->getOrderItem()->getProductOptions();
-        if ($options) {
-            if (isset($options['bundle_options'])) {
-                return $options['bundle_options'];
-            }
+        if (!$options) {
+            return $options['bundle_options'] ?? [];
         }
-        return [];
+
+        return $options['bundle_options'] ?? [];
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Block/Product/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Abstract.php
@@ -193,11 +193,14 @@ abstract class Mage_Catalog_Block_Product_Abstract extends Mage_Core_Block_Templ
      */
     protected function _getPriceBlockTemplate($productTypeId)
     {
-        if (isset($this->_priceBlockTypes[$productTypeId])) {
-            if ($this->_priceBlockTypes[$productTypeId]['template'] != '') {
-                return $this->_priceBlockTypes[$productTypeId]['template'];
-            }
+        if (!isset($this->_priceBlockTypes[$productTypeId])) {
+            return $this->_priceBlockDefaultTemplate;
         }
+
+        if ($this->_priceBlockTypes[$productTypeId]['template'] != '') {
+            return $this->_priceBlockTypes[$productTypeId]['template'];
+        }
+
         return $this->_priceBlockDefaultTemplate;
     }
 

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
@@ -727,11 +727,14 @@ class Mage_Catalog_Model_Product_Type_Configurable extends Mage_Catalog_Model_Pr
     #[\Override]
     public function isVirtual($product = null)
     {
-        if ($productOption = $this->getProduct($product)->getCustomOption('simple_product')) {
-            if ($optionProduct = $productOption->getProduct()) {
-                return $optionProduct->isVirtual();
-            }
+        if (!$productOption = $this->getProduct($product)->getCustomOption('simple_product')) {
+            return parent::isVirtual($product);
         }
+
+        if ($optionProduct = $productOption->getProduct()) {
+            return $optionProduct->isVirtual();
+        }
+
         return parent::isVirtual($product);
     }
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Attribute.php
@@ -243,11 +243,14 @@ class Mage_Catalog_Model_Resource_Eav_Attribute extends Mage_Eav_Model_Entity_At
     public function getSourceModel()
     {
         $model = $this->getData('source_model');
-        if (empty($model)) {
-            if ($this->getBackendType() == 'int' && $this->getFrontendInput() == 'select') {
-                return $this->getDefaultSourceModel();
-            }
+        if (!empty($model)) {
+            return $model;
         }
+
+        if ($this->getBackendType() == 'int' && $this->getFrontendInput() == 'select') {
+            return $this->getDefaultSourceModel();
+        }
+
         return $model;
     }
 

--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -797,16 +797,17 @@ abstract class Mage_Core_Controller_Varien_Action
      */
     protected function _isUrlInternal($url)
     {
-        if (str_contains($url, 'http')) {
-            /**
-             * Url must start from base secure or base unsecure url
-             */
-            if (str_starts_with($url, Mage::app()->getStore()->getBaseUrl())
-                || str_starts_with($url, Mage::app()->getStore()->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_LINK, true))
-            ) {
-                return true;
-            }
+        if (!str_contains($url, 'http')) {
+            return false;
         }
+
+        // Url must start from base secure or base unsecure url
+        if (str_starts_with($url, Mage::app()->getStore()->getBaseUrl())
+            || str_starts_with($url, Mage::app()->getStore()->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_LINK, true))
+        ) {
+            return true;
+        }
+
         return false;
     }
 

--- a/app/code/core/Mage/Core/Helper/String.php
+++ b/app/code/core/Mage/Core/Helper/String.php
@@ -563,10 +563,12 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
      */
     public function validateSerializedObject($str)
     {
-        if ($this->isSerializedArrayOrObject($str)) {
-            if (!unserialize($str)) {
-                return false;
-            }
+        if (!$this->isSerializedArrayOrObject($str)) {
+            return true;
+        }
+
+        if (!unserialize($str)) {
+            return false;
         }
 
         return true;

--- a/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Password.php
+++ b/app/code/core/Mage/Customer/Model/Customer/Attribute/Backend/Password.php
@@ -49,10 +49,12 @@ class Mage_Customer_Model_Customer_Attribute_Backend_Password extends Mage_Eav_M
     #[\Override]
     public function validate($object)
     {
-        if ($password = $object->getPassword()) {
-            if ($password == $object->getPasswordConfirm()) {
-                return true;
-            }
+        if (!$password = $object->getPassword()) {
+            return parent::validate($object);
+        }
+
+        if ($password == $object->getPasswordConfirm()) {
+            return true;
         }
 
         return parent::validate($object);

--- a/app/code/core/Mage/Index/Model/Indexer/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Indexer/Abstract.php
@@ -104,11 +104,14 @@ abstract class Mage_Index_Model_Indexer_Abstract extends Mage_Core_Model_Abstrac
      */
     public function matchEntityAndType($entity, $type)
     {
-        if (isset($this->_matchedEntities[$entity])) {
-            if (in_array($type, $this->_matchedEntities[$entity])) {
-                return true;
-            }
+        if (!isset($this->_matchedEntities[$entity])) {
+            return false;
         }
+
+        if (in_array($type, $this->_matchedEntities[$entity])) {
+            return true;
+        }
+
         return false;
     }
 

--- a/app/code/core/Mage/Rss/Block/Catalog/Abstract.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Abstract.php
@@ -71,11 +71,14 @@ class Mage_Rss_Block_Catalog_Abstract extends Mage_Rss_Block_Abstract
      */
     protected function _getPriceBlockTemplate($productTypeId)
     {
-        if (isset($this->_priceBlockTypes[$productTypeId])) {
-            if ($this->_priceBlockTypes[$productTypeId]['template'] != '') {
-                return $this->_priceBlockTypes[$productTypeId]['template'];
-            }
+        if (!isset($this->_priceBlockTypes[$productTypeId])) {
+            return $this->_priceBlockDefaultTemplate;
         }
+
+        if ($this->_priceBlockTypes[$productTypeId]['template'] != '') {
+            return $this->_priceBlockTypes[$productTypeId]['template'];
+        }
+
         return $this->_priceBlockDefaultTemplate;
     }
 


### PR DESCRIPTION
This PR applies the `ChangeNestedIfsToEarlyReturnRector` rule to convert nested if statements to early returns for better code readability.

## Changes
- Added `ChangeNestedIfsToEarlyReturnRector` to `.rector.php`
- Applied the rule across 12 core files in various modules (Adminhtml, Bundle, Catalog, Core, Customer, Index, Rss)

## Credits
Thanks to @sreichel for finding this rector rule.
See: https://github.com/OpenMage/magento-lts/pull/5210