### PR TITLE
Fixed empty Date & Time in Payment Transaction Failed email

### DIFF
--- a/app/code/core/Mage/Checkout/Helper/Data.php
+++ b/app/code/core/Mage/Checkout/Helper/Data.php
@@ -233,7 +233,7 @@ class Mage_Checkout_Helper_Data extends Mage_Core_Helper_Abstract
                     [
                         'reason'          => $message,
                         'checkoutType'    => $checkoutType,
-                        'dateAndTime'     => Mage::app()->getLocale()->storeDate(null, null, true, 'html5'),
+                        'dateAndTime'     => Mage::app()->getLocale()->storeDate(null, new DateTime(), true, 'html5'),
                         'customer'        => Mage::helper('customer')->getFullCustomerName($checkout),
                         'customerEmail'   => $checkout->getCustomerEmail(),
                         'billingAddress'  => $checkout->getBillingAddress(),


### PR DESCRIPTION
## Summary
- `storeDate()` was called with `null` as the date parameter, which returns `null` when using `html5` format
- Pass `new DateTime()` to provide the current UTC time for conversion to store timezone

Closes #730