### PR TITLE
Fixed missing customer_email on orders placed in sessionless contexts

### DIFF
--- a/app/code/core/Mage/Checkout/Model/Type/Onepage.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Onepage.php
@@ -622,6 +622,9 @@ class Mage_Checkout_Model_Type_Onepage
         $shipping   = $quote->isVirtual() ? null : $quote->getShippingAddress();
 
         $customer = $this->getCustomerSession()->getCustomer();
+        if (!$customer->getId() && $quote->getCustomerId()) {
+            $customer = Mage::getModel('customer/customer')->load($quote->getCustomerId());
+        }
         if (!$billing->getCustomerId() || $billing->getSaveInAddressBook()) {
             $customerBilling = $billing->exportCustomerAddress();
             $customer->addAddress($customerBilling);

--- a/app/code/core/Maho/Paypal/Helper/Data.php
+++ b/app/code/core/Maho/Paypal/Helper/Data.php
@@ -120,19 +120,15 @@ class Maho_Paypal_Helper_Data extends Mage_Core_Helper_Abstract
 
         $payment->save();
 
-        $this->importPaypalAddress($paypalResult, $quote);
+        if (!$quote->getBillingAddress()->getFirstname()) {
+            $this->importPaypalAddress($paypalResult, $quote);
+        }
 
         $this->saveVaultToken($paypalResult, $quote);
 
         // Ensure correct checkout method for sessionless contexts (webhooks)
         if ($quote->getCustomerId() && !$quote->getData('checkout_method')) {
             $quote->setData('checkout_method', Mage_Checkout_Model_Type_Onepage::METHOD_CUSTOMER);
-            // Load and attach the customer so _prepareCustomerQuote() doesn't
-            // overwrite the quote's customer with an empty session object
-            $customer = Mage::getModel('customer/customer')->load($quote->getCustomerId());
-            if ($customer->getId()) {
-                $quote->setCustomer($customer);
-            }
         }
 
         $quote->collectTotals();


### PR DESCRIPTION
## Summary

- `_prepareCustomerQuote()` assumed the customer session was always available, but in webhook-driven PayPal order placement there is no session
- The empty session customer overwrote the quote customer data (including email) with blank values via the `customer_account` to `to_quote` fieldset copy in `setCustomer()`
- This resulted in orders with no `customer_email`, breaking CRM integrations and SOAP API responses

## Fix

- **`Mage_Checkout_Model_Type_Onepage::_prepareCustomerQuote()`**: fall back to loading the customer from the database when the session customer is empty — fixes the root cause for any payment method operating without a session, not just PayPal
- **`Maho_Paypal_Helper_Data::placeOrderFromPaypalResult()`**: restore the billing-address guard around `importPaypalAddress()` so checkout-entered address data is not overwritten with PayPal payer data; remove redundant customer loading that is now handled by `_prepareCustomerQuote()`

## Test plan

- [ ] Place an order as a logged-in customer via PayPal (standard checkout) — verify `sales_flat_order.customer_email` is populated
- [ ] Place an order via PayPal express from cart (no billing filled) — verify address is imported from PayPal as before
- [ ] Simulate webhook-driven order placement — verify customer_email is set on the order
- [ ] Place a non-PayPal order as guest and logged-in — verify no regression