### PR TITLE
Fixed cross-sell duplicate item error with multi-parent links

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Product/Collection.php
@@ -48,6 +48,19 @@ class Mage_Catalog_Model_Resource_Product_Link_Product_Collection extends Mage_C
     protected $_hasLinkFilter  = false;
 
     /**
+     * Skip duplicate items when DISTINCT deduplication is active, which can happen
+     * when multiple parent products link to the same target (e.g. cart cross-sells)
+     */
+    #[\Override]
+    public function addItem(Maho\DataObject $item)
+    {
+        if ($this->getSelect()->getPart(Maho\Db\Select::DISTINCT) && $this->getItemById($item->getId())) {
+            return $this;
+        }
+        return parent::addItem($item);
+    }
+
+    /**
      * Declare link model and initialize type attributes join
      *
      * @return $this
@@ -163,11 +176,7 @@ class Mage_Catalog_Model_Resource_Product_Link_Product_Collection extends Mage_C
      */
     public function setGroupBy($groupBy = 'e.entity_id')
     {
-        // Use DISTINCT instead of GROUP BY for cross-database compatibility
-        // GROUP BY requires all selected columns in PostgreSQL, but DISTINCT
-        // achieves the same goal of eliminating duplicates without this restriction
         $this->getSelect()->distinct(true);
-
         return $this;
     }
 


### PR DESCRIPTION
## Summary
- When two cart products each have a cross-sell to the same SKU, the link join produces duplicate rows. DISTINCT cannot collapse them because link-specific columns (link_id, position) differ per row, causing an "Item with the same id already exists" exception.
- Fixed by overriding addItem() in the link product collection to silently skip duplicates when DISTINCT is active. All joins remain intact for full cross-database compatibility.

## Test plan
- [ ] Add two products to cart that both cross-sell to the same product
- [ ] Verify the cart page loads without errors and the cross-sell product appears once
- [ ] Verify admin product edit cross-sell/related/upsell grids still work correctly

Co-Authored-By: jparker1986 <jparker1986@users.noreply.github.com>