### PR TITLE
Added support for subdirectories in `lib/MahoCLI/Commands`

### DIFF
--- a/lib/MahoCLI/CommandDiscoverer.php
+++ b/lib/MahoCLI/CommandDiscoverer.php
@@ -21,24 +21,42 @@ class CommandDiscoverer
 
     public function discover(string $baseDir, string $namespace = 'MahoCLI\\Commands\\'): array
     {
-        $this->baseDir = $baseDir;
         $this->namespace = $namespace;
 
         $commands = [];
-        $files = glob("{$this->baseDir}/lib/MahoCLI/Commands/*.php");
+        $baseDirs = glob($baseDir) ?: [$baseDir];
 
-        foreach ($files as $file) {
-            if (str_contains($file, 'vendor/mahocommerce/maho')) {
+        foreach ($baseDirs as $dir) {
+            $this->baseDir = $dir;
+            $commandsDir = "{$dir}/lib/MahoCLI/Commands";
+
+            if (!is_dir($commandsDir)) {
                 continue;
             }
 
-            if (str_ends_with($file, 'BaseMahoCommand.php')) {
-                continue;
-            }
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($commandsDir, \FilesystemIterator::SKIP_DOTS),
+            );
 
-            $className = $this->getFullyQualifiedClassName($file);
-            if (is_subclass_of($className, Command::class)) {
-                $commands[] = new $className();
+            foreach ($iterator as $file) {
+                if (!$file->isFile() || $file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $path = $file->getPathname();
+
+                if (str_contains($path, 'vendor/mahocommerce/maho')) {
+                    continue;
+                }
+
+                if (str_ends_with($path, 'BaseMahoCommand.php')) {
+                    continue;
+                }
+
+                $className = $this->getFullyQualifiedClassName($path);
+                if (is_subclass_of($className, Command::class)) {
+                    $commands[] = new $className();
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Replaces the flat `*.php` glob in `CommandDiscoverer::discover()` with `RecursiveDirectoryIterator`, allowing CLI commands to be organized into subdirectories under `lib/MahoCLI/Commands/`
- Resolves the `vendor/*/*` base directory glob pattern first via `glob()` before recursing, preserving vendor package command discovery
- No changes needed to `getFullyQualifiedClassName()` — it already handles subdirectory paths correctly

Closes #606

## Test plan

- [ ] `./maho list` shows all existing commands unchanged
- [ ] A command placed in a subdirectory (e.g. `lib/MahoCLI/Commands/Sub/MyCommand.php` with namespace `MahoCLI\Commands\Sub`) is discovered and executable
- [ ] Vendor package commands are still discovered via the `vendor/*/*` pattern