### PR TITLE
Fixed WYSIWYG directive passing URL to `ImageManager::read()`

### DIFF
--- a/app/code/core/Mage/Cms/Model/Adminhtml/Template/Filter.php
+++ b/app/code/core/Mage/Cms/Model/Adminhtml/Template/Filter.php
@@ -13,14 +13,10 @@
 class Mage_Cms_Model_Adminhtml_Template_Filter extends Mage_Cms_Model_Template_Filter
 {
     /**
-     * Retrieve media file local path directive
-     *
-     * @internal to avoid usage of urls at functions sensitive to "allow_url_fopen" php setting at GD2 adapter
+     * Retrieve media file local path instead of URL, so it can be read by Intervention Image
      *
      * @param array $construction
-     *
      * @return string
-     *
      * @throws Mage_Core_Exception
      */
     #[\Override]
@@ -32,5 +28,26 @@ class Mage_Cms_Model_Adminhtml_Template_Filter extends Mage_Cms_Model_Template_F
         }
 
         return Mage::getBaseDir('media') . DS . $params['url'];
+    }
+
+    /**
+     * Retrieve skin file local path instead of URL, so it can be read by Intervention Image
+     *
+     * @param array $construction
+     * @return string
+     */
+    #[\Override]
+    public function skinDirective($construction)
+    {
+        $params = $this->_getIncludeParameters($construction[2]);
+        if (!isset($params['url'])) {
+            Mage::throwException('Undefined url parameter for skin directive.');
+        }
+
+        $file = $params['url'];
+        unset($params['url']);
+        $params['_type'] = 'skin';
+
+        return Mage::getDesign()->getFilename($file, $params);
     }
 }


### PR DESCRIPTION
## Summary
- Override `skinDirective()` in `Mage_Cms_Model_Adminhtml_Template_Filter` to return a local filesystem path instead of a URL, matching the existing `mediaDirective()` pattern
- Intervention Image v3 does not accept URL strings — it expects file paths, binary data, or stream resources
- Uses `Mage::getDesign()->getFilename()` which preserves theme fallback logic and works regardless of CDN configuration

Fixes #729

## Test plan
- [ ] In admin, use WYSIWYG editor with a `{{skin url="..."}}` directive
- [ ] Verify the directive preview renders correctly without `DecoderException`
- [ ] Verify `{{media url="..."}}` directives still preview correctly