### PR TITLE
Fixed fatal error when configurable product has orphaned super attributes

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable.php
@@ -259,16 +259,20 @@ class Mage_Catalog_Model_Product_Type_Configurable extends Mage_Catalog_Model_Pr
     {
         $res = [];
         foreach ($this->getConfigurableAttributes($product) as $attribute) {
+            $productAttribute = $attribute->getProductAttribute();
+            if (!$productAttribute) {
+                continue;
+            }
             $res[] = [
                 'id'             => $attribute->getId(),
                 'label'          => $attribute->getLabel(),
                 'use_default'    => $attribute->getUseDefault(),
                 'position'       => $attribute->getPosition(),
                 'values'         => $attribute->getPrices() ?: [],
-                'attribute_id'   => $attribute->getProductAttribute()->getId(),
-                'attribute_code' => $attribute->getProductAttribute()->getAttributeCode(),
-                'frontend_label' => $attribute->getProductAttribute()->getFrontend()->getLabel(),
-                'store_label'    => $attribute->getProductAttribute()->getStoreLabel(),
+                'attribute_id'   => $productAttribute->getId(),
+                'attribute_code' => $productAttribute->getAttributeCode(),
+                'frontend_label' => $productAttribute->getFrontend()->getLabel(),
+                'store_label'    => $productAttribute->getStoreLabel(),
             ];
         }
         return $res;
@@ -405,7 +409,9 @@ class Mage_Catalog_Model_Product_Type_Configurable extends Mage_Catalog_Model_Pr
             }
         }
         foreach ($this->getConfigurableAttributes($product) as $attribute) {
-            $this->getProduct($product)->setData($attribute->getProductAttribute()->getAttributeCode());
+            if ($attribute->getProductAttribute()) {
+                $this->getProduct($product)->setData($attribute->getProductAttribute()->getAttributeCode());
+            }
         }
 
         return $this;

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Configurable/Price.php
@@ -63,7 +63,11 @@ class Mage_Catalog_Model_Product_Type_Configurable_Price extends Mage_Catalog_Mo
 
         /** @var Mage_Catalog_Model_Product_Type_Configurable_Attribute $attribute */
         foreach ($attributes as $attribute) {
-            $attributeId = $attribute->getProductAttribute()->getId();
+            $productAttribute = $attribute->getProductAttribute();
+            if (!$productAttribute) {
+                continue;
+            }
+            $attributeId = $productAttribute->getId();
             $value = $this->_getValueByIndex(
                 $attribute->getPrices() ?: [],
                 $selectedAttributes[$attributeId] ?? null,


### PR DESCRIPTION
## Summary
- Guard against `getProductAttribute()` returning `null` in configurable product type, preventing fatal errors when a super attribute references a deleted or misassigned EAV attribute
- Affected methods: `getConfigurableAttributesAsArray()`, `beforeSave()` in `Configurable.php`, and `getTotalConfigurableItemsPrice()` in `Configurable/Price.php`
- Orphaned attributes are now silently skipped instead of causing a crash

## Test plan
- [x] Load a configurable product page with valid super attributes — should render normally
- [x] If a configurable product has an orphaned `catalog_product_super_attribute` entry pointing to a non-existent EAV attribute, the page should load without fatal errors