### PR TITLE
Fixed guest order shipping address overwritten by billing address during order edit

### DIFF
--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Sales
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2018-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2018-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -341,7 +341,7 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
              * Set same_as_billing to "1" when default shipping address is set as default
              * and it is not equal billing address
              */
-            if (!$this->getId()) {
+            if (!$this->getId() && !$this->hasSameAsBilling()) {
                 $this->setSameAsBilling((int) $this->_isSameAsBilling());
             }
         }


### PR DESCRIPTION
## Summary

- Fixes a bug where editing a guest order in admin with different billing and shipping addresses caused the shipping address to be overwritten by the billing address
- Added `&& !$this->hasSameAsBilling()` check to preserve explicitly set `same_as_billing` values during order conversion

## Root Cause

The `_populateBeforeSaveData()` method in `Mage_Sales_Model_Quote_Address` unconditionally set `same_as_billing` for new addresses based on guest customer status, overriding explicitly determined address relationships set during order conversion.

## Solution

Modified the condition to check if `same_as_billing` was already explicitly set before overriding it:

```php
// Before
if (!$this->getId())

// After  
if (!$this->getId() && !$this->hasSameAsBilling())
```

## Credit

Ported from OpenMage: https://github.com/OpenMage/magento-lts/pull/5213