### PR TITLE
Improved admin product grid COUNT query performance

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -67,7 +67,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
                 'catalog_product/name',
                 'entity_id',
                 null,
-                'inner',
+                'left',
                 $adminStore,
             );
             $collection->joinAttribute(
@@ -75,7 +75,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
                 'catalog_product/name',
                 'entity_id',
                 null,
-                'inner',
+                'left',
                 $store->getId(),
             );
             $collection->joinAttribute(
@@ -83,7 +83,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
                 'catalog_product/status',
                 'entity_id',
                 null,
-                'inner',
+                'left',
                 $store->getId(),
             );
             $collection->joinAttribute(
@@ -91,7 +91,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
                 'catalog_product/visibility',
                 'entity_id',
                 null,
-                'inner',
+                'left',
                 $store->getId(),
             );
             $collection->joinAttribute(
@@ -104,8 +104,8 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
             );
         } else {
             $collection->addAttributeToSelect('price');
-            $collection->joinAttribute('status', 'catalog_product/status', 'entity_id', null, 'inner');
-            $collection->joinAttribute('visibility', 'catalog_product/visibility', 'entity_id', null, 'inner');
+            $collection->joinAttribute('status', 'catalog_product/status', 'entity_id', null, 'left');
+            $collection->joinAttribute('visibility', 'catalog_product/visibility', 'entity_id', null, 'left');
         }
 
         $this->setCollection($collection);


### PR DESCRIPTION
## Problem

The admin product grid takes 3-5+ seconds to load on catalogs with 5000+ products. Profiling shows most time is spent on the COUNT query:

```sql
SELECT COUNT(DISTINCT e.entity_id) 
FROM catalog_product_entity e
INNER JOIN catalog_product_entity_int at_status ON (...)
INNER JOIN catalog_product_entity_int at_visibility ON (...)
```

## Root Cause

`joinAttribute()` calls use `'inner'` joins for status, visibility, name, and custom_name attributes.

Maho's `getSelectCountSql()` calls `resetJoinLeft()` to strip unnecessary joins from count queries - but this only works on LEFT JOINs. The INNER JOINs remain, forcing the count to scan the EAV int table unnecessarily.

## Solution

Changed all `joinAttribute()` calls from `'inner'` to `'left'`.

## Why This Is Safe

1. **Status and visibility are required attributes** - every product has them, so INNER vs LEFT returns identical results in practice

2. **Filtering is unaffected** - `WHERE status = 1` excludes NULLs regardless of join type

3. **Edge case benefit** - if a product somehow lacks these attributes (data corruption), it now appears in the grid rather than being silently hidden, helping admins identify data issues

## Result

COUNT query becomes:
```sql
SELECT COUNT(DISTINCT e.entity_id) FROM catalog_product_entity e
```

Load time drops from 3-5 seconds to under 200ms.