### PR TITLE
Fixed payment month dropdown showing 'format - Array'

### DIFF
--- a/app/code/core/Mage/Payment/Model/Config.php
+++ b/app/code/core/Mage/Payment/Model/Config.php
@@ -112,11 +112,13 @@ class Mage_Payment_Model_Config
     public function getMonths()
     {
         $data = Mage::app()->getLocale()->getTranslationList('month');
-        foreach ($data as $key => $value) {
+        $months = $data['format']['wide'] ?? $data;
+        $result = [];
+        foreach ($months as $key => $value) {
             $monthNum = ($key < 10) ? '0' . $key : $key;
-            $data[$key] = $monthNum . ' - ' . $value;
+            $result[$key] = $monthNum . ' - ' . $value;
         }
-        return $data;
+        return $result;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Fixes credit card expiration month dropdown displaying "format - Array" instead of month names (e.g., "01 - January")
- `getTranslationList('month')` now returns a nested structure with wide/abbreviated/narrow formats; `getMonths()` was iterating the top-level keys instead of extracting the wide month names

Fixes #662

## Test plan

- [ ] Go to checkout with a credit card payment method enabled
- [ ] Verify the expiration month dropdown shows proper values like "01 - January", "02 - February", etc.