### PR TITLE
Skip confirmation prompt when install --force is used

### DIFF
--- a/lib/MahoCLI/Commands/Install.php
+++ b/lib/MahoCLI/Commands/Install.php
@@ -340,21 +340,6 @@ class Install extends BaseMahoCommand
     {
         $output->writeln('<comment>Force installation requested - clearing existing installation...</comment>');
 
-        // Check if we're not in interactive mode or user has confirmed
-        if ($input->isInteractive()) {
-            /** @var \Symfony\Component\Console\Helper\QuestionHelper $helper */
-            $helper = $this->getHelper('question');
-            $question = new \Symfony\Component\Console\Question\ConfirmationQuestion(
-                "\n<question>WARNING: This will clear all tables in the database and remove configuration. Continue? [y/N]</question> ",
-                false,
-            );
-
-            if (!$helper->ask($input, $output, $question)) {
-                $output->writeln('<comment>Operation cancelled.</comment>');
-                return false;
-            }
-        }
-
         // Remove local.xml if it exists (use hardcoded path since Mage isn't initialized yet)
         $localXmlPath = getcwd() . '/app/etc/local.xml';
         if (file_exists($localXmlPath)) {


### PR DESCRIPTION
## Summary
- Removes the interactive confirmation prompt from `handleForceInstall()` in the install command
- The `--force` flag already signals explicit user intent for a destructive operation, making the confirmation redundant
- Fixes unattended/scripted installs (e.g., `docker exec` without `-i`) that would hang waiting for input

Fixes #598

## Test plan
- [ ] Run `./maho install --force` and verify it proceeds without prompting for confirmation
- [ ] Run `./maho install` (without `--force`) and verify normal behavior is unchanged
- [ ] Verify `vendor/bin/php-cs-fixer fix` and `vendor/bin/phpstan analyze` pass