### PR TITLE
Allow .thumbs directory in .htaccess rewrite rules

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -48,7 +48,9 @@ DirectoryIndex index.php
     RewriteEngine on
 
     # Prevent serving "hidden" files like git repository
+    # Allow .thumbs directory used by WYSIWYG media storage
     RewriteCond %{REQUEST_URI} /\.
+    RewriteCond %{REQUEST_URI} !/\.thumbs/
     RewriteRule ^(.*)$ / [R=404,L]
 
     # Uncomment next line to enable light API calls processing


### PR DESCRIPTION
## Summary
- The `.htaccess` rewrite rule that blocks serving hidden files (paths containing `/.`) was also blocking access to the `.thumbs` directory
- Added an exception so the `.thumbs` directory used by WYSIWYG media storage can serve image thumbnails correctly

## Test plan
- [ ] Verify WYSIWYG media browser thumbnails load correctly in admin
- [ ] Verify other hidden files/directories (e.g. `.git`) are still blocked