### PR TITLE
Added gift card totals to PDF invoices and credit memos

### DIFF
--- a/app/code/core/Mage/Sales/Block/Order/Pdf/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Block/Order/Pdf/Creditmemo.php
@@ -46,6 +46,14 @@ class Mage_Sales_Block_Order_Pdf_Creditmemo extends Mage_Sales_Block_Order_Pdf_A
         return $this->_creditmemo ? $this->_creditmemo->getIncrementId() : '';
     }
 
+    public function getInvoiceNumber(): string
+    {
+        if ($this->_creditmemo && $this->_creditmemo->getInvoice()) {
+            return $this->_creditmemo->getInvoice()->getIncrementId();
+        }
+        return '';
+    }
+
     public function getCreditmemoDate(): string
     {
         if ($this->_creditmemo) {
@@ -187,6 +195,22 @@ class Mage_Sales_Block_Order_Pdf_Creditmemo extends Mage_Sales_Block_Order_Pdf_A
             $totals[] = [
                 'label' => $this->__('Tax'),
                 'value' => $this->formatPrice($this->_creditmemo->getTaxAmount()),
+            ];
+        }
+
+        // Gift Card
+        if (abs((float) $this->_creditmemo->getGiftcardAmount()) >= 0.01) {
+            $label = $this->__('Gift Card');
+            $giftcardCodes = $this->_order->getGiftcardCodes();
+            if ($giftcardCodes) {
+                $codesArray = json_decode($giftcardCodes, true);
+                if (is_array($codesArray) && $codesArray !== []) {
+                    $label .= ' (' . implode(', ', array_keys($codesArray)) . ')';
+                }
+            }
+            $totals[] = [
+                'label' => $label,
+                'value' => $this->formatPrice(-abs($this->_creditmemo->getGiftcardAmount())),
             ];
         }
 

--- a/app/code/core/Mage/Sales/Block/Order/Pdf/Invoice.php
+++ b/app/code/core/Mage/Sales/Block/Order/Pdf/Invoice.php
@@ -174,6 +174,22 @@ class Mage_Sales_Block_Order_Pdf_Invoice extends Mage_Sales_Block_Order_Pdf_Abst
             ];
         }
 
+        // Gift Card
+        if (abs((float) $this->_invoice->getGiftcardAmount()) >= 0.01) {
+            $label = $this->__('Gift Card');
+            $giftcardCodes = $this->_order->getGiftcardCodes();
+            if ($giftcardCodes) {
+                $codesArray = json_decode($giftcardCodes, true);
+                if (is_array($codesArray) && $codesArray !== []) {
+                    $label .= ' (' . implode(', ', array_keys($codesArray)) . ')';
+                }
+            }
+            $totals[] = [
+                'label' => $label,
+                'value' => $this->formatPrice(-abs($this->_invoice->getGiftcardAmount())),
+            ];
+        }
+
         // Grand Total
         $totals[] = [
             'label' => $this->__('Grand Total'),

--- a/app/locale/en_US/Mage_Sales.csv
+++ b/app/locale/en_US/Mage_Sales.csv
@@ -259,6 +259,7 @@
 "Get Payment Update","Get Payment Update"
 "Get shipping methods and rates","Get shipping methods and rates"
 "Get Update","Get Update"
+"Gift Card","Gift Card"
 "Gift Message","Gift Message"
 "Gift Message for the Entire Order","Gift Message for the Entire Order"
 "Gift Message for This Order","Gift Message for This Order"


### PR DESCRIPTION
## Summary

- Display gift card amounts in PDF invoice/creditmemo totals section
- Show full gift card codes (PDFs are legal/accounting documents)
- Added `getInvoiceNumber()` method to creditmemo PDF block (template referenced this but method was missing)
- Added "Gift Card" translation to `Mage_Sales.csv`

## Test plan

- [ ] Create an order using a gift card
- [ ] Generate PDF invoice - verify gift card line appears in totals with full code
- [ ] Generate PDF credit memo - verify gift card line appears in totals with full code
- [ ] Verify credit memo PDF shows invoice number (if applicable)

Fixes #521