### PR TITLE
Fixed payment methods display for virtual orders in one-step checkout

### DIFF
--- a/app/design/frontend/base/default/template/checkout/onepage/payment/info.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/payment/info.phtml
@@ -5,9 +5,16 @@
  * @package     base_default
  * @copyright   Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright   Copyright (c) 2022 The OpenMage Contributors (https://openmage.org)
+ * @copyright   Copyright (c) 2026 Maho (https://mahocommerce.com)
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+/** @var Mage_Checkout_Block_Onepage_Payment_Methods $this */
 ?>
 <dl class="sp-methods" id="checkout-payment-method-load">
-   <!-- Content dynamically loaded. Content from the methods.phtml is loaded during the ajax call -->
+<?php if ($this->getQuote()->isVirtual()): ?>
+<?= $this->getLayout()->createBlock('checkout/onepage_payment_methods')
+    ->setTemplate('checkout/onepage/payment/methods.phtml')
+    ->toHtml() ?>
+<?php endif ?>
 </dl>

--- a/app/design/frontend/base/default/template/checkout/onestep.phtml
+++ b/app/design/frontend/base/default/template/checkout/onestep.phtml
@@ -79,9 +79,11 @@ $isLoggedIn = $this->isCustomerLoggedIn();
             </div>
             <div class="onestep-section-content" id="checkout-step-payment">
                 <?= $this->getChildHtml('payment') ?>
+                <?php if (!$isVirtual): ?>
                 <div class="onestep-placeholder" id="payment-method-placeholder">
                     <p><?= $this->__('Waiting for shipping method...') ?></p>
                 </div>
+                <?php endif ?>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Virtual orders (e.g., gift cards, downloadable products) don't have shipping
- The one-step checkout was showing "Waiting for shipping method..." placeholder for payment methods, which was confusing
- Now payment methods render server-side immediately for virtual orders
- The placeholder is hidden for virtual orders

## Changes
- `info.phtml`: For virtual orders, create a block instance and render `methods.phtml` directly
- `onestep.phtml`: Hide the placeholder for virtual orders

## Test plan
- Add a virtual product (gift card, downloadable) to cart
- Go to one-step checkout
- Verify payment methods appear immediately without "Waiting for shipping method..." message