### PR TITLE
Fixed product list widget markup and styles inside CMS pages

### DIFF
--- a/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_grid.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_grid.phtml
@@ -24,16 +24,41 @@
         <ul class="products-grid products-grid--max-<?= $_columnCount ?>-col-widget">
             <?php foreach ($_products->getItems() as $_product): ?>
                 <li class="item">
-                    <?php $_imgSize = 210; ?>
-                    <?php // The image size is locked at 210 for this for display purposes. CSS has it at 75% which should equate to 278px?>
-                    <a href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>" class="product-image">
-                        <img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize(210) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize(420) ?> 2x" alt="<?= $this->stripTags($_product->getName(), null, true) ?>" />
-                    </a>
+                    <div>
+                        <?php $_imgSize = 210; ?>
+                        <a href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>" class="product-image">
+                            <img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x" alt="<?= $this->stripTags($_product->getName(), null, true) ?>" />
+                        </a>
+                        <ul>
+                            <?php if ($this->helper('wishlist')->isAllow()) : ?>
+                                <?php $_wishlistUrl = $this->getAddToWishlistUrlCustom($_product, false); ?>
+                                <li>
+                                    <a href="#" data-url="<?= $_wishlistUrl ?>" data-params="<?= $_params ?>"
+                                       class="link-wishlist" title="<?= $this->__('Add to Wishlist') ?>"
+                                       onclick="customFormSubmit('<?= $_wishlistUrl ?>', '<?= $_params ?>', 'post')">
+                                        <?= $this->getIconSvg('heart') ?>
+                                        <?= $this->__('Add to Wishlist') ?>
+                                    </a>
+                                </li>
+                            <?php endif ?>
+                            <?php if ($_compareUrl = $this->getAddToCompareUrlCustom($_product, false)) : ?>
+                                <li>
+                                    <a href="#" title="<?= $this->__('Add to Compare') ?>"
+                                       onclick="customFormSubmit('<?= $_compareUrl ?>', '<?= $_params ?>', 'post')">
+                                        <?= $this->getIconSvg('scale') ?>
+                                        <?= $this->__('Add to Compare') ?>
+                                    </a>
+                                </li>
+                            <?php endif ?>
+                        </ul>
+                    </div>
                     <div class="product-info">
                         <h3 class="product-name"><a href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>"><?= $this->helper('catalog/output')->productAttribute($_product, $_product->getName() , 'name') ?></a></h3>
                         <?= $this->getPriceHtml($_product, true, '-widget-new-grid') ?>
                         <?= $this->getReviewsSummaryHtml($_product, 'short') ?>
-                        <div class="actions">
+                    </div>
+                    <div class="actions">
+                        <?php if(Mage::getStoreConfigFlag('catalog/frontend/enable_addtocart_in_product_listings')): ?>
                             <?php if ($_product->isSaleable()): ?>
                                 <button type="button"
                                         title="<?= $this->quoteEscape($this->__('Add to Cart')) ?>"
@@ -44,32 +69,12 @@
                                                 'post')">
                                     <?= $this->__('Add to Cart') ?>
                                 </button>
+                            <?php elseif($_product->getStockItem() && $_product->getStockItem()->getIsInStock()): ?>
+                                <a title="<?= $this->quoteEscape($this->__('View Details')) ?>" class="button" href="<?= $_product->getProductUrl() ?>"><?= $this->__('View Details') ?></a>
                             <?php else: ?>
                                 <p class="availability out-of-stock"><span><?= $this->__('Out of stock') ?></span></p>
                             <?php endif ?>
-                            <ul class="add-to-links">
-                                <?php if ($this->helper('wishlist')->isAllow()) : ?>
-                                    <?php $_wishlistUrl = $this->getAddToWishlistUrlCustom($_product, false); ?>
-                                    <li>
-                                        <a href="#" data-url="<?= $_wishlistUrl ?>" data-params="<?= $_params ?>"
-                                           class="link-wishlist" title="<?= $this->__('Add to Wishlist') ?>"
-                                           onclick="customFormSubmit('<?= $_wishlistUrl ?>', '<?= $_params ?>', 'post')">
-                                            <?= $this->getIconSvg('heart') ?>
-                                            <?= $this->__('Add to Wishlist') ?>
-                                        </a>
-                                    </li>
-                                <?php endif ?>
-                                <?php if ($_compareUrl = $this->getAddToCompareUrlCustom($_product, false)) : ?>
-                                    <li>
-                                        <a href="#" title="<?= $this->__('Add to Compare') ?>"
-                                           onclick="customFormSubmit('<?= $_compareUrl ?>', '<?= $_params ?>', 'post')">
-                                            <?= $this->getIconSvg('scale') ?>
-                                            <?= $this->__('Add to Compare') ?>
-                                        </a>
-                                    </li>
-                                <?php endif ?>
-                            </ul>
-                        </div>
+                        <?php endif ?>
                     </div>
                 </li>
             <?php endforeach ?>

--- a/public/skin/frontend/base/default/css/styles.css
+++ b/public/skin/frontend/base/default/css/styles.css
@@ -3467,6 +3467,8 @@ p.product-name a:hover {
   gap: 0.2rem;
   background-color: var(--maho-color-background);
   padding: 0.1rem;
+  list-style: none;
+  margin: 0;
 }
 .products-grid > li > div:first-child ul a {
   font-size: 0;


### PR DESCRIPTION
Fixes #633

## Summary
- Updated new products widget grid template (`new_grid.phtml`) to match the current `catalog/product/list.phtml` structure: wishlist/compare links now render inside the image wrapper area instead of the actions div
- Add-to-cart button now respects the `catalog/frontend/enable_addtocart_in_product_listings` store config setting, with proper "View Details" fallback for configurable products
- Added `list-style: none` to `.products-grid` image overlay `<ul>` in `styles.css` to prevent bullet points when widgets are rendered inside `.std` containers on CMS pages

## Test plan
- [ ] Insert a "Catalog New Products List" widget into a CMS page
- [ ] Verify no bullet points appear on the product grid
- [ ] Verify wishlist/compare icons display in the image area (top-right corner)
- [ ] Toggle "Show Add to Cart button in product listings" in config and verify the widget respects it
- [ ] Verify regular `<ul>`/`<ol>` lists in CMS content still show bullets correctly