### PR TITLE
Deprecated product visibility filter wrapper methods, use static calls

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Random.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Random.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2022-2025 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2022-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -62,7 +62,6 @@ class Mage_Adminhtml_Model_Sales_Order_Random
     {
         if (!$this->_productCollection) {
             $this->_productCollection = Mage::getResourceModel('catalog/product_collection');
-            Mage::getSingleton('catalog/product_visibility')->addVisibleInSearchFilterToCollection($this->_productCollection);
             $this->_productCollection
                 ->addAttributeToSelect('name')
                 ->addAttributeToSelect('sku')
@@ -70,6 +69,7 @@ class Mage_Adminhtml_Model_Sales_Order_Random
                 ->addAttributeToFilter('status', [
                     'in' => Mage::getSingleton('catalog/product_status')->getVisibleStatusIds(),
                 ])
+                ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSearchIds())
                 ->load();
         }
         return $this->_productCollection->getItems();

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/List/Partof.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/List/Partof.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Bundle
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2020-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -30,6 +30,7 @@ class Mage_Bundle_Block_Catalog_Product_List_Partof extends Mage_Catalog_Block_P
                 'in' => Mage::getSingleton('catalog/product_status')->getSaleableStatusIds(),
             ])
             ->addPriceData()
+            ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInCatalogIds())
             ->joinTable('bundle/option', 'parent_id=entity_id', ['option_id' => 'option_id'])
             ->joinTable('bundle/selection', 'option_id=option_id', ['product_id' => 'product_id'], '{{table}}.product_id=' . $this->getProduct()->getId());
 
@@ -38,8 +39,6 @@ class Mage_Bundle_Block_Catalog_Product_List_Partof extends Mage_Catalog_Block_P
         if (count($ids)) {
             $collection->addIdFilter(Mage::getSingleton('checkout/cart')->getProductIds(), true);
         }
-
-        Mage::getSingleton('catalog/product_visibility')->addVisibleInCatalogFilterToCollection($collection);
         $collection->getSelect()->group('entity_id');
 
         $collection->load();

--- a/app/code/core/Mage/Bundle/Model/Observer.php
+++ b/app/code/core/Mage/Bundle/Model/Observer.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Bundle
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2018-2023 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2018-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -96,10 +96,8 @@ class Mage_Bundle_Model_Observer
             ->addAttributeToSelect(Mage::getSingleton('catalog/config')->getProductAttributes())
             ->addStoreFilter()
             ->addPriceData()
+            ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInCatalogIds())
             ->addTaxPercents();
-
-        Mage::getSingleton('catalog/product_visibility')
-            ->addVisibleInCatalogFilterToCollection($bundleCollection);
 
         if (!is_null($limit)) {
             $bundleCollection->setPageSize($limit);

--- a/app/code/core/Mage/Catalog/Block/Product/Compare/List.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Compare/List.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Catalog
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -95,10 +95,8 @@ class Mage_Catalog_Block_Product_Compare_List extends Mage_Catalog_Block_Product
                 ->addAttributeToSelect(Mage::getSingleton('catalog/config')->getProductAttributes())
                 ->loadComparableAttributes()
                 ->addPriceData()
+                ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSiteIds())
                 ->addTaxPercents();
-
-            Mage::getSingleton('catalog/product_visibility')
-                ->addVisibleInSiteFilterToCollection($this->_items);
         }
 
         return $this->_items;

--- a/app/code/core/Mage/Catalog/Block/Product/List/Related.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Related.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Catalog
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2020-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -32,6 +32,7 @@ class Mage_Catalog_Block_Product_List_Related extends Mage_Catalog_Block_Product
         $this->_itemCollection = $product->getRelatedProductCollection()
             ->addAttributeToSelect('required_options')
             ->setPositionOrder()
+            ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInCatalogIds())
             ->addStoreFilter()
         ;
 
@@ -42,7 +43,6 @@ class Mage_Catalog_Block_Product_List_Related extends Mage_Catalog_Block_Product
             );
             $this->_addProductAttributesAndPrices($this->_itemCollection);
         }
