### PR TITLE
Fixed symlink warning not being fully suppressed in error handler

### DIFF
--- a/app/code/core/Mage/Core/functions.php
+++ b/app/code/core/Mage/Core/functions.php
@@ -73,7 +73,7 @@ function mageCoreErrorHandler($errno, $errstr, $errfile, $errline)
         && str_contains($errstr, 'symlink(): File exists')
         && str_contains($errfile, 'FilesystemTagAwareAdapter.php')
     ) {
-        return false;
+        return true;
     }
 
     $errno = $errno & error_reporting();


### PR DESCRIPTION
## Summary
- The custom error handler in `mageCoreErrorHandler` was returning `false` for symlink "File exists" warnings from Symfony's `FilesystemTagAwareAdapter`, which tells PHP to continue with the default error handler — resulting in the warning still being logged as an ERROR
- Changed to `return true` to fully suppress the warning, since the condition already correctly identifies this as a harmless race condition in Symfony's tag-based filesystem cache

Reported by @jparker1986

## Test plan
- [ ] Verify symlink "File exists" warnings from `FilesystemTagAwareAdapter.php` no longer appear in error logs