### PR TITLE
Auto-inject `form_key` for JSON request bodies in `mahoFetch()`

### DIFF
--- a/public/js/varien/js.js
+++ b/public/js/varien/js.js
@@ -46,7 +46,7 @@ async function mahoFetch(url, options) {
             } else if (typeof fetchOptions.body === 'string') {
                 try {
                     const parsed = JSON.parse(fetchOptions.body);
-                    if (typeof parsed === 'object' && parsed !== null && !parsed.form_key) {
+                    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed) && !('form_key' in parsed)) {
                         parsed.form_key = FORM_KEY;
                         fetchOptions.body = JSON.stringify(parsed);
                     }


### PR DESCRIPTION
## Summary

- mahoFetch() now automatically injects form_key into JSON string request bodies, matching the existing behavior for URLSearchParams and FormData bodies
- When the body is a string, it attempts to parse as JSON and adds form_key if the parsed object doesn't already have one
- Non-JSON string bodies are silently skipped via try/catch

Closes #705