### PR TITLE
Updated TipTap to 3.20.1

### DIFF
--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
@@ -6,13 +6,13 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-import { Editor, Node, Mark, Extension, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.20.0';
-import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.20.0';
-import Image from 'https://esm.sh/@tiptap/extension-image@3.20.0';
-import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.20.0';
-import { Table, TableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.20.0';
-import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.20.0';
-import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.20.0';
+import { Editor, Node, Mark, Extension, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.20.1';
+import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.20.1';
+import Image from 'https://esm.sh/@tiptap/extension-image@3.20.1';
+import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.20.1';
+import { Table, TableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.20.1';
+import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.20.1';
+import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.20.1';
 import { MahoColumns, MahoColumn, COLUMN_PRESETS } from './extensions/columns.js';
 import { MahoBentoGrid, MahoBentoCell, BENTO_PRESETS } from './extensions/bento.js';
 

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/bento.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/bento.js
@@ -6,7 +6,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.20.0';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.20.1';
 import { findParentNodeOfType, createGridNodeView } from './grid-utils.js';
 
 /**

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
@@ -6,7 +6,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.20.0';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.20.1';
 import { findParentNodeOfType, createGridNodeView } from './grid-utils.js';
 
 /**


### PR DESCRIPTION
## Summary
- Bumped all TipTap packages from 3.20.0 to 3.20.1 across `extensions.js`, `extensions/bento.js`, and `extensions/columns.js`
- Patch release with bug fixes for code blocks, drag handles, and inline style parsing

## Test plan
- [ ] Open a CMS page or block editor in admin
- [ ] Verify the TipTap WYSIWYG loads correctly
- [ ] Test basic editing (text, images, tables)
- [ ] Test drag handle functionality
- [ ] Test code block editing