### PR TITLE
Fixed missing page break between multiple PDF documents

### DIFF
--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
@@ -97,6 +97,7 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends \Maho\DataObject
         }
 
         $html = '';
+        $isFirst = true;
 
         // Set adminhtml design area for template/block loading
         $originalArea = Mage::getDesign()->getArea();
@@ -118,7 +119,11 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends \Maho\DataObject
                 $blockHtml = $block->toHtml();
 
                 if (!empty($blockHtml)) {
+                    if (!$isFirst) {
+                        $html .= '<div style="page-break-before: always;"></div>';
+                    }
                     $html .= $blockHtml;
+                    $isFirst = false;
                 }
 
                 // Clear block reference for memory management


### PR DESCRIPTION
## Summary
- Added explicit page break (`page-break-before: always`) between documents in `_renderDocumentsHtml()`
- Fixes invoices, shipments, and credit memos overlapping when printing multiple at once

Closes #668

## Test plan
- [ ] Select 2+ orders with invoices, print invoices, verify each starts on a new page
- [ ] Repeat for shipments and credit memos
- [ ] Verify single document PDFs are unaffected (no extra blank page)