### PR TITLE
Fixed cron schedule times stored in the past when store timezone != UTC

### DIFF
--- a/app/code/core/Mage/Cron/Model/Observer.php
+++ b/app/code/core/Mage/Cron/Model/Observer.php
@@ -210,7 +210,7 @@ class Mage_Cron_Model_Observer
                 ->setStatus(Mage_Cron_Model_Schedule::STATUS_PENDING);
 
             for ($time = $now; $time < $timeAhead; $time += 60) {
-                $ts = Mage::getSingleton('core/date')->gmtDate('Y-m-d H:i:00', $time);
+                $ts = gmdate('Y-m-d H:i:00', $time);
                 if (!empty($exists[$jobCode . '/' . $ts])) {
                     // already scheduled
                     continue;

--- a/app/code/core/Mage/Cron/Model/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Schedule.php
@@ -100,7 +100,7 @@ class Mage_Cron_Model_Schedule extends Mage_Core_Model_Abstract
 
         if ($match) {
             $this->setCreatedAt(Mage::getSingleton('core/date')->gmtDate());
-            $this->setScheduledAt(Mage::getSingleton('core/date')->gmtDate('Y-m-d H:i:00', $time));
+            $this->setScheduledAt(gmdate('Y-m-d H:i:00', $time));
         }
         return $match;
     }


### PR DESCRIPTION
## Summary

Fixes #770

When the store timezone is set to anything other than UTC, `gmtDate($format, $numericTimestamp)` double-converts the already-UTC timestamp by subtracting the store UTC offset. This causes all `cron_schedule` entries to be stored with timestamps shifted into the past, making them immediately marked as missed.

Replace with `gmdate()` since `$time` is already a UTC Unix timestamp — no conversion needed, just formatting.

## Changes

- **Observer.php**: dedup key timestamp formatting
- **Schedule.php**: `scheduled_at` storage formatting

## Test plan

- Set store timezone to a non-UTC value (e.g. Australia/Melbourne)
- Run `php ./maho cron:run default`
- Verify `cron_schedule.scheduled_at` values are correct (not shifted into the past)
- Verify cron jobs execute instead of being marked as missed