### PR TITLE
Fixed Admin Activity Log grid SQL error

### DIFF
--- a/app/code/core/Maho/AdminActivityLog/Block/Adminhtml/Activity/Grid.php
+++ b/app/code/core/Maho/AdminActivityLog/Block/Adminhtml/Activity/Grid.php
@@ -27,7 +27,7 @@ class Maho_AdminActivityLog_Block_Adminhtml_Activity_Grid extends Mage_Adminhtml
 
         // Group by action_group_id to show only one entry per group
         $collection->getSelect()
-            ->group('COALESCE(main_table.action_group_id, main_table.activity_id)')
+            ->group(new Maho\Db\Expr('COALESCE(main_table.action_group_id, main_table.activity_id)'))
             ->columns([
                 'activity_count' => new Maho\Db\Expr('COUNT(*)'),
             ]);


### PR DESCRIPTION
## Summary
- Wraps the GROUP BY `COALESCE(...)` expression in `Maho\Db\Expr` so the database adapter treats it as raw SQL instead of quoting it as a column identifier
- Fixes the `Column not found: 1054` error on MariaDB 11.4

Fixes #713