### PR TITLE
Added SKU attribute and event to search autocomplete product collection

### DIFF
--- a/app/code/core/Mage/CatalogSearch/Block/Autocomplete/Product/List.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Autocomplete/Product/List.php
@@ -33,9 +33,14 @@ class Mage_CatalogSearch_Block_Autocomplete_Product_List extends Mage_Catalog_Bl
             /** @var Mage_CatalogSearch_Model_Resource_Fulltext_Collection $productCollection */
             $productCollection = Mage::getResourceModel('catalogsearch/fulltext_collection');
             $productCollection->addSearchFilter($query)
+                ->addAttributeToSelect('sku')
                 ->setOrder('relevance', 'desc')
                 ->setPageSize(10);
             Mage::getModel('catalog/layer')->prepareProductCollection($productCollection);
+
+            Mage::dispatchEvent('catalogsearch_autocomplete_product_collection', [
+                'collection' => $productCollection,
+            ]);
 
             $this->_productCollection = $productCollection;
         }


### PR DESCRIPTION
## Summary
- Adds `sku` to the default attribute selection in the autocomplete product collection, so it is available without block rewrites
- Dispatches `catalogsearch_autocomplete_product_collection` event after the collection is built, allowing modules to add custom attributes or filters via observers

Closes #652

## Test plan
- [ ] Verify search autocomplete still works correctly
- [ ] Confirm SKU is available on product items in the autocomplete results
- [ ] Test that observers on `catalogsearch_autocomplete_product_collection` can modify the collection