### PR TITLE
Fixed duplicate AJAX requests on grid filter keypress

### DIFF
--- a/public/js/mage/adminhtml/grid.js
+++ b/public/js/mage/adminhtml/grid.js
@@ -252,20 +252,15 @@ class varienGrid {
     bindFilterFields() {
         // Use event delegation on document body to catch all filter keypresses
         // This survives AJAX reloads since body doesn't get replaced
-        if (!document.body._gridFilterDelegated) {
+        // Track per-grid to support multiple grids on the same page
+        document.body._gridFilterDelegated = document.body._gridFilterDelegated || {};
+        if (!document.body._gridFilterDelegated[this.containerId]) {
             document.body.addEventListener('keypress', (event) => {
-                // Check if this is a filter field in our grid
                 if (event.target.matches(`#${this.containerId} .filter input, #${this.containerId} .filter select`)) {
                     this.filterKeyPress(event);
                 }
             });
-            document.body._gridFilterDelegated = true;
-        }
-
-        // Also try direct binding as fallback
-        const filters = document.querySelectorAll('#' + this.containerId + ' .filter input, #' + this.containerId + ' .filter select');
-        for (let i = 0; i < filters.length; i++) {
-            filters[i].addEventListener('keypress', this.filterKeyPress.bind(this));
+            document.body._gridFilterDelegated[this.containerId] = true;
         }
     }
 


### PR DESCRIPTION
## Summary
- Removes redundant direct event binding in `bindFilterFields()` that accumulated on each AJAX grid refresh
- Changes delegation tracking from boolean to per-grid object to support multiple grids on same page

## Problem
When pressing Enter in a grid filter field, 2-3 AJAX requests were triggered instead of one. The `bindFilterFields()` method was binding the keypress event twice:
1. Via event delegation on `document.body` (survives AJAX reloads)
2. Directly on each filter element (accumulated on each AJAX refresh)

## Test plan
- [x] Navigate to Sales > Orders grid
- [x] Enter a value in any filter field and press Enter
- [x] Verify only one AJAX request is made (check Network tab)
- [x] Refresh the grid a few times, then filter again - still only one request

Fixes #501