### PR TITLE
Fixed undefined array key "totalPrice" in USPS shipping carrier

### DIFF
--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
@@ -583,7 +583,7 @@ class Mage_Usa_Model_Shipping_Carrier_Usps extends Mage_Usa_Model_Shipping_Carri
                     foreach ($pricingOption['shippingOptions'] as $shippingOption) {
                         if (!empty($shippingOption['rateOptions'])) {
                             foreach ($shippingOption['rateOptions'] as $rateOption) {
-                                if (!empty($rateOption['rates'])) {
+                                if (!empty($rateOption['rates']) && isset($rateOption['totalPrice'])) {
                                     foreach ($rateOption['rates'] as $rateData) {
                                         $allRates[] = array_merge($rateData, [
                                             'totalPrice' => $rateOption['totalPrice'],


### PR DESCRIPTION
## Summary
- Skip rate options that lack a `totalPrice` key when parsing the USPS Shipping Options API response, preventing PHP warnings on line 589

## Test plan
- [ ] Verify USPS shipping rates still return correctly for domestic/international addresses
- [ ] Confirm no PHP warnings when API returns rate options without `totalPrice`