### PR TITLE
Set default sort direction to DESC in base grid and add missing sort defaults

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Price.php
@@ -18,7 +18,6 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Alerts_Price extends Mage_Ad
 
         $this->setId('alertPrice');
         $this->setDefaultSort('add_date');
-        $this->setDefaultDir('desc');
         $this->setUseAjax(true);
         $this->setFilterVisibility(false);
         $this->setEmptyText(Mage::helper('catalog')->__('There are no customers for this alert'));

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Stock.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Stock.php
@@ -18,7 +18,6 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Alerts_Stock extends Mage_Ad
 
         $this->setId('alertStock');
         $this->setDefaultSort('add_date');
-        $this->setDefaultDir('desc');
         $this->setUseAjax(true);
         $this->setFilterVisibility(false);
         $this->setEmptyText(Mage::helper('catalog')->__('There are no customers for this alert.'));

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Grid.php
@@ -26,7 +26,6 @@ class Mage_Adminhtml_Block_Catalog_Product_Grid extends Mage_Adminhtml_Block_Wid
         parent::__construct();
         $this->setId('productGrid');
         $this->setDefaultSort('entity_id');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
         $this->setVarNameFilter('product_filter');

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid.php
@@ -17,7 +17,6 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_Newsletter_Grid extends Mage_Adminh
         parent::__construct();
         $this->setId('queueGrid');
         $this->setDefaultSort('start_at');
-        $this->setDefaultDir('desc');
 
         $this->setUseAjax(true);
 

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Orders.php
@@ -20,7 +20,6 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_Orders extends Mage_Adminhtml_Block
         parent::__construct();
         $this->setId('customer_orders_grid');
         $this->setDefaultSort('created_at');
-        $this->setDefaultDir('desc');
         $this->setUseAjax(true);
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Cart.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Cart.php
@@ -20,7 +20,6 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View_Cart extends Mage_Adminhtml_Bl
         parent::__construct();
         $this->setId('customer_view_cart_grid');
         $this->setDefaultSort('added_at');
-        $this->setDefaultDir('desc');
         $this->setSortable(false);
         $this->setPagerVisibility(false);
         $this->setFilterVisibility(false);

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Orders.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/View/Orders.php
@@ -20,7 +20,6 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_View_Orders extends Mage_Adminhtml_
         parent::__construct();
         $this->setId('customer_view_orders_grid');
         $this->setDefaultSort('created_at');
-        $this->setDefaultDir('desc');
         $this->setSortable(false);
         $this->setPagerVisibility(false);
         $this->setFilterVisibility(false);

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid.php
@@ -21,7 +21,6 @@ class Mage_Adminhtml_Block_Customer_Online_Grid extends Mage_Adminhtml_Block_Wid
         $this->setId('onlineGrid');
         $this->setSaveParametersInSession(true);
         $this->setDefaultSort('last_activity');
-        $this->setDefaultDir('DESC');
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Problem/Grid.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2022-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -16,6 +16,7 @@ class Mage_Adminhtml_Block_Newsletter_Problem_Grid extends Mage_Adminhtml_Block_
     {
         parent::__construct();
         $this->setId('problemGrid');
+        $this->setDefaultSort('problem_id');
         $this->setSaveParametersInSession(true);
         $this->setMessageBlockVisibility(true);
         $this->setUseAjax(true);

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Grid.php
@@ -17,7 +17,6 @@ class Mage_Adminhtml_Block_Newsletter_Queue_Grid extends Mage_Adminhtml_Block_Wi
         parent::__construct();
         $this->setId('queueGrid');
         $this->setDefaultSort('start_at');
-        $this->setDefaultDir('desc');
         $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Subscriber/Grid.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -23,7 +23,7 @@ class Mage_Adminhtml_Block_Newsletter_Subscriber_Grid extends Mage_Adminhtml_Blo
         $this->setId('subscriberGrid');
         $this->setUseAjax(true);
         $this->setDefaultSort('subscriber_id');
-        $this->setDefaultDir('desc');
+        $this->setSaveParametersInSession(true);
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Grid.php
@@ -17,7 +17,6 @@ class Mage_Adminhtml_Block_Newsletter_Template_Grid extends Mage_Adminhtml_Block
         parent::__construct();
         $this->setId('newsletterTemplateGrid');
         $this->setDefaultSort('template_code');
-        $this->setDefaultDir('desc');
         $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }

