### PR TITLE
Fixed incorrect getUserParam() usage in controllers with getParam()

### DIFF
--- a/app/code/core/Mage/Directory/controllers/Adminhtml/Directory/CountryController.php
+++ b/app/code/core/Mage/Directory/controllers/Adminhtml/Directory/CountryController.php
@@ -23,7 +23,7 @@ class Mage_Directory_Adminhtml_Directory_CountryController extends Mage_Adminhtm
 
     protected function _initCountry(): Mage_Directory_Model_Country|false
     {
-        $id = $this->getRequest()->getUserParam('id');
+        $id = $this->getRequest()->getParam('id');
         $model = Mage::getModel('directory/country');
 
         if ($id) {

--- a/app/code/core/Mage/Directory/controllers/Adminhtml/Directory/RegionController.php
+++ b/app/code/core/Mage/Directory/controllers/Adminhtml/Directory/RegionController.php
@@ -23,7 +23,7 @@ class Mage_Directory_Adminhtml_Directory_RegionController extends Mage_Adminhtml
 
     protected function _initRegion(): Mage_Directory_Model_Region|false
     {
-        $id = $this->getRequest()->getUserParam('id');
+        $id = $this->getRequest()->getParam('id');
         $model = Mage::getModel('directory/region');
 
         if ($id) {

--- a/app/code/core/Maho/Blog/controllers/Adminhtml/Blog/PostController.php
+++ b/app/code/core/Maho/Blog/controllers/Adminhtml/Blog/PostController.php
@@ -43,7 +43,7 @@ class Maho_Blog_Adminhtml_Blog_PostController extends Mage_Adminhtml_Controller_
     {
         $this->_title($this->__('Blog Post'));
 
-        $id = $this->getRequest()->getUserParam('id');
+        $id = $this->getRequest()->getParam('id');
         $model = Mage::getModel('blog/post');
 
         if ($id) {
@@ -78,7 +78,7 @@ class Maho_Blog_Adminhtml_Blog_PostController extends Mage_Adminhtml_Controller_
     {
         if ($data = $this->getRequest()->getPost()) {
             $model = Mage::getModel('blog/post');
-            $id = $this->getRequest()->getUserParam('id');
+            $id = $this->getRequest()->getParam('id');
 
             if ($id) {
                 $model->load($id);
@@ -104,7 +104,7 @@ class Maho_Blog_Adminhtml_Blog_PostController extends Mage_Adminhtml_Controller_
             } catch (Exception $e) {
                 Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
                 Mage::getSingleton('adminhtml/session')->setFormData($data);
-                $this->_redirect('*/*/edit', ['id' => $this->getRequest()->getUserParam('id')]);
+                $this->_redirect('*/*/edit', ['id' => $this->getRequest()->getParam('id')]);
                 return;
             }
         }
@@ -113,7 +113,7 @@ class Maho_Blog_Adminhtml_Blog_PostController extends Mage_Adminhtml_Controller_
 
     public function deleteAction(): void
     {
-        if ($id = $this->getRequest()->getUserParam('id')) {
+        if ($id = $this->getRequest()->getParam('id')) {
             try {
                 $model = Mage::getModel('blog/post');
                 $model->load($id);
@@ -133,7 +133,7 @@ class Maho_Blog_Adminhtml_Blog_PostController extends Mage_Adminhtml_Controller_
 
     public function massDeleteAction(): void
     {
-        $postIds = $this->getRequest()->getUserParam('post');
+        $postIds = $this->getRequest()->getParam('post');
         if (!is_array($postIds)) {
             Mage::getSingleton('adminhtml/session')->addError(
                 Mage::helper('blog')->__('Please select post(s)'),

--- a/app/code/core/Maho/CatalogLinkRule/controllers/Adminhtml/Cataloglinkrule/RuleController.php
+++ b/app/code/core/Maho/CatalogLinkRule/controllers/Adminhtml/Cataloglinkrule/RuleController.php
@@ -31,7 +31,7 @@ class Maho_CatalogLinkRule_Adminhtml_Cataloglinkrule_RuleController extends Mage
 
     public function editAction(): void
     {
-        $id = $this->getRequest()->getUserParam('id');
+        $id = $this->getRequest()->getParam('id');
         $model = Mage::getModel('cataloglinkrule/rule');
 
         if ($id) {
@@ -110,7 +110,7 @@ class Maho_CatalogLinkRule_Adminhtml_Cataloglinkrule_RuleController extends Mage
 
     public function deleteAction(): void
     {
-        if ($id = $this->getRequest()->getUserParam('id')) {
+        if ($id = $this->getRequest()->getParam('id')) {
             try {
                 $model = Mage::getModel('cataloglinkrule/rule')->load($id);
                 $model->delete();
@@ -128,7 +128,7 @@ class Maho_CatalogLinkRule_Adminhtml_Cataloglinkrule_RuleController extends Mage
 
     public function massDeleteAction(): void
     {
-        $ruleIds = $this->getRequest()->getUserParam('rule_ids');
+        $ruleIds = $this->getRequest()->getParam('rule_ids');
         if (!is_array($ruleIds)) {
             Mage::getSingleton('adminhtml/session')->addError(
                 Mage::helper('cataloglinkrule')->__('Please select rule(s).'),
@@ -152,8 +152,8 @@ class Maho_CatalogLinkRule_Adminhtml_Cataloglinkrule_RuleController extends Mage
 
     public function massStatusAction(): void
     {
-        $ruleIds = $this->getRequest()->getUserParam('rule_ids');
-        $status = (int) $this->getRequest()->getUserParam('status');
+        $ruleIds = $this->getRequest()->getParam('rule_ids');
+        $status = (int) $this->getRequest()->getParam('status');
 
         if (!is_array($ruleIds)) {
             Mage::getSingleton('adminhtml/session')->addError(

--- a/app/locale/en_US/Mage_Directory.csv
+++ b/app/locale/en_US/Mage_Directory.csv
@@ -1,3 +1,4 @@
+"%d country(s) were skipped because they no longer exist.","%d country(s) were skipped because they no longer exist."
 "%d region(s) were skipped because they have existing region names.","%d region(s) were skipped because they have existing region names."
 "-- Please select --","-- Please select --"
 "A country with this ID already exists.","A country with this ID already exists."


### PR DESCRIPTION
## Summary

- Replaces all `getUserParam()` calls with `getParam()` in admin controllers
- Ensures query string URLs (`?id=123`) work correctly alongside path-style URLs (`/id/123`)

## Problem

`getUserParam()` only checks route parameters set by the router from path-style URLs. It does NOT check query string parameters or POST data, causing issues when URLs use query string format.

## Changes

**4 files, 12 occurrences fixed:**

- `Maho_Blog/PostController.php` - 5 fixes (editAction, saveAction, deleteAction, massDeleteAction)
- `Maho_CatalogLinkRule/RuleController.php` - 5 fixes (editAction, deleteAction, massDeleteAction, massStatusAction)
- `Mage_Directory/RegionController.php` - 1 fix (_initRegion)
- `Mage_Directory/CountryController.php` - 1 fix (_initCountry)

Fixes #494