### PR TITLE
Upgraded TipTap from 3.20.1 to 3.22.2

### DIFF
--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
@@ -6,13 +6,13 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-import { Editor, Node, Mark, Extension, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.20.1';
-import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.20.1';
-import Image from 'https://esm.sh/@tiptap/extension-image@3.20.1';
-import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.20.1';
-import { Table, TableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.20.1';
-import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.20.1';
-import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.20.1';
+import { Editor, Node, Mark, Extension, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.22.2';
+import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.22.2';
+import Image from 'https://esm.sh/@tiptap/extension-image@3.22.2';
+import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.22.2';
+import { Table, TableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.22.2';
+import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.22.2';
+import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.22.2';
 import { MahoColumns, MahoColumn, COLUMN_PRESETS } from './extensions/columns.js';
 import { MahoBentoGrid, MahoBentoCell, BENTO_PRESETS } from './extensions/bento.js';
 

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/bento.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/bento.js
@@ -6,7 +6,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.20.1';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.22.2';
 import { findParentNodeOfType, createGridNodeView } from './grid-utils.js';
 
 /**

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
@@ -6,7 +6,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.20.1';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.22.2';
 import { findParentNodeOfType, createGridNodeView } from './grid-utils.js';
 
 /**


### PR DESCRIPTION
## Summary
- Updated all TipTap ESM imports from v3.20.1 to v3.22.2 across `extensions.js`, `columns.js`, and `bento.js`

## Notable upstream fixes included
- **@tiptap/core**: NodeView re-rendering, mark range handling, HTML entity escaping, markdown roundtripping
- **@tiptap/extension-bubble-menu**: Hidden menus no longer reappear on scroll/resize
- **@tiptap/extension-drag-handle**: RTL ghost image fix, drag preview cleanup, improved position fallback
- **@tiptap/extension-table**: Markdown table alignment support (align attribute on cells/headers)

No breaking changes between 3.20.1 and 3.22.2.

## Test plan
- [ ] Open admin WYSIWYG editor and verify it loads without console errors
- [ ] Test basic editing (bold, italic, lists, headings)
- [ ] Test table insertion and editing
- [ ] Test drag handle functionality
- [ ] Test bubble menu behavior on text selection