### PR TITLE
Added template directive processing to blog post content

### DIFF
--- a/app/code/core/Maho/Blog/Block/Post/View.php
+++ b/app/code/core/Maho/Blog/Block/Post/View.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Maho
  *

--- a/app/code/core/Maho/Blog/Model/Post.php
+++ b/app/code/core/Maho/Blog/Model/Post.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Maho
  *
@@ -8,7 +10,7 @@
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *
- * @method string getContent()
+ * @method string getContent() Returns raw content. For frontend display, use getFilteredContent() instead.
  * @method string getPublishedAt()
  * @method string getTitle()
  * @method string getImage()
@@ -91,5 +93,24 @@ class Maho_Blog_Model_Post extends Mage_Core_Model_Abstract
         $prefix = $helper->getBlogUrlPrefix();
 
         return Mage::getUrl($prefix . '/' . $this->getUrlKey());
+    }
+
+    /**
+     * Get content with template directives processed
+     *
+     * Processes directives like {{media url="..."}}, {{widget ...}}, etc.
+     * Use this method for frontend display instead of getContent().
+     */
+    public function getFilteredContent(): string
+    {
+        $content = $this->getContent();
+        if (!$content) {
+            return '';
+        }
+
+        /** @var Mage_Cms_Helper_Data $helper */
+        $helper = Mage::helper('cms');
+
+        return $helper->getPageTemplateProcessor()->filter($content);
     }
 }

--- a/app/design/frontend/base/default/template/blog/view.phtml
+++ b/app/design/frontend/base/default/template/blog/view.phtml
@@ -19,4 +19,4 @@ $post = $this->getPost();
     <img class="blog_post_image" src="<?= $post->getImageUrl() ?>" alt="<?= $this->escapeHtml($post->getTitle()) ?>" />
 <?php endif ?>
 
-<div><?= $post->getContent() ?></div>
+<div><?= $post->getFilteredContent() ?></div>


### PR DESCRIPTION
## Summary
- Added `getFilteredContent()` method to `Maho_Blog_Model_Post` that processes CMS template directives
- Updated blog view template to use filtered content for proper directive rendering
- Added PHPDoc to `getContent()` guiding developers to use `getFilteredContent()` for frontend display

Fixes #513

## Test plan
- [ ] Create a blog post with `{{media url="wysiwyg/test.png"}}` in the content
- [ ] Verify the directive renders as an actual URL path on the frontend
- [ ] Test other directives like `{{widget}}` and `{{config}}`