-        Mage::getSingleton('catalog/product_visibility')->addVisibleInCatalogFilterToCollection($this->_itemCollection);
 
         if (!Mage::helper('cataloginventory')->isShowOutOfStock()) {
             Mage::getSingleton('cataloginventory/stock')->addInStockFilterToCollection($this->_itemCollection);

--- a/app/code/core/Mage/Catalog/Block/Product/List/Upsell.php
+++ b/app/code/core/Mage/Catalog/Block/Product/List/Upsell.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Catalog
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -36,6 +36,7 @@ class Mage_Catalog_Block_Product_List_Upsell extends Mage_Catalog_Block_Product_
         /** @var Mage_Catalog_Model_Product $product */
         $this->_itemCollection = $product->getUpSellProductCollection()
             ->setPositionOrder()
+            ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInCatalogIds())
             ->addStoreFilter()
         ;
         if ($this->isModuleEnabled('Mage_Checkout', 'catalog')) {
@@ -46,7 +47,6 @@ class Mage_Catalog_Block_Product_List_Upsell extends Mage_Catalog_Block_Product_
 
             $this->_addProductAttributesAndPrices($this->_itemCollection);
         }
-        Mage::getSingleton('catalog/product_visibility')->addVisibleInCatalogFilterToCollection($this->_itemCollection);
 
         if (!Mage::helper('cataloginventory')->isShowOutOfStock()) {
             Mage::getSingleton('cataloginventory/stock')->addInStockFilterToCollection($this->_itemCollection);

--- a/app/code/core/Mage/Catalog/Block/Product/New.php
+++ b/app/code/core/Mage/Catalog/Block/Product/New.php
@@ -77,7 +77,7 @@ class Mage_Catalog_Block_Product_New extends Mage_Catalog_Block_Product_Abstract
 
         /** @var Mage_Catalog_Model_Resource_Product_Collection $collection */
         $collection = Mage::getResourceModel('catalog/product_collection');
-        $collection->setVisibility(Mage::getSingleton('catalog/product_visibility')->getVisibleInCatalogIds());
+        $collection->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInCatalogIds());
 
         $collection = $this->_addProductAttributesAndPrices($collection)
             ->addStoreFilter()

--- a/app/code/core/Mage/Catalog/Block/Product/Widget/New.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Widget/New.php
@@ -81,7 +81,7 @@ class Mage_Catalog_Block_Product_Widget_New extends Mage_Catalog_Block_Product_N
     {
         /** @var Mage_Catalog_Model_Resource_Product_Collection $collection */
         $collection = Mage::getResourceModel('catalog/product_collection');
-        $collection->setVisibility(Mage::getSingleton('catalog/product_visibility')->getVisibleInCatalogIds());
+        $collection->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInCatalogIds());
 
         $collection = $this->_addProductAttributesAndPrices($collection)
             ->addStoreFilter()

--- a/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Product.php
+++ b/app/code/core/Mage/Catalog/Block/Seo/Sitemap/Product.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Catalog
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -33,10 +33,10 @@ class Mage_Catalog_Block_Seo_Sitemap_Product extends Mage_Catalog_Block_Seo_Site
             ->addAttributeToSelect('name')
             ->addAttributeToSelect('url_key')
             ->addStoreFilter()
+            ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInCatalogIds())
             ->addAttributeToFilter('status', [
                 'in' => Mage::getSingleton('catalog/product_status')->getVisibleStatusIds(),
             ]);
-        Mage::getSingleton('catalog/product_visibility')->addVisibleInCatalogFilterToCollection($collection);
 
         $this->setCollection($collection);
         return $this;

--- a/app/code/core/Mage/Catalog/Helper/Product/Compare.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Compare.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Catalog
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2023 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -207,7 +207,7 @@ class Mage_Catalog_Helper_Product_Compare extends Mage_Core_Helper_Url
                 $this->_itemCollection->setVisitorId($this->_logVisitor->getId());
             }
 
