### PR TITLE
Fixed TipTap toolbar tooltip and dropdown menu clipping

### DIFF
--- a/public/js/mage/adminhtml/wysiwyg/tiptap/tiptap.css
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/tiptap.css
@@ -154,6 +154,16 @@
             opacity: 1;
             transform: translateX(-50%) translateY(4px);
         }
+
+        &:last-child[title]::after {
+            left: auto;
+            right: 0;
+            transform: translateY(8px);
+        }
+
+        &:last-child[title]:hover::after {
+            transform: translateY(4px);
+        }
     }
 
     select {
@@ -801,6 +811,8 @@
     left: 0;
     z-index: 1000;
     min-width: 180px;
+    max-height: 50vh;
+    overflow-y: auto;
     background-color: var(--tt-color-bg);
     border: 1px solid var(--tt-color-border);
     border-radius: var(--tt-radius-lg);


### PR DESCRIPTION
## Summary
- Right-align the fullscreen button tooltip so it doesn't get cut off at the wrapper edge
- Add `max-height: 50vh` and `overflow-y: auto` to dropdown menus so long lists are scrollable when the editor height is short

Fixes #759