### PR TITLE
Fixed SVG validator rejecting non-SVG favicon uploads

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image.php
@@ -44,8 +44,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_Image extends Mage_Adminhtml_Mo
 
         // Add SVG validator only if SVG is allowed and the uploaded file is actually an SVG
         if (in_array('svg', $allowedExtensions)) {
-            $filenameToCheck = $originalFileName ?: '';
-            if (strtolower(pathinfo($filenameToCheck, PATHINFO_EXTENSION)) === 'svg') {
+            if (strtolower(pathinfo($originalFileName, PATHINFO_EXTENSION)) === 'svg') {
                 $svgValidator = Mage::getModel('core/file_validator_svg');
                 $uploader->addValidateCallback(Mage_Core_Model_File_Validator_Svg::NAME, $svgValidator, 'validate');
             }


### PR DESCRIPTION
## Summary
- The SVG validator was running on **all** uploaded files when SVG was in the allowed extensions list (e.g., favicon uploads), causing non-SVG files (PNG, JPG, etc.) to fail with "File is not a valid SVG." error
- Added original filename awareness to the SVG validator so it skips non-SVG files, matching the same pattern already used by the image validator

## Test plan
- [ ] Upload a PNG file as favicon in System > Configuration > Design > HTML Head — should succeed
- [ ] Upload an ICO file as favicon — should succeed
- [ ] Upload an SVG file as favicon — should still be validated and sanitized
- [ ] Upload an invalid SVG file — should still be rejected