--- a/app/code/core/Mage/Adminhtml/Block/Notification/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Notification/Grid.php
@@ -21,7 +21,6 @@ class Mage_Adminhtml_Block_Notification_Grid extends Mage_Adminhtml_Block_Widget
         $this->setId('notificationGrid');
         $this->setIdFieldName('notification_id');
         $this->setDefaultSort('date_added');
-        $this->setDefaultDir('desc');
         $this->setFilterVisibility(false);
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Report/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Product/Grid.php
@@ -17,7 +17,6 @@ class Mage_Adminhtml_Block_Report_Product_Grid extends Mage_Adminhtml_Block_Widg
         parent::__construct();
         $this->setId('productsReportGrid');
         $this->setDefaultSort('entity_id');
-        $this->setDefaultDir('desc');
     }
 
     #[\Override]

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Customer/Grid.php
@@ -17,7 +17,6 @@ class Mage_Adminhtml_Block_Report_Review_Customer_Grid extends Mage_Adminhtml_Bl
         parent::__construct();
         $this->setId('customers_grid');
         $this->setDefaultSort('review_cnt');
-        $this->setDefaultDir('desc');
     }
 
     #[\Override]

--- a/app/code/core/Mage/Adminhtml/Block/Report/Review/Product/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Review/Product/Grid.php
@@ -17,7 +17,6 @@ class Mage_Adminhtml_Block_Report_Review_Product_Grid extends Mage_Adminhtml_Blo
         parent::__construct();
         $this->setId('gridProducts');
         $this->setDefaultSort('review_cnt');
-        $this->setDefaultDir('desc');
     }
 
     #[\Override]

--- a/app/code/core/Mage/Adminhtml/Block/Report/Search/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Search/Grid.php
@@ -20,7 +20,6 @@ class Mage_Adminhtml_Block_Report_Search_Grid extends Mage_Adminhtml_Block_Widge
         parent::__construct();
         $this->setId('searchReportGrid');
         $this->setDefaultSort('query_id');
-        $this->setDefaultDir('desc');
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Creditmemo/Grid.php
@@ -19,7 +19,6 @@ class Mage_Adminhtml_Block_Sales_Creditmemo_Grid extends Mage_Adminhtml_Block_Wi
         parent::__construct();
         $this->setId('sales_creditmemo_grid');
         $this->setDefaultSort('created_at');
-        $this->setDefaultDir('DESC');
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Invoice/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Invoice/Grid.php
@@ -20,7 +20,6 @@ class Mage_Adminhtml_Block_Sales_Invoice_Grid extends Mage_Adminhtml_Block_Widge
         $this->setId('sales_invoice_grid');
         $this->setUseAjax(true);
         $this->setDefaultSort('created_at');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
@@ -22,7 +22,6 @@ class Mage_Adminhtml_Block_Sales_Order_Grid extends Mage_Adminhtml_Block_Widget_
         $this->setId('sales_order_grid');
         $this->setUseAjax(true);
         $this->setDefaultSort('created_at');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
@@ -19,7 +19,6 @@ class Mage_Adminhtml_Block_Sales_Order_Status_Grid extends Mage_Adminhtml_Block_
         //$this->setFilterVisibility(false);
         $this->setPagerVisibility(false);
         $this->setDefaultSort('state');
-        $this->setDefaultDir('DESC');
     }
 
     #[\Override]

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Shipment/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Shipment/Grid.php
@@ -22,7 +22,6 @@ class Mage_Adminhtml_Block_Sales_Shipment_Grid extends Mage_Adminhtml_Block_Widg
         parent::__construct();
         $this->setId('sales_shipment_grid');
         $this->setDefaultSort('created_at');
-        $this->setDefaultDir('DESC');
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Transactions/Grid.php
@@ -28,7 +28,6 @@ class Mage_Adminhtml_Block_Sales_Transactions_Grid extends Mage_Adminhtml_Block_
         $this->setId('order_transactions');
         $this->setUseAjax(true);
         $this->setDefaultSort('created_at');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/History.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Tab/History.php
