### PR TITLE
Skip JS preload hints when `load-on-intent` mode is active

### DIFF
--- a/app/code/core/Mage/Core/Helper/Minify.php
+++ b/app/code/core/Mage/Core/Helper/Minify.php
@@ -309,11 +309,10 @@ class Mage_Core_Helper_Minify extends Mage_Core_Helper_Abstract
 
         // Don't send preload hints for JS when load-on-intent is active,
         // as it would defeat the purpose of deferring script downloads
-        if ($as === 'script') {
-            $deferMode = (int) Mage::getStoreConfig('dev/js/defer_mode');
-            if ($deferMode === Mage_Core_Model_Source_Js_Defer::MODE_LOAD_ON_INTENT) {
-                return;
-            }
+        if ($as === 'script'
+            && (int) Mage::getStoreConfig('dev/js/defer_mode') === Mage_Core_Model_Source_Js_Defer::MODE_LOAD_ON_INTENT
+        ) {
+            return;
         }
 
         // Send Link header for preload


### PR DESCRIPTION
## Summary

- The minification helper (`sendEarlyHint`) sends `Link: rel=preload; as=script` HTTP headers for every JS file during head rendering
- These preload headers instruct the browser to download all scripts immediately, completely bypassing the `type="text/plain"` load-on-intent deferral mechanism
- This fix skips sending preload hints for JS files when load-on-intent defer mode is active, preserving the intended behavior of deferring both download and execution until user interaction

## Test plan

- [ ] Enable JS minification and load-on-intent defer mode
- [ ] Load a frontend page and check browser Network tab
- [ ] Verify JS files are NOT downloaded until user interaction (click, scroll, etc.)
- [ ] Verify CSS preload hints still work normally
- [ ] Verify JS preload hints still work when defer mode is disabled or set to defer-only