### PR TITLE
Fixed CustomerSegmentation cron passing default value as store ID

### DIFF
--- a/app/code/core/Maho/CustomerSegmentation/Model/Cron.php
+++ b/app/code/core/Maho/CustomerSegmentation/Model/Cron.php
@@ -85,7 +85,7 @@ class Maho_CustomerSegmentation_Model_Cron
             return;
         }
 
-        $daysOld = (int) Mage::getStoreConfig('customer_segmentation/email_automation/cleanup_days', 90);
+        $daysOld = (int) (Mage::getStoreConfig('customer_segmentation/email_automation/cleanup_days') ?? 90);
 
         try {
             $resource = Mage::getResourceSingleton('customersegmentation/sequenceProgress');


### PR DESCRIPTION
## Summary
- `Mage::getStoreConfig('...', 90)` was passing `90` as a store ID instead of using it as a default for `cleanup_days`
- This caused `Mage_Core_Model_Store_Exception: Invalid store code requested` when the cron job ran
- Changed to `Mage::getStoreConfig('...') ?? 90` to correctly provide a fallback default

## Test plan
- [ ] Verify cron job `customer_segmentation_cleanup_old_progress` runs without store exception
- [ ] Verify cleanup uses configured value from system config when set
- [ ] Verify cleanup falls back to 90 days when no config value exists