### PR TITLE
Fixed Symfony Validator deprecations and V2 API foreach on null

### DIFF
--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -1091,7 +1091,7 @@ XML;
      */
     public function isValidRegex(string $value, string $pattern): bool
     {
-        $violations = $this->getSymfonyValidator()->validate($value, new Assert\Regex(['pattern' => $pattern]));
+        $violations = $this->getSymfonyValidator()->validate($value, new Assert\Regex(pattern: $pattern));
         return count($violations) === 0;
     }
 
@@ -1100,15 +1100,7 @@ XML;
      */
     public function isValidLength(string $value, ?int $min = null, ?int $max = null): bool
     {
-        $options = [];
-        if ($min !== null) {
-            $options['min'] = $min;
-        }
-        if ($max !== null) {
-            $options['max'] = $max;
-        }
-
-        $violations = $this->getSymfonyValidator()->validate($value, new Assert\Length($options));
+        $violations = $this->getSymfonyValidator()->validate($value, new Assert\Length(min: $min, max: $max));
         return count($violations) === 0;
     }
 
@@ -1117,15 +1109,7 @@ XML;
      */
     public function isValidRange(mixed $value, int|float|null $min = null, int|float|null $max = null): bool
     {
-        $options = [];
-        if ($min !== null) {
-            $options['min'] = $min;
-        }
-        if ($max !== null) {
-            $options['max'] = $max;
-        }
-
-        $violations = $this->getSymfonyValidator()->validate($value, new Assert\Range($options));
+        $violations = $this->getSymfonyValidator()->validate($value, new Assert\Range(min: $min, max: $max));
         return count($violations) === 0;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api/V2.php
@@ -75,7 +75,7 @@ class Mage_Sales_Model_Order_Invoice_Api_V2 extends Mage_Sales_Model_Order_Invoi
     protected function _prepareItemQtyData($data)
     {
         $quantity = [];
-        foreach ($data as $item) {
+        foreach ($data ?? [] as $item) {
             if (isset($item->order_item_id) && isset($item->qty)) {
                 $quantity[$item->order_item_id] = $item->qty;
             }

--- a/app/code/core/Mage/Sales/Model/Order/Shipment/Api/V2.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment/Api/V2.php
@@ -19,7 +19,7 @@ class Mage_Sales_Model_Order_Shipment_Api_V2 extends Mage_Sales_Model_Order_Ship
     protected function _prepareItemQtyData($data)
     {
         $_data = [];
-        foreach ($data as $item) {
+        foreach ($data ?? [] as $item) {
             if (isset($item->order_item_id) && isset($item->qty)) {
                 $_data[$item->order_item_id] = $item->qty;
             }

--- a/lib/Maho/File/Uploader.php
+++ b/lib/Maho/File/Uploader.php
@@ -371,7 +371,7 @@ class Uploader
         try {
             if (count($validTypes) > 0) {
                 $validator = Validation::createValidator();
-                $constraint = new Assert\File(['mimeTypes' => $validTypes]);
+                $constraint = new Assert\File(mimeTypes: $validTypes);
                 $violations = $validator->validate($this->_file['tmp_name'], $constraint);
                 return count($violations) === 0;
             }


### PR DESCRIPTION
## Summary
- Use named arguments instead of deprecated array options for Symfony Validator constraints (`Length`, `Regex`, `Range`, `File`) to resolve deprecation warnings in symfony/validator 7.3+
- Guard against null in `_prepareItemQtyData()` in Invoice and Shipment V2 API classes to prevent `foreach()` on null

## Test plan
- [ ] Verify no Symfony Validator deprecation warnings in logs
- [ ] Test SOAP V2 API invoice creation with and without item quantities
- [ ] Test SOAP V2 API shipment creation with and without item quantities
- [ ] Verify `isValidLength()`, `isValidRange()`, `isValidRegex()` helper methods still work correctly
- [ ] Verify file upload MIME type validation still works