### PR TITLE
Fixed category/SKU chooser tree in Product Relationship Rules

### DIFF
--- a/app/code/core/Maho/CatalogLinkRule/controllers/Adminhtml/Cataloglinkrule/RuleController.php
+++ b/app/code/core/Maho/CatalogLinkRule/controllers/Adminhtml/Cataloglinkrule/RuleController.php
@@ -45,6 +45,9 @@ class Maho_CatalogLinkRule_Adminhtml_Cataloglinkrule_RuleController extends Mage
             }
         }
 
+        $model->getConditions()->setJsFormObject('rule_conditions_fieldset');
+        $model->getActions()->setJsFormObject('rule_actions_fieldset');
+
         // Register the current rule for use in blocks
         Mage::register('current_linkrule', $model);
 


### PR DESCRIPTION
Closes #763

## Summary

- When editing a saved Product Relationship Rule, the category and SKU chooser tree failed to load with a SyntaxError
- Root cause: editAction() did not call setJsFormObject() on the rule conditions/actions, so the chooser URL omitted the /form/ parameter, causing invalid JS in the tree template
- Added the missing setJsFormObject() calls, matching the pattern used by Promo/CatalogController and Promo/QuoteController

## Test plan

- [ ] Create a new Product Relationship Rule with a Category condition, select a category via the tree, save the rule
- [ ] Edit the saved rule, open the category tree chooser — verify it loads and allows changing the selection
- [ ] Verify the same works for SKU chooser conditions
- [ ] Verify the Target Product Conditions tab also works with category/SKU choosers