### PR TITLE
Fixed one-step checkout payment methods not loading with pre-selected shipping method

### DIFF
--- a/public/js/varien/onestepcheckout.js
+++ b/public/js/varien/onestepcheckout.js
@@ -83,20 +83,14 @@ class OneStepCheckout {
 
     /**
      * Check if billing form has pre-filled data and trigger shipping method load.
-     * Also triggers payment method load if a shipping method is already selected.
+     * Payment methods are loaded automatically via autoSelectSingleShippingMethod()
+     * when saveBilling() populates the shipping methods and one is pre-checked.
      */
     checkPrefilledBilling() {
         if (!this.billingForm || this.isVirtual) return;
 
         if (this.hasMinimumAddressData('billing')) {
             this.saveBilling();
-        }
-
-        // If a shipping method is already selected (e.g. page refresh),
-        // trigger save to load payment methods
-        const selectedShipping = document.querySelector('input[name="shipping_method"]:checked');
-        if (selectedShipping) {
-            this.saveShippingMethod();
         }
     }
 
@@ -453,11 +447,11 @@ class OneStepCheckout {
     }
 
     /**
-     * If only one shipping method available and checked, trigger save to load payment methods
+     * If a shipping method is already checked, trigger save to load payment methods
      */
     autoSelectSingleShippingMethod() {
-        const shippingMethods = document.querySelectorAll('input[name="shipping_method"]');
-        if (shippingMethods.length === 1 && shippingMethods[0].checked) {
+        const selected = document.querySelector('input[name="shipping_method"]:checked');
+        if (selected) {
             setTimeout(() => this.saveShippingMethod(), 50);
         }
     }


### PR DESCRIPTION
## Summary

- When multiple shipping methods were available and one was pre-selected on page refresh, the payment section showed "Waiting for shipping method..." and never loaded payment methods
- Root cause: `checkPrefilledBilling()` checked for a selected shipping method before `saveBilling()` had populated the (initially empty) shipping methods container via AJAX. After shipping methods loaded, `autoSelectSingleShippingMethod()` only triggered payment loading for exactly one method, ignoring multiple methods with one pre-checked
- Fixed `autoSelectSingleShippingMethod()` to trigger `saveShippingMethod()` whenever any shipping method is already checked, regardless of count

## Test plan

- [ ] Go to checkout with multiple shipping methods available (e.g. Flat Rate + Free Shipping)
- [ ] Complete checkout and place order, or refresh the page so billing address is pre-filled
- [ ] Verify payment methods load automatically without needing to switch shipping methods
- [ ] Verify single shipping method case still works correctly