### PR TITLE
Removed dead `AREA_ADMIN` constant and related code

### DIFF
--- a/app/code/core/Mage/Core/Model/App/Area.php
+++ b/app/code/core/Mage/Core/Model/App/Area.php
@@ -14,7 +14,6 @@ class Mage_Core_Model_App_Area
 {
     public const AREA_GLOBAL   = 'global';
     public const AREA_FRONTEND = 'frontend';
-    public const AREA_ADMIN    = 'admin';
     public const AREA_ADMINHTML = 'adminhtml';
 
     public const PART_CONFIG   = 'config';

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -89,7 +89,6 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      * @var array
      */
     protected $_cacheSections = [
-        'admin'     => 0,
         'adminhtml' => 0,
         'crontab'   => 0,
         'install'   => 0,
@@ -1021,7 +1020,6 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
                     if ($mergeModel->loadFile($configFile)) {
                         $this->_makeEventsLowerCase(Mage_Core_Model_App_Area::AREA_GLOBAL, $mergeModel);
                         $this->_makeEventsLowerCase(Mage_Core_Model_App_Area::AREA_FRONTEND, $mergeModel);
-                        $this->_makeEventsLowerCase(Mage_Core_Model_App_Area::AREA_ADMIN, $mergeModel);
                         $this->_makeEventsLowerCase(Mage_Core_Model_App_Area::AREA_ADMINHTML, $mergeModel);
 
                         $mergeToObject->extend($mergeModel, true);
@@ -1663,7 +1661,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      * Get fieldset from configuration
      *
      * @param string $name fieldset name
-     * @param string $root fieldset area, could be 'admin'
+     * @param string $root fieldset area, could be 'adminhtml'
      * @return null|Mage_Core_Model_Config_Element[]|SimpleXMLElement
      */
     public function getFieldset($name, $root = 'global')


### PR DESCRIPTION
## Summary
- Removed unused `AREA_ADMIN` constant from `Mage_Core_Model_App_Area`
- Removed `'admin'` from `$_cacheSections` in `Mage_Core_Model_Config`
- Removed dead `_makeEventsLowerCase()` call for the `admin` area
- Updated `getFieldset()` docstring

The `admin` event area was never loaded at runtime — `addEventArea('admin')` is never called. Only `global`, `frontend`, `adminhtml`, and `crontab` are actually dispatched.

Closes #810