-            $this->_productVisibility->addVisibleInSiteFilterToCollection($this->_itemCollection);
+            $this->_itemCollection->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSiteIds());
 
             /* Price data is added to consider item stock status using price index */
             $this->_itemCollection->addPriceData();
@@ -248,7 +248,7 @@ class Mage_Catalog_Helper_Product_Compare extends Mage_Core_Helper_Url
             /* Price data is added to consider item stock status using price index */
             $collection->addPriceData();
 
-            $this->_productVisibility->addVisibleInSiteFilterToCollection($collection);
+            $collection->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSiteIds());
 
             $count = $collection->getSize();
         }

--- a/app/code/core/Mage/Catalog/Model/Layer.php
+++ b/app/code/core/Mage/Catalog/Model/Layer.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Catalog
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2018-2025 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2018-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -99,8 +99,8 @@ class Mage_Catalog_Model_Layer extends \Maho\DataObject
             ->addAttributeToSelect(Mage::getSingleton('catalog/config')->getProductAttributes())
             ->addPriceData()
             ->addTaxPercents()
+            ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInCatalogIds())
             ->addUrlRewrite($this->getCurrentCategory()->getId());
-        Mage::getSingleton('catalog/product_visibility')->addVisibleInCatalogFilterToCollection($collection);
 
         return $this;
     }

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -1503,7 +1503,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
      */
     public function getVisibleInSiteVisibilities()
     {
-        return Mage::getSingleton('catalog/product_visibility')->getVisibleInSiteIds();
+        return Mage_Catalog_Model_Product_Visibility::getVisibleInSiteIds();
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Model/Product/Visibility.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Visibility.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Catalog
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2016-2023 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2016-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -34,33 +34,32 @@ class Mage_Catalog_Model_Product_Visibility extends \Maho\DataObject
     }
 
     /**
-     * Add visible in catalog filter to collection
-     *
+     * @deprecated since 26.5 Use $collection->setVisibility($this->getVisibleInCatalogIds()) instead
      * @return $this
      */
     public function addVisibleInCatalogFilterToCollection(Mage_Catalog_Model_Resource_Product_Collection $collection)
     {
-        $collection->setVisibility($this->getVisibleInCatalogIds());
+        $collection->setVisibility(static::getVisibleInCatalogIds());
         return $this;
     }
+
     /**
-     * Add visibility in searchfilter to collection
-     *
+     * @deprecated since 26.5 Use $collection->setVisibility($this->getVisibleInSearchIds()) instead
      * @return $this
      */
     public function addVisibleInSearchFilterToCollection(Mage_Catalog_Model_Resource_Product_Collection $collection)
     {
-        $collection->setVisibility($this->getVisibleInSearchIds());
+        $collection->setVisibility(static::getVisibleInSearchIds());
         return $this;
     }
+
     /**
-     * Add visibility in site filter to collection
-     *
+     * @deprecated since 26.5 Use $collection->setVisibility($this->getVisibleInSiteIds()) instead
      * @return $this
      */
     public function addVisibleInSiteFilterToCollection(Mage_Catalog_Model_Resource_Product_Collection $collection)
     {
-        $collection->setVisibility($this->getVisibleInSiteIds());
+        $collection->setVisibility(static::getVisibleInSiteIds());
         return $this;
     }
 
@@ -69,7 +68,7 @@ class Mage_Catalog_Model_Product_Visibility extends \Maho\DataObject
      *
      * @return array
      */
-    public function getVisibleInCatalogIds()
+    public static function getVisibleInCatalogIds()
     {
         return [self::VISIBILITY_IN_CATALOG, self::VISIBILITY_BOTH];
     }
@@ -79,7 +78,7 @@ class Mage_Catalog_Model_Product_Visibility extends \Maho\DataObject
      *
      * @return array
      */
-    public function getVisibleInSearchIds()
+    public static function getVisibleInSearchIds()
     {
         return [self::VISIBILITY_IN_SEARCH, self::VISIBILITY_BOTH];
     }
