### PR TITLE
Fixed custom option file download 404 for guest orders

### DIFF
--- a/app/code/core/Mage/Sales/controllers/DownloadController.php
+++ b/app/code/core/Mage/Sales/controllers/DownloadController.php
@@ -21,7 +21,7 @@ class Mage_Sales_DownloadController extends Mage_Core_Controller_Front_Action
     {
         $secretKey = $this->getRequest()->getParam('key');
         try {
-            if ($secretKey != $info['secret_key']) {
+            if (!isset($info['secret_key']) || !hash_equals($info['secret_key'], (string) $secretKey)) {
                 throw new Exception();
             }
 

--- a/app/code/core/Mage/Sales/controllers/DownloadController.php
+++ b/app/code/core/Mage/Sales/controllers/DownloadController.php
@@ -114,18 +114,38 @@ class Mage_Sales_DownloadController extends Mage_Core_Controller_Front_Action
             return;
         }
 
-        // Verify the quote belongs to the current customer or session
+        // Verify access: session-based (logged-in customer or checkout session)
+        // OR secret key validation (for admin view or headless/API flows without frontend sessions)
         $quoteItem = Mage::getModel('sales/quote_item')->load($option->getItemId());
         $quote = Mage::getModel('sales/quote')->load($quoteItem->getQuoteId());
         $customerSession = Mage::getSingleton('customer/session');
         $checkoutQuoteId = Mage::getSingleton('checkout/session')->getQuoteId();
 
+        $hasSessionAccess = false;
         if ($quote->getCustomerId()) {
-            if (!$customerSession->isLoggedIn() || $quote->getCustomerId() != $customerSession->getCustomerId()) {
-                $this->_forward('noRoute');
-                return;
+            $hasSessionAccess = $customerSession->isLoggedIn()
+                && $quote->getCustomerId() == $customerSession->getCustomerId();
+        } else {
+            $hasSessionAccess = $quote->getId() == $checkoutQuoteId;
+        }
+
+        // Fallback: validate secret key from URL against the stored file data.
+        // This allows downloads from admin order view and headless storefronts
+        // where no frontend customer/checkout session exists.
+        $hasKeyAccess = false;
+        if (!$hasSessionAccess) {
+            $requestKey = $this->getRequest()->getParam('key');
+            if ($requestKey) {
+                try {
+                    $info = Mage::helper('core/unserializeArray')->unserialize($option->getValue());
+                    $hasKeyAccess = isset($info['secret_key']) && hash_equals($info['secret_key'], $requestKey);
+                } catch (Exception $e) {
+                    // Invalid data — deny access
+                }
             }
-        } elseif ($quote->getId() != $checkoutQuoteId) {
+        }
+
+        if (!$hasSessionAccess && !$hasKeyAccess) {
             $this->_forward('noRoute');
             return;
         }

--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -786,7 +786,7 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
             $filePath  = Mage::getBaseDir() . $info['quote_path'];
             $secretKey = $this->getRequest()->getParam('key');
 
-            if ($secretKey == $info['secret_key']) {
+            if (isset($info['secret_key']) && hash_equals($info['secret_key'], (string) $secretKey)) {
                 $this->_prepareDownloadResponse($info['title'], [
                     'value' => $filePath,
                     'type'  => 'filename',


### PR DESCRIPTION
## Summary

- `downloadCustomOptionAction()` returns 404 for all guest order file downloads — from admin, frontend, or headless storefronts
- Root cause: session check always fails for guest orders because no frontend customer/checkout session exists in admin or API contexts
- Adds secret key validation as fallback auth (key is already in the URL, uses `hash_equals()`)

Fixes #694

## Test plan

- [ ] Place a guest order with a file-type custom option
- [ ] View order in admin → click file download link → should download (was 404)
- [ ] Verify logged-in customer orders still download via session auth
- [ ] Verify invalid/missing key still returns 404