### PR TITLE
Remove args parameter from Observer attribute

### DIFF
--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -1335,36 +1335,6 @@ class Mage_Core_Model_App
     /**
      * Dispatch event to observers
      *
-     * Default arguments can be defined in `config.xml` using the `<args>` node. These are merged with the $args parameter.
-     *
-     * For example, this defines `is_ajax=1` for the `controller_action_predispatch` event:
-     * ```xml
-     * <global>
-     *     <events>
-     *         <controller_action_predispatch>
-     *             <observers>
-     *                 <my_event_observer>
-     *                     <class>Company_Name_Model_Observer</class>
-     *                     <method>process</method>
-     *                     <args>
-     *                         <is_ajax>1</is_ajax>
-     *                     </args>
-     *                 </my_event_observer>
-     *             </observers>
-     *         </controller_action_predispatch>
-     *     </events>
-     * </global>
-     * ```
-     *
-     * In the observer method, `Company_Name_Model_Observer->process()`, access the args with:
-     * ```php
-     * public function process(\Maho\Event\Observer $observer): void
-     * {
-     *     $isAjax = (bool) $observer->getIsAjax();
-     *     // ...
-     * }
-     * ```
-     *
      * @param string $eventName
      * @param array $args
      * @return $this
@@ -1399,7 +1369,6 @@ class Mage_Core_Model_App
                         'model'  => $entry['alias'],
                         'module' => $entry['module'],
                         'method' => $entry['method'],
-                        'args'   => $entry['args'],
                     ];
                 }
 
@@ -1420,14 +1389,15 @@ class Mage_Core_Model_App
             }
 
             foreach ($events[$eventName]['observers'] as $obsName => $obs) {
+                $obsArgs = $obs['args'] ?? [];
                 $observer = new \Maho\Event\Observer([
                     'event' => new \Maho\Event([
-                        ...$obs['args'], // Default config.xml <args>
-                        ...$args,        // Mage::dispatchEvent() $args
+                        ...$obsArgs, // Default config.xml <args>
+                        ...$args,    // Mage::dispatchEvent() $args
                         'name' => $eventName,
                     ]),
-                    ...$obs['args'], // Default config.xml <args>
-                    ...$args,        // Mage::dispatchEvent() $args
+                    ...$obsArgs, // Default config.xml <args>
+                    ...$args,    // Mage::dispatchEvent() $args
                 ]);
                 \Maho\Profiler::start('OBSERVER: ' . $obsName);
                 switch ($obs['type']) {

--- a/app/code/core/Maho/Captcha/Model/Observer.php
+++ b/app/code/core/Maho/Captcha/Model/Observer.php
@@ -10,7 +10,7 @@
 
 class Maho_Captcha_Model_Observer
 {
-    #[Maho\Config\Observer('controller_action_predispatch_checkout_onepage_savebilling', area: 'frontend', args: ['is_ajax' => 1])]
+    #[Maho\Config\Observer('controller_action_predispatch_checkout_onepage_savebilling', area: 'frontend')]
     #[Maho\Config\Observer('controller_action_predispatch_contacts_index_post', area: 'frontend')]
     #[Maho\Config\Observer('controller_action_predispatch_customer_account_createpost', area: 'frontend')]
     #[Maho\Config\Observer('controller_action_predispatch_customer_account_forgotpasswordpost', area: 'frontend')]
@@ -32,7 +32,7 @@ class Maho_Captcha_Model_Observer
             return;
         }
 
-        $isAjax = (bool) $observer->getEvent()->getIsAjax();
+        $isAjax = $controller->getRequest()->isAjax();
         $this->failedVerification($controller, $isAjax);
     }
 

--- a/composer.lock
+++ b/composer.lock
@@ -1223,16 +1223,16 @@
         },
         {
             "name": "mahocommerce/maho-composer-plugin",
-            "version": "v4.0.8",
+            "version": "v4.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MahoCommerce/maho-composer-plugin.git",
-                "reference": "59bc2e8a3b3661712d1f529cfda9aefe33ab547e"
+                "reference": "dbcaf42e2313ad4ea2faed3fd81e2510c913a836"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MahoCommerce/maho-composer-plugin/zipball/59bc2e8a3b3661712d1f529cfda9aefe33ab547e",
-                "reference": "59bc2e8a3b3661712d1f529cfda9aefe33ab547e",
+                "url": "https://api.github.com/repos/MahoCommerce/maho-composer-plugin/zipball/dbcaf42e2313ad4ea2faed3fd81e2510c913a836",
+                "reference": "dbcaf42e2313ad4ea2faed3fd81e2510c913a836",
                 "shasum": ""
             },
             "require": {
@@ -1265,9 +1265,9 @@
             "description": "Extension for Composer to copy assets and enable autoloading for Maho projects.",
             "support": {
                 "issues": "https://github.com/MahoCommerce/maho-composer-plugin/issues",
-                "source": "https://github.com/MahoCommerce/maho-composer-plugin/tree/v4.0.8"
+                "source": "https://github.com/MahoCommerce/maho-composer-plugin/tree/v4.0.9"
             },
-            "time": "2026-04-12T19:39:21+00:00"
+            "time": "2026-04-12T20:13:44+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/lib/Maho/Config/Observer.php
+++ b/lib/Maho/Config/Observer.php
@@ -35,7 +35,6 @@ readonly class Observer
      *                          Accepts either the explicit id, the class name, or the class alias format
      *                          (e.g. `'my_observer'`, `'Mage_Catalog_Model_Observer::myMethod'`,
      *                          or `'catalog/observer::myMethod'`).
-     * @param array   $args     Additional arguments passed to the observer via the event object
      */
     public function __construct(
         public string $event,
@@ -43,6 +42,5 @@ readonly class Observer
         public string $type = 'singleton',
         public ?string $id = null,
         public ?string $replaces = null,
-        public array $args = [],
     ) {}
 }


### PR DESCRIPTION
## Summary
- Removed `args` parameter from `#[Maho\Config\Observer]` attribute
- Updated Captcha billing observer to detect AJAX via `$controller->getRequest()->isAjax()` instead of relying on args
- Updated `dispatchEvent()` to no longer expect `args` from compiled attribute entries (XML-based observers still supported via `?? []`)
- Bumped maho-composer-plugin to v4.0.9 which removes `args` from compiled output

Closes #817

## Test plan
- [ ] Verify captcha validation still returns JSON error on AJAX checkout actions
- [ ] Verify captcha validation still redirects with error on non-AJAX form submissions
- [ ] Run `composer dump-autoload` and confirm compiled attributes contain no `args` keys