### PR TITLE
Fixed CSS relative url() paths breaking when minification is enabled

### DIFF
--- a/app/code/core/Mage/Core/Helper/Minify.php
+++ b/app/code/core/Mage/Core/Helper/Minify.php
@@ -170,10 +170,9 @@ class Mage_Core_Helper_Minify extends Mage_Core_Helper_Abstract
                 } elseif ($type === 'css') {
                     $minifier = new CSSMinifier($absolutePath);
                     $minifier->setImportExtensions([]);
-                    $minifiedContent = $minifier->execute($cachedFile);
-                    file_put_contents($cachedFile, $minifiedContent);
+                    $minifier->minify($cachedFile);
                 } else {
-                    $minifiedContent = $this->minifyContent(file_get_contents($absolutePath), $type);
+                    $minifiedContent = (new JSMinifier(file_get_contents($absolutePath)))->minify();
                     file_put_contents($cachedFile, $minifiedContent);
                 }
                 return $cachedUrl;
@@ -208,18 +207,6 @@ class Mage_Core_Helper_Minify extends Mage_Core_Helper_Abstract
     {
         return file_exists($cachedFile) &&
                filemtime($cachedFile) >= filemtime($sourceFile);
-    }
-
-    /**
-     * Minify content based on type
-     */
-    private function minifyContent(string $content, string $type): string
-    {
-        return match ($type) {
-            'css' => (new CSSMinifier($content))->minify(),
-            'js' => (new JSMinifier($content))->minify(),
-            default => $content,
-        };
     }
 
     /**


### PR DESCRIPTION
## Summary

- When CSS minification is enabled, minified files are served from `/media/mahominify/` instead of their original location, causing relative `url()` references (images, fonts) to resolve to wrong paths and 404
- Pass source and destination file paths to the CSS minifier so its built-in `PathConverter` rewrites relative URLs correctly
- Disable asset inlining (`setImportExtensions([])`) to prevent base64-embedding referenced files, preserving browser caching

## Test plan

- [ ] Enable CSS minification in System > Config > Developer > CSS Settings
- [ ] Run `./maho cache:minify:flush`
- [ ] Load frontend — verify no 404s for images/fonts in browser network tab
- [ ] Inspect minified CSS in `/public/media/mahominify/` — relative paths should be rewritten to correct locations
- [ ] Verify JS minification still works unchanged