### PR TITLE
Added conditional return type PHPDoc to `escapeHtml` and `jsQuoteEscape`

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Comments/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Comments/View.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2022-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -63,9 +63,9 @@ class Mage_Adminhtml_Block_Sales_Order_Comments_View extends Mage_Adminhtml_Bloc
     /**
      * Replace links in string
      *
-     * @param string|string[] $data
-     * @param array|null $allowedTags
-     * @return null|string|string[]
+     * @param null|string|string[] $data
+     * @param null|string[] $allowedTags
+     * @return ($data is array ? array<?string> : ?string)
      */
     #[\Override]
     public function escapeHtml($data, $allowedTags = null)

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/History.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/History.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2022-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -71,9 +71,9 @@ class Mage_Adminhtml_Block_Sales_Order_View_History extends Mage_Adminhtml_Block
     /**
      * Replace links in string
      *
-     * @param string|string[] $data
-     * @param array|null $allowedTags
-     * @return null|string|string[]
+     * @param null|string|string[] $data
+     * @param null|string[] $allowedTags
+     * @return ($data is array ? array<?string> : ?string)
      */
     #[\Override]
     public function escapeHtml($data, $allowedTags = null)

--- a/app/code/core/Mage/Adminhtml/Helper/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Sales.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2022-2026 The OpenMage Contributors (https://openmage.org)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -101,9 +101,9 @@ class Mage_Adminhtml_Helper_Sales extends Mage_Core_Helper_Abstract
     /**
      * Escape string preserving links
      *
-     * @param string|string[] $data
-     * @param array|null $allowedTags
-     * @return null|string|string[]
+     * @param null|string|string[] $data
+     * @param null|string[] $allowedTags
+     * @return ($data is array ? array<?string> : ?string)
      */
     public function escapeHtmlWithLinks($data, $allowedTags = null)
     {

--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Core
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2025 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -1229,9 +1229,9 @@ abstract class Mage_Core_Block_Abstract extends \Maho\DataObject
     /**
      * Escape html entities
      *
-     * @param string|string[] $data
-     * @param array|null $allowedTags
-     * @return null|string|string[]
+     * @param null|string|string[] $data
+     * @param null|string[] $allowedTags
+     * @return ($data is array ? array<?string> : ?string)
      */
     public function escapeHtml($data, $allowedTags = null)
     {

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Core
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2020-2025 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2020-2026 The OpenMage Contributors (https://openmage.org)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
@@ -173,9 +173,9 @@ abstract class Mage_Core_Helper_Abstract
     /**
      * Escape html entities
      *
-     * @param string|string[] $data
-     * @param array|null $allowedTags
-     * @return null|string|string[]
+     * @param null|string|string[] $data
+     * @param null|string[] $allowedTags
+     * @return ($data is array ? array<?string> : ?string)
      */
     public function escapeHtml($data, $allowedTags = null)
     {
@@ -292,7 +292,7 @@ abstract class Mage_Core_Helper_Abstract
      *
      * @param string|string[] $data
      * @param string $quote
-     * @return string|string[]
+     * @return ($data is array ? string[] : string)
      */
     public function jsQuoteEscape($data, $quote = '\'')
     {


### PR DESCRIPTION
## Summary
- Added PHPStan conditional return type annotations (`@return ($data is array ? ... : ...)`) to `escapeHtml()` and `jsQuoteEscape()` methods
- Fixed `@param` types for `$data` (added `null`) and `$allowedTags` (`null|string[]` instead of `array|null`)

Thanks to @Hanmac and OpenMage/magento-lts#5402.