### PR TITLE
Fixed web installer sample data foreign key errors after PR #497

### DIFF
--- a/app/code/core/Mage/Install/Model/Installer/SampleData.php
+++ b/app/code/core/Mage/Install/Model/Installer/SampleData.php
@@ -246,7 +246,10 @@ class Mage_Install_Model_Installer_SampleData
         // Execute the remapped SQL
         $this->executeSqlForEngine($pdo, $remappedSql, $dbEngine);
 
-        // Merge sample data's attribute set assignments
+        // Merge sample data's attribute groups first (builds group ID remap)
+        $importer->mergeAttributeGroups();
+
+        // Merge sample data's attribute set assignments (uses the group ID remap)
         $importer->mergeEntityAttributes();
 
         // Store importer for config remapping


### PR DESCRIPTION
## Summary
- Added missing `mergeAttributeGroups()` call in the web installer's sample data import process
- This method was added in PR #497 and correctly implemented in the CLI installer but was missing from the web installer
- Without this call, foreign key constraint violations occurred when inserting `eav_entity_attribute` records with unmapped `attribute_group_id` values

## Test plan
- [ ] Run web installer with sample data option enabled
- [ ] Verify no foreign key errors occur during sample data import
- [ ] Verify attribute groups are correctly created/merged