### PR TITLE
Fixed one-step checkout summary table overflow clipping

### DIFF
--- a/public/skin/frontend/base/default/css/onestep-checkout.css
+++ b/public/skin/frontend/base/default/css/onestep-checkout.css
@@ -114,6 +114,10 @@
     overflow: hidden;
 }
 
+#onestep-review {
+    overflow: visible;
+}
+
 .onestep-section-header {
     padding-block-start: 1rem;
 
@@ -503,6 +507,7 @@
         td {
             padding: 0.5rem;
             font-size: 0.875rem;
+            white-space: normal;
             border-block-end: none;
 
             &:last-child {


### PR DESCRIPTION
Closes #640

## Summary
- Set `overflow: visible` on `#onestep-review` to prevent the order summary table from being clipped by the parent `.onestep-section`'s `overflow: hidden`
- Added `white-space: normal` to `tfoot td` so long shipping method names (e.g. "United States Postal Service - USPS Ground Advantage") wrap naturally instead of forcing `nowrap`

## Test plan
- [ ] Add a product to cart and go to one-step checkout
- [ ] Select a shipping method with a long carrier + method name
- [ ] Verify the summary table displays fully without clipping (price columns, Grand Total, shipping label all visible)
- [ ] Verify other `.onestep-section` elements still behave correctly with `overflow: hidden`