### PR TITLE
Replaced broad `data-*` skip in JS defer with explicit `data-maho-nodefer` attribute

### DIFF
--- a/app/code/core/Mage/Core/Controller/Response/Http.php
+++ b/app/code/core/Mage/Core/Controller/Response/Http.php
@@ -886,10 +886,10 @@ class Mage_Core_Controller_Response_Http
             function ($matches) use (&$scriptIndex, $mode, &$scripts) {
                 // For load on intent mode, transform scripts
                 if ($mode == Mage_Core_Model_Source_Js_Defer::MODE_LOAD_ON_INTENT) {
-                    // Skip if contains our loader, already has data attributes, or is a speculation rules script
+                    // Skip if contains our loader, is a speculation rules script, or has data-maho-nodefer
                     $shouldSkip = str_contains($matches[0], 'mahoLazyJs') ||
                                   str_contains($matches[0], 'type="speculationrules"') ||
-                                  preg_match('/\sdata-(?!maho-script)\w+=/i', $matches[0]);
+                                  preg_match('/\sdata-maho-nodefer[\s>=]/i', $matches[0]);
 
                     if ($shouldSkip) {
                         $scripts[] = $matches[0];


### PR DESCRIPTION
## Summary

- The previous regex in deferJavaScriptLoading() matched any data-* attribute to skip deferral, which was too broad and did not work for boolean attributes (e.g. data-immediate without =)
- Replaced with an explicit data-maho-nodefer attribute that works both as a boolean attribute and with a value

## Usage

```html
<script data-maho-nodefer>
  // This script will not be deferred by load-on-intent
</script>
```

## Test plan

- [ ] Verify scripts with data-maho-nodefer are not deferred and run immediately
- [ ] Verify scripts without the attribute are still deferred normally
- [ ] Verify data-maho-script (internal attribute) still works correctly for the load-on-intent loader