### PR TITLE
Fixed category save FK violation when Select All checkbox is used

### DIFF
--- a/public/js/mage/adminhtml/catalog/category.js
+++ b/public/js/mage/adminhtml/catalog/category.js
@@ -136,7 +136,8 @@ class CategoryEditForm {
         }
 
         gridObj.checkboxCheckCallback = (gridObj, element, checked) => {
-            const positionEl = event.target.closest('tr')?.querySelector('input[name=position]');
+            if (!element.value || !/^\d+$/.test(element.value)) return;
+            const positionEl = element.closest('tr')?.querySelector('input[name=position]');
             if (positionEl) {
                 positionEl.disabled = !checked;
             }


### PR DESCRIPTION
Fixes #787

## Summary

- Guard `checkboxCheckCallback` against the header "Select All" checkbox, which has no explicit value and defaults to `"on"` per the HTML spec — this caused `product_id = 0` to be inserted into `catalog_category_product`, violating the FK constraint
- Fix incorrect `event.target` reference (global/ambient) to use the `element` parameter passed to the callback

## Test plan

- [ ] Go to Catalog > Categories, select a category with products
- [ ] On the "Category Products" tab, use "Select All" checkbox
- [ ] Save the category — should succeed without FK violation
- [ ] Verify individual checkbox selection still works correctly
- [ ] Verify position field enable/disable still toggles correctly