### PR TITLE
Fixed USPS international shipping rates mixing flat-rate and package prices

### DIFF
--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
@@ -529,10 +529,25 @@ class Mage_Usa_Model_Shipping_Carrier_Usps extends Mage_Usa_Model_Shipping_Carri
         // Map REST API descriptions back to our method codes
         // Order matters: most specific patterns first!
         $mapping = [
-            // International (must come before domestic)
+            // International (most specific first, must come before domestic)
+            'Priority Mail Express International Padded Flat Rate Envelope' => 'INT_27',
+            'Priority Mail Express International Legal Flat Rate Envelope' => 'INT_17',
+            'Priority Mail Express International Flat Rate Envelope' => 'INT_10',
             'Priority Mail Express International' => 'INT_1',
+            'Priority Mail International Padded Flat Rate Envelope' => 'INT_23',
+            'Priority Mail International Legal Flat Rate Envelope' => 'INT_22',
+            'Priority Mail International Gift Card Flat Rate Envelope' => 'INT_18',
+            'Priority Mail International Window Flat Rate Envelope' => 'INT_19',
+            'Priority Mail International Small Flat Rate Envelope' => 'INT_20',
+            'Priority Mail International Flat Rate Envelope' => 'INT_8',
+            'Priority Mail International Large Flat Rate Box' => 'INT_11',
+            'Priority Mail International Medium Flat Rate Box' => 'INT_9',
+            'Priority Mail International Small Flat Rate Box' => 'INT_16',
             'Priority Mail International' => 'INT_2',
             'First-Class Package International Service' => 'INT_15',
+            'First-Class Mail International Large Envelope' => 'INT_14',
+            'First-Class Mail International Postcard' => 'INT_21',
+            'First-Class Mail International Letter' => 'INT_13',
             'First-Class Mail International' => 'INT_13',
             'Global Express Guaranteed' => 'INT_4',
 


### PR DESCRIPTION
## Summary

- The USPS REST API description-to-method-code mapping in `extractMethodCodeFromDescription()` only had generic entries for international services (e.g. `Priority Mail International` → `INT_2`), so all flat-rate variants (Small Flat Rate Box, Flat Rate Envelope, Medium Flat Rate Box, etc.) matched the same generic pattern via `stripos`
- The rate grouping logic then kept only the cheapest rate per method code, causing incorrect prices — e.g. Priority Mail International showing $49.75 (a Flat Rate Small Box price) instead of the actual package rate of ~$75
- Added specific flat-rate description patterns for international Priority Mail, Priority Mail Express, and First-Class services, mapping them to their correct existing method codes (`INT_8`, `INT_9`, `INT_10`, `INT_11`, `INT_16`, `INT_17`, `INT_18`, `INT_19`, `INT_20`, `INT_22`, `INT_23`, `INT_27`, `INT_14`, `INT_21`)
- These method codes were already defined in the admin "Allowed Methods" configuration but were never matched by the REST API parser

## Test plan

- [ ] Configure USPS shipping with REST API credentials
- [ ] Test international shipping rates (US to Japan or similar) — verify each service shows its correct rate
- [ ] Verify flat-rate international methods (Small Flat Rate Box, Flat Rate Envelope, etc.) appear as separate options when enabled in allowed methods
- [ ] Verify rate ordering is correct: First-Class < Priority Mail < Priority Mail Express for package rates
- [ ] Test domestic rates still work correctly (no regression)