### PR TITLE
Improved slideshow image display with object-fit cover

### DIFF
--- a/public/skin/frontend/base/default/css/styles.css
+++ b/public/skin/frontend/base/default/css/styles.css
@@ -6601,6 +6601,7 @@ div.paypal-logo span > img {
 .slideshow {
   width: 100%;
   overflow-x: auto;
+  overflow-y: hidden;
   scroll-behavior: smooth;
   scroll-snap-type: x mandatory;
   margin-bottom: 41px;
@@ -6620,9 +6621,9 @@ div.paypal-logo span > img {
 }
 
 .slideshow ul li img {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
+  width: 100%;
+  object-fit: cover;
+  object-position: center;
 }
 
 .slideshow-dots {


### PR DESCRIPTION
## Summary
- Use `object-fit: cover` for full-width images that crop gracefully
- Add `overflow-y: hidden` to prevent vertical scroll
- Change from `contain` to `cover` for better visual presentation

## Test plan
- Visit any page with a slideshow
- Verify images fill the full width without letterboxing
- Verify vertical content doesn't cause scroll within the slideshow