### PR TITLE
Fixed duplicate product error in cart crosssell block

### DIFF
--- a/app/code/core/Mage/Checkout/Block/Cart/Crosssell.php
+++ b/app/code/core/Mage/Checkout/Block/Cart/Crosssell.php
@@ -35,6 +35,7 @@ class Mage_Checkout_Block_Cart_Crosssell extends Mage_Catalog_Block_Product_Abst
                     $collection = $this->_getCollection()
                         ->addProductFilter($lastAdded)
                         ->addExcludeProductFilter($ninProductIds)
+                        ->setGroupBy()
                         ->setPositionOrder()
                         ->load();
 


### PR DESCRIPTION
## Summary
- The first crosssell collection query (for `lastAdded` product) was missing `setGroupBy()`, which adds `DISTINCT` to prevent duplicate product IDs
- When a product is cross-linked through multiple link entries, the collection would throw: `Item (Mage_Catalog_Model_Product) with the same id "X" already exist`
- The second query in the same method already had `setGroupBy()` — this just adds it to the first one too

Relates to #688

## Test plan
- [ ] Add a product to cart where the last-added product has crosssell links that could produce duplicates
- [ ] Verify the cart page renders without "same id already exist" errors