### PR TITLE
Fixed FrankenPHP compatibility by adding SAPI to allowed list

### DIFF
--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -346,7 +346,7 @@ class Mage_Core_Model_App
         $this->getFrontController()->dispatch();
 
         // Finish the request explicitly, no output allowed beyond this point
-        if (php_sapi_name() == 'fpm-fcgi' && function_exists('fastcgi_finish_request')) {
+        if (in_array(php_sapi_name(), ['fpm-fcgi', 'frankenphp'], true) && function_exists('fastcgi_finish_request')) {
             fastcgi_finish_request();
         } else {
             flush();


### PR DESCRIPTION
## Summary
- Added `frankenphp` to the SAPI check in `App.php`

FrankenPHP was failing only during sample data installation via the web installer, while working fine for all other operations. This is because the `App::run()` method's SAPI check didn't recognize `frankenphp`, causing a fallback to `flush()` which triggers an HTTP/2 panic in FrankenPHP/Caddy after the request has finished.

## Test plan
- Install Maho using FrankenPHP Docker image with sample data via web installer
- Verify no HTTP/2 panic occurs during installation

Fixes #509