### PR TITLE
Fixed missing `getConditions()` on `DynamicRule` causing fatal error

### DIFF
--- a/app/code/core/Maho/FeedManager/Model/DynamicRule.php
+++ b/app/code/core/Maho/FeedManager/Model/DynamicRule.php
@@ -47,6 +47,11 @@ class Maho_FeedManager_Model_DynamicRule extends Mage_Core_Model_Abstract
     protected ?array $_cases = null;
 
     /**
+     * Conditions model instance
+     */
+    protected ?Maho_FeedManager_Model_Rule_Condition_Combine $_conditions = null;
+
+    /**
      * Form instance for conditions rendering
      */
     protected ?\Maho\Data\Form $_form = null;
@@ -69,6 +74,29 @@ class Maho_FeedManager_Model_DynamicRule extends Mage_Core_Model_Abstract
     {
         $this->_form = $form;
         return $this;
+    }
+
+    /**
+     * Get conditions model instance (required by rules engine UI)
+     */
+    public function getConditions(): Maho_FeedManager_Model_Rule_Condition_Combine
+    {
+        if ($this->_conditions === null) {
+            $this->_conditions = Mage::getModel('feedmanager/rule_condition_combine');
+            $this->_conditions->setRule($this)->setId('1')->setPrefix('conditions');
+
+            if ($this->hasConditionsSerialized()) {
+                $conditions = $this->getConditionsSerialized();
+                if (!empty($conditions)) {
+                    $decoded = Mage::helper('core')->jsonDecode($conditions);
+                    if (is_array($decoded) && !empty($decoded)) {
+                        $this->_conditions->loadArray($decoded);
+                    }
+                }
+                $this->unsConditionsSerialized();
+            }
+        }
+        return $this->_conditions;
     }
 
     #[\Override]


### PR DESCRIPTION
## Summary

- Regression from 3e92381 which refactored `Feed` to extend `Mage_Rule_Model_Abstract` but left `DynamicRule` extending `Mage_Core_Model_Abstract` without a `getConditions()` method
- This caused a fatal error ("Call to a member function setJsFormObject() on null") when editing or creating dynamic rules in the admin
- Adds `getConditions()` to `DynamicRule` following the same pattern as `Mage_Rule_Model_Abstract`

## Test plan

- [ ] Navigate to admin Feed Manager > Dynamic Rules > Edit/New rule
- [ ] Verify the page loads without fatal error
- [ ] Verify conditions can be added and saved