### PR TITLE
Fixed bulk attribute update form never submitting

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/attribute.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/attribute.phtml
@@ -24,8 +24,7 @@
 </form>
 <script type="text/javascript">
 var attributesForm = new varienForm('attributes_edit_form', '<?= $this->getValidationUrl() ?>');
-attributesForm._processValidationResult = function(transport) {
-    var response = JSON.parse(transport.responseText);
+attributesForm._processValidationResult = function(response) {
 
     if (response.error){
         if (response.attribute && document.getElementById(response.attribute)) {


### PR DESCRIPTION
## Summary
- The `_processValidationResult` callback in `attribute.phtml` still expected a Prototype-style `transport` object with `.responseText`, but `varienForm._validate()` now uses `mahoFetch` which passes already-parsed JSON directly
- Updated the function signature to accept the parsed response directly, matching the pattern already used in `product/edit.phtml`

Fixes #615

## Test plan
- [ ] Admin → Catalog → Manage Products → select products → Update Attributes → Websites tab → check a website → Save → should submit successfully