### PR TITLE
Fix: Show Advanced Search in Footer Quick Links Only When Enabled

### DIFF
--- a/app/design/frontend/base/default/layout/catalogsearch.xml
+++ b/app/design/frontend/base/default/layout/catalogsearch.xml
@@ -18,7 +18,7 @@
             <block type="core/template" name="top.search" as="topSearch" template="catalogsearch/form.mini.phtml"/>
         </reference>
         <reference name="footer_links">
-            <action method="addLink" translate="label title" module="catalogsearch">
+            <action method="addLink" translate="label title" module="catalogsearch" ifconfig="catalog/advanced_search/enabled">
                 <label>Advanced Search</label>
                 <url helper="catalogsearch/getAdvancedSearchUrl" />
                 <title>Advanced Search</title>


### PR DESCRIPTION
## Description

This PR adds a missing `ifconfig` to the Quick Link `Advanced Search` in the default footer of the frontend.
When `catalog/advanced_search/enabled` is set to `No`, the link will be removed instead of referencing to the 404 page. :)