### PR TITLE
Removed ICO image support from image validator and favicon uploads

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Favicon.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Image/Favicon.php
@@ -48,6 +48,6 @@ class Mage_Adminhtml_Model_System_Config_Backend_Image_Favicon extends Mage_Admi
     #[\Override]
     protected function _getAllowedExtensions(): array
     {
-        return ['ico', 'png', 'gif', 'jpg', 'jpeg', 'apng', 'webp', 'avif', 'svg'];
+        return ['png', 'gif', 'jpg', 'jpeg', 'apng', 'webp', 'avif', 'svg'];
     }
 }

--- a/app/code/core/Mage/Core/Model/File/Validator/Image.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/Image.php
@@ -23,7 +23,6 @@ class Mage_Core_Model_File_Validator_Image
         IMAGETYPE_GIF,
         IMAGETYPE_JPEG2000,
         IMAGETYPE_PNG,
-        IMAGETYPE_ICO,
         IMAGETYPE_TIFF_II,
         IMAGETYPE_TIFF_MM,
     ];
@@ -57,7 +56,6 @@ class Mage_Core_Model_File_Validator_Image
             'jpeg' => [IMAGETYPE_JPEG, IMAGETYPE_JPEG2000],
             'gif' => [IMAGETYPE_GIF],
             'png' => [IMAGETYPE_PNG],
-            'ico' => [IMAGETYPE_ICO],
             'apng' => [IMAGETYPE_PNG],
             'svg' => [], // SVG is XML-based, not a raster format - handled by separate validator
         ];
@@ -95,9 +93,6 @@ class Mage_Core_Model_File_Validator_Image
 
         [$imageWidth, $imageHeight, $fileType] = \Maho\Io::getImageSize($filePath);
         if ($fileType) {
-            if ($fileType === IMAGETYPE_ICO) {
-                return null;
-            }
             if ($this->isImageType($fileType)) {
                 $imageQuality = Mage::getStoreConfigAsInt('system/media_storage_configuration/image_quality');
                 //replace tmp image with re-sampled copy to exclude images with malicious data


### PR DESCRIPTION
## Summary

- Removed `IMAGETYPE_ICO` from the allowed image types in the image validator
- Removed the special case that skipped image reprocessing for ICO files
- Removed `ico` from the allowed favicon upload extensions

## Why

The image validator reprocesses uploaded images with GD to strip any malicious embedded data. ICO files were special-cased to skip this reprocessing because GD doesn't support the ICO format, meaning any malicious payload in an ICO file would survive sanitization. Modern browsers all support PNG favicons, so there's no practical need to keep ICO around.

## Credits

Inspired by OpenMage/magento-lts#5461 — thanks to @colinmollenhour and @sreichel for the original work.