### PR TITLE
Log warning when model or helper class cannot be loaded

### DIFF
--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1334,6 +1334,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     {
         $className = $this->getHelperClassName($helperAlias);
         if (!class_exists($className)) {
+            Mage::log("Helper class '$className' (alias: '$helperAlias') could not be loaded.", Mage::LOG_WARNING);
             return false;
         }
         \Maho\Profiler::start('CORE::create_object_of::' . $className);
@@ -1407,6 +1408,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     {
         $className = $this->getModelClassName($modelAlias);
         if (!class_exists($className)) {
+            Mage::log("Model class '$className' (alias: '$modelAlias') could not be loaded.", Mage::LOG_WARNING);
             return false;
         }
         \Maho\Profiler::start('CORE::create_object_of::' . $className);


### PR DESCRIPTION
## Summary
- When `getModelInstance()` or `getHelperInstance()` cannot find a class, a warning is now logged with the resolved class name and alias before returning `false`
- This helps diagnose cryptic "call to member function on false" errors without breaking existing code that checks the return value

## Test plan
- [ ] Verify that referencing a non-existent model alias produces a log entry like: `Model class 'X' (alias: 'y/z') could not be loaded.`
- [ ] Verify that existing defensive checks (`if ($model = Mage::getModel(...))`) still work as before

Closes #698