### PR TITLE
Urlencode SMTP credentials in mailer DSN

### DIFF
--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -953,8 +953,8 @@ XML;
     {
         $coreHelper = Mage::helper('core');
         $emailTransport = Mage::getStoreConfig('system/smtp/enabled');
-        $user = $coreHelper->decrypt(Mage::getStoreConfig('system/smtp/username'));
-        $pass = $coreHelper->decrypt(Mage::getStoreConfig('system/smtp/password'));
+        $user = urlencode($coreHelper->decrypt(Mage::getStoreConfig('system/smtp/username')));
+        $pass = urlencode($coreHelper->decrypt(Mage::getStoreConfig('system/smtp/password')));
         $host = Mage::getStoreConfig('system/smtp/host');
         $port = Mage::getStoreConfig('system/smtp/port');
         $region = Mage::getStoreConfig('system/smtp/region');


### PR DESCRIPTION
## Summary

- Wrap `$user` and `$pass` with `urlencode()` in `getMailerDsn()` so that special characters (e.g. `#`, `@`, `:`) in SMTP credentials don't break the DSN URI parsing

Thanks to @tmewes for spotting this!

## Test plan

- Configure SMTP credentials containing special characters (e.g. `my#secret` as password)
- Verify email sending works correctly