### PR TITLE
Removed deprecated finfo_close() call in Mage_Core_Block_Pdf

### DIFF
--- a/app/code/core/Mage/Core/Block/Pdf.php
+++ b/app/code/core/Mage/Core/Block/Pdf.php
@@ -91,7 +91,6 @@ class Mage_Core_Block_Pdf extends Mage_Core_Block_Template
             $finfo = finfo_open(FILEINFO_MIME_TYPE);
             if ($finfo) {
                 $mimeType = finfo_buffer($finfo, $content);
-                finfo_close($finfo);
             }
         }
 


### PR DESCRIPTION
Closes #666

## Summary
- Removed the `finfo_close()` call in `Mage_Core_Block_Pdf::processLogoFile()`, which is deprecated since PHP 8.5
- `finfo` objects have been freed automatically since PHP 8.0, making this call a no-op
- In developer mode on PHP 8.5, the deprecation warning triggers `mageCoreErrorHandler` which throws an exception, breaking PDF generation (invoices, credit memos, shipments)

## Test plan
- [ ] Generate PDF invoices/credit memos/shipments in developer mode on PHP 8.5
- [ ] Verify no deprecation warnings are triggered
- [ ] Verify PDF output is correct with logo displayed properly