### PR TITLE
Fixed price layer filter crash with flat catalog enabled

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Layer/Filter/Price.php
@@ -104,11 +104,22 @@ class Mage_Catalog_Model_Resource_Layer_Filter_Price extends Mage_Core_Model_Res
         $wherePart = $select->getPart(Maho\Db\Select::WHERE);
         $excludedWherePart = Mage_Catalog_Model_Resource_Product_Collection::MAIN_TABLE_ALIAS . '.status';
         foreach ($wherePart as $key => $wherePartItem) {
-            if (str_contains($wherePartItem, $excludedWherePart)) {
-                $wherePart[$key] = new Maho\Db\Expr('1=1');
+            $conditionString = is_array($wherePartItem) ? current($wherePartItem) : $wherePartItem;
+            $conditionKey = is_array($wherePartItem) ? key($wherePartItem) : null;
+
+            if (is_string($conditionString) && str_contains($conditionString, $excludedWherePart)) {
+                $wherePart[$key] = $conditionKey !== null
+                    ? [$conditionKey => '1=1']
+                    : new Maho\Db\Expr('1=1');
                 continue;
             }
-            $wherePart[$key] = $this->_replaceTableAlias($wherePartItem);
+
+            if (is_string($conditionString)) {
+                $replaced = $this->_replaceTableAlias($conditionString);
+                $wherePart[$key] = $conditionKey !== null
+                    ? [$conditionKey => $replaced]
+                    : $replaced;
+            }
         }
         $select->setPart(Maho\Db\Select::WHERE, $wherePart);
         $excludeJoinPart = Mage_Catalog_Model_Resource_Product_Collection::MAIN_TABLE_ALIAS . '.entity_id';


### PR DESCRIPTION
Fixes #753 — thanks @postadelmaga for the detailed report and suggested fix!

## Summary

- `Mage_Catalog_Model_Resource_Layer_Filter_Price::_getSelect()` assumed WHERE parts are plain strings, but `Maho\Db\Select::_where()` returns associative arrays (`['AND' => '(condition)']`)
- This caused a `str_contains()` TypeError when iterating WHERE parts, silently breaking the entire layered navigation block
- The bug only manifests with **flat catalog enabled**, since that is what adds a `WHERE e.status = 1` clause to the collection select

## Fix

Unwrap array-format WHERE parts before string operations, preserving the array structure when writing back.

**Note:** flat catalog is deprecated and will be removed in a future version, but this fix ensures it works correctly in the meantime.

## Test plan

- [x] Enable flat catalog product
- [x] Reindex all
- [x] Visit an anchor category page — confirmed `str_contains()` TypeError before fix
- [x] After fix, `_getSelect()` completes successfully and WHERE parts are correctly processed