### PR TITLE
Removed unwanted italic style from CMS page paragraphs

### DIFF
--- a/public/skin/frontend/base/default/css/styles.css
+++ b/public/skin/frontend/base/default/css/styles.css
@@ -7206,7 +7206,6 @@ div.paypal-logo span > img {
 .cms-no-route .std p {
   color: var(--maho-color-text-primary);
   font-size: 0.875rem;
-  font-style: italic;
   line-height: 24px;
 }
 .cms-page-view .std h1,


### PR DESCRIPTION
## Summary
- Removed `font-style: italic` from `.cms-page-view .std p` and `.cms-no-route .std p` CSS rules
- Paragraph text in CMS pages was incorrectly styled as italic by default

## Test plan
- [ ] Visit any CMS page and verify paragraph text renders in normal (non-italic) style
- [ ] Check the 404 (no-route) page paragraphs also render correctly