### PR TITLE
Fixed PayPal orders stuck in pending_payment status

### DIFF
--- a/app/code/core/Maho/Paypal/Model/Api/Client.php
+++ b/app/code/core/Maho/Paypal/Model/Api/Client.php
@@ -102,9 +102,13 @@ class Maho_Paypal_Model_Api_Client
         return $this->_decodeResponse($response);
     }
 
-    public function getOrder(string $orderId): array
+    public function getOrder(string $orderId, ?string $fields = null): array
     {
-        $response = $this->getSdkClient()->getOrdersController()->getOrder(['id' => $orderId]);
+        $options = ['id' => $orderId];
+        if ($fields !== null) {
+            $options['fields'] = $fields;
+        }
+        $response = $this->getSdkClient()->getOrdersController()->getOrder($options);
         return $this->_decodeResponse($response);
     }
 

--- a/app/code/core/Maho/Paypal/Model/Webhook/Handler/OrderCompleted.php
+++ b/app/code/core/Maho/Paypal/Model/Webhook/Handler/OrderCompleted.php
@@ -56,10 +56,10 @@ class Maho_Paypal_Model_Webhook_Handler_OrderCompleted extends Maho_Paypal_Model
             $config = Mage::getModel('paypal/config');
             $intent = $config->getNewPaymentAction($methodCode, (int) $quote->getStoreId());
 
-            // Fetch fresh order data from PayPal API to ensure all transaction IDs are populated
+            // Fetch fresh order data with payment details to ensure capture/auth IDs are populated
             /** @var Maho_Paypal_Model_Api_Client $client */
             $client = Mage::getModel('maho_paypal/api_client', ['store_id' => (int) $quote->getStoreId()]);
-            $paypalResult = $client->getOrder($paypalOrderId);
+            $paypalResult = $client->getOrder($paypalOrderId, 'purchase_units.payments');
 
             $status = $paypalResult['status'] ?? '';
             if ($status !== 'COMPLETED') {

--- a/app/code/core/Maho/Paypal/controllers/CheckoutController.php
+++ b/app/code/core/Maho/Paypal/controllers/CheckoutController.php
@@ -260,8 +260,8 @@ class Maho_Paypal_CheckoutController extends Mage_Core_Controller_Front_Action
                     /** @var Maho_Paypal_Model_Api_Client $client */
                     $client = Mage::getModel('maho_paypal/api_client', ['store_id' => (int) $quote->getStoreId()]);
 
-                    // Fetch current order status first
-                    $paypalResult = $client->getOrder($paypalOrderId);
+                    // Fetch current order status (include payment details in case it's already completed)
+                    $paypalResult = $client->getOrder($paypalOrderId, 'purchase_units.payments');
                     $status = $paypalResult['status'] ?? '';
 
                     // If order is not yet completed (standard/advanced checkout flow),


### PR DESCRIPTION
## Summary
- PayPal Get Order API does not return purchase_units[].payments by default - the fields query parameter is required
- When a PayPal order was already COMPLETED before the checkout controller processed it (e.g. auto-capture by certain payment methods), the getOrder() response had no capture/auth IDs, causing initialize() to set the order to pending_payment instead of processing
- Added optional fields parameter to Client::getOrder() and pass purchase_units.payments in both approveOrderAction and the OrderCompleted webhook handler

## Test plan
- [ ] Place an order with PayPal Standard checkout and verify it lands in processing status
- [ ] Place an order with PayPal Advanced checkout (card) and verify it lands in processing status
- [ ] Simulate an already-COMPLETED PayPal order reaching the controller and verify capture IDs are correctly extracted