### PR TITLE
Adminhtml: Add PHP version output to footer template

### DIFF
--- a/app/design/adminhtml/default/default/template/page/footer.phtml
+++ b/app/design/adminhtml/default/default/template/page/footer.phtml
@@ -14,6 +14,10 @@
 
 <a href="<?= $this->getMahoProjectUrl() ?>" target="_blank">Powered by Maho <?= Mage::getVersion() ?></a>
 <span>|</span>
+PHP <?= str_contains(PHP_VERSION, '-')
+    ? substr(PHP_VERSION, 0, strpos(PHP_VERSION, '-'))
+    : PHP_VERSION ?>
+<span>|</span>
 <?= $this->__('Interface Locale: %s', $this->getLanguageSelect()) ?>
 
 <script type="text/javascript">


### PR DESCRIPTION
## Description

This PR adds the used PHP version to the adminhtml footer as an information that might be useful and good to know.
We've included this information in the adminhtml footer of all our instances since M1, and I thought it would also be a good fit for the out-of-the-box experience of Maho.

Feel free to adjust the code if you like. I just wanted to show a possible solution. :)

<img width="583" height="52" alt="grafik" src="https://github.com/user-attachments/assets/f002183d-1d20-4dec-985b-3807f884841f" />
