### PR TITLE
Fixed PayPal Pay Later messages API parameters per v6 SDK docs

### DIFF
--- a/app/code/core/Maho/Paypal/Block/Paylater/Message.php
+++ b/app/code/core/Maho/Paypal/Block/Paylater/Message.php
@@ -34,10 +34,10 @@ class Maho_Paypal_Block_Paylater_Message extends Mage_Core_Block_Template
                 $this->_shouldRender = false;
                 return $result;
             }
-            $this->setAmount((float) $currentProduct->getFinalPrice());
+            $this->setAmount(number_format((float) $currentProduct->getFinalPrice(), 2, '.', ''));
         } else {
             $quote = Mage::getSingleton('checkout/session')->getQuote();
-            $this->setAmount((float) $quote->getGrandTotal());
+            $this->setAmount(number_format((float) $quote->getGrandTotal(), 2, '.', ''));
         }
         $this->setPlacement($placement);
         $this->setCurrencyCode($this->_getConfig()->getCurrencyCode());

--- a/app/design/frontend/base/default/template/maho/paypal/paylater/message.phtml
+++ b/app/design/frontend/base/default/template/maho/paypal/paylater/message.phtml
@@ -14,6 +14,6 @@ $containerId = $this->getMessageHtmlId();
     class="paypal-paylater-message"
     data-sdk-url="<?= $this->escapeUrl($this->getJsSdkUrl()) ?>"
     data-client-token-url="<?= $this->escapeUrl($this->getClientTokenUrl()) ?>"
-    data-amount="<?= $this->escapeHtml((string) $this->getAmount()) ?>"
+    data-amount="<?= $this->escapeHtml($this->getAmount()) ?>"
     data-currency="<?= $this->escapeHtml($this->getCurrencyCode()) ?>"
     data-placement="<?= $this->escapeHtml($this->getPlacement()) ?>"></div>

--- a/public/js/maho/paypal/paylater-message.js
+++ b/public/js/maho/paypal/paylater-message.js
@@ -36,14 +36,15 @@ class MahoPaypalPayLaterMessage {
         }
 
         const messagesInstance = sdk.createPayPalMessages({
-            amount: parseFloat(this.amount),
-            currency: this.currency,
+            currencyCode: this.currency,
             placement: this.el.dataset.placement || 'product',
         });
         const messageEl = document.createElement('paypal-message');
         this.el.appendChild(messageEl);
 
         messagesInstance.fetchContent({
+            amount: this.amount,
+            currencyCode: this.currency,
             onContentReady: (content) => messageEl.setContent(content),
         });
     }


### PR DESCRIPTION
## Summary
- Per [PayPal v6 SDK docs](https://docs.paypal.ai/payments/methods/pay-later/get-started), the parameter name should be `currencyCode` not `currency`
- Amount must be passed as a string (e.g. `"1211.00"`) to `fetchContent()`, not as a float to `createPayPalMessages()`
- Format amount with 2 decimal places via `number_format()` in the block

## Test plan
- [ ] Verify Pay Later banner shows per-payment amounts (e.g. "3 payments of £403.67") instead of generic range on product page
- [ ] Verify cart page Pay Later banner also shows correct amounts
- [ ] Test with different currencies (GBP, EUR, USD)