### PR TITLE
Pass Mage_Core_Model_Store_Exception to error reporting

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -43,18 +43,6 @@ parameters:
 			path: app/Mage.php
 
 		-
-			rawMessage: 'Method Mage::printException() has no return type specified.'
-			identifier: missingType.return
-			count: 1
-			path: app/Mage.php
-
-		-
-			rawMessage: 'Method Mage::printException() has parameter $extra with no type specified.'
-			identifier: missingType.parameter
-			count: 1
-			path: app/Mage.php
-
-		-
 			rawMessage: 'Method Mage::register() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -10431,7 +10419,7 @@ parameters:
 		-
 			rawMessage: Variable $query might not be defined.
 			identifier: variable.undefined
-			count: 2
+			count: 1
 			path: app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable/Product/Collection.php
 
 		-

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -623,11 +623,9 @@ final class Mage
             header('Location: ' . self::getBaseUrl());
             die;
         } catch (Mage_Core_Model_Store_Exception $e) {
-            Maho::errorReport([], 404);
-            die;
+            self::printException($e, '', 404);
         } catch (Exception $e) {
             self::printException($e);
-            die;
         }
     }
 
@@ -663,13 +661,11 @@ final class Mage
             header('Location: ' . self::getBaseUrl());
             die();
         } catch (Mage_Core_Model_Store_Exception $e) {
-            Maho::errorReport([], 404);
-            die();
+            self::printException($e, '', 404);
         } catch (Exception $e) {
             if (self::isInstalled()) {
                 self::dispatchEvent('mage_run_installed_exception', ['exception' => $e]);
                 self::printException($e);
-                exit();
             }
             try {
                 self::dispatchEvent('mage_run_exception', ['exception' => $e]);
@@ -821,7 +817,7 @@ final class Mage
     /**
      * Display exception
      */
-    public static function printException(Throwable $e, $extra = '')
+    public static function printException(Throwable $e, string $extra = '', int $httpResponseCode = 503): never
     {
         if (self::$_isDeveloperMode) {
             print '<pre>';
@@ -847,7 +843,7 @@ final class Mage
                 $reportData['script_name'] = $_SERVER['SCRIPT_NAME'];
             }
 
-            Maho::errorReport($reportData);
+            Maho::errorReport($reportData, $httpResponseCode);
         }
 
         die();

--- a/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable/Product/Collection.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Model/Resource/Catalog/Product/Type/Configurable/Product/Collection.php
@@ -45,8 +45,6 @@ class Mage_ConfigurableSwatches_Model_Resource_Catalog_Product_Type_Configurable
             $rows = $this->_fetchAll($query);
         } catch (Exception $e) {
             Mage::printException($e, $query);
-            $this->printLogQuery(true, true, $query);
-            throw $e;
         }
 
         foreach ($rows as $v) {

--- a/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php
@@ -1013,8 +1013,6 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends \Maho\Data\Coll
             $rows = $this->_fetchAll($query);
         } catch (Exception $e) {
             Mage::printException($e, $query);
-            $this->printLogQuery(true, true, $query);
-            throw $e;
         }
 
         foreach ($rows as $v) {
@@ -1088,8 +1086,6 @@ abstract class Mage_Eav_Model_Entity_Collection_Abstract extends \Maho\Data\Coll
                     $values = $this->getConnection()->fetchAll($select);
                 } catch (Exception $e) {
                     Mage::printException($e, $select);
-                    $this->printLogQuery(true, true, $select);
-                    throw $e;
                 }
 
                 foreach ($values as $value) {

--- a/app/code/core/Mage/Install/Model/Observer.php
+++ b/app/code/core/Mage/Install/Model/Observer.php
@@ -26,6 +26,6 @@ class Mage_Install_Model_Observer
     {
         echo '<h2>There was a problem proceeding with Maho installation.</h2>';
         echo '<p>Please contact developers with error messages on this page.</p>';
-        echo Mage::printException($observer->getEvent()->getException());
+        Mage::printException($observer->getEvent()->getException());
     }
 }


### PR DESCRIPTION
## Summary
- Both `Mage_Core_Model_Store_Exception` catch blocks in `Mage::init()` and `Mage::run()` were calling `Maho::errorReport([], 404)`, silently swallowing the exception — no error was logged and the report page showed no report ID
- Now delegates to `Mage::printException()` with a 404 HTTP response code, so the exception message, stack trace, and request context are properly saved to `var/report/`
- Fully typed `printException()` signature (`string $extra`, `int $httpResponseCode`, `: never`) and removed 2 resolved phpstan baseline entries

Fixes #625

## Test plan
- Set an invalid store code via `MAGE_RUN_CODE=invalid` and `MAGE_RUN_TYPE=store`
- Verify a 404 is returned with an error report number
- Verify the report file exists in `var/report/` with the exception details
- In developer mode, verify the exception is printed to screen