### PR TITLE
Fixed ShippingBridge logging response body on API errors

### DIFF
--- a/app/code/core/Maho/ShippingBridge/Model/Carrier.php
+++ b/app/code/core/Maho/ShippingBridge/Model/Carrier.php
@@ -78,8 +78,9 @@ class Maho_ShippingBridge_Model_Carrier extends Mage_Shipping_Model_Carrier_Abst
 
             $statusCode = $response->getStatusCode();
             if ($statusCode < 200 || $statusCode >= 300) {
+                $errorBody = $response->getContent(false);
                 Mage::log(
-                    "Shipping Bridge: API returned HTTP {$statusCode}",
+                    "Shipping Bridge: API returned HTTP {$statusCode}\n{$errorBody}",
                     Mage::LOG_ERROR,
                     'shipping_bridge.log',
                 );


### PR DESCRIPTION
## Summary
- Include the API response body in error logs when ShippingBridge gets a non-2xx response
- Uses `getContent(false)` to retrieve the body without throwing on error status codes
- Makes diagnosing issues like HTTP 422 much easier since the validation details are now logged

## Test plan
- [ ] Configure ShippingBridge with an API endpoint that returns a 4xx/5xx error
- [ ] Verify `shipping_bridge.log` now includes the response body alongside the status code