### PR TITLE
Fixed one-step checkout payment method issues

### DIFF
--- a/app/code/core/Mage/Checkout/Helper/Data.php
+++ b/app/code/core/Mage/Checkout/Helper/Data.php
@@ -233,7 +233,7 @@ class Mage_Checkout_Helper_Data extends Mage_Core_Helper_Abstract
                     [
                         'reason'          => $message,
                         'checkoutType'    => $checkoutType,
-                        'dateAndTime'     => Mage::app()->getLocale()->dateImmutable(),
+                        'dateAndTime'     => Mage::app()->getLocale()->storeDate(null, null, true, 'html5'),
                         'customer'        => Mage::helper('customer')->getFullCustomerName($checkout),
                         'customerEmail'   => $checkout->getCustomerEmail(),
                         'billingAddress'  => $checkout->getBillingAddress(),

--- a/lib/Maho/Filter/Template.php
+++ b/lib/Maho/Filter/Template.php
@@ -162,7 +162,10 @@ class Template
         }
 
         $replacedValue = $this->_getVariable($construction[2], '');
-        return $replacedValue;
+        if ($replacedValue instanceof \DateTimeInterface) {
+            $replacedValue = $replacedValue->format('Y-m-d H:i:s');
+        }
+        return (string) $replacedValue;
     }
 
     public function includeDirective($construction)

--- a/public/js/varien/onestepcheckout.js
+++ b/public/js/varien/onestepcheckout.js
@@ -82,13 +82,21 @@ class OneStepCheckout {
     }
 
     /**
-     * Check if billing form has pre-filled data and trigger shipping method load
+     * Check if billing form has pre-filled data and trigger shipping method load.
+     * Also triggers payment method load if a shipping method is already selected.
      */
     checkPrefilledBilling() {
         if (!this.billingForm || this.isVirtual) return;
 
         if (this.hasMinimumAddressData('billing')) {
             this.saveBilling();
+        }
+
+        // If a shipping method is already selected (e.g. page refresh),
+        // trigger save to load payment methods
+        const selectedShipping = document.querySelector('input[name="shipping_method"]:checked');
+        if (selectedShipping) {
+            this.saveShippingMethod();
         }
     }
 
@@ -400,7 +408,14 @@ class OneStepCheckout {
         const paymentForm = document.getElementById('co-payment-form');
         if (!paymentForm) return;
 
-        const formData = new FormData(paymentForm);
+        const selectedMethod = paymentForm.querySelector('input[name="payment[method]"]:checked');
+        if (!selectedMethod) return;
+
+        // Only send the payment method selection, not CC details.
+        // Full payment data (CC number, expiration, etc.) is validated during saveOrder.
+        // Sending incomplete CC fields here would trigger server-side validation errors.
+        const formData = new FormData();
+        formData.set('payment[method]', selectedMethod.value);
 
         // Show review loading immediately since that's what gets updated
         this.setLoading('onestep-review', true);
@@ -413,7 +428,7 @@ class OneStepCheckout {
                     loaderArea: false
                 });
             } catch (error) {
-                // Silently handle errors
+                // Silently handle validation errors during auto-save
             }
         });
         // Refresh review (queued after the above)


### PR DESCRIPTION
## Summary
- Fixed payment methods not loading on page refresh when a shipping method was already selected — the section showed "Waiting for shipping method..." indefinitely instead of loading available payment methods
- Fixed CC expiration date validation errors (`mahoFetch error: MahoError: Incorrect credit card expiration date`) during payment method auto-save by only sending the method selection instead of the full CC form with empty fields
- Fixed `DateTimeInterface` object being passed as email template variable in payment failure emails
- Fixed `Template` filter to handle `DateTimeInterface` objects and cast return value to string

## Test plan
- [ ] Go to one-step checkout with a CC payment method (e.g. Authorize.net)
- [ ] Verify selecting the payment method no longer triggers "Incorrect credit card expiration date" console errors
- [ ] Fill in valid CC details and place order — should work correctly
- [ ] Refresh the checkout page when a shipping method is already selected — payment methods should load instead of showing "Waiting for shipping method..."
- [ ] Trigger a payment failure email and verify the date renders correctly