@@ -20,7 +20,6 @@ class Mage_Adminhtml_Block_System_Convert_Profile_Edit_Tab_History extends Mage_
         parent::__construct();
         $this->setId('history_grid');
         $this->setDefaultSort('performed_at');
-        $this->setDefaultDir('desc');
         $this->setUseAjax(true);
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Grid.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -19,6 +19,8 @@ class Mage_Adminhtml_Block_System_Design_Grid extends Mage_Adminhtml_Block_Widge
     {
         parent::__construct();
         $this->setId('designGrid');
+        $this->setDefaultSort('package');
+        $this->setDefaultDir('ASC');
         $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Grid.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2022-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -17,6 +17,8 @@ class Mage_Adminhtml_Block_System_Email_Template_Grid extends Mage_Adminhtml_Blo
     {
         $this->setEmptyText(Mage::helper('adminhtml')->__('No Templates Found'));
         $this->setId('systemEmailTemplateGrid');
+        $this->setDefaultSort('template_id');
+        $this->setDefaultDir('ASC');
         $this->setUseAjax(true);
         $this->setSaveParametersInSession(true);
     }

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Assigned/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Assigned/Grid.php
@@ -30,7 +30,6 @@ class Mage_Adminhtml_Block_Tag_Assigned_Grid extends Mage_Adminhtml_Block_Widget
         $this->_currentTagModel = Mage::registry('current_tag');
         $this->setId('tag_assigned_product_grid');
         $this->setDefaultSort('entity_id');
-        $this->setDefaultDir('DESC');
         $this->setUseAjax(true);
         if ($this->_getTagId()) {
             $this->setDefaultFilter(['in_products' => 1]);

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Grid/All.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Grid/All.php
@@ -27,7 +27,6 @@ class Mage_Adminhtml_Block_Tag_Grid_All extends Mage_Adminhtml_Block_Widget_Grid
         parent::__construct();
         $this->setId('tagsGrid');
         $this->setDefaultSort('tag_id');
-        $this->setDefaultDir('desc');
     }
 
     #[\Override]

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2018-2025 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2018-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -70,7 +70,7 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
     /**
      * @var string
      */
-    protected $_defaultDir      = 'desc';
+    protected $_defaultDir      = 'DESC';
 
     /**
      * @var array

--- a/app/code/core/Mage/Core/Block/Adminhtml/Email/Log/Grid.php
+++ b/app/code/core/Mage/Core/Block/Adminhtml/Email/Log/Grid.php
@@ -17,7 +17,6 @@ class Mage_Core_Block_Adminhtml_Email_Log_Grid extends Mage_Adminhtml_Block_Widg
         parent::__construct();
         $this->setId('emailLogGrid');
         $this->setDefaultSort('created_at');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }

--- a/app/code/core/Mage/Cron/Block/Adminhtml/System/Tools/Cronjobs/Grid.php
+++ b/app/code/core/Mage/Cron/Block/Adminhtml/System/Tools/Cronjobs/Grid.php
@@ -15,7 +15,6 @@ class Mage_Cron_Block_Adminhtml_System_Tools_Cronjobs_Grid extends Mage_Adminhtm
         parent::__construct();
         $this->setId('cronjobsGrid');
         $this->setDefaultSort('schedule_id');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
     }
 

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Index
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -36,6 +36,7 @@ class Mage_Index_Block_Adminhtml_Process_Grid extends Mage_Adminhtml_Block_Widge
         parent::__construct();
         $this->_processModel = Mage::getSingleton('index/process');
         $this->setId('indexer_processes_grid');
+        $this->setDefaultSort('ended_at');
         $this->_filterVisibility = false;
         $this->_pagerVisibility  = false;
     }

--- a/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/Grid.php
+++ b/app/code/core/Mage/Sales/Block/Adminhtml/Billing/Agreement/Grid.php
@@ -21,7 +21,6 @@ class Mage_Sales_Block_Adminhtml_Billing_Agreement_Grid extends Mage_Adminhtml_B
         $this->setId('billing_agreements');
         $this->setUseAjax(true);
         $this->setDefaultSort('agreement_id');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
     }
 

--- a/app/code/core/Maho/AdminActivityLog/Block/Adminhtml/Activity/Grid.php
+++ b/app/code/core/Maho/AdminActivityLog/Block/Adminhtml/Activity/Grid.php
@@ -16,7 +16,6 @@ class Maho_AdminActivityLog_Block_Adminhtml_Activity_Grid extends Mage_Adminhtml
         parent::__construct();
         $this->setId('adminActivityLogGrid');
         $this->setDefaultSort('created_at');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }

--- a/app/code/core/Maho/AdminActivityLog/Block/Adminhtml/Login/Grid.php
+++ b/app/code/core/Maho/AdminActivityLog/Block/Adminhtml/Login/Grid.php
@@ -16,7 +16,6 @@ class Maho_AdminActivityLog_Block_Adminhtml_Login_Grid extends Mage_Adminhtml_Bl
         parent::__construct();
         $this->setId('adminLoginActivityGrid');
         $this->setDefaultSort('created_at');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }

--- a/app/code/core/Maho/Blog/Block/Adminhtml/Post/Grid.php
+++ b/app/code/core/Maho/Blog/Block/Adminhtml/Post/Grid.php
@@ -16,7 +16,6 @@ class Maho_Blog_Block_Adminhtml_Post_Grid extends Mage_Adminhtml_Block_Widget_Gr
         parent::__construct();
         $this->setId('blogPostGrid');
         $this->setDefaultSort('entity_id');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
     }
 

--- a/app/code/core/Maho/ContentVersion/Block/Adminhtml/Version/Grid.php
+++ b/app/code/core/Maho/ContentVersion/Block/Adminhtml/Version/Grid.php
@@ -21,7 +21,6 @@ class Maho_ContentVersion_Block_Adminhtml_Version_Grid extends Mage_Adminhtml_Bl
         parent::__construct();
         $this->setId('contentversion_grid');
         $this->setDefaultSort('version_number');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(false);
         $this->setUseAjax(false);
         $this->setFilterVisibility(false);

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Destination/Grid.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Destination/Grid.php
@@ -17,7 +17,6 @@ class Maho_FeedManager_Block_Adminhtml_Destination_Grid extends Mage_Adminhtml_B
         parent::__construct();
         $this->setId('feedmanagerDestinationGrid');
         $this->setDefaultSort('destination_id');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
     }
 

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Logs.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Logs.php
@@ -19,7 +19,6 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Logs extends Mage_Adminhtml
         parent::__construct();
         $this->setId('feedLogsGrid');
         $this->setDefaultSort('started_at');
-        $this->setDefaultDir('DESC');
         $this->setUseAjax(true);
     }
 

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Grid.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Grid.php
@@ -17,7 +17,6 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Grid extends Mage_Adminhtml_Block_Wi
         parent::__construct();
         $this->setId('feedmanagerFeedGrid');
         $this->setDefaultSort('feed_id');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
     }
 

--- a/app/code/core/Maho/Giftcard/Block/Adminhtml/Giftcard/Grid.php
+++ b/app/code/core/Maho/Giftcard/Block/Adminhtml/Giftcard/Grid.php
@@ -18,7 +18,6 @@ class Maho_Giftcard_Block_Adminhtml_Giftcard_Grid extends Mage_Adminhtml_Block_W
         parent::__construct();
         $this->setId('giftcardGrid');
         $this->setDefaultSort('giftcard_id');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }

--- a/app/code/core/Maho/Giftcard/Block/Adminhtml/Giftcard/History/Grid.php
+++ b/app/code/core/Maho/Giftcard/Block/Adminhtml/Giftcard/History/Grid.php
@@ -18,7 +18,6 @@ class Maho_Giftcard_Block_Adminhtml_Giftcard_History_Grid extends Mage_Adminhtml
         parent::__construct();
         $this->setId('giftcardHistoryGrid');
         $this->setDefaultSort('created_at');
-        $this->setDefaultDir('DESC');
         $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }


### PR DESCRIPTION
## Summary

- Changed base `Widget Grid` `$_defaultDir` from `'desc'` to `'DESC'`
- Removed redundant `setDefaultDir('DESC')` calls from all grid classes (since the base class now defaults to DESC)
- Added missing `setDefaultSort()` to Newsletter Problem, Index Process, System Design, and Email Template grids
- Added `setSaveParametersInSession(true)` to Newsletter Subscriber grid

Ported from OpenMage/magento-lts#5313 by @sreichel, extended to cover Maho-specific grids as well.