### PR TITLE
Fixed TipTap WYSIWYG editor leaking HTML comment text as visible content

### DIFF
--- a/public/js/mage/adminhtml/tools.js
+++ b/public/js/mage/adminhtml/tools.js
@@ -616,6 +616,6 @@ function debounce(func, delay) {
 function xssFilter(str) {
     const sanitize = xssKillah();
     const safeNodes = sanitize(str);
-    // Filter out comment nodes (nodeType 8) to prevent their text from leaking as visible content
+    // Filter out comment nodes to prevent their text from leaking as visible content
     return Array.from(safeNodes).filter(n => n.nodeType !== Node.COMMENT_NODE).map(n => n.outerHTML || n.textContent).join('');
 }


### PR DESCRIPTION
## Summary
- HTML comments (`<!-- ... -->`) were leaking their inner text as visible content in the TipTap editor
- Root cause: `xssFilter()` serializes nodes via `n.outerHTML || n.textContent` — comment nodes have no `outerHTML`, so the `textContent` fallback outputs their inner text as plain visible content
- Fix: filter out comment nodes (`nodeType === 8`) during serialization

## Test plan
- [ ] Edit a CMS page containing `<!-- wp:paragraph --><p>Content</p><!-- /wp:paragraph -->`
- [ ] Toggle TipTap on — `wp:paragraph` text should NOT appear as visible content
- [ ] Only `<p>Content</p>` should be visible in the editor

Fixes #610