### PR TITLE
Updated TipTap editor from 3.16 to 3.19.0

### DIFF
--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
@@ -6,13 +6,13 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-import { Editor, Node, Mark, Extension, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.16';
-import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.16';
-import Image from 'https://esm.sh/@tiptap/extension-image@3.16';
-import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.16';
-import { Table, TableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.16';
-import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.16';
-import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.16';
+import { Editor, Node, Mark, Extension, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.19.0';
+import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.19.0';
+import Image from 'https://esm.sh/@tiptap/extension-image@3.19.0';
+import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.19.0';
+import { Table, TableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.19.0';
+import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.19.0';
+import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.19.0';
 import { MahoColumns, MahoColumn, COLUMN_PRESETS } from './extensions/columns.js';
 
 export {

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
@@ -6,7 +6,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.16';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.19.0';
 
 /**
  * Column presets configuration


### PR DESCRIPTION
## Summary
- Updated all TipTap CDN imports (esm.sh) from `@3.16` to `@3.19.0`
- Affects `extensions.js` (7 imports) and `extensions/columns.js` (1 import)
- No breaking changes between these versions for the packages we use

## Test plan
- [x] Open any CMS page or block in the admin and verify the TipTap editor loads correctly
- [x] Test basic editing (text formatting, lists, headings)
- [x] Test table editing with bubble menu
- [x] Test image insertion and widget insertion
- [x] Test column layout extension
- [x] Test drag handle functionality