### PR TITLE
Fixed free shipping not showing due to circular total collector dependency

### DIFF
--- a/app/code/core/Mage/Tax/etc/config.xml
+++ b/app/code/core/Mage/Tax/etc/config.xml
@@ -145,7 +145,7 @@
                 <totals>
                     <tax_subtotal>
                         <class>tax/sales_total_quote_subtotal</class>
-                        <after>subtotal,nominal,shipping,freeshipping</after>
+                        <after>subtotal,nominal,freeshipping</after>
                         <before>tax,discount</before>
                     </tax_subtotal>
                     <tax_shipping>


### PR DESCRIPTION
## Summary

- The `tax_subtotal` total collector had `shipping` in its `<after>` dependency list, while `shipping` had `tax_subtotal` in its own `<after>` list, creating a **circular dependency**
- The sort resolver consistently put `shipping` first, so `BaseSubtotalInclTax` was never set when shipping carriers checked it, causing the free shipping method to never appear
- The `tax_subtotal` collector doesn't use any shipping data — it only works with item prices and tax rates — so the `shipping` dependency was unnecessary
- Removing it gives the correct collection order: `subtotal` → `freeshipping` → `tax_subtotal` → `shipping`

## Background

This was originally introduced by an OpenMage merge that incorrectly changed `<after>freeshipping</after>` to `<after>subtotal,nominal,shipping,freeshipping</after>`. The issue was extensively discussed in the OpenMage community:

- [OpenMage#1813](https://github.com/OpenMage/magento-lts/issues/1813) — Free Shipping not displaying (confirmed bug)
- [OpenMage#3407](https://github.com/OpenMage/magento-lts/issues/3407) — Shipping cannot calculate costs based on tax_subtotal
- [OpenMage#1104](https://github.com/OpenMage/magento-lts/pull/1104) — Proposed fix (closed without merge)
- [OpenMage#3408](https://github.com/OpenMage/magento-lts/pull/3408) — Same fix re-proposed (closed without merge)

Both Magento 1.9.4.5 vanilla and [Magento 2](https://github.com/magento/magento2/blob/f096fe1bd249be1191a607f97d0327ecf09169b9/app/code/Magento/Sales/Test/Unit/Model/Config/_files/core_totals_config.php) do **not** have `shipping` in `tax_subtotal`'s dependencies.

## Test plan

- [ ] Enable Free Shipping carrier with a minimum order amount (e.g. 5)
- [ ] Add product to cart with subtotal above the minimum
- [ ] Go to checkout and verify Free Shipping appears as a shipping option
- [ ] Test with both "Ship to this address" and "Ship to different address"
- [ ] Verify tax calculations remain correct on the order summary
- [ ] Test with prices including tax and prices excluding tax configurations