### PR TITLE
Fixed PHP 8.5 deprecation in SalesRule address validation cache

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Rule.php
@@ -436,7 +436,10 @@ class Mage_SalesRule_Model_Rule extends Mage_Rule_Model_Abstract
     public function hasIsValidForAddress($address)
     {
         $addressId = $this->_getAddressId($address);
-        return isset($this->_validatedAddresses[$addressId]) ? true : false;
+        if ($addressId === null) {
+            return false;
+        }
+        return isset($this->_validatedAddresses[$addressId]);
     }
 
     /**
@@ -449,6 +452,9 @@ class Mage_SalesRule_Model_Rule extends Mage_Rule_Model_Abstract
     public function setIsValidForAddress($address, $validationResult)
     {
         $addressId = $this->_getAddressId($address);
+        if ($addressId === null) {
+            return $this;
+        }
         $this->_validatedAddresses[$addressId] = $validationResult;
         return $this;
     }
@@ -462,6 +468,9 @@ class Mage_SalesRule_Model_Rule extends Mage_Rule_Model_Abstract
     public function getIsValidForAddress($address)
     {
         $addressId = $this->_getAddressId($address);
+        if ($addressId === null) {
+            return false;
+        }
         return $this->_validatedAddresses[$addressId] ?? false;
     }
 


### PR DESCRIPTION
## Summary
- When a quote address hasn't been saved yet, `getId()` returns `null`, which was used as an array key in the `_validatedAddresses` cache
- PHP 8.5 deprecated using `null` as an array offset, and in developer mode `mageCoreErrorHandler` promotes this to an exception, breaking add-to-cart entirely
- Fix: guard all three cache methods (`has`, `get`, `set`) with a `null` check — if there's no address ID, skip caching (the caller in `Validator::_canProcessRule` already guards with `!address->isObjectNew()` so the cache is never needed for unsaved addresses)

## Test plan
- [ ] Add a product to cart in developer mode on PHP 8.5 — should succeed without errors
- [ ] Verify sales rules still apply correctly during checkout