### PR TITLE
Fixed XSS vulnerability in shipping packaging error messages

### DIFF
--- a/public/js/mage/adminhtml/sales/packaging.js
+++ b/public/js/mage/adminhtml/sales/packaging.js
@@ -115,7 +115,7 @@ class Packaging
 
     updateMessage(message) {
         const block = this.window.querySelector('.messages');
-        block.innerHTML = message;
+        block.textContent = message;
         toggleVis(block, true);
     }
 


### PR DESCRIPTION
## Summary
- `Packaging.updateMessage()` used `innerHTML` to display error messages, which allowed exception text from `mahoFetch` (originating from server responses) to be interpreted as HTML — a potential XSS vector
- Changed to `textContent` so messages are always rendered as plain text
- All callers pass plain translated strings, so there is no functional impact

Fixes https://github.com/MahoCommerce/maho/security/code-scanning/79