### PR TITLE
Fixed incorrect @package docblock in base_default theme files

### DIFF
--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/availability.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle/availability.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/catalog/product/view/type/availability/default.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/availability/default.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/catalog/product/view/type/availability/grouped.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/type/availability/grouped.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/checkout/cart/minicart.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/minicart.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/checkout/cart/minicart/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/minicart/default.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/checkout/cart/minicart/items.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/minicart/items.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/checkout/multishipping/overview.phtml
+++ b/app/design/frontend/base/default/template/checkout/multishipping/overview.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/configurableswatches/catalog/layer/filter/swatches.phtml
+++ b/app/design/frontend/base/default/template/configurableswatches/catalog/layer/filter/swatches.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/configurableswatches/catalog/layer/state/swatch.phtml
+++ b/app/design/frontend/base/default/template/configurableswatches/catalog/layer/state/swatch.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/configurableswatches/catalog/media/js.phtml
+++ b/app/design/frontend/base/default/template/configurableswatches/catalog/media/js.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/configurableswatches/catalog/product/list/price/js.phtml
+++ b/app/design/frontend/base/default/template/configurableswatches/catalog/product/list/price/js.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/configurableswatches/catalog/product/list/swatches.phtml
+++ b/app/design/frontend/base/default/template/configurableswatches/catalog/product/list/swatches.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/configurableswatches/catalog/product/view/type/configurable/swatch-js.phtml
+++ b/app/design/frontend/base/default/template/configurableswatches/catalog/product/view/type/configurable/swatch-js.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)

--- a/app/design/frontend/base/default/template/configurableswatches/catalog/product/view/type/options/configurable/swatches.phtml
+++ b/app/design/frontend/base/default/template/configurableswatches/catalog/product/view/type/options/configurable/swatches.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/customer/form/forgotpassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/forgotpassword.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/email/catalog/product/list.phtml
+++ b/app/design/frontend/base/default/template/email/catalog/product/list.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/email/catalog/product/new.phtml
+++ b/app/design/frontend/base/default/template/email/catalog/product/new.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/email/order/totals/wrapper.phtml
+++ b/app/design/frontend/base/default/template/email/order/totals/wrapper.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/newsletter/subscribe.phtml
+++ b/app/design/frontend/base/default/template/newsletter/subscribe.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/page/html/topmenu/renderer.phtml
+++ b/app/design/frontend/base/default/template/page/html/topmenu/renderer.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://openmage.org)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)

--- a/app/design/frontend/base/default/template/page/print.phtml
+++ b/app/design/frontend/base/default/template/page/print.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2020-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/paypal/express/minicart/shortcut.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/minicart/shortcut.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/paypal/express/product/shortcut.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/product/shortcut.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/paypal/express/review.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/paypal/express/review/address.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review/address.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2022 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/wishlist/item/column/price.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/price.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/app/design/frontend/base/default/template/wishlist/item/column/quantity.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/column/quantity.phtml
@@ -2,7 +2,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2024 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/public/skin/frontend/base/default/css/styles.css
+++ b/public/skin/frontend/base/default/css/styles.css
@@ -1,7 +1,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2021-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/public/skin/frontend/base/default/js/app.js
+++ b/public/skin/frontend/base/default/js/app.js
@@ -1,7 +1,7 @@
 /**
  * Maho
  *
- * @package    rwd_default
+ * @package     base_default
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2019-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/public/skin/frontend/base/default/js/configurableswatches/configurable-swatch-prices.js
+++ b/public/skin/frontend/base/default/js/configurableswatches/configurable-swatch-prices.js
@@ -1,7 +1,7 @@
 /**
  * Maho
  *
- * @package     rwd_default
+ * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://openmage.org)
  * @copyright   Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/public/skin/frontend/base/default/js/configurableswatches/product-media.js
+++ b/public/skin/frontend/base/default/js/configurableswatches/product-media.js
@@ -1,7 +1,7 @@
 /**
  * Maho
  *
- * @package    rwd_default
+ * @package     base_default
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/public/skin/frontend/base/default/js/configurableswatches/swatches-list.js
+++ b/public/skin/frontend/base/default/js/configurableswatches/swatches-list.js
@@ -1,7 +1,7 @@
 /**
  * Maho
  *
- * @package    rwd_default
+ * @package     base_default
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/public/skin/frontend/base/default/js/configurableswatches/swatches-product.js
+++ b/public/skin/frontend/base/default/js/configurableswatches/swatches-product.js
@@ -1,7 +1,7 @@
 /**
  * Maho
  *
- * @package    rwd_default
+ * @package     base_default
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)

--- a/public/skin/frontend/base/default/js/minicart.js
+++ b/public/skin/frontend/base/default/js/minicart.js
@@ -1,7 +1,7 @@
 /**
  * Maho
  *
- * @package    rwd_default
+ * @package     base_default
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2023 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)


### PR DESCRIPTION
## Summary
- Changed `@package rwd_default` to `@package base_default` in 36 files located in the base/default theme
- These files were moved from the RWD (Responsive Web Design) theme but retained incorrect package annotations

## Affected Files
- 29 template files in `app/design/frontend/base/default/template/`
- 6 JS files in `public/skin/frontend/base/default/js/`
- 1 CSS file in `public/skin/frontend/base/default/css/`

Fixes #525