### PR TITLE
Fixed deprecated OTPHP method calls in Auth helper

### DIFF
--- a/app/code/core/Mage/Admin/Helper/Auth.php
+++ b/app/code/core/Mage/Admin/Helper/Auth.php
@@ -33,13 +33,14 @@ class Mage_Admin_Helper_Auth extends Mage_Core_Helper_Abstract
 
     public function getTwofaQRCode(#[\SensitiveParameter] string $username, #[\SensitiveParameter] string $secret): string
     {
-        $otp = \OTPHP\TOTP::createFromSecret($secret);
-        $otp->setLabel($username);
-        $otp->setParameter('image', 'https://mahocommerce.com/assets/maho-logo-square.png');
+        $otp = \OTPHP\TOTP::createFromSecret($secret)
+            ->withLabel($username)
+            ->withParameter('image', 'https://mahocommerce.com/assets/maho-logo-square.png');
+
         if ($storeName = Mage::getStoreConfig('general/store_information/name')) {
-            $otp->setIssuer($storeName);
+            $otp = $otp->withIssuer($storeName);
         } else {
-            $otp->setIssuer('Maho Admin');
+            $otp = $otp->withIssuer('Maho Admin');
         }
 
         $qrWriter = new \BaconQrCode\Writer(


### PR DESCRIPTION
## Summary
- Replaced deprecated OTPHP mutable methods with immutable alternatives
- `setLabel()` → `withLabel()`
- `setParameter()` → `withParameter()`
- `setIssuer()` → `withIssuer()`

These methods were deprecated in OTPHP v11.4. The new methods follow an immutable pattern, returning new instances instead of mutating the existing object.