### PR TITLE
Fixed magic link email template ID mismatch

### DIFF
--- a/app/code/core/Mage/Customer/etc/config.xml
+++ b/app/code/core/Mage/Customer/etc/config.xml
@@ -418,11 +418,11 @@
                     <file>account_password_reset_confirmation.html</file>
                     <type>html</type>
                 </customer_password_link_email_template>
-                <customer_magic_link_email_template translate="label" module="customer">
+                <customer_login_magic_link_email_template translate="label" module="customer">
                     <label>Magic Link Login</label>
                     <file>account_magic_link.html</file>
                     <type>html</type>
-                </customer_magic_link_email_template>
+                </customer_login_magic_link_email_template>
             </email>
         </template>
         <events>
@@ -561,7 +561,7 @@
                 <magic_link_rate_limit_email>3</magic_link_rate_limit_email>
                 <magic_link_rate_limit_ip>10</magic_link_rate_limit_ip>
                 <magic_link_email_identity>general</magic_link_email_identity>
-                <magic_link_email_template>customer_magic_link_email_template</magic_link_email_template>
+                <magic_link_email_template>customer_login_magic_link_email_template</magic_link_email_template>
                 <magic_link_registration_mode>no_password</magic_link_registration_mode>
             </login>
             <vat_validation>


### PR DESCRIPTION
## Summary
- The magic link email template node in `config.xml` was named `customer_magic_link_email_template`, but the admin system config source model (`Mage_Adminhtml_Model_System_Config_Source_Email_Template`) generates template IDs by converting the config path to underscores: `customer/login/magic_link_email_template` → `customer_login_magic_link_email_template`
- When the magic link config is saved in admin, this mismatched ID gets stored in `core_config_data`, causing "Invalid transactional email code: customer_login_magic_link_email_template" when sending magic link emails
- Renamed the template node and default value to `customer_login_magic_link_email_template` to follow the same convention as all other email templates

Thanks to @gputignano for reporting this issue!

## Test plan
- [ ] Enable magic link login in admin (Customers > Configuration > Login Options)
- [ ] Save the config
- [ ] Request a magic link login on the frontend
- [ ] Verify the email is sent without errors