### PR TITLE
Avoid full bootstrap for 404s on static asset requests

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -21,8 +21,7 @@ if ($requestPath !== '/') {
     $ext = strtolower(pathinfo($requestPath, PATHINFO_EXTENSION));
     $staticExts = [
         'jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'svg', 'svgz', 'ico', 'bmp', 'apng',
-        'css', 'js', 'mjs', 'map',
-        'woff', 'woff2', 'ttf', 'otf', 'eot',
+        'css', 'js', 'mjs', 'map', 'woff', 'woff2', 'ttf', 'otf', 'eot',
         'mp3', 'mp4', 'ogg', 'webm', 'wav', 'flac', 'aac', 'm4a', 'm4v', 'ogv', 'mov',
         'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx',
         'zip', 'gz', 'tar', 'rar', '7z',


### PR DESCRIPTION
## Summary

- Adds an early-exit check in `public/index.php` **before** the autoloader and bootstrap run
- When a request has a known static file extension (images, CSS, JS, fonts, media, etc.) and the file doesn't exist on disk, returns a bare `404` immediately
- Uses `realpath()` + `str_starts_with()` to prevent path traversal attacks
- Uses `in_array()` with strict comparison for extension lookup

This is a safety net for environments where the web server doesn't handle this natively — `php -S` dev server, default FrankenPHP/Caddy, shared hosting, etc. Apache users are already partially covered by the existing `.htaccess` rules for `/media/`, `/skin/`, `/js/` paths.

Closes #582

## Follow-up work in other repositories

### [`MahoCommerce/docker-images`](https://github.com/MahoCommerce/docker-images)

The official Docker image uses FrankenPHP (Caddy-based) with no custom Caddyfile, so all requests — including missing static assets — hit PHP. A `Caddyfile` should be added to handle static files at the web server level:

```caddyfile
{
    order php_server last
}

:80 {
    root * /app/public

    @static path *.jpg *.jpeg *.png *.gif *.webp *.avif *.svg *.ico *.bmp *.css *.js *.map *.woff *.woff2 *.ttf *.eot *.otf *.mp3 *.mp4 *.ogg *.webm *.pdf
    handle @static {
        file_server
    }

    php_server
}
```

This avoids PHP entirely for static assets — the proper fix at the web server layer.

### [`MahoCommerce/demo.mahocommerce.com`](https://github.com/MahoCommerce/demo.mahocommerce.com)

The demo site also uses FrankenPHP with no custom Caddyfile. It could either:
- Inherit the fix from an updated `docker-images` base image, or
- Add its own Caddyfile with the same static asset handling

## Test plan

- [ ] Request an existing static asset (e.g., `/skin/frontend/.../styles.css`) — should serve normally
- [ ] Request a non-existent static asset (e.g., `/js/nonexistent.js`) — should return bare 404 without bootstrap
- [ ] Request a non-existent page route (e.g., `/some/missing/page`) — should still go through full bootstrap and return themed 404
- [ ] Attempt path traversal (e.g., `/../../etc/passwd.js`) — should return 404, not leak filesystem info
- [ ] Test with `php -S localhost:8080 -t public/` dev server
