### PR TITLE
Fixed search autocomplete showing wrong result count

### DIFF
--- a/app/design/frontend/base/default/template/catalogsearch/suggest.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/suggest.phtml
@@ -17,7 +17,8 @@ $hasCategories = $categories && count($categories) > 0;
 // Product search block
 $productList = $this->getLayout()->createBlock('catalogsearch/autocomplete_product_list')
     ->setTemplate('catalog/product/list.phtml');
-$numProducts = count($productList->getLoadedProductCollection());
+$products = $productList->getLoadedProductCollection();
+$numProducts = $products->getSize();
 
 // Collect additional autocomplete content through events
 $autocompleteData = new \Maho\DataObject([


### PR DESCRIPTION
## Summary
- The "View all X results" link in search autocomplete always showed max 10 results because it used `count()` on the loaded (page-size-limited) collection instead of `getSize()` which queries the actual total count

Fixes #647 — thanks @jparker1986 for the report and the fix suggestion!