### PR TITLE
Fixed duplicate product error in Recently Viewed/Compared collections

### DIFF
--- a/app/code/core/Mage/Reports/Model/Resource/Product/Index/Collection/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Product/Index/Collection/Abstract.php
@@ -50,6 +50,7 @@ abstract class Mage_Reports_Model_Resource_Product_Index_Collection_Abstract ext
                 ],
                 $this->_getWhereCondition(),
             );
+            $this->getSelect()->group('e.entity_id');
             $this->setFlag('is_idx_table_joined', true);
         }
         return $this;


### PR DESCRIPTION
## Summary
- When the same product appears multiple times in the report index table (e.g. viewed from different store views), the join in _joinIdxTable() produces duplicate rows
- This causes an Item with the same id already exist exception when loading the collection
- Added GROUP BY e.entity_id in _joinIdxTable() to deduplicate results, covering both addIndexFilter() and excludeProductIds() code paths

## Test plan
- [ ] Enable Recently Viewed Products sidebar block
- [ ] View products across multiple store views
- [ ] Verify the homepage and other pages with the Recently Viewed block render without errors
- [ ] Verify Recently Compared block also works correctly