### PR TITLE
Added autocomplete attributes to prevent password manager prompts on non-auth forms

### DIFF
--- a/app/design/frontend/base/default/template/contacts/form.phtml
+++ b/app/design/frontend/base/default/template/contacts/form.phtml
@@ -15,7 +15,7 @@
 <div class="page-title">
     <h1><?= Mage::helper('contacts')->__('Contact Us') ?></h1>
 </div>
-<form action="<?= $this->getFormAction() ?>" id="contactForm" method="post" class="scaffold-form">
+<form action="<?= $this->getFormAction() ?>" id="contactForm" method="post" class="scaffold-form" autocomplete="off">
     <?= $this->getBlockHtml('formkey') ?>
     <div class="fieldset">
         <ul class="form-list">
@@ -29,7 +29,7 @@
                 <div class="field">
                     <label for="email" class="required"><?= Mage::helper('contacts')->__('Email') ?></label>
                     <div class="input-box">
-                        <input name="email" id="email" title="<?= $this->quoteEscape(Mage::helper('contacts')->__('Email')) ?>" value="<?= $this->escapeHtml($this->helper('contacts')->getUserEmail()) ?>" class="input-text required-entry validate-email" type="email" autocapitalize="off" autocorrect="off" spellcheck="false" />
+                        <input name="email" id="email" title="<?= $this->quoteEscape(Mage::helper('contacts')->__('Email')) ?>" value="<?= $this->escapeHtml($this->helper('contacts')->getUserEmail()) ?>" class="input-text required-entry validate-email" type="email" autocomplete="email" autocapitalize="off" autocorrect="off" spellcheck="false" />
                     </div>
                 </div>
             </li>

--- a/app/design/frontend/base/default/template/maho/giftcard/catalog/product/view/type/options/giftcard.phtml
+++ b/app/design/frontend/base/default/template/maho/giftcard/catalog/product/view/type/options/giftcard.phtml
@@ -161,7 +161,7 @@ $preDeliveryDate = $this->getPreconfiguredValue('giftcard_delivery_date');
         </div>
         <div class="field">
             <label for="giftcard_sender_email" class="required"><?php echo $this->__('Your Email'); ?></label>
-            <input type="email" name="giftcard_sender_email" id="giftcard_sender_email" class="required-entry validate-email" maxlength="255" required value="<?php echo $preSenderEmail !== null ? $this->escapeHtml($preSenderEmail) : ''; ?>" />
+            <input type="email" name="giftcard_sender_email" id="giftcard_sender_email" class="required-entry validate-email" maxlength="255" required autocomplete="email" value="<?php echo $preSenderEmail !== null ? $this->escapeHtml($preSenderEmail) : ''; ?>" />
         </div>
     </div>
 
@@ -173,7 +173,7 @@ $preDeliveryDate = $this->getPreconfiguredValue('giftcard_delivery_date');
         </div>
         <div class="field">
             <label for="giftcard_recipient_email" class="required"><?php echo $this->__('Recipient Email'); ?></label>
-            <input type="email" name="giftcard_recipient_email" id="giftcard_recipient_email" class="required-entry validate-email" maxlength="255" required value="<?php echo $preRecipientEmail !== null ? $this->escapeHtml($preRecipientEmail) : ''; ?>" />
+            <input type="email" name="giftcard_recipient_email" id="giftcard_recipient_email" class="required-entry validate-email" maxlength="255" required autocomplete="off" value="<?php echo $preRecipientEmail !== null ? $this->escapeHtml($preRecipientEmail) : ''; ?>" />
         </div>
     </div>
 

--- a/app/design/frontend/base/default/template/newsletter/subscribe.phtml
+++ b/app/design/frontend/base/default/template/newsletter/subscribe.phtml
@@ -13,12 +13,12 @@
 ?>
 <div class="block block-subscribe">
     <div class="block-title"><?= $this->__('Newsletter') ?></div>
-    <form action="<?= $this->getFormActionUrl() ?>" method="post" id="newsletter-validate-detail">
+    <form action="<?= $this->getFormActionUrl() ?>" method="post" id="newsletter-validate-detail" autocomplete="off">
         <?= $this->getBlockHtml('formkey') ?>
         <div class="block-content">
             <div class="input-box">
                 <label for="newsletter" class="visually-hidden"><?= $this->__('Sign Up for Our Newsletter:') ?></label>
