### PR TITLE
Fixed `admin:user:create` failing when admin role has different name

### DIFF
--- a/lib/MahoCLI/Commands/AdminUserCreate.php
+++ b/lib/MahoCLI/Commands/AdminUserCreate.php
@@ -32,6 +32,7 @@ class AdminUserCreate extends BaseMahoCommand
         $this->initMaho();
 
         $role = Mage::getModel('admin/roles')->getCollection()
+            ->addFieldToFilter('role_type', 'G')
             ->addFieldToFilter('tree_level', 1)
             ->setOrder('role_id', 'ASC')
             ->getFirstItem();
@@ -63,7 +64,7 @@ class AdminUserCreate extends BaseMahoCommand
         $email = $questionHelper->ask($input, $output, $question);
         $email = trim($email);
         if (!strlen($email)) {
-            $output->writeln('<error>Username cannot be empty</error>');
+            $output->writeln('<error>Email cannot be empty</error>');
             return Command::INVALID;
         }
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `"Administrators"` role name lookup with a structural query (`tree_level=1`, ordered by `role_id ASC`) so the command works regardless of the role display name
- Fixes databases migrated from Magento 1 / OpenMage where the role is named `"Administrator"` (singular)

Fixes #586

## Test plan

- [ ] Run `./maho admin:user:create` on a fresh install (role named "Administrators")
- [ ] Run `./maho admin:user:create` on a migrated database (role named "Administrator")