@@ -89,7 +88,7 @@ class Mage_Catalog_Model_Product_Visibility extends \Maho\DataObject
      *
      * @return array
      */
-    public function getVisibleInSiteIds()
+    public static function getVisibleInSiteIds()
     {
         return [self::VISIBILITY_IN_SEARCH, self::VISIBILITY_IN_CATALOG, self::VISIBILITY_BOTH];
     }

--- a/app/code/core/Mage/CatalogIndex/Model/Indexer.php
+++ b/app/code/core/Mage/CatalogIndex/Model/Indexer.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_CatalogIndex
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2017-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2017-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -298,7 +298,7 @@ class Mage_CatalogIndex_Model_Indexer extends Mage_Core_Model_Abstract
             foreach ($stores as $store) {
                 foreach ($this->_getPriorifiedProductTypes() as $type) {
                     $collection = $this->_getProductCollection($store, $products);
-                    Mage::getSingleton('catalog/product_visibility')->addVisibleInSiteFilterToCollection($collection);
+                    $collection->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSiteIds());
                     $collection->addFieldToFilter('type_id', $type);
 
                     $this->_walkCollection($collection, $store, $attributeCodes);

--- a/app/code/core/Mage/CatalogSearch/Model/Advanced.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Advanced.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_CatalogSearch
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -304,10 +304,10 @@ class Mage_CatalogSearch_Model_Advanced extends Mage_Core_Model_Abstract
             ->addPriceData()
             ->addTaxPercents()
             ->addStoreFilter()
+            ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSearchIds())
             ->addAttributeToFilter('status', [
                 'in' => Mage::getSingleton('catalog/product_status')->getVisibleStatusIds(),
             ]);
-        Mage::getSingleton('catalog/product_visibility')->addVisibleInSearchFilterToCollection($collection);
 
         return $this;
     }

--- a/app/code/core/Mage/CatalogSearch/Model/Layer.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Layer.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_CatalogSearch
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2018-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2018-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -48,8 +48,8 @@ class Mage_CatalogSearch_Model_Layer extends Mage_Catalog_Model_Layer
             ->addPriceData()
             ->addTaxPercents()
             ->addStoreFilter()
+            ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSearchIds())
             ->addUrlRewrite();
-        Mage::getSingleton('catalog/product_visibility')->addVisibleInSearchFilterToCollection($collection);
 
         return $this;
     }

--- a/app/code/core/Mage/CatalogSearch/Model/Query.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Query.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_CatalogSearch
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */

--- a/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Engine.php
+++ b/app/code/core/Mage/CatalogSearch/Model/Resource/Fulltext/Engine.php
@@ -75,7 +75,7 @@ class Mage_CatalogSearch_Model_Resource_Fulltext_Engine extends Mage_Core_Model_
      */
     public function getAllowedVisibility()
     {
-        return Mage::getSingleton('catalog/product_visibility')->getVisibleInSearchIds();
+        return Mage_Catalog_Model_Product_Visibility::getVisibleInSearchIds();
     }
 
     /**

--- a/app/code/core/Mage/Checkout/Block/Cart/Crosssell.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Crosssell.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Checkout
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2020-2026 The OpenMage Contributors (https://openmage.org)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -154,7 +154,7 @@ class Mage_Checkout_Block_Cart_Crosssell extends Mage_Catalog_Block_Product_Abst
             ->setPageSize($this->_maxItemCount);
         $this->_addProductAttributesAndPrices($collection);
 
-        Mage::getSingleton('catalog/product_visibility')->addVisibleInCatalogFilterToCollection($collection);
+        $collection->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInCatalogIds());
         // Always filter out-of-stock regardless of setting, since cart crosssell items are meant for immediate purchase
         Mage::getSingleton('cataloginventory/stock')->addInStockFilterToCollection($collection);
 

--- a/app/code/core/Mage/Reports/Block/Product/Abstract.php
+++ b/app/code/core/Mage/Reports/Block/Product/Abstract.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Reports
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2020-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -126,7 +126,8 @@ abstract class Mage_Reports_Block_Product_Abstract extends Mage_Catalog_Block_Pr
                     ->setCurPage(1);
 
             /* Price data is added to consider item stock status using price index */
