### PR TITLE
Pass currency code to PayPal Pay Later messages

### DIFF
--- a/app/code/core/Maho/Paypal/Block/Paylater/Message.php
+++ b/app/code/core/Maho/Paypal/Block/Paylater/Message.php
@@ -40,6 +40,7 @@ class Maho_Paypal_Block_Paylater_Message extends Mage_Core_Block_Template
             $this->setAmount((float) $quote->getGrandTotal());
         }
         $this->setPlacement($placement);
+        $this->setCurrencyCode($this->_getConfig()->getCurrencyCode());
 
         $this->setMessageHtmlId(Mage::helper('core')->uniqHash('maho_paypal_paylater_'));
 

--- a/app/design/frontend/base/default/template/maho/paypal/paylater/message.phtml
+++ b/app/design/frontend/base/default/template/maho/paypal/paylater/message.phtml
@@ -15,4 +15,5 @@ $containerId = $this->getMessageHtmlId();
     data-sdk-url="<?= $this->escapeUrl($this->getJsSdkUrl()) ?>"
     data-client-token-url="<?= $this->escapeUrl($this->getClientTokenUrl()) ?>"
     data-amount="<?= $this->escapeHtml((string) $this->getAmount()) ?>"
+    data-currency="<?= $this->escapeHtml($this->getCurrencyCode()) ?>"
     data-placement="<?= $this->escapeHtml($this->getPlacement()) ?>"></div>

--- a/public/js/maho/paypal/paylater-message.js
+++ b/public/js/maho/paypal/paylater-message.js
@@ -11,7 +11,8 @@ class MahoPaypalPayLaterMessage {
         this.el = el;
         this.sdkUrl = el.dataset.sdkUrl;
         this.clientTokenUrl = el.dataset.clientTokenUrl;
-        this.amount = el.dataset.amount || '0';
+        this.amount = el.dataset.amount;
+        this.currency = el.dataset.currency;
         this._mounted = false;
     }
 
@@ -35,7 +36,8 @@ class MahoPaypalPayLaterMessage {
         }
 
         const messagesInstance = sdk.createPayPalMessages({
-            amount: parseFloat(this.amount) || 0,
+            amount: parseFloat(this.amount),
+            currency: this.currency,
             placement: this.el.dataset.placement || 'product',
         });
         const messageEl = document.createElement('paypal-message');


### PR DESCRIPTION
## Summary
- The Pay Later banner was showing a generic range message (e.g. "from £20-£3,000") instead of specific per-payment amounts
- The currency code was not being passed to the PayPal SDK `createPayPalMessages()` call, which is needed for non-USD stores to compute installment breakdowns
- Also removed silent fallback defaults for amount and currency in the JS — if the data attributes are missing, something is already wrong upstream

## Test plan
- [ ] Enable Pay Later on a non-USD store (e.g. GBP)
- [ ] Verify the product page banner shows per-payment amounts instead of generic range
- [ ] Verify the cart page banner also shows correct amounts
- [ ] Verify USD stores still work correctly