### PR TITLE
Fixed orphaned reorder sidebar layout references causing fatal error

### DIFF
--- a/app/design/frontend/base/default/layout/sales.xml
+++ b/app/design/frontend/base/default/layout/sales.xml
@@ -17,20 +17,6 @@ Customer account pages, rendered for all tabs in dashboard
 -->
 
 
-    <customer_logged_in>
-        <reference name="right">
-            <block type="sales/reorder_sidebar" name="sale.reorder.sidebar" as="reorder" template="sales/reorder/sidebar.phtml"/>
-        </reference>
-    </customer_logged_in>
-    <checkout_onepage_index>
-        <remove name="sale.reorder.sidebar"/>
-    </checkout_onepage_index>
-    <checkout_onepage_reorder>
-        <reference name="right">
-            <action method="unsetChild"><name>reorder</name></action>
-        </reference>
-    </checkout_onepage_reorder>
-
     <customer_account>
         <!-- Mage_Sales -->
         <reference name="customer_account_navigation">


### PR DESCRIPTION
## Summary

- Removes orphaned layout XML references to `sales/reorder_sidebar` block in `sales.xml`
- The block class and template were removed in #434 but three layout handles were left behind (`customer_logged_in`, `checkout_onepage_index`, `checkout_onepage_reorder`)
- This caused `Invalid block type: sales/reorder_sidebar` errors on any page where a customer is logged in

## Test plan

- [ ] Log in as a customer on the frontend
- [ ] Visit My Account and address pages — no more "Invalid block type" errors