### PR TITLE
Fixed empty sidebar showing on blog pages when categories are disabled

### DIFF
--- a/app/code/core/Maho/Blog/Block/Category/Sidebar.php
+++ b/app/code/core/Maho/Blog/Block/Category/Sidebar.php
@@ -19,20 +19,6 @@ class Maho_Blog_Block_Category_Sidebar extends Mage_Core_Block_Template
     protected ?array $_urlKeys = null;
 
     #[\Override]
-    protected function _beforeToHtml(): self
-    {
-        if (!Mage::helper('blog')->areCategoriesEnabled() || empty($this->getCategoryTree())) {
-            // Switch to 1-column layout when sidebar has no content
-            $root = $this->getLayout()->getBlock('root');
-            if ($root) {
-                $root->setTemplate('page/1column.phtml');
-            }
-        }
-
-        return $this;
-    }
-
-    #[\Override]
     protected function _toHtml(): string
     {
         if (!Mage::helper('blog')->areCategoriesEnabled() || empty($this->getCategoryTree())) {

--- a/app/code/core/Maho/Blog/controllers/IndexController.php
+++ b/app/code/core/Maho/Blog/controllers/IndexController.php
@@ -19,6 +19,7 @@ class Maho_Blog_IndexController extends Mage_Core_Controller_Front_Action
         }
 
         $this->loadLayout();
+        $this->_switchToSingleColumnIfNoSidebar();
         $this->_initPageTitle(Mage::helper('blog')->__('Blog'));
         $this->_initBreadcrumbs();
         $this->renderLayout();
@@ -49,6 +50,7 @@ class Maho_Blog_IndexController extends Mage_Core_Controller_Front_Action
 
         Mage::register('current_blog_category', $category);
         $this->loadLayout();
+        $this->_switchToSingleColumnIfNoSidebar();
         $this->_initPageTitle($category->getName());
         $this->_initMeta($category);
         $this->_initBreadcrumbs($category);
@@ -71,10 +73,22 @@ class Maho_Blog_IndexController extends Mage_Core_Controller_Front_Action
 
         Mage::register('current_blog_post', $post);
         $this->loadLayout();
+        $this->_switchToSingleColumnIfNoSidebar();
         $this->_initPageTitle($post->getTitle());
         $this->_initMeta($post);
         $this->_initBreadcrumbs(null, $post);
         $this->renderLayout();
+    }
+
+    protected function _switchToSingleColumnIfNoSidebar(): void
+    {
+        $sidebar = $this->getLayout()->getBlock('blog.category.sidebar');
+        if (!$sidebar || !$sidebar->toHtml()) {
+            $root = $this->getLayout()->getBlock('root');
+            if ($root) {
+                $root->setTemplate('page/1column.phtml');
+            }
+        }
     }
 
     protected function _initPageTitle(string $title): void


### PR DESCRIPTION
## Summary
- When blog categories are disabled (the default), blog pages showed an empty sidebar column due to the 2-column layout
- Moved the 1-column layout switch from the Sidebar block's `_beforeToHtml` (which ran too late — the root template was already mid-render) to the controller, between `loadLayout()` and `renderLayout()`
- All three blog actions (index, view, category) now properly fall back to single-column when the sidebar has no content

## Test plan
- [ ] Verify blog listing page (`/blog`) has no empty sidebar when categories are disabled
- [ ] Verify blog post pages have no empty sidebar when categories are disabled
- [ ] Enable blog categories and verify the sidebar appears correctly with 2-column layout
- [ ] Verify non-blog pages with sidebars (e.g. category pages with layered nav) are unaffected