### PR TITLE
Block sensitive file extensions in early 404 guard

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -25,6 +25,10 @@ if ($requestPath !== '/') {
         'mp3', 'mp4', 'ogg', 'webm', 'wav', 'flac', 'aac', 'm4a', 'm4v', 'ogv', 'mov',
         'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx',
         'zip', 'gz', 'tar', 'rar', '7z',
+        'sql', 'sqlite', 'db', 'mdb', 'log', 'bak', 'backup', 'old', 'orig', 'swp', 'swo',
+        'phtml', 'phar', 'sh', 'bash', 'py', 'pl', 'rb', 'cgi',
+        'key', 'pem', 'crt', 'cer', 'p12', 'pfx',
+        'yaml', 'yml', 'toml', 'ini', 'conf', 'env', 'htaccess', 'htpasswd',
     ];
     if (in_array($ext, $staticExts, true)) {
         http_response_code(404);


### PR DESCRIPTION
## Summary
- Extends the static asset early-exit list in `public/index.php` with extensions commonly probed by scanners
- Added: database dumps (`sql`, `sqlite`, `db`, `mdb`), backup/editor artifacts (`log`, `bak`, `backup`, `old`, `orig`, `swp`, `swo`), PHP/script files (`phtml`, `phar`, `sh`, `bash`, `py`, `pl`, `rb`, `cgi`), certificates/keys (`key`, `pem`, `crt`, `cer`, `p12`, `pfx`), and config files (`yaml`, `yml`, `toml`, `ini`, `conf`, `env`, `htaccess`, `htpasswd`)
- Defense-in-depth hardening on top of #583

Ref: https://github.com/MahoCommerce/maho/commit/100705ec1ebea8f7394f7da04e2c8b1eef2d94cc#commitcomment-178435877

## Test plan
- [ ] Verify requests to files with new extensions (e.g. `/test.sql`, `/backup.bak`, `/.env`) return 404 without bootstrapping Maho
- [ ] Verify normal routes (homepage, catalog, API endpoints) still work