### PR TITLE
Removed deprecated curl_close() calls in UPS shipping carrier

### DIFF
--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
@@ -714,7 +714,6 @@ class Mage_Usa_Model_Shipping_Carrier_Ups extends Mage_Usa_Model_Shipping_Carrie
             $this->_debug($debugData);
             $this->_parseRestTrackingResponse($tracking, $responseData);
         }
-        curl_close($ch);
 
         return $this->_trackingResult;
     }
@@ -940,7 +939,6 @@ class Mage_Usa_Model_Shipping_Carrier_Ups extends Mage_Usa_Model_Shipping_Carrie
         } else {
             $debugData['result'] = $responseData;
         }
-        curl_close($ch);
 
         $responseData = json_decode($responseData);
         if (!$responseData) {
@@ -1508,7 +1506,6 @@ class Mage_Usa_Model_Shipping_Carrier_Ups extends Mage_Usa_Model_Shipping_Carrie
         } else {
             $debugData['result'] = $responseData;
         }
-        curl_close($ch);
 
         $this->_debug($debugData);
         return $this->_parseRestResponse($responseData);

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/UpsAuth.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/UpsAuth.php
@@ -48,15 +48,11 @@ class Mage_Usa_Model_Shipping_Carrier_UpsAuth extends Mage_Usa_Model_Shipping_Ca
         curl_setopt($ch, CURLOPT_TIMEOUT, 30);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->getConfigFlag('verify_peer'));
         $responseData = curl_exec($ch);
-        try {
-            if ($responseData === false) {
-                $code = curl_errno($ch);
-                $description = curl_strerror($ch);
-                $message = curl_error($ch);
-                Mage::throwException("cURL Error: ($code) $description - \"$message\"");
-            }
-        } finally {
-            curl_close($ch);
+        if ($responseData === false) {
+            $code = curl_errno($ch);
+            $description = curl_strerror($ch);
+            $message = curl_error($ch);
+            Mage::throwException("cURL Error: ($code) $description - \"$message\"");
         }
 
         $responseData = json_decode($responseData);


### PR DESCRIPTION
## Summary
- Removed all `curl_close()` calls from `Mage_Usa_Model_Shipping_Carrier_Ups` and `UpsAuth`
- `curl_close()` has been a no-op since PHP 8.0 and is formally deprecated in PHP 8.5, causing runtime deprecation notices
- Also cleaned up a now-unnecessary `try/finally` block in `UpsAuth`

## Test plan
- [ ] Verify UPS rate requests work correctly
- [ ] Verify UPS shipment tracking works correctly
- [ ] Verify UPS OAuth authentication works correctly
- [ ] Confirm no `curl_close` deprecation notices in PHP 8.5 error logs