-            $this->_collection->addPriceData();
+            $this->_collection->addPriceData()
+                ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSiteIds());
 
             $ids = $this->getProductIds();
             if (empty($ids)) {
@@ -138,9 +139,6 @@ abstract class Mage_Reports_Block_Product_Abstract extends Mage_Catalog_Block_Pr
             if ($this-> _useProductIdsOrder && is_array($ids)) {
                 $this->_collection->setSortIds($ids);
             }
-
-            Mage::getSingleton('catalog/product_visibility')
-                ->addVisibleInSiteFilterToCollection($this->_collection);
         }
 
         return $this->_collection;

--- a/app/code/core/Mage/Reports/Model/Product/Index/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Product/Index/Abstract.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Reports
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2020-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -157,10 +157,8 @@ abstract class Mage_Reports_Model_Product_Index_Abstract extends Mage_Core_Model
     {
         $collection = $this->getCollection()
             ->setCustomerId($this->getCustomerId())
+            ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSiteIds())
             ->addIndexFilter();
-
-        Mage::getSingleton('catalog/product_visibility')
-            ->addVisibleInSiteFilterToCollection($collection);
 
         $count = $collection->getSize();
         $this->_getSession()->setData($this->_countCacheKey, $count);

--- a/app/code/core/Mage/Rss/Block/Catalog/Category.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Category.php
@@ -80,7 +80,7 @@ class Mage_Rss_Block_Catalog_Category extends Mage_Rss_Block_Catalog_Abstract
                 $categoryProductCollection = $currentCategory
                     ->getProductCollection()
                     ->addAttributeToSort('updated_at', 'desc')
-                    ->setVisibility(Mage::getSingleton('catalog/product_visibility')->getVisibleInCatalogIds())
+                    ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInCatalogIds())
                     ->setCurPage(1)
                     ->setPageSize(50)
                 ;

--- a/app/code/core/Mage/Rss/Block/Catalog/New.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/New.php
@@ -78,7 +78,7 @@ class Mage_Rss_Block_Catalog_New extends Mage_Rss_Block_Catalog_Abstract
             ->applyFrontendPriceLimitations()
         ;
 
-        $products->setVisibility(Mage::getSingleton('catalog/product_visibility')->getVisibleInCatalogIds());
+        $products->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInCatalogIds());
 
         /*
         using resource iterator to load the data one by one

--- a/app/code/core/Mage/Rss/Block/Catalog/Tag.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Tag.php
@@ -52,7 +52,7 @@ class Mage_Rss_Block_Catalog_Tag extends Mage_Rss_Block_Catalog_Abstract
             ->addTagFilter($tagModel->getId())
             ->addStoreFilter($storeId);
 
-        $collection->setVisibility(Mage::getSingleton('catalog/product_visibility')->getVisibleInCatalogIds());
+        $collection->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInCatalogIds());
 
         $product = Mage::getModel('catalog/product');
 

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -1726,7 +1726,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
         $productsCollection = Mage::getModel('catalog/product')
             ->getCollection()
             ->addIdFilter($products)
-            ->setVisibility(Mage::getSingleton('catalog/product_visibility')->getVisibleInSiteIds())
+            ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSiteIds())
             /* Price data is added to consider item stock status using price index */
             ->addPriceData()
             ->setPageSize($limit)

--- a/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Product.php
+++ b/app/code/core/Mage/Sitemap/Model/Resource/Catalog/Product.php
@@ -49,7 +49,7 @@ class Mage_Sitemap_Model_Resource_Catalog_Product extends Mage_Sitemap_Model_Res
         $this->_addFilter(
             $storeId,
             'visibility',
-            Mage::getSingleton('catalog/product_visibility')->getVisibleInSiteIds(),
+            Mage_Catalog_Model_Product_Visibility::getVisibleInSiteIds(),
             'in',
         );
         $this->_addFilter(

--- a/app/code/core/Mage/Tag/Block/Customer/Recent.php
+++ b/app/code/core/Mage/Tag/Block/Customer/Recent.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Tag
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2020-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -29,11 +29,9 @@ class Mage_Tag_Block_Customer_Recent extends Mage_Core_Block_Template
             ->setDescOrder()
             ->setPageSize(5)
             ->setActiveFilter()
+            ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSiteIds())
             ->load()
             ->addProductTags();
