### PR TITLE
Replaced admin grid pager arrow images with SVG icons

### DIFF
--- a/app/design/adminhtml/default/default/template/widget/grid.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid.phtml
@@ -34,17 +34,17 @@ $numColumns = count($this->getColumns());
             <?php $_curPage  = $this->getCollection()->getCurPage() ?>
             <?php $_lastPage = $this->getCollection()->getLastPageNumber() ?>
             <?php if($_curPage>1): ?>
-                <a href="#" title="<?= $this->quoteEscape($this->__('Previous page')) ?>" onclick="<?= $this->getJsObjectName() ?>.setPage('<?= ($_curPage-1) ?>');return false;"><img src="<?= $this->getSkinUrl('images/pager_arrow_left.gif') ?>" alt="<?= $this->quoteEscape($this->__('Go to Previous page')) ?>" class="arrow"/></a>
+                <a href="#" title="<?= $this->quoteEscape($this->__('Previous page')) ?>" aria-label="<?= $this->quoteEscape($this->__('Go to Previous page')) ?>" class="pager-arrow" onclick="<?= $this->getJsObjectName() ?>.setPage('<?= ($_curPage-1) ?>');return false;"><?= $this->getIconSvg('circle-arrow-left') ?></a>
             <?php else: ?>
-                <img src="<?= $this->getSkinUrl('images/pager_arrow_left_off.gif') ?>" alt="<?= $this->quoteEscape($this->__('Go to Previous page')) ?>" class="arrow"/>
+                <span class="pager-arrow disabled" aria-label="<?= $this->quoteEscape($this->__('Go to Previous page')) ?>"><?= $this->getIconSvg('circle-arrow-left') ?></span>
             <?php endif ?>
 
             <input type="text" name="<?= $this->getVarNamePage() ?>" value="<?= $_curPage ?>" class="input-text page" onkeypress="<?= $this->getJsObjectName() ?>.inputPage(event, '<?= $_lastPage ?>')"/>
 
             <?php if($_curPage < $_lastPage): ?>
-                <a href="#" title="<?= $this->quoteEscape($this->__('Next page')) ?>" onclick="<?= $this->getJsObjectName() ?>.setPage('<?= ($_curPage+1) ?>');return false;"><img src="<?= $this->getSkinUrl('images/pager_arrow_right.gif') ?>" alt="<?= $this->quoteEscape($this->__('Go to Next page')) ?>" class="arrow"/></a>
+                <a href="#" title="<?= $this->quoteEscape($this->__('Next page')) ?>" aria-label="<?= $this->quoteEscape($this->__('Go to Next page')) ?>" class="pager-arrow" onclick="<?= $this->getJsObjectName() ?>.setPage('<?= ($_curPage+1) ?>');return false;"><?= $this->getIconSvg('circle-arrow-right') ?></a>
             <?php else: ?>
-                <img src="<?= $this->getSkinUrl('images/pager_arrow_right_off.gif') ?>" alt="<?= $this->quoteEscape($this->__('Go to Next page')) ?>" class="arrow"/>
+                <span class="pager-arrow disabled" aria-label="<?= $this->quoteEscape($this->__('Go to Next page')) ?>"><?= $this->getIconSvg('circle-arrow-right') ?></span>
             <?php endif ?>
 
             <?= $this->__('of %s pages', $this->getCollection()->getLastPageNumber()) ?>

--- a/public/skin/adminhtml/default/default/base.css
+++ b/public/skin/adminhtml/default/default/base.css
@@ -407,10 +407,6 @@ table.actions td {
     width: 2em!important
 }
 
-.pager .arrow {
-    margin: 0 3px;
-    vertical-align: middle
-}
 
 .grid tr.headings th {
     border-width: 1px;
@@ -5571,38 +5567,22 @@ img.rule-param-add {
     background-size: 13px
 }
 
-.pager img[src$="pager_arrow_left.gif"].arrow {
-    padding-left: 17px;
-    box-sizing: border-box;
-    width: 17px;
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' style='width:24px;height:24px' viewBox='0 0 24 24'%3E%3Cpath fill='%230090FF' d='M22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2A10,10 0 0,1 22,12M14,7L9,12L14,17V7Z' /%3E%3C/svg%3E")no-repeat;
-    height: 17px
+.pager .pager-arrow {
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+    margin: 0 3px;
+    color: #888
 }
 
-.pager img[src$="pager_arrow_right.gif"].arrow {
-    padding-left: 17px;
-    box-sizing: border-box;
-    width: 17px;
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' style='width:24px;height:24px' viewBox='0 0 24 24'%3E%3Cpath fill='%230090FF' d='M2,12A10,10 0 0,1 12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12M10,17L15,12L10,7V17Z' /%3E%3C/svg%3E")no-repeat;
-    height: 17px
+.pager .pager-arrow svg {
+    width: 20px;
+    height: 20px
 }
 
-.pager img[src$="pager_arrow_left_off.gif"].arrow {
-    padding-left: 17px;
-    box-sizing: border-box;
-    width: 17px;
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' style='width:24px;height:24px' viewBox='0 0 24 24'%3E%3Cpath fill='%230090FF' d='M22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2A10,10 0 0,1 22,12M14,7L9,12L14,17V7Z' /%3E%3C/svg%3E")no-repeat;
-    height: 17px;
-    opacity: .5
-}
-
-.pager img[src$="pager_arrow_right_off.gif"].arrow {
-    padding-left: 17px;
-    box-sizing: border-box;
-    width: 17px;
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' style='width:24px;height:24px' viewBox='0 0 24 24'%3E%3Cpath fill='%230090FF' d='M2,12A10,10 0 0,1 12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12M10,17L15,12L10,7V17Z' /%3E%3C/svg%3E")no-repeat;
-    height: 17px;
-    opacity: .5
+.pager .pager-arrow.disabled {
+    opacity: .5;
+    cursor: default
 }
 
 .export img {


### PR DESCRIPTION
## Summary
- Replace legacy GIF pager arrows with `getIconSvg('circle-arrow-left')` and `getIconSvg('circle-arrow-right')`
- Clean up old CSS rules targeting image files
- Add cleaner SVG-based styling with proper disabled state

## Test plan
- [ ] Navigate to any admin grid (e.g., Catalog > Products)
- [ ] Verify pagination arrows display correctly
- [ ] Test disabled state on first/last page