### PR TITLE
Fixed Select::columns() not accepting Expr objects

### DIFF
--- a/lib/Maho/Db/Select.php
+++ b/lib/Maho/Db/Select.php
@@ -592,7 +592,7 @@ class Select implements \Stringable
      * @param string $correlationName Correlation name or table alias
      * @return $this
      */
-    public function columns(array|string $cols = '*', ?string $correlationName = null): self
+    public function columns(array|string|Expr $cols = '*', ?string $correlationName = null): self
     {
         if ($correlationName === null && count($this->_parts[self::FROM])) {
             $correlationNameKeys = array_keys($this->_parts[self::FROM]);


### PR DESCRIPTION
## Summary

- `Select::columns()` type hint only allowed `array|string`, so passing an `Expr` directly caused it to be stringified before reaching `_tableCols()`, which then prefixed it with the table alias (e.g. `e.1` instead of `1`)
- Added `Expr` to the union type — no other changes needed since `_tableCols()` already handles `Expr` objects correctly

Fixes #785

## Test plan

- [ ] Go to Admin → Reports → Reviews → Products Reviews and verify the page loads without SQL errors