-               <input type="email" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" name="email" id="newsletter" title="<?= $this->quoteEscape($this->__('Sign up for our newsletter')) ?>" class="input-text required-entry validate-email" aria-required="true" />
+               <input type="email" autocomplete="email" autocapitalize="off" autocorrect="off" spellcheck="false" name="email" id="newsletter" title="<?= $this->quoteEscape($this->__('Sign up for our newsletter')) ?>" class="input-text required-entry validate-email" aria-required="true" />
             </div>
             <div class="actions">
                 <button type="submit" title="<?= $this->quoteEscape($this->__('Subscribe')) ?>" class="button"><?= $this->__('Subscribe') ?></button>

--- a/app/design/frontend/base/default/template/sales/guest/form.phtml
+++ b/app/design/frontend/base/default/template/sales/guest/form.phtml
@@ -16,7 +16,7 @@
 </div>
 
 
-<form id="oar_widget_orders_and_returns_form" action="<?= $this->getActionUrl() ?>" method="post" class="search-form" name="guest_post">
+<form id="oar_widget_orders_and_returns_form" action="<?= $this->getActionUrl() ?>" method="post" class="search-form" name="guest_post" autocomplete="off">
     <div class="fieldset">
         <h2 class="legend"><?= Mage::helper('sales')->__('Order Information') ?></h2>
 
@@ -58,7 +58,7 @@
                    <label for="oar_email" class="required"><?= Mage::helper('sales')->__('Email Address') ?></label>
                </div>
                <div class="input-box">
-                   <input type="text" class="input-text validate-email required-entry" id="oar_email" name="oar_email"  style="width:300px;"/>
+                   <input type="email" autocomplete="email" class="input-text validate-email required-entry" id="oar_email" name="oar_email"  style="width:300px;"/>
                </div>
            </li>
            <li id="oar-zip" style="display:none;">

--- a/app/design/frontend/base/default/template/sales/widget/guest/form.phtml
+++ b/app/design/frontend/base/default/template/sales/widget/guest/form.phtml
@@ -19,7 +19,7 @@
                 </strong>
             </div>
             <div class="block-content">
-               <form id="oar_widget_orders_and_returns_form" action="<?= $this->getActionUrl() ?>" method="post" class="search-form" name="guest_post">
+               <form id="oar_widget_orders_and_returns_form" action="<?= $this->getActionUrl() ?>" method="post" class="search-form" name="guest_post" autocomplete="off">
                    <ul class="form-alt">
                        <li>
                            <label class="required"><?= Mage::helper('sales')->__('Find Order By:') ?></label>
@@ -45,7 +45,7 @@
                        <li id="oar-email">
                            <label for="oar_email" class="required"><?= Mage::helper('sales')->__('Email Address') ?> </label>
                            <div class="input-box">
-                               <input type="email" autocomplete="on" autocapitalize="off" autocorrect="off" spellcheck="false" class="input-text validate-email required-entry" id="oar_email" name="oar_email" />
+                               <input type="email" autocomplete="email" autocapitalize="off" autocorrect="off" spellcheck="false" class="input-text validate-email required-entry" id="oar_email" name="oar_email" />
                            </div>
                        </li>
                        <li id="oar-zip" style="display:none;">

--- a/app/design/frontend/base/default/template/wishlist/sharing.phtml
+++ b/app/design/frontend/base/default/template/wishlist/sharing.phtml
@@ -15,7 +15,7 @@
     <h1><?= $this->__('Share Your Wishlist') ?></h1>
 </div>
 <?= $this->getMessagesBlock()->toHtml() ?>
-<form action="<?= $this->getSendUrl() ?>" id="form-validate" method="post">
+<form action="<?= $this->getSendUrl() ?>" id="form-validate" method="post" autocomplete="off">
     <div class="fieldset">
         <?= $this->getBlockHtml('formkey') ?>
         <h2 class="legend"><?= $this->__('Sharing Information') ?></h2>


### PR DESCRIPTION
## Summary
- Password managers (BitWarden, 1Password, etc.) interpret POST followed by 302 redirect as a successful login, prompting to save credentials on forms like newsletter signup and contact
- Added autocomplete=off on form tags for non-authentication forms to signal these are not credential forms
- Used autocomplete=email on email inputs so browser email autofill still works
- Affected forms: newsletter subscribe, contact, wishlist sharing, guest order lookup (widget + full page), gift card

## Test plan
- [ ] Submit the newsletter form - password manager should NOT prompt to save
- [ ] Submit the contact form - password manager should NOT prompt to save
- [ ] Verify email autofill still suggests previously-used emails on these forms
- [ ] Verify login/register forms still work normally with password managers