### PR TITLE
Fixed SOAP API broken in Composer installs

### DIFF
--- a/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
@@ -126,10 +126,10 @@ class Mage_Api_Model_Server_Adapter_Soap extends \Maho\DataObject implements Mag
 
         if ($this->getController()->getRequest()->getParam('wsdl') !== null) {
             // Generating wsdl content from template
+            $wsdlFile = Maho::findFile(Mage::getModuleDir('etc', 'Mage_Api') . DS . 'wsdl.xml');
             $io = new \Maho\Io\File();
-            $io->open(['path' => Mage::getModuleDir('etc', 'Mage_Api')]);
-
-            $wsdlContent = $io->read('wsdl.xml');
+            $io->open(['path' => dirname($wsdlFile)]);
+            $wsdlContent = $io->read($wsdlFile);
 
             $template = Mage::getModel('core/email_template_filter');
 


### PR DESCRIPTION
## Summary
- SOAP API fails in Composer-based installs because `Mage::getModuleDir('etc', 'Mage_Api')` resolves to `{project_root}/app/code/core/Mage/Api/etc/` which does not exist when code lives under `vendor/`
- Switched to `Maho::findFile()` to locate `wsdl.xml` across all installed Composer packages, consistent with the email template fix in 1b38175183
- Passes `dirname($wsdlFile)` to `Io\File::open()` and the full absolute path to `read()`

Fixes #603

## Test plan
- [x] PHPStan passes clean
- [x] Backend test suite passes (1756 tests)
- [ ] Verify SOAP API `?wsdl` endpoint returns valid WSDL in a Composer-based install