### PR TITLE
Fixed PayPal total_invoiced always being 0 for captured orders

### DIFF
--- a/app/code/core/Maho/Paypal/Model/Method/Abstract.php
+++ b/app/code/core/Maho/Paypal/Model/Method/Abstract.php
@@ -58,6 +58,7 @@ abstract class Maho_Paypal_Model_Method_Abstract extends Mage_Payment_Model_Meth
                 $payment->setTransactionId($captureId);
                 $payment->setIsTransactionClosed(true);
                 $payment->addTransaction(Mage_Sales_Model_Order_Payment_Transaction::TYPE_CAPTURE);
+                $this->_createCaptureInvoice($payment, $captureId);
             } else {
                 $payment->setTransactionId($authId);
                 $payment->setIsTransactionClosed(false);
@@ -198,6 +199,18 @@ abstract class Maho_Paypal_Model_Method_Abstract extends Mage_Payment_Model_Meth
     public function cancel(\Maho\DataObject $payment): self
     {
         return $this->void($payment);
+    }
+
+    protected function _createCaptureInvoice(Mage_Sales_Model_Order_Payment $payment, string $captureId): void
+    {
+        $order = $payment->getOrder();
+        if (!$order->canInvoice()) {
+            return;
+        }
+        $invoice = $order->prepareInvoice();
+        $invoice->setTransactionId($captureId);
+        $invoice->register();
+        $order->addRelatedObject($invoice);
     }
 
     protected function _importPaymentInfo(array $result, Mage_Payment_Model_Info $payment): void

--- a/app/code/core/Maho/Paypal/Model/Method/Vault.php
+++ b/app/code/core/Maho/Paypal/Model/Method/Vault.php
@@ -112,6 +112,7 @@ class Maho_Paypal_Model_Method_Vault extends Maho_Paypal_Model_Method_Abstract
             $payment->setIsTransactionClosed(true);
             $payment->setAdditionalInformation('paypal_capture_id', $captureId);
             $payment->addTransaction(Mage_Sales_Model_Order_Payment_Transaction::TYPE_CAPTURE);
+            $this->_createCaptureInvoice($payment, $captureId);
         } elseif ($authId) {
             $payment->setTransactionId($authId);
             $payment->setIsTransactionClosed(false);

--- a/app/code/core/Maho/Paypal/Model/Webhook/Handler/CaptureCompleted.php
+++ b/app/code/core/Maho/Paypal/Model/Webhook/Handler/CaptureCompleted.php
@@ -17,6 +17,7 @@ class Maho_Paypal_Model_Webhook_Handler_CaptureCompleted extends Maho_Paypal_Mod
     {
         $resource = $payload['resource'] ?? [];
         $captureId = $resource['id'] ?? '';
+        $amount = (float) ($resource['amount']['value'] ?? 0);
 
         $order = $this->_findOrder($payload);
         if (!$order) {
@@ -26,17 +27,11 @@ class Maho_Paypal_Model_Webhook_Handler_CaptureCompleted extends Maho_Paypal_Mod
 
         $payment = $order->getPayment();
         $payment->setAdditionalInformation('paypal_capture_id', $captureId);
+        $payment->setTransactionId($captureId);
+        $payment->setIsTransactionClosed(true);
+        $payment->registerCaptureNotification($amount);
 
-        $invoice = null;
-        if ($order->canInvoice()) {
-            $invoice = $order->prepareInvoice();
-            $invoice->setRequestedCaptureCase(Mage_Sales_Model_Order_Invoice::CAPTURE_ONLINE);
-            $invoice->setTransactionId($captureId);
-            $invoice->register();
-            $invoice->pay();
-        }
-
-        $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING, true, "PayPal capture completed: {$captureId}");
+        $invoice = $payment->getCreatedInvoice();
 
         $transactionSave = Mage::getModel('core/resource_transaction')
             ->addObject($order);


### PR DESCRIPTION
## Summary

- Fixed `CaptureCompleted` webhook handler using `CAPTURE_ONLINE` which re-triggered a PayPal API capture call on an already-captured payment, causing the call to fail and `total_invoiced` to never be set
- Invoice is now created during `initialize()` at order placement when a capture ID is already available, eliminating dependency on the webhook for invoice creation
- Webhook handler now uses `registerCaptureNotification()` (the framework's built-in method for externally-completed captures) which correctly creates transactions, invoices, and updates totals without hitting the PayPal API

## Root Cause

Two issues combined to cause `total_invoiced = 0`:

**1. Webhook handler tried to re-capture an already-captured payment**

`CaptureCompleted` set `CAPTURE_ONLINE` on the invoice, which made `Invoice::register()` call `Payment::capture()` → `Method::capture()` → PayPal API. Since the capture was already completed (that's what the webhook is reporting), the API call failed and `register()` never reached the line that sets `total_invoiced`.

**2. No invoice was created during order placement**

`initialize()` recorded the capture transaction but never created an invoice. Invoice creation depended entirely on the webhook. If the webhook arrived before the order was committed to the database (race condition between `approveOrderAction` and the webhook) or never arrived, the order would permanently have no invoice and `total_invoiced = 0`.

## Changes

### `CaptureCompleted.php`
Replaced manual invoice creation with `registerCaptureNotification()`, which handles invoice creation, transaction records, and total updates without calling the payment gateway.

### `Abstract.php`
Added `_createCaptureInvoice()` method and call it from `initialize()` when a `captureId` is present. The invoice is added via `addRelatedObject()` and saved with the order in `_afterSave()`.

### `Vault.php`
Same invoice creation for vault payments with immediate capture.

## Payment Action Flows

### CAPTURE intent (payment_action = capture)

This is the most common flow. The JS SDK captures the payment before order placement.

**Without webhook (or webhook not configured):**
1. `approveOrderAction()` calls PayPal `captureOrder()` → capture succeeds, returns `captureId`
2. `initialize()` creates a CAPTURE transaction and now also creates the invoice via `_createCaptureInvoice()`
3. `Invoice::register()` sets `total_invoiced`, calls `pay()` which sets `total_paid`
4. Order is saved with state=processing, invoice and transaction as related objects
5. **Result:** `total_invoiced` ✅, `total_paid` ✅ — fully self-contained, no webhook needed

**With webhook:**
1. Same as above — invoice already exists at order placement
2. `PAYMENT.CAPTURE.COMPLETED` webhook arrives later
3. `registerCaptureNotification()` calls `_getInvoiceForTransactionId($captureId)` → finds existing invoice
4. Invoice state is already `PAID` → `pay()` is skipped
5. `_addTransaction()` finds existing capture transaction → updates it (no duplicate)
6. **Result:** webhook is a safe no-op, idempotent ✅

**Race condition (webhook arrives before order is committed to DB):**
1. `approveOrderAction()` calls PayPal `captureOrder()` → PayPal immediately fires webhook
2. Webhook arrives, `_findOrder()` returns null (order not in DB yet) → handler logs and returns
3. `saveOrder()` completes with the invoice already created by `initialize()`
4. **Result:** `total_invoiced` ✅ — race condition no longer matters

### AUTHORIZE intent (payment_action = authorize)

The JS SDK authorizes the payment before order placement. Capture happens later.

**Admin captures from backend (no webhook needed):**
1. `approveOrderAction()` calls PayPal `authorizeOrder()` → returns `authId`
2. `initialize()` creates an AUTH transaction, no invoice (correct — money not captured yet)
3. Order is saved with state=processing
4. Admin opens order → creates invoice with "Capture Online"
5. `Invoice::register()` with `CAPTURE_ONLINE` → `Payment::capture()` → `Method::capture()` calls PayPal `captureAuthorization()` API
6. PayPal returns `captureId`, capture transaction is created with `parentTxnId = authId`, auth transaction is closed
7. Invoice is paid, `total_invoiced` and `total_paid` are set
8. **Result:** `total_invoiced` ✅, `total_paid` ✅, auth transaction closed ✅

**Webhook captures (e.g. PayPal auto-captures after auth period, or admin captured and webhook confirms):**
1. `initialize()` creates AUTH transaction, no invoice
2. `PAYMENT.CAPTURE.COMPLETED` webhook arrives
3. `registerCaptureNotification()`:
   - `getAuthorizationTransaction()` finds the AUTH transaction
   - `_generateTransactionId()` sets `parentTransactionId = authId`
   - `_isCaptureFinal()` returns true → sets `shouldCloseParentTransaction = true`
   - Creates invoice via `prepareInvoice()->register()`
   - `_addTransaction()` creates CAPTURE transaction linked to AUTH, closes AUTH transaction
4. **Result:** `total_invoiced` ✅, `total_paid` ✅, auth transaction closed ✅, capture linked to auth ✅

**Admin captures, then webhook arrives (duplicate protection):**
1. Admin captures from backend → invoice created, CAPTURE transaction created
2. `PAYMENT.CAPTURE.COMPLETED` webhook arrives
3. `_getInvoiceForTransactionId($captureId)` finds existing invoice with matching `transaction_id`
4. Invoice state is `PAID` → `pay()` is skipped
5. `_addTransaction()` finds existing capture transaction → updates it
6. **Result:** no duplicate invoice, no double-counting ✅

**Without webhook, admin never captures:**
1. Order stays in processing with AUTH transaction, no invoice
2. `total_invoiced` = 0 — correct behavior, money was only authorized not captured
3. Admin can capture at any time from the backend
4. **Result:** correct ✅

### DEFERRED flow (only paypal_order_id, no immediate auth/capture)

Happens when the PayPal order was approved but not yet authorized or captured at order placement.

1. `initialize()` sets state=pending_payment, no transactions created
2. `PAYMENT.CAPTURE.COMPLETED` webhook arrives
3. `registerCaptureNotification()` creates invoice and capture transaction from scratch
4. **Result:** `total_invoiced` ✅, `total_paid` ✅

Without webhook, order stays in pending_payment. Admin action or webhook retry is required.

### Vault payments

**Vault with capture intent:**
1. `_processAdminVaultOrder()` calls PayPal API, gets `captureId`
2. Creates CAPTURE transaction and now also creates invoice via `_createCaptureInvoice()`
3. **Result:** same as regular capture intent ✅

**Vault with authorize intent:**
1. `_processAdminVaultOrder()` calls PayPal API, gets `authId`
2. Creates AUTH transaction, no invoice
3. Admin captures later from backend
4. **Result:** same as regular authorize intent ✅

## Summary Table

| Flow | Webhook configured | Invoice created by | total_invoiced | total_paid |
|---|---|---|---|---|
| Capture | No | `initialize()` | ✅ = grand total | ✅ = grand total |
| Capture | Yes | `initialize()` (webhook = no-op) | ✅ = grand total | ✅ = grand total |
| Authorize | No | Admin backend capture | ✅ after capture | ✅ after capture |
| Authorize | Yes (before admin) | `registerCaptureNotification()` | ✅ | ✅ |
| Authorize | Yes (after admin) | Admin capture (webhook = no-op) | ✅ | ✅ |
| Deferred | Yes | `registerCaptureNotification()` | ✅ | ✅ |
| Deferred | No | — (requires webhook or admin) | 0 | 0 |
| Vault capture | No | `initialize()` | ✅ = grand total | ✅ = grand total |
| Vault capture | Yes | `initialize()` (webhook = no-op) | ✅ = grand total | ✅ = grand total |
| Vault authorize | No | Admin backend capture | ✅ after capture | ✅ after capture |

## Test plan

- [ ] Place an order with PayPal Standard Checkout (capture intent) → verify `total_invoiced` and `total_paid` equal the order grand total immediately after placement
- [ ] Place an order with PayPal Standard Checkout (authorize intent) → verify no invoice exists yet → capture from admin → verify `total_invoiced` and `total_paid` are set
- [ ] Place a vault payment order (capture intent) → verify `total_invoiced` is set
- [ ] Simulate `PAYMENT.CAPTURE.COMPLETED` webhook for an order that already has an invoice → verify no duplicate invoice or double-counted totals
- [ ] Simulate `PAYMENT.CAPTURE.COMPLETED` webhook for an authorize-only order → verify invoice is created, capture transaction is linked to auth, auth transaction is closed
- [ ] Verify refunds still work correctly on captured orders (refund looks up capture transaction by `paypal_capture_id`)