### PR TITLE
Made TipTap editor scrollable to keep toolbar accessible

### DIFF
--- a/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
@@ -215,6 +215,7 @@ class tiptapWysiwygSetup {
         // Create container for Tiptap editor content
         const container = document.createElement('div');
         container.id = `${this.id}_editor`;
+        container.className = 'tiptap-content';
         this.wrapper.appendChild(container);
 
         // Insert wrapper after textarea

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/tiptap.css
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/tiptap.css
@@ -42,8 +42,17 @@
     border: 1px solid var(--tt-color-border-light);
     border-radius: var(--tt-radius-lg);
     background-color: var(--tt-color-bg);
-    overflow: hidden;
     box-shadow: var(--tt-shadow-sm);
+    display: flex;
+    flex-direction: column;
+    max-height: 70vh;
+    overflow: hidden;
+}
+
+.tiptap-content {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
 }
 
 .tiptap-toolbar {
@@ -54,6 +63,7 @@
     flex-wrap: wrap;
     gap: 0.125rem;
     align-items: center;
+    flex-shrink: 0;
 
     .toolbar-group {
         display: flex;


### PR DESCRIPTION
## Summary
- When the TipTap editor has a lot of content (columns, bento grids, images, etc.), the editor grows very tall, pushing the toolbar out of view and making it uncomfortable to use
- The editor wrapper now uses a flex column layout with `max-height: 70vh`, keeping the toolbar pinned at the top while the content area scrolls independently

## Test plan
- [ ] Open a CMS page with a lot of content in the TipTap editor
- [ ] Verify the toolbar stays visible at the top while scrolling through content
- [ ] Verify fullscreen mode still works correctly
- [ ] Verify bubble menus (table, columns, bento) still appear correctly
- [ ] Verify drag handle still works