### PR TITLE
Fixed CLI cron:run TypeError when no pending schedule exists

### DIFF
--- a/lib/MahoCLI/Commands/CronRun.php
+++ b/lib/MahoCLI/Commands/CronRun.php
@@ -20,7 +20,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Maho\Db\Adapter\Pdo\Mysql;
 
 #[AsCommand(
     name: 'cron:run',
@@ -90,11 +89,9 @@ class CronRun extends BaseMahoCommand
             ->addFieldToFilter('job_code', $jobCode)
             ->orderByScheduledAt()
             ->getFirstItem();
-        if (!$schedule->getId()) {
-            $schedule = false;
-        }
+        $hasPersistentSchedule = (bool) $schedule->getId();
 
-        if ($schedule) {
+        if ($hasPersistentSchedule) {
             if (!$schedule->tryLockJob()) {
                 $output->writeln("<error>{$jobCode} is already running</error>");
                 return Command::INVALID;
@@ -102,17 +99,20 @@ class CronRun extends BaseMahoCommand
 
             $schedule
                 ->setStatus(Mage_Cron_Model_Schedule::STATUS_RUNNING)
-                ->setExecutedAt(date(\Maho\Db\Adapter\Pdo\Mysql::TIMESTAMP_FORMAT))
+                ->setExecutedAt(\Mage_Core_Model_Locale::now())
                 ->save();
+        } else {
+            $schedule = Mage::getModel('cron/schedule');
+            $schedule->setJobCode($jobCode);
         }
 
         try {
             $callback = [$model, $run[2]];
             call_user_func($callback, $schedule);
         } catch (\Exception $e) {
-            if ($schedule) {
+            if ($hasPersistentSchedule) {
                 $schedule
-                    ->setFinishedAt(date(\Maho\Db\Adapter\Pdo\Mysql::TIMESTAMP_FORMAT))
+                    ->setFinishedAt(\Mage_Core_Model_Locale::now())
                     ->setStatus(Mage_Cron_Model_Schedule::STATUS_ERROR)
                     ->setMessages($e->__toString())
                     ->save();
@@ -122,10 +122,10 @@ class CronRun extends BaseMahoCommand
             return Command::FAILURE;
         }
 
-        if ($schedule) {
+        if ($hasPersistentSchedule) {
             $schedule
                 ->setStatus(Mage_Cron_Model_Schedule::STATUS_SUCCESS)
-                ->setFinishedAt(date(\Maho\Db\Adapter\Pdo\Mysql::TIMESTAMP_FORMAT))
+                ->setFinishedAt(\Mage_Core_Model_Locale::now())
                 ->save();
         }
 


### PR DESCRIPTION
## Summary
- When running `./maho cron:run <job_code>` without a pending schedule record in the database, the callback received `false` instead of a `Mage_Cron_Model_Schedule` object, causing a TypeError
- Now creates a transient (unsaved) schedule object when no database record exists, satisfying typed parameters in cron callbacks
- Replaced `date()` with `Mage_Core_Model_Locale::now()` for proper UTC timestamps and removed MySQL-specific adapter dependency

Closes #777

Co-Authored-By: Tino Mewes <tmewes@users.noreply.github.com>