### PR TITLE
Added `fetchpriority="high"` to main product image

### DIFF
--- a/app/design/frontend/base/default/template/catalog/product/view/media.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/media.phtml
@@ -22,6 +22,7 @@ $mainImage = $this->helper('catalog/image')->init($_product, 'image');
                 src="<?= $mainImage ?>"
                 alt="<?= $this->escapeHtml($this->getImageLabel()) ?>"
                 title="<?= $this->escapeHtml($this->getImageLabel()) ?>"
+                fetchpriority="high"
                 width="<?= $mainImage->getOriginalWidth() ?>" height="<?= $mainImage->getOriginalHeight() ?>" />
 
             <?php $i=0; foreach ($this->getGalleryImages() as $_image): ?>


### PR DESCRIPTION
## Summary
- Adds `fetchpriority="high"` to the main product image on the product detail page
- Improves Largest Contentful Paint (LCP) by telling the browser to prioritize the hero image

## Test plan
- [ ] Visit a product detail page and inspect the main `<img>` tag to confirm the attribute is present
- [ ] Run Lighthouse or PageSpeed Insights and verify LCP improvement