### PR TITLE
Fixed PayPal approveOrder using stale order ID on retries

### DIFF
--- a/app/code/core/Maho/Paypal/Model/Api/OrderBuilder.php
+++ b/app/code/core/Maho/Paypal/Model/Api/OrderBuilder.php
@@ -129,7 +129,7 @@ class Maho_Paypal_Model_Api_OrderBuilder
                 'currency_code' => $currency,
                 'value' => $grandTotal,
             ],
-            'invoice_id' => $quote->setReservedOrderId('')->reserveOrderId()->getReservedOrderId(),
+            'invoice_id' => $quote->getReservedOrderId() ?: $quote->reserveOrderId()->getReservedOrderId(),
         ];
 
         $breakdown = $this->buildBreakdown($quote, $currency);

--- a/app/code/core/Maho/Paypal/controllers/CheckoutController.php
+++ b/app/code/core/Maho/Paypal/controllers/CheckoutController.php
@@ -188,8 +188,33 @@ class Maho_Paypal_CheckoutController extends Mage_Core_Controller_Front_Action
                 Mage::throwException(Mage::helper('maho_paypal')->__('This order has already been placed.'));
             }
 
-            $paypalOrderId = $quote->getPayment()->getAdditionalInformation('paypal_order_id');
-            if (!$paypalOrderId) {
+            // Prefer the PayPal order ID sent by the frontend (the one the user actually
+            // approved in the popup) over the quote's stored value, which can be stale
+            // when the buyer retried and a newer createOrder overwrote it.
+            $requestedPaypalOrderId = (string) $this->getRequest()->getParam('paypal_order_id');
+            $storedPaypalOrderId = $quote->getPayment()->getAdditionalInformation('paypal_order_id');
+
+            if ($requestedPaypalOrderId && preg_match('/^[A-Z0-9]+$/', $requestedPaypalOrderId)) {
+                $paypalOrderId = $requestedPaypalOrderId;
+                if ($storedPaypalOrderId && $storedPaypalOrderId !== $paypalOrderId) {
+                    Mage::log(
+                        sprintf(
+                            'PayPal order ID mismatch – quote had "%s", request sent "%s" (quote %s). Using request value.',
+                            $storedPaypalOrderId,
+                            $paypalOrderId,
+                            $quote->getId(),
+                        ),
+                        Mage::LOG_WARNING,
+                        'paypal.log',
+                    );
+                    // Update the quote payment so downstream code sees the correct ID
+                    $quote->getPayment()->setAdditionalInformation('paypal_order_id', $paypalOrderId);
+                    $quote->getPayment()->setData('paypal_order_id', $paypalOrderId);
+                    $quote->getPayment()->save();
+                }
+            } elseif ($storedPaypalOrderId) {
+                $paypalOrderId = $storedPaypalOrderId;
+            } else {
                 Mage::throwException(Mage::helper('maho_paypal')->__('Missing PayPal order ID.'));
             }
             $methodCode = $this->_validateMethodCode(


### PR DESCRIPTION
## Summary

- **approveOrderAction** reads paypal_order_id from the quote payment storage, but the frontend sends the freshly-approved order ID in the request body. When a buyer retries (closes the PayPal popup and re-opens it), each createOrder call overwrites the quote value, so the backend can end up capturing/authorizing a stale PayPal order that the user never approved.
- **OrderBuilder** force-clears reserved_order_id and generates a new one on every createOrder call, burning through increment IDs on retries and causing gaps in the order number sequence.

## Changes

### CheckoutController.php - approveOrderAction
- Read paypal_order_id from the request parameter first, validated with the same regex used elsewhere in the controller
- Fall back to the quote stored value if the request param is missing/invalid
- When a mismatch is detected, log a warning to paypal.log and update the quote payment to match the request value

### OrderBuilder.php - _buildPurchaseUnit
- Reuse the existing reserved_order_id on the quote if one is already set
- Only reserve a new one when the quote has no reserved order ID yet

## Test plan

- [ ] Complete a normal PayPal checkout (single attempt) - should work identically to before
- [ ] Start PayPal checkout, close the popup, retry - the second attempt should complete successfully
- [ ] Check paypal.log after a retry - should contain the mismatch warning with both order IDs
- [ ] Verify that retrying does not skip increment IDs (same invoice_id sent to PayPal on retry)