### PR TITLE
Fixed USPS REST API returning $0.00 shipping rates

### DIFF
--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
@@ -532,6 +532,9 @@ class Mage_Usa_Model_Shipping_Carrier_Usps extends Mage_Usa_Model_Shipping_Carri
             // International (must come before domestic)
             'Priority Mail Express International' => 'INT_1',
             'Priority Mail International' => 'INT_2',
+            'First-Class Package International Service' => 'INT_15',
+            'First-Class Mail International' => 'INT_13',
+            'Global Express Guaranteed' => 'INT_4',
 
             // Priority Mail Express variations (must come before regular Priority Mail)
             'Priority Mail Express Padded Flat Rate Envelope' => '62',
@@ -583,10 +586,11 @@ class Mage_Usa_Model_Shipping_Carrier_Usps extends Mage_Usa_Model_Shipping_Carri
                     foreach ($pricingOption['shippingOptions'] as $shippingOption) {
                         if (!empty($shippingOption['rateOptions'])) {
                             foreach ($shippingOption['rateOptions'] as $rateOption) {
-                                if (!empty($rateOption['rates']) && isset($rateOption['totalPrice'])) {
+                                $totalPrice = $rateOption['totalBasePrice'] ?? $rateOption['totalPrice'] ?? null;
+                                if (!empty($rateOption['rates']) && $totalPrice !== null && (float) $totalPrice > 0) {
                                     foreach ($rateOption['rates'] as $rateData) {
                                         $allRates[] = array_merge($rateData, [
-                                            'totalPrice' => $rateOption['totalPrice'],
+                                            'totalPrice' => (float) $totalPrice,
                                         ]);
                                     }
                                 }


### PR DESCRIPTION
## Summary

- The USPS Shipping Options v3 API returns `totalBasePrice` in rate options, not `totalPrice`. The code was checking for `totalPrice` which does not exist in the response, causing all shipping rates to display as $0.00.
- Added missing international service description patterns for First-Class Package International Service (`INT_15`), First-Class Mail International (`INT_13`), and Global Express Guaranteed (`INT_4`).
- Zero-price rate options are now skipped to prevent $0.00 rates from reaching customers.

## Test plan

- [ ] Configure USPS shipping with REST API credentials
- [ ] Test domestic shipping rates (US to US) - verify prices are correct
- [ ] Test international shipping rates (US to non-US) - verify prices are no longer $0.00
- [ ] Verify flat-rate sub-methods (Large Flat Rate Box, Medium Flat Rate Box, etc.) still appear as separate options when configured in allowed methods
- [ ] Verify First-Class Package International Service rates appear for international shipments