### PR TITLE
Fixed AJAX add to cart breaking file upload custom options

### DIFF
--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -260,7 +260,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
             if ($this->getRequest()->getParam('isAjax')) {
                 $this->getResponse()->setBodyJson([
                     'success' => false,
-                    'error' => $e->getMessage(),
+                    'error' => strip_tags($e->getMessage()),
                 ]);
                 return;
             }
@@ -451,7 +451,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
             if ($isAjax) {
                 $this->getResponse()->setBodyJson([
                     'success' => false,
-                    'error' => $e->getMessage(),
+                    'error' => strip_tags($e->getMessage()),
                 ]);
                 return;
             }

--- a/app/design/frontend/base/default/template/catalog/product/view.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view.phtml
@@ -113,7 +113,7 @@
                 try {
                     const result = await mahoFetch(targetUrl, {
                         method: 'POST',
-                        body: new URLSearchParams(new FormData(form)),
+                        body: new FormData(form),
                         loaderArea: form.closest('.product-view')
                     });
 


### PR DESCRIPTION
Closes #561

## Summary

- **Fixed file uploads**: Replaced `new URLSearchParams(new FormData(form))` with `new FormData(form)` in the AJAX add-to-cart flow. `URLSearchParams` silently discards `File` objects by calling `.toString()`, turning them into the literal string `"[object File]"`. `FormData` preserves binary file data and lets the browser set the correct `Content-Type: multipart/form-data` header automatically.

- **Fixed raw HTML in alert dialogs**: Error messages like `Please specify the product required option <em>name</em>.` were showing raw HTML tags in `alert()` dialogs. Applied `strip_tags()` to AJAX error responses so they display clean text. The non-AJAX path still renders `<em>` tags properly in session flash messages.

## Test plan

- [ ] Create a product with a **required** file upload custom option
- [ ] Select a file and click "Add to Cart" — should succeed without error
- [ ] Create a product with an **optional** file upload custom option
- [ ] Add to cart with and without a file — both should work
- [ ] Try adding to cart without selecting a file on a required file option — alert should show clean text (no HTML tags)
- [ ] Verify regular (non-file) custom options still work correctly