### PR TITLE
Fixed encryption key regeneration failing on missing column

### DIFF
--- a/app/code/core/Mage/Checkout/Model/Observer.php
+++ b/app/code/core/Mage/Checkout/Model/Observer.php
@@ -48,7 +48,7 @@ class Mage_Checkout_Model_Observer
         $decryptCallback = $observer->getEvent()->getDecryptCallback();
 
         $output->write('Re-encrypting data on sales_flat_quote table... ');
-        Mage::helper('core')->recryptTable(
+        $result = Mage::helper('core')->recryptTable(
             Mage::getSingleton('core/resource')->getTableName('sales_flat_quote'),
             'entity_id',
             ['password_hash'],
@@ -56,6 +56,6 @@ class Mage_Checkout_Model_Observer
             $decryptCallback,
             output: $output,
         );
-        $output->writeln('OK');
+        $output->writeln($result ? 'OK' : '<comment>SKIPPED</comment>');
     }
 }

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -1195,7 +1195,7 @@ XML;
         callable $decryptCallback,
         int $batchSize = 1000,
         ?\Symfony\Component\Console\Output\OutputInterface $output = null,
-    ): void {
+    ): bool {
         $readConnection = Mage::getSingleton('core/resource')->getConnection('core_read');
         $writeConnection = Mage::getSingleton('core/resource')->getConnection('core_write');
         $lastId = 0;
@@ -1208,7 +1208,7 @@ XML;
         }
         $columns = array_values(array_intersect($columns, $tableColumns));
         if (empty($columns)) {
-            return;
+            return false;
         }
 
         $quotedPk = $readConnection->quoteIdentifier($primaryKey);
@@ -1254,5 +1254,7 @@ XML;
 
             unset($rows);
         }
+
+        return true;
     }
 }

--- a/app/code/core/Mage/Payment/Model/Observer.php
+++ b/app/code/core/Mage/Payment/Model/Observer.php
@@ -167,7 +167,7 @@ class Mage_Payment_Model_Observer
         $decryptCallback = $observer->getEvent()->getDecryptCallback();
 
         $output->write('Re-encrypting data on sales_flat_quote_payment table... ');
-        Mage::helper('core')->recryptTable(
+        $result = Mage::helper('core')->recryptTable(
             Mage::getSingleton('core/resource')->getTableName('sales_flat_quote_payment'),
             'payment_id',
             ['cc_number_enc', 'cc_cid_enc'],
@@ -175,10 +175,10 @@ class Mage_Payment_Model_Observer
             $decryptCallback,
             output: $output,
         );
-        $output->writeln('OK');
+        $output->writeln($result ? 'OK' : '<comment>SKIPPED</comment>');
 
         $output->write('Re-encrypting data on sales_flat_order_payment table... ');
-        Mage::helper('core')->recryptTable(
+        $result = Mage::helper('core')->recryptTable(
             Mage::getSingleton('core/resource')->getTableName('sales_flat_order_payment'),
             'entity_id',
             ['cc_number_enc'],
@@ -186,6 +186,6 @@ class Mage_Payment_Model_Observer
             $decryptCallback,
             output: $output,
         );
-        $output->writeln('OK');
+        $output->writeln($result ? 'OK' : '<comment>SKIPPED</comment>');
     }
 }

--- a/app/code/core/Maho/AdminActivityLog/Model/Observer.php
+++ b/app/code/core/Maho/AdminActivityLog/Model/Observer.php
@@ -464,7 +464,7 @@ class Maho_AdminActivityLog_Model_Observer
         $decryptCallback = $observer->getEvent()->getDecryptCallback();
 
         $output->write('Re-encrypting data on adminactivitylog_activity table... ');
-        Mage::helper('core')->recryptTable(
+        $result = Mage::helper('core')->recryptTable(
             Mage::getSingleton('core/resource')->getTableName('adminactivitylog/activity'),
             'activity_id',
             ['old_data', 'new_data'],
@@ -472,7 +472,7 @@ class Maho_AdminActivityLog_Model_Observer
             $decryptCallback,
             output: $output,
         );
-        $output->writeln('OK');
+        $output->writeln($result ? 'OK' : '<comment>SKIPPED</comment>');
     }
 
 }

--- a/app/code/core/Maho/FeedManager/Model/Observer.php
+++ b/app/code/core/Maho/FeedManager/Model/Observer.php
@@ -23,7 +23,7 @@ class Maho_FeedManager_Model_Observer
         $decryptCallback = $observer->getEvent()->getDecryptCallback();
 
         $output->write('Re-encrypting data on feedmanager_destination table... ');
-        Mage::helper('core')->recryptTable(
+        $result = Mage::helper('core')->recryptTable(
             Mage::getSingleton('core/resource')->getTableName('feedmanager/destination'),
             'destination_id',
             ['config'],
@@ -31,6 +31,6 @@ class Maho_FeedManager_Model_Observer
             $decryptCallback,
             output: $output,
         );
-        $output->writeln('OK');
+        $output->writeln($result ? 'OK' : '<comment>SKIPPED</comment>');
     }
 }

--- a/lib/MahoCLI/Commands/SysEncryptionKeyRegenerate.php
+++ b/lib/MahoCLI/Commands/SysEncryptionKeyRegenerate.php
@@ -154,7 +154,7 @@ class SysEncryptionKeyRegenerate extends BaseMahoCommand
     protected function recryptAdminUserTable(OutputInterface $output): void
     {
         $output->write('Re-encrypting data on admin_user table... ');
-        Mage::helper('core')->recryptTable(
+        $result = Mage::helper('core')->recryptTable(
             Mage::getSingleton('core/resource')->getTableName('admin_user'),
             'user_id',
             ['twofa_secret'],
@@ -162,7 +162,7 @@ class SysEncryptionKeyRegenerate extends BaseMahoCommand
             [$this, 'decrypt'],
             output: $output,
         );
-        $output->writeln('OK');
+        $output->writeln($result ? 'OK' : '<comment>SKIPPED</comment>');
     }
 
     protected function recryptCoreConfigDataTable(OutputInterface $output, \Maho\Db\Adapter\AdapterInterface $readConnection, \Maho\Db\Adapter\AdapterInterface $writeConnection): void


### PR DESCRIPTION
## Summary

- `sys:encryptionkey:regenerate` crashed with "Unknown column 'sales_flat_order_payment.cc_cid_enc'" because the Payment observer included `cc_cid_enc` in the order payment re-encryption list, but that column never existed in `sales_flat_order_payment` (the CVV is only stored encrypted on the quote, not persisted to orders per PCI compliance)
- Removed `cc_cid_enc` from the order payment column list in `Mage_Payment_Model_Observer`
- Added defensive column existence check in `recryptTable()` — missing columns are now logged as warnings and skipped instead of causing a fatal error

## Test plan
- [ ] Run `./maho sys:encryptionkey:regenerate` on a database and verify it completes without errors
- [ ] Verify warning is logged when a non-existent column is passed to `recryptTable()`
- [ ] Verify encrypted config values and payment data are correctly re-encrypted