### PR TITLE
Added `./maho migrate` CLI command for database migrations (setup scripts)

### DIFF
--- a/lib/MahoCLI/Commands/Migrate.php
+++ b/lib/MahoCLI/Commands/Migrate.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @package    MahoCLI
+ * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Commands;
+
+use Mage;
+use Mage_Core_Model_Resource_Setup;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'migrate',
+    description: 'Apply pending database schema and data updates from modules',
+)]
+class Migrate extends BaseMahoCommand
+{
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->initMaho();
+
+        $output->writeln('<info>Applying pending updates...</info>');
+
+        // Replicate the exact logic from CacheController::flushSystemAction()
+        Mage::app()->getCache()->banUse('config');
+        Mage::getConfig()->reinit();
+        Mage::getConfig()->getCacheSaveLock(30, true);
+
+        try {
+            Mage::app()->cleanCache();
+            $output->writeln('✓ Cleaned cache');
+
+            Mage_Core_Model_Resource_Setup::applyAllUpdates();
+            $output->writeln('✓ Applied schema updates');
+
+            Mage_Core_Model_Resource_Setup::applyAllDataUpdates();
+            $output->writeln('✓ Applied data updates');
+
+            Mage_Core_Model_Resource_Setup::applyAllMahoUpdates();
+            $output->writeln('✓ Applied Maho updates');
+
+            Mage::app()->getCache()->unbanUse('config');
+            Mage::getConfig()->saveCache();
+            $output->writeln('✓ Saved cache configuration');
+        } finally {
+            Mage::getConfig()->releaseCacheSaveLock();
+        }
+
+        Mage::dispatchEvent('adminhtml_cache_flush_system');
+
+        $output->writeln('<info>All updates applied successfully!</info>');
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
## Problem

When deploying Maho applications, especially with **maho-starter** where the core is in `vendor/`, there was no CLI way to trigger database migrations. This meant:

- ❌ New module setup scripts wouldn't run automatically after `composer update`
- ❌ Developers had to manually click "Flush & Apply Updates" in admin backend
- ❌ Deployment scripts couldn't be fully automated
- ❌ CI/CD pipelines couldn't apply database updates

**Real example:** When the Giftcard module was added via `composer update`, its setup scripts (creating attributes, tables) wouldn't execute until someone manually clicked the button in admin, causing runtime errors like:
```
SQLSTATE[HY000]: General error: 1 near "AND": syntax error
```

## Solution

Introduces `./maho migrate` command that replicates the exact behavior of the "Flush & Apply Updates" admin button.

### What it does

1. Bans config cache to prevent stale cache during updates
2. Reinitializes configuration  
3. Acquires cache save lock (prevents concurrent updates)
4. Cleans all caches
5. Applies schema updates (`applyAllUpdates`)
6. Applies data updates (`applyAllDataUpdates`)
7. Applies Maho-specific updates (`applyAllMahoUpdates`)
8. Unbans config cache and saves fresh cache
9. Releases lock (via finally block, even on errors)
10. Dispatches `adminhtml_cache_flush_system` event

### Usage

```bash
./maho migrate
```

**Example deployment workflow:**
```bash
composer update --no-dev
./maho migrate           # Handles cache + applies updates
./maho index:reindex:all
```

Note: Separate `cache:flush` is **not needed** as `migrate` handles caching internally.

## Naming Rationale

- ✅ Follows industry conventions: Laravel's `php artisan migrate`, Django's `./manage.py migrate`
- ✅ Short and memorable (7 characters)
- ✅ Accurately describes the action: migrating database from one code version to another
- ✅ No namespace needed - common enough operation to be at root level
- ✅ Familiar to developers coming from other frameworks

## Testing

```bash
./maho migrate
```

Output:
```
Applying pending updates...
✓ Cleaned cache
✓ Applied schema updates
✓ Applied data updates
✓ Applied Maho updates
✓ Saved cache configuration
All updates applied successfully!
```

✅ Passes PHP-CS-Fixer
✅ Passes PHPStan
✅ Successfully applies pending module updates