### PR TITLE
Fixed varienGrid doFilter() losing <select multiple> values and reload() not executing inline scripts

### DIFF
--- a/public/js/mage/adminhtml/grid.js
+++ b/public/js/mage/adminhtml/grid.js
@@ -77,6 +77,14 @@ class varienGrid {
         }
     }
     initGridAjax() {
+        const container = document.getElementById(this.containerId);
+        if (container) {
+            container.querySelectorAll('script').forEach(oldScript => {
+                const newScript = document.createElement('script');
+                newScript.textContent = oldScript.textContent;
+                oldScript.parentNode.replaceChild(newScript, oldScript);
+            });
+        }
         this.initGrid();
         this.initGridRows();
     }
@@ -308,7 +316,12 @@ class varienGrid {
             // Serialize elements manually since we don't have prototypejs Form.serializeElements
             const formData = new FormData();
             elements.forEach(element => {
-                formData.append(element.name, element.value);
+                if (element.tagName === 'SELECT' && element.multiple) {
+                    const vals = Array.from(element.selectedOptions).map(o => o.value);
+                    formData.append(element.name, vals.join(','));
+                } else {
+                    formData.append(element.name, element.value);
+                }
             });
             const serialized = new URLSearchParams(formData).toString();
             this.reload(this.addVarToUrl(this.filterVar, btoa(serialized)));


### PR DESCRIPTION
## Summary
Fixes #806

- **doFilter():** `element.value` on a `<select multiple>` returns only the first selected option. Now iterates `selectedOptions` and joins values with commas.
- **reload()/initGridAjax():** Per HTML5 spec, `<script>` tags inserted via `innerHTML` are not executed. Now re-creates script elements so the browser runs them.

## Test plan
- [ ] Add a `<select multiple>` filter to an admin grid (e.g. via IWD OrderManager)
- [ ] Select multiple values and click Search — verify all selections are sent and results match
- [ ] Verify that after AJAX grid reload, inline `<script>` blocks from the response are executed