-
-        Mage::getSingleton('catalog/product_visibility')
-            ->addVisibleInSiteFilterToCollection($this->_collection);
     }
 
     /**

--- a/app/code/core/Mage/Tag/Block/Customer/View.php
+++ b/app/code/core/Mage/Tag/Block/Customer/View.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Tag
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -130,10 +130,8 @@ class Mage_Tag_Block_Customer_View extends Mage_Catalog_Block_Product_Abstract
                 ->addCustomerFilter(Mage::getSingleton('customer/session')->getCustomerId())
                 ->addStoreFilter(Mage::app()->getStore()->getId())
                 ->addAttributeToSelect(Mage::getSingleton('catalog/config')->getProductAttributes())
+                ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSiteIds())
                 ->setActiveFilter();
-
-            Mage::getSingleton('catalog/product_visibility')
-                ->addVisibleInSiteFilterToCollection($this->_collection);
         }
         return $this->_collection;
     }

--- a/app/code/core/Mage/Tag/Block/Product/Result.php
+++ b/app/code/core/Mage/Tag/Block/Product/Result.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Tag
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2020-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2020-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -87,10 +87,8 @@ class Mage_Tag_Block_Product_Result extends Mage_Catalog_Block_Product_Abstract
                 ])
                 ->addPriceData()
                 ->addUrlRewrite()
+                ->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSiteIds())
                 ->setActiveFilter();
-            Mage::getSingleton('catalog/product_visibility')->addVisibleInSiteFilterToCollection(
-                $this->_productCollection,
-            );
         }
 
         return $this->_productCollection;

--- a/app/code/core/Mage/Wishlist/Model/Resource/Item/Collection.php
+++ b/app/code/core/Mage/Wishlist/Model/Resource/Item/Collection.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Wishlist
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -171,7 +171,7 @@ class Mage_Wishlist_Model_Resource_Item_Collection extends Mage_Core_Model_Resou
             ->addTaxPercents();
 
         if ($this->_productVisible) {
-            Mage::getSingleton('catalog/product_visibility')->addVisibleInSiteFilterToCollection($productCollection);
+            $productCollection->setVisibility(Mage_Catalog_Model_Product_Visibility::getVisibleInSiteIds());
         }
         if ($this->_productSalable) {
             $productCollection = Mage::helper('adminhtml/sales')->applySalableProductTypesFilter($productCollection);


### PR DESCRIPTION
## Summary

Credits to OpenMage/magento-lts#5329 - thanks to @Hanmac for the original work!

- **Deprecated** `addVisibleInCatalogFilterToCollection()`, `addVisibleInSearchFilterToCollection()`, and `addVisibleInSiteFilterToCollection()` on `Mage_Catalog_Model_Product_Visibility` (kept for backward compatibility with third-party modules)
- **Updated all call sites** to use `$collection->setVisibility()` directly
- **Made `getVisibleInCatalogIds()`, `getVisibleInSearchIds()`, `getVisibleInSiteIds()` static** -- they only return constant arrays and don't need an instance
- **Replaced all `Mage::getSingleton('catalog/product_visibility')` calls** with direct `Mage_Catalog_Model_Product_Visibility::` static calls
- **Deprecated unused** `Mage_CatalogInventory_Model_Stock_Status::addIsInStockFilterToCollection()` (zero call sites)

## Test plan

- [ ] Verify product visibility filtering works on category pages
- [ ] Verify search results respect visibility settings
- [ ] Verify cross-sell, up-sell, and related products display correctly
- [ ] Verify compare products list works
- [ ] Verify sitemap generation includes correct products
- [ ] Verify RSS feeds show correct products