### PR TITLE
Avoided unnecessary `payment_method_is_active` event on every page load

### DIFF
--- a/app/code/core/Mage/Paypal/Block/Express/Shortcut.php
+++ b/app/code/core/Mage/Paypal/Block/Express/Shortcut.php
@@ -101,6 +101,10 @@ class Mage_Paypal_Block_Express_Shortcut extends Mage_Core_Block_Template
         }
 
         // check payment method availability
+        if (!$config->isMethodActive($this->_paymentMethodCode)) {
+            $this->_shouldRender = false;
+            return $result;
+        }
         $methodInstance = Mage::helper('payment')->getMethodInstance($this->_paymentMethodCode);
         if (!$methodInstance || !$methodInstance->isAvailable($quote)) {
             $this->_shouldRender = false;

--- a/app/design/frontend/base/default/layout/paypal.xml
+++ b/app/design/frontend/base/default/layout/paypal.xml
@@ -13,14 +13,14 @@
 <layout version="0.1.0">
     <checkout_cart_index>
         <reference name="checkout.cart.top_methods">
-            <block type="paypal/express_shortcut" name="checkout.cart.methods.paypal_express.top" before="checkout.cart.methods.onepage.top" template="paypal/express/shortcut.phtml">
+            <block type="paypal/express_shortcut" name="checkout.cart.methods.paypal_express.top" before="checkout.cart.methods.onepage.top" template="paypal/express/shortcut.phtml" ifconfig="payment/paypal_express/active">
                 <action method="setIsQuoteAllowed"><value>1</value></action>
                 <action method="setShowOrPosition"><value>after</value></action>
             </block>
         </reference>
 
         <reference name="checkout.cart.methods">
-            <block type="paypal/express_shortcut" name="checkout.cart.methods.paypal_express.bottom" before="checkout.cart.methods.onepage.bottom" template="paypal/express/shortcut.phtml">
+            <block type="paypal/express_shortcut" name="checkout.cart.methods.paypal_express.bottom" before="checkout.cart.methods.onepage.bottom" template="paypal/express/shortcut.phtml" ifconfig="payment/paypal_express/active">
                 <action method="setIsQuoteAllowed"><value>1</value></action>
                 <action method="setShowOrPosition"><value>after</value></action>
             </block>
@@ -80,7 +80,7 @@ Available logo types can be assigned with action="setLogoType":
             <block type="page/html_wrapper" name="product.info.addtocart.paypal.wrapper" translate="label">
                 <action method="setMayBeInvisible"><value>true</value></action>
                 <label>PayPal Express Checkout Shortcut Wrapper</label>
-                <block type="paypal/express_shortcut" name="product.info.addtocart.paypal" template="paypal/express/product/shortcut.phtml">
+                <block type="paypal/express_shortcut" name="product.info.addtocart.paypal" template="paypal/express/product/shortcut.phtml" ifconfig="payment/paypal_express/active">
                     <action method="setIsInCatalogProduct"><value>1</value></action>
                 </block>
             </block>
@@ -131,10 +131,10 @@ Available logo types can be assigned with action="setLogoType":
 
     <default>
         <reference name="topCart.extra_actions">
-            <block type="paypal/express_shortcut" name="paypal.partner.top_cart.shortcut" template="paypal/express/shortcut.phtml"/>
+            <block type="paypal/express_shortcut" name="paypal.partner.top_cart.shortcut" template="paypal/express/shortcut.phtml" ifconfig="payment/paypal_express/active"/>
         </reference>
         <reference name="cart_sidebar.extra_actions">
-            <block type="paypal/express_shortcut" name="paypal.partner.cart_sidebar.shortcut" template="paypal/express/minicart/shortcut.phtml"/>
+            <block type="paypal/express_shortcut" name="paypal.partner.cart_sidebar.shortcut" template="paypal/express/minicart/shortcut.phtml" ifconfig="payment/paypal_express/active"/>
         </reference>
     </default>
 
@@ -162,7 +162,7 @@ Available logo types can be assigned with action="setLogoType":
     <SHORTCUT_popup>
         <reference name="product.tooltip">
             <block type="page/html_wrapper" name="product.info.addtocart.paypal.wrapper" translate="label">
-                <block type="paypal/express_shortcut" name="product.info.addtocart.paypal" template="paypal/express/shortcut.phtml">
+                <block type="paypal/express_shortcut" name="product.info.addtocart.paypal" template="paypal/express/shortcut.phtml" ifconfig="payment/paypal_express/active">
                     <action method="setIsInCatalogProduct"><value>1</value></action>
                     <action method="setShowOrPosition"><value>after</value></action>
                 </block>

--- a/app/design/frontend/base/default/layout/paypaluk.xml
+++ b/app/design/frontend/base/default/layout/paypaluk.xml
@@ -13,12 +13,12 @@
 <layout version="0.1.0">
     <checkout_cart_index>
         <reference name="checkout.cart.top_methods">
-            <block type="paypaluk/express_shortcut" name="checkout.cart.methods.paypaluk_express.top" before="-" template="paypal/express/shortcut.phtml">
+            <block type="paypaluk/express_shortcut" name="checkout.cart.methods.paypaluk_express.top" before="-" template="paypal/express/shortcut.phtml" ifconfig="payment/paypaluk_express/active">
                 <action method="setIsQuoteAllowed"><value>1</value></action>
             </block>
         </reference>
         <reference name="checkout.cart.methods">
-            <block type="paypaluk/express_shortcut" name="checkout.cart.methods.paypaluk_express.bottom" before="-" template="paypal/express/shortcut.phtml">
+            <block type="paypaluk/express_shortcut" name="checkout.cart.methods.paypaluk_express.bottom" before="-" template="paypal/express/shortcut.phtml" ifconfig="payment/paypaluk_express/active">
                 <action method="setIsQuoteAllowed"><value>1</value></action>
             </block>
         </reference>
@@ -67,7 +67,7 @@
                 <label>PayPal Express Checkout (Payflow Edition) Shortcut Wrapper</label>
                 <action method="setHtmlTagName"><tag>p</tag></action>
                 <action method="setElementClass"><class>paypal-logo</class></action>
-                <block type="paypaluk/express_shortcut" name="product.info.addtocart.paypaluk" template="paypal/express/shortcut.phtml">
+                <block type="paypaluk/express_shortcut" name="product.info.addtocart.paypaluk" template="paypal/express/shortcut.phtml" ifconfig="payment/paypaluk_express/active">
                     <action method="setIsInCatalogProduct"><value>1</value></action>
                 </block>
             </block>
@@ -77,10 +77,10 @@
 
     <default>
         <reference name="topCart.extra_actions">
-            <block type="paypaluk/express_shortcut" name="paypaluk.partner.top_cart.shortcut" template="paypal/express/shortcut.phtml"/>
+            <block type="paypaluk/express_shortcut" name="paypaluk.partner.top_cart.shortcut" template="paypal/express/shortcut.phtml" ifconfig="payment/paypaluk_express/active"/>
         </reference>
         <reference name="cart_sidebar.extra_actions">
-            <block type="paypaluk/express_shortcut" name="paypaluk.partner.cart_sidebar.shortcut" template="paypal/express/shortcut.phtml"/>
+            <block type="paypaluk/express_shortcut" name="paypaluk.partner.cart_sidebar.shortcut" template="paypal/express/shortcut.phtml" ifconfig="payment/paypaluk_express/active"/>
         </reference>
     </default>
 
@@ -129,7 +129,7 @@
     <SHORTCUT_uk_popup>
         <reference name="product.tooltip">
             <block type="page/html_wrapper" name="product.info.addtocart.paypaluk.wrapper" translate="label">
-                <block type="paypaluk/express_shortcut" name="product.info.addtocart.paypaluk" template="paypal/express/shortcut.phtml">
+                <block type="paypaluk/express_shortcut" name="product.info.addtocart.paypaluk" template="paypal/express/shortcut.phtml" ifconfig="payment/paypaluk_express/active">
                     <action method="setIsInCatalogProduct"><value>1</value></action>
                     <action method="setShowOrPosition"><value>after</value></action>
                 </block>


### PR DESCRIPTION
## Summary

- `Mage_Paypal_Block_Express_Shortcut` is rendered on every page via the `<default>` layout handle
- When PayPal Express is disabled, `_beforeToHtml()` still calls `isAvailable()` which dispatches the `payment_method_is_active` event unnecessarily
- Added an early `isMethodActive()` config check (simple store config lookup, no event dispatch) before the `isAvailable()` call to skip rendering immediately when the method is inactive

## Test plan

- [ ] Disable PayPal Express in admin config → browse catalog/cart pages → confirm `payment_method_is_active` event no longer fires from this block
- [ ] Enable PayPal Express → confirm shortcut buttons still render correctly
- [ ] `vendor/bin/phpstan analyze` and `vendor/bin/php-cs-fixer fix --dry-run` pass clean

Fixes #576