### PR TITLE
Fixed checkout exception handling to always return JSON response

### DIFF
--- a/app/code/core/Mage/Checkout/controllers/OnepageController.php
+++ b/app/code/core/Mage/Checkout/controllers/OnepageController.php
@@ -637,82 +637,97 @@ class Mage_Checkout_OnepageController extends Mage_Checkout_Controller_Action
         }
 
         $result = [];
+        $redirectUrl = null;
+
         try {
-            $requiredAgreements = Mage::helper('checkout')->getRequiredAgreementIds();
-            if ($requiredAgreements) {
-                $postedAgreements = array_keys($this->getRequest()->getPost('agreement', []));
-                $diff = array_diff($requiredAgreements, $postedAgreements);
-                if ($diff) {
-                    $result['success'] = false;
-                    $result['error'] = true;
-                    $result['error_messages'] = $this->__('Please agree to all the terms and conditions before placing the order.');
-                    $this->_prepareDataJSON($result);
-                    return;
+            try {
+                $requiredAgreements = Mage::helper('checkout')->getRequiredAgreementIds();
+                if ($requiredAgreements) {
+                    $postedAgreements = array_keys($this->getRequest()->getPost('agreement', []));
+                    $diff = array_diff($requiredAgreements, $postedAgreements);
+                    if ($diff) {
+                        $result['success'] = false;
+                        $result['error'] = true;
+                        $result['error_messages'] = $this->__('Please agree to all the terms and conditions before placing the order.');
+                        $this->_prepareDataJSON($result);
+                        return;
+                    }
                 }
+
+                $data = $this->getRequest()->getPost('payment', []);
+                if ($data) {
+                    $data['checks'] = Mage_Payment_Model_Method_Abstract::CHECK_USE_CHECKOUT
+                        | Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_COUNTRY
+                        | Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_CURRENCY
+                        | Mage_Payment_Model_Method_Abstract::CHECK_ORDER_TOTAL_MIN_MAX
+                        | Mage_Payment_Model_Method_Abstract::CHECK_ZERO_TOTAL;
+                    $this->getOnepage()->getQuote()->getPayment()->importData($data);
+                }
+
+                $this->getOnepage()->saveOrder();
+
+                $redirectUrl = $this->getOnepage()->getCheckout()->getRedirectUrl();
+                $result['success'] = true;
+                $result['error']   = false;
+            } catch (Mage_Payment_Model_Info_Exception $e) {
+                $message = $e->getMessage();
+                if (!empty($message)) {
+                    $result['error_messages'] = $message;
+                }
+                $result['goto_section'] = 'payment';
+                $result['update_section'] = [
+                    'name' => 'payment-method',
+                    'html' => $this->_getPaymentMethodsHtml(),
+                ];
+            } catch (Mage_Core_Exception $e) {
+                Mage::logException($e);
+                Mage::helper('checkout')->sendPaymentFailedEmail($this->getOnepage()->getQuote(), $e->getMessage());
+                $result['success'] = false;
+                $result['error'] = true;
+                $result['error_messages'] = $e->getMessage();
+
+                $gotoSection = $this->getOnepage()->getCheckout()->getGotoSection();
+                if ($gotoSection) {
+                    $result['goto_section'] = $gotoSection;
+                    $this->getOnepage()->getCheckout()->setGotoSection(null);
+                }
+                $updateSection = $this->getOnepage()->getCheckout()->getUpdateSection();
+                if ($updateSection) {
+                    if (isset($this->_sectionUpdateFunctions[$updateSection])) {
+                        $updateSectionFunction = $this->_sectionUpdateFunctions[$updateSection];
+                        $result['update_section'] = [
+                            'name' => $updateSection,
+                            'html' => $this->$updateSectionFunction(),
+                        ];
+                    }
+                    $this->getOnepage()->getCheckout()->setUpdateSection(null);
+                }
+            } catch (Exception $e) {
+                Mage::logException($e);
+                Mage::helper('checkout')->sendPaymentFailedEmail($this->getOnepage()->getQuote(), $e->getMessage());
+                $result['success']  = false;
+                $result['error']    = true;
+                $result['error_messages'] = $this->__('There was an error processing your order. Please contact us or try again later.');
             }
 
-            $data = $this->getRequest()->getPost('payment', []);
-            if ($data) {
-                $data['checks'] = Mage_Payment_Model_Method_Abstract::CHECK_USE_CHECKOUT
-                    | Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_COUNTRY
-                    | Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_CURRENCY
-                    | Mage_Payment_Model_Method_Abstract::CHECK_ORDER_TOTAL_MIN_MAX
-                    | Mage_Payment_Model_Method_Abstract::CHECK_ZERO_TOTAL;
-                $this->getOnepage()->getQuote()->getPayment()->importData($data);
+            try {
+                $this->getOnepage()->getQuote()->save();
+            } catch (Throwable $e) {
+                Mage::logException($e);
             }
 
-            $this->getOnepage()->saveOrder();
-
-            $redirectUrl = $this->getOnepage()->getCheckout()->getRedirectUrl();
-            $result['success'] = true;
-            $result['error']   = false;
-        } catch (Mage_Payment_Model_Info_Exception $e) {
-            $message = $e->getMessage();
-            if (!empty($message)) {
-                $result['error_messages'] = $message;
+            /**
+             * when there is redirect to third party, we don't want to save order yet.
+             * we will save the order in return action.
+             */
+            if ($redirectUrl) {
+                $result['redirect'] = $redirectUrl;
             }
-            $result['goto_section'] = 'payment';
-            $result['update_section'] = [
-                'name' => 'payment-method',
-                'html' => $this->_getPaymentMethodsHtml(),
-            ];
-        } catch (Mage_Core_Exception $e) {
+        } catch (Throwable $e) {
             Mage::logException($e);
-            Mage::helper('checkout')->sendPaymentFailedEmail($this->getOnepage()->getQuote(), $e->getMessage());
             $result['success'] = false;
             $result['error'] = true;
-            $result['error_messages'] = $e->getMessage();
-
-            $gotoSection = $this->getOnepage()->getCheckout()->getGotoSection();
-            if ($gotoSection) {
-                $result['goto_section'] = $gotoSection;
-                $this->getOnepage()->getCheckout()->setGotoSection(null);
-            }
-            $updateSection = $this->getOnepage()->getCheckout()->getUpdateSection();
-            if ($updateSection) {
-                if (isset($this->_sectionUpdateFunctions[$updateSection])) {
-                    $updateSectionFunction = $this->_sectionUpdateFunctions[$updateSection];
-                    $result['update_section'] = [
-                        'name' => $updateSection,
-                        'html' => $this->$updateSectionFunction(),
-                    ];
-                }
-                $this->getOnepage()->getCheckout()->setUpdateSection(null);
-            }
-        } catch (Exception $e) {
-            Mage::logException($e);
-            Mage::helper('checkout')->sendPaymentFailedEmail($this->getOnepage()->getQuote(), $e->getMessage());
-            $result['success']  = false;
-            $result['error']    = true;
             $result['error_messages'] = $this->__('There was an error processing your order. Please contact us or try again later.');
-        }
-        $this->getOnepage()->getQuote()->save();
-        /**
-         * when there is redirect to third party, we don't want to save order yet.
-         * we will save the order in return action.
-         */
-        if (isset($redirectUrl)) {
-            $result['redirect'] = $redirectUrl;
         }
 
         $this->_prepareDataJSON($result);


### PR DESCRIPTION
Fixes #536

## Problem

When a payment module throws an exception during checkout, users may see a generic 503 HTML error page instead of being handled gracefully by the checkout JavaScript.

## Root Cause

**This is NOT a new Maho bug** - it was inherited from Magento 1 and exists in OpenMage as well. The same code structure can be found in [OpenMage's OnepageController.php](https://github.com/OpenMage/magento-lts/blob/main/app/code/core/Mage/Checkout/controllers/OnepageController.php#L654).

The issues in the original code:

1. `$this->getOnepage()->getQuote()->save()` was outside the try/catch - any exception here bypassed all error handling
2. Only `Exception` was caught - PHP 7+ `Error` objects (TypeError, etc.) would bypass all catch blocks  
3. Exceptions thrown inside catch blocks (e.g., from `_getPaymentMethodsHtml()`) would also bubble up

## Why This Matters More Now

While OpenMage's checkout would redirect to the failure page on a 503 (via the JS `ajaxFailure` handler), it's better UX to:
- Keep the user on the checkout page
- Show the actual error message inline
- Allow them to retry without navigating away

## Solution

- Wrapped the quote save in its own try/catch to prevent exceptions from breaking the checkout flow
- Added an outer `Throwable` catch to handle any unhandled exceptions or PHP errors
- Ensures a JSON response is **always** returned to the frontend

## Backward Compatibility

✅ Fully backward compatible - both multi-step and one-step checkout use the same `saveOrderAction` and expect the same JSON response format.