### PR TITLE
Fixed currency dropdowns broken for regional locales

### DIFF
--- a/app/code/core/Mage/Core/Model/Locale.php
+++ b/app/code/core/Mage/Core/Model/Locale.php
@@ -382,33 +382,27 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
         $locale = $this->getLocaleCode();
         $currencies = [];
 
-        // Get all available currencies from ICU data using ResourceBundle
-        $bundle = ResourceBundle::create($locale, 'ICUDATA-curr');
-        if ($bundle !== null) {
+        // For regional locales (e.g. en_GB), the ICU bundle only contains
+        // locale-specific currency name overrides, not the full list.
+        // Load from the root language bundle first, then merge overrides.
+        $primaryLanguage = \Locale::getPrimaryLanguage($locale);
+        $bundlesToLoad = ($primaryLanguage !== $locale)
+            ? [$primaryLanguage, $locale]
+            : [$locale];
+
+        foreach ($bundlesToLoad as $bundleLocale) {
+            $bundle = ResourceBundle::create($bundleLocale, 'ICUDATA-curr');
+            if ($bundle === null) {
+                continue;
+            }
             $currencyData = $bundle->get('Currencies');
-
-            if ($currencyData !== null) {
-                // Get list of all currency codes
-                $allCodes = [];
-                foreach ($currencyData as $code => $data) {
-                    if (strlen($code) === 3 && ctype_alpha($code)) {
-                        $allCodes[] = $code;
-                    }
-                }
-
-                // Now get the data for each code
-                foreach ($allCodes as $code) {
-                    $currInfo = $currencyData->get($code);
-                    if ($currInfo !== null) {
-                        // Get the display name (at index 1)
-                        $displayName = $currInfo->get(1);
-                        if ($displayName !== null) {
-                            $currencies[$code] = $displayName;
-                        } else {
-                            // Fallback to code
-                            $currencies[$code] = $code;
-                        }
-                    }
+            if ($currencyData === null) {
+                continue;
+            }
+            foreach ($currencyData as $code => $data) {
+                if (strlen($code) === 3 && ctype_alpha($code)) {
+                    $displayName = $data->get(1);
+                    $currencies[$code] = $displayName ?? $code;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes #609

- When using a regional locale like `en_GB`, the ICU ResourceBundle only contains locale-specific currency name overrides (~11 entries), not the full list (~307 currencies)
- Now loads currencies from the root language bundle (e.g. `en`) first, then merges the regional locale overrides on top, so customized display names still take precedence
- Also simplified the inner loop by removing the unnecessary two-pass approach

## Test plan

- [x] PHPStan passes with no errors
- [x] PHP-CS-Fixer reports no style issues
- [x] All 1756 backend tests pass