### PR TITLE
Fixed Gift Card order renderer to use joined data

### DIFF
--- a/app/code/core/Maho/Giftcard/Block/Adminhtml/Giftcard/Renderer/Order.php
+++ b/app/code/core/Maho/Giftcard/Block/Adminhtml/Giftcard/Renderer/Order.php
@@ -16,20 +16,15 @@ class Maho_Giftcard_Block_Adminhtml_Giftcard_Renderer_Order extends Mage_Adminht
     #[\Override]
     public function render(Maho\DataObject $row)
     {
-        $orderId = $row->getPurchaseOrderId();
+        $orderId = $row->getOrderId();
 
         if (!$orderId) {
             return '-';
         }
 
-        $order = Mage::getModel('sales/order')->load($orderId);
-
-        if (!$order->getId()) {
-            return '-';
-        }
-
         $url = $this->getUrl('adminhtml/sales_order/view', ['order_id' => $orderId]);
+        $incrementId = $row->getOrderIncrementId();
 
-        return sprintf('<a href="%s">#%s</a>', $url, $order->getIncrementId());
+        return sprintf('<a href="%s">#%s</a>', $url, $incrementId ?: $orderId);
     }
 }


### PR DESCRIPTION
## Summary
- Optimizes the order link renderer in Gift Card grid to use data already available in the collection
- Uses `getOrderId()` and `getOrderIncrementId()` from joined data instead of loading the full order model
- Removes N+1 query issue when viewing gift card grid

## Test plan
- [ ] Navigate to Admin > Sales > Gift Cards
- [ ] Verify order links display correctly with increment IDs
- [ ] Confirm no additional order queries are made per row

🤖 Generated with [Claude Code](https://claude.com/claude-code)