### PR TITLE
Removed redundant `type="text/javascript"` from script tags

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Pricestep.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Pricestep.php
@@ -54,7 +54,7 @@ class Mage_Adminhtml_Block_Catalog_Category_Helper_Pricestep extends \Maho\Data\
 
         $html .= ' <label for="' . $htmlId . '" class="normal">'
             . Mage::helper('adminhtml')->__('Use Config Settings') . '</label>';
-        $html .= '<script type="text/javascript">' . 'toggleValueElements(document.getElementById(\'' . $htmlId . '\'), document.getElementById(\'' . $htmlId
+        $html .= '<script>' . 'toggleValueElements(document.getElementById(\'' . $htmlId . '\'), document.getElementById(\'' . $htmlId
             . '\').parentNode);' . '</script>';
 
         return $html;

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Available.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Available.php
@@ -52,7 +52,7 @@ class Mage_Adminhtml_Block_Catalog_Category_Helper_Sortby_Available extends \Mah
         $html .= ' onclick="toggleValueElements(this, this.parentNode);" class="checkbox" type="checkbox" />';
         $html .= ' <label for="' . $htmlId . '" class="normal">'
             . Mage::helper('adminhtml')->__('Use All Available Attributes') . '</label>';
-        $html .= '<script type="text/javascript">toggleValueElements(document.getElementById(\'' . $htmlId . '\'), document.getElementById(\'' . $htmlId
+        $html .= '<script>toggleValueElements(document.getElementById(\'' . $htmlId . '\'), document.getElementById(\'' . $htmlId
             . '\').parentNode);</script>';
 
         return $html;

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Helper/Sortby/Default.php
@@ -53,7 +53,7 @@ class Mage_Adminhtml_Block_Catalog_Category_Helper_Sortby_Default extends \Maho\
         $html .= ' onclick="toggleValueElements(this, this.parentNode);" class="checkbox" type="checkbox" />';
         $html .= ' <label for="' . $htmlId . '" class="normal">'
             . Mage::helper('adminhtml')->__('Use Config Settings') . '</label>';
-        $html .= '<script type="text/javascript">toggleValueElements(document.getElementById(\'' . $htmlId . '\'), document.getElementById(\'' . $htmlId
+        $html .= '<script>toggleValueElements(document.getElementById(\'' . $htmlId . '\'), document.getElementById(\'' . $htmlId
             . '\').parentNode);</script>';
 
         return $html;

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Attributes.php
@@ -226,7 +226,7 @@ class Mage_Adminhtml_Block_Catalog_Category_Tab_Attributes extends Mage_Adminhtm
         if ($group && $group->getAttributeGroupName() == 'Dynamic Category') {
             $newChildUrl = $this->getUrl('*/*/newConditionHtml/form/dynamic_conditions_fieldset');
 
-            $script = '<script type="text/javascript">
+            $script = '<script>
                 document.addEventListener("DOMContentLoaded", function() {
                     if (typeof VarienRulesForm !== "undefined") {
                         var conditionsFieldset = document.getElementById("dynamic_conditions_fieldset");

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Attributes.php
@@ -88,7 +88,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Action_Attribute_Tab_Attributes 
              . '-checkbox" ' . $nameAttributeHtml . ' onclick="toggleFieldEditMode(this, \'' . $element->getId()
              . '\')" /><label for="' . $element->getId() . '-checkbox">' . Mage::helper('catalog')->__('Change')
              . '</label></span>
-                <script type="text/javascript">initDisableFields(\'' . $element->getId() . '\')</script>';
+                <script>initDisableFields(\'' . $element->getId() . '\')</script>';
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Config.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Config.php
@@ -33,7 +33,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Helper_Form_Config extends \Maho\Data
         $html .= '<input id="' . $htmlId . '" name="product[' . $htmlId . ']" ' . $disabled . ' value="1" ' . $checked;
         $html .= ' onclick="toggleValueElements(this, this.parentNode);" class="checkbox" type="checkbox" />';
         $html .= ' <label for="' . $htmlId . '">' . Mage::helper('adminhtml')->__('Use Config Settings') . '</label>';
-        $html .= '<script type="text/javascript">toggleValueElements(document.getElementById(\'' . $htmlId . '\'), document.getElementById(\'' . $htmlId . '\').parentNode);</script>';
+        $html .= '<script>toggleValueElements(document.getElementById(\'' . $htmlId . '\'), document.getElementById(\'' . $htmlId . '\').parentNode);</script>';
 
         return $html;
     }

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/File.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/File.php
@@ -75,7 +75,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Helper_Form_File extends \Maho\Data\F
                 $html .= '</span>';
             } elseif ($attribute->getIsRequired() && $this->getValue()) {
                 $html .= '<input value="' . $this->getValue() . '" id="' . $this->getHtmlId() . '_hidden" type="hidden" class="required-entry" />';
-                $html .= '<script type="text/javascript">
+                $html .= '<script>
                     syncOnchangeValue(\'' . $this->getHtmlId() . '\', \'' . $this->getHtmlId() . '_hidden\');
                 </script>';
             }

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Image.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Image.php
@@ -31,7 +31,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Helper_Form_Image extends \Maho\Data\
                 $html .= parent::_getDeleteCheckbox();
             } else {
                 $html .= '<input value="' . $this->getValue() . '" id="' . $this->getHtmlId() . '_hidden" type="hidden" class="required-entry" />';
-                $html .= '<script type="text/javascript">
+                $html .= '<script>
                     syncOnchangeValue(\'' . $this->getHtmlId() . '\', \'' . $this->getHtmlId() . '_hidden\');
                 </script>';
             }

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
@@ -61,7 +61,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Helper_Form_Price extends \Maho\Data\
     {
         $spanId = "dynamic-tax-{$attribute->getAttributeCode()}";
 
-        return "<script type='text/javascript'>if (dynamicTaxes == undefined) var dynamicTaxes = new Array(); dynamicTaxes[dynamicTaxes.length]='{$attribute->getAttributeCode()}'</script>";
+        return "<script>if (dynamicTaxes == undefined) var dynamicTaxes = new Array(); dynamicTaxes[dynamicTaxes.length]='{$attribute->getAttributeCode()}'</script>";
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Adminpass.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Adminpass.php
@@ -37,7 +37,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Renderer_Adminpass extends Mage_Adminht
     protected function _getScriptHtml(\Maho\Data\Form\Element\AbstractElement $element)
     {
         return <<<SCRIPT
-<script type="text/javascript">
+<script>
     document.querySelectorAll('#_accountnew_password,#account-send-pass').forEach(function(elem) {
         elem.addEventListener('change', function() {
             var newPasswordField = document.getElementById('_accountnew_password');

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Region.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Renderer/Region.php
@@ -53,7 +53,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Renderer_Region extends Mage_Adminhtml_
         $html .= '<option value="">' . $this->_factory->getHelper('customer')->__('Please select') . '</option>';
         $html .= '</select>';
 
-        $html .= '<script type="text/javascript">' . "\n";
+        $html .= '<script>' . "\n";
         $html .= 'document.getElementById("' . $selectId . '").setAttribute("defaultValue", "' . $regionId . '");' . "\n";
         $html .= 'new RegionUpdater("' . $country->getHtmlId() . '", "' . $element->getHtmlId() . '", "' .
             $selectId . '", ' . Mage::helper('directory')->getRegionJsonByStore($quoteStoreId) . ');' . "\n";

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Account.php
@@ -67,7 +67,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_Account extends Mage_Adminhtml_Bloc
 
             // @codingStandardsIgnoreStart
             $form->getElement('website_id')->setAfterElementHtml(
-                '<script type="text/javascript">'
+                '<script>'
                 . "
                 var {$prefix}_websites = " . Mage::helper('core')->jsonEncode($websites) . ";
                 Validation.add(
@@ -254,7 +254,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_Account extends Mage_Adminhtml_Bloc
                 $disableStoreField = "document.getElementById('{$prefix}sendemail_store_id').disabled=(''==this.value || '0'==this.value);";
             }
             $sendEmail->setAfterElementHtml(
-                '<script type="text/javascript">'
+                '<script>'
                 . "
                 document.getElementById('{$prefix}website_id').disableSendemail = function() {
                     document.getElementById('{$prefix}sendemail').disabled = ('' == this.value || '0' == this.value);" .

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Sales/Order/Address/Form/Renderer/Vat.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Sales/Order/Address/Form/Renderer/Vat.php
@@ -92,7 +92,7 @@ class Mage_Adminhtml_Block_Customer_Sales_Order_Address_Form_Renderer_Vat extend
             ]);
 
             $optionsVarName = $this->getJsVariablePrefix() . 'VatParameters';
-            $beforeHtml = '<script type="text/javascript">var ' . $optionsVarName . ' = ' . $vatValidateOptions
+            $beforeHtml = '<script>var ' . $optionsVarName . ' = ' . $vatValidateOptions
                 . ';</script>';
 
             /** @var Mage_Adminhtml_Block_Widget_Button $block */

--- a/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Daterange.php
+++ b/app/code/core/Mage/Adminhtml/Block/Promo/Widget/Chooser/Daterange.php
@@ -68,7 +68,7 @@ class Mage_Adminhtml_Block_Promo_Widget_Chooser_Daterange extends Mage_Adminhtml
             $element->setId($id);
             $form->addElement($element);
         }
-        return $form->toHtml() . "<script type=\"text/javascript\">
+        return $form->toHtml() . "<script>
             const dateTimeChoose_{$idSuffix} = function() {
                 const targetEl = document.getElementById('{$this->_targetElementId}');
                 const fromEl = document.getElementById('from_{$idSuffix}');

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Import.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Import.php
@@ -32,7 +32,7 @@ class Mage_Adminhtml_Block_System_Config_Form_Field_Import extends \Maho\Data\Fo
         $html .= '<input id="time_condition" type="hidden" name="' . $this->getName() . '" value="' . time() . '" />';
 
         $html .= <<<EndHTML
-        <script type="text/javascript">
+        <script>
         document.getElementById('carriers_tablerate_condition_name').addEventListener('change', checkConditionName);
         function checkConditionName(event)
         {

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Allowspecific.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form/Field/Select/Allowspecific.php
@@ -16,7 +16,7 @@ class Mage_Adminhtml_Block_System_Config_Form_Field_Select_Allowspecific extends
     public function getAfterElementHtml()
     {
         $javaScript = "
-            <script type=\"text/javascript\">
+            <script>
                 document.getElementById('{$this->getHtmlId()}').addEventListener('change', function(){
                     specific=document.getElementById('{$this->getHtmlId()}').value;
                     document.getElementById('{$this->_getSpecificCountryElementId()}').disabled = (!specific || specific!=1);

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Edit/Form.php
@@ -46,7 +46,7 @@ class Mage_Adminhtml_Block_System_Email_Template_Edit_Form extends Mage_Adminhtm
                 'label' => Mage::helper('adminhtml')->__('Used Currently For'),
                 'container_id' => 'used_currently_for',
                 'after_element_html' =>
-                    '<script type="text/javascript">' .
+                    '<script>' .
                     ($this->getEmailTemplate()->getSystemConfigPathsWhereUsedCurrently()
                         ? '' : 'document.getElementById(\'' . 'used_currently_for' . '\').style.display = \'none\'; ') .
                     '</script>',
@@ -58,7 +58,7 @@ class Mage_Adminhtml_Block_System_Email_Template_Edit_Form extends Mage_Adminhtm
                 'label' => Mage::helper('adminhtml')->__('Used as Default For'),
                 'container_id' => 'used_default_for',
                 'after_element_html' =>
-                    '<script type="text/javascript">' .
+                    '<script>' .
                     ((bool) $this->getEmailTemplate()->getOrigTemplateCode()
                         ? '' : 'document.getElementById(\'' . 'used_default_for' . '\').style.display = \'none\'; ') .
                     '</script>',

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
@@ -183,7 +183,7 @@ class Mage_Adminhtml_Block_Widget_Form_Container extends Mage_Adminhtml_Block_Wi
     public function getFormInitScripts()
     {
         if (!empty($this->_formInitScripts) && is_array($this->_formInitScripts)) {
-            return '<script type="text/javascript">' . implode("\n", $this->_formInitScripts) . '</script>';
+            return '<script>' . implode("\n", $this->_formInitScripts) . '</script>';
         }
         return '';
     }
@@ -194,7 +194,7 @@ class Mage_Adminhtml_Block_Widget_Form_Container extends Mage_Adminhtml_Block_Wi
     public function getFormScripts()
     {
         if (!empty($this->_formScripts) && is_array($this->_formScripts)) {
-            return '<script type="text/javascript">' . implode("\n", $this->_formScripts) . '</script>';
+            return '<script>' . implode("\n", $this->_formScripts) . '</script>';
         }
         return '';
     }

--- a/app/code/core/Mage/Adminhtml/controllers/IndexController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/IndexController.php
@@ -217,7 +217,7 @@ class Mage_Adminhtml_IndexController extends Mage_Adminhtml_Controller_Action
      */
     protected function _getDeniedIframe()
     {
-        return '<script type="text/javascript">parent.window.location = \''
+        return '<script>parent.window.location = \''
             . $this->getUrl('*/index/login') . '\';</script>';
     }
 

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Checkbox.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Checkbox.php
@@ -31,7 +31,7 @@ class Mage_Bundle_Block_Adminhtml_Catalog_Product_Composite_Fieldset_Options_Typ
     #[\Override]
     public function setValidationContainer($elementId, $containerId)
     {
-        return '<script type="text/javascript">
+        return '<script>
             document.getElementById(\'' . $elementId . '\').advaiceContainer = \'' . $containerId . '\';
             </script>';
     }

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Multi.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Multi.php
@@ -31,7 +31,7 @@ class Mage_Bundle_Block_Adminhtml_Catalog_Product_Composite_Fieldset_Options_Typ
     #[\Override]
     public function setValidationContainer($elementId, $containerId)
     {
-        return '<script type="text/javascript">
+        return '<script>
             document.getElementById(\'' . $elementId . '\').advaiceContainer = \'' . $containerId . '\';
             </script>';
     }

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Radio.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Radio.php
@@ -31,7 +31,7 @@ class Mage_Bundle_Block_Adminhtml_Catalog_Product_Composite_Fieldset_Options_Typ
     #[\Override]
     public function setValidationContainer($elementId, $containerId)
     {
-        return '<script type="text/javascript">
+        return '<script>
             document.getElementById(\'' . $elementId . '\').advaiceContainer = \'' . $containerId . '\';
             </script>';
     }

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Select.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Select.php
@@ -31,7 +31,7 @@ class Mage_Bundle_Block_Adminhtml_Catalog_Product_Composite_Fieldset_Options_Typ
     #[\Override]
     public function setValidationContainer($elementId, $containerId)
     {
-        return '<script type="text/javascript">
+        return '<script>
             document.getElementById(\'' . $elementId . '\').advaiceContainer = \'' . $containerId . '\';
             </script>';
     }

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes.php
@@ -56,7 +56,7 @@ class Mage_Bundle_Block_Adminhtml_Catalog_Product_Edit_Tab_Attributes extends Ma
         $tax = $this->getForm()->getElement('tax_class_id');
         if ($tax) {
             $tax->setAfterElementHtml(
-                '<script type="text/javascript">'
+                '<script>'
                 . "
                 function changeTaxClassId() {
                     if (document.getElementById('price_type').value == '" . Mage_Bundle_Model_Product_Price::PRICE_TYPE_DYNAMIC . "') {
@@ -113,7 +113,7 @@ class Mage_Bundle_Block_Adminhtml_Catalog_Product_Edit_Tab_Attributes extends Ma
         $mapEnabled = $this->getForm()->getElement('msrp_enabled');
         if ($mapEnabled && $this->getCanEditPrice() !== false) {
             $mapEnabled->setAfterElementHtml(
-                '<script type="text/javascript">'
+                '<script>'
                 . "
                 function changePriceTypeMap() {
                     if (document.getElementById('price_type').value == " . Mage_Bundle_Model_Product_Price::PRICE_TYPE_DYNAMIC . ") {

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php
@@ -66,7 +66,7 @@ class Mage_Bundle_Block_Adminhtml_Catalog_Product_Edit_Tab_Attributes_Extend ext
             $html .= '<span class="next-toselect">' . $elementHtml . '</span>';
         }
         if ($this->getDisableChild() && !$this->getElement()->getReadonly()) {
-            $html .= '<script type="text/javascript">
+            $html .= '<script>
                 function ' . $switchAttributeCode . "_change() {
                     if (document.getElementById('" . $switchAttributeCode . "').value == '" . self::DYNAMIC . "') {
                         if (document.getElementById('" . $this->getAttribute()->getAttributeCode() . "')) {

--- a/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option.php
+++ b/app/code/core/Mage/Bundle/Block/Catalog/Product/View/Type/Bundle/Option.php
@@ -240,7 +240,7 @@ class Mage_Bundle_Block_Catalog_Product_View_Type_Bundle_Option extends Mage_Bun
      */
     public function setValidationContainer($elementId, $containerId)
     {
-        return '<script type="text/javascript">
+        return '<script>
             document.getElementById(\'' . $elementId . '\').advaiceContainer = \'' . $containerId . '\';
             document.getElementById(\'' . $elementId . '\').callbackFunction  = \'bundle.validationCallback\';
             </script>';

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Select.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Select.php
@@ -127,7 +127,7 @@ class Mage_Catalog_Block_Product_View_Options_Type_Select extends Mage_Catalog_B
                     . '<span class="label"><label for="options_' . $option->getId() . '_' . $count . '">'
                     . $this->escapeHtml($value->getTitle()) . ' ' . $priceStr . '</label></span>';
                 if ($option->getIsRequire()) {
-                    $selectHtml .= '<script type="text/javascript">' . 'document.getElementById(\'options_' . $option->getId() . '_'
+                    $selectHtml .= '<script>' . 'document.getElementById(\'options_' . $option->getId() . '_'
                     . $count . '\').advaiceContainer = \'options-' . $option->getId() . '-container\';'
                     . 'document.getElementById(\'options_' . $option->getId() . '_' . $count
                     . '\').callbackFunction = \'validateOptionsCallback\';' . '</script>';

--- a/app/code/core/Mage/Core/Helper/Js.php
+++ b/app/code/core/Mage/Core/Helper/Js.php
@@ -67,7 +67,7 @@ class Mage_Core_Helper_Js extends Mage_Core_Helper_Abstract
      */
     public function getScript($script)
     {
-        return '<script type="text/javascript">' . $script . '</script>' . "\n";
+        return '<script>' . $script . '</script>' . "\n";
     }
 
     /**
@@ -78,7 +78,7 @@ class Mage_Core_Helper_Js extends Mage_Core_Helper_Abstract
      */
     public function includeScript($file)
     {
-        return '<script type="text/javascript" src="' . $this->getJsUrl($file) . '"></script>' . "\n";
+        return '<script src="' . $this->getJsUrl($file) . '"></script>' . "\n";
     }
 
     /**
@@ -89,7 +89,7 @@ class Mage_Core_Helper_Js extends Mage_Core_Helper_Abstract
      */
     public function includeSkinScript($file)
     {
-        return '<script type="text/javascript" src="' . $this->getJsSkinUrl($file) . '"></script>';
+        return '<script src="' . $this->getJsSkinUrl($file) . '"></script>';
     }
 
     /**

--- a/app/code/core/Mage/Core/Model/Translate/Inline.php
+++ b/app/code/core/Mage/Core/Model/Translate/Inline.php
@@ -239,13 +239,13 @@ class Mage_Core_Model_Translate_Inline
         $trigImg = 'data:image/svg+xml,' . rawurlencode(Mage::helper('core')->getIconSvg('book'));
 
         ob_start(); ?>
-<script type="text/javascript" src="<?= $baseJsUrl ?>maho-dialog.js"></script>
+<script src="<?= $baseJsUrl ?>maho-dialog.js"></script>
 
-<script type="text/javascript" src="<?= $baseJsUrl ?>mage/translate_inline.js"></script>
+<script src="<?= $baseJsUrl ?>mage/translate_inline.js"></script>
 <link rel="stylesheet" type="text/css" href="<?= $baseJsUrl ?>mage/translate_inline.css"/>
 
 <div id="translate-inline-trig"><img src="<?= $trigImg ?>" alt="[TR]" style="background: white; padding: 4px; border: 2px solid #ccc; border-radius: 3px; cursor: pointer;"/></div>
-<script type="text/javascript">
+<script>
     new TranslateInline('translate-inline-trig', '<?= $ajaxUrl ?>', '<?= Mage::getDesign()->getArea() ?>');
 </script>
         <?php

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator.php
@@ -64,7 +64,7 @@ class Mage_Dataflow_Model_Session_Adapter_Iterator extends Mage_Dataflow_Model_C
         </div>
     </div>
 </li>
-<script type="text/javascript">
+<script>
 function updateProgress(sessionId, idx, time, memory) {
     var total_rows = ' . $totalRows . ';
     var elapsed_time = time-' . time() . ';
@@ -102,7 +102,7 @@ function updateProgress(sessionId, idx, time, memory) {
     public function updateProgress($args)
     {
         $memory = empty($args['memory']) ? '' : $args['memory'];
-        echo '<script type="text/javascript">updateProgress("'
+        echo '<script>updateProgress("'
             . $args['row']['session_id'] . '", "' . $args['idx'] . '", "' . time() . '", "' . $memory . '");</script>';
         echo '<li>' . $memory . '</li>';
 

--- a/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Region/Updater.php
+++ b/app/code/core/Mage/Directory/Block/Adminhtml/Frontend/Region/Updater.php
@@ -19,7 +19,7 @@ class Mage_Directory_Block_Adminhtml_Frontend_Region_Updater extends Mage_Adminh
     protected function _getElementHtml(\Maho\Data\Form\Element\AbstractElement $element)
     {
         $html = parent::_getElementHtml($element);
-        $html .= "<script type=\"text/javascript\">var updater = new RegionUpdater('tax_defaults_country', 'tax_region', 'tax_defaults_region', " . Mage::helper('directory')->getRegionJsonByStore() . ", 'disable');</script>";
+        $html .= "<script>var updater = new RegionUpdater('tax_defaults_country', 'tax_region', 'tax_defaults_region', " . Mage::helper('directory')->getRegionJsonByStore() . ", 'disable');</script>";
 
         return $html;
     }

--- a/app/code/core/Mage/Paypal/Block/Standard/Redirect.php
+++ b/app/code/core/Mage/Paypal/Block/Standard/Redirect.php
@@ -36,7 +36,7 @@ class Mage_Paypal_Block_Standard_Redirect extends Mage_Core_Block_Abstract
         $html = '<html><body>';
         $html .= $this->__('You will be redirected to the PayPal website in a few seconds.');
         $html .= $form->toHtml();
-        $html .= '<script type="text/javascript">document.getElementById("paypal_standard_checkout").submit();</script>';
+        $html .= '<script>document.getElementById("paypal_standard_checkout").submit();</script>';
         $html .= '</body></html>';
 
         return $html;

--- a/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
+++ b/app/code/core/Mage/Paypal/Controller/Express/Abstract.php
@@ -261,7 +261,7 @@ abstract class Mage_Paypal_Controller_Express_Abstract extends Mage_Core_Control
             Mage::logException($e);
         }
         if (isset($isAjax) && $isAjax) {
-            $this->getResponse()->setBody('<script type="text/javascript">window.location.href = '
+            $this->getResponse()->setBody('<script>window.location.href = '
                 . Mage::getUrl('*/*/review') . ';</script>');
         } else {
             $this->_redirect('*/*/review');
@@ -288,7 +288,7 @@ abstract class Mage_Paypal_Controller_Express_Abstract extends Mage_Core_Control
             $this->_getSession()->addError($this->__('Unable to update shipping method.'));
             Mage::logException($e);
         }
-        $this->getResponse()->setBody('<script type="text/javascript">window.location.href = '
+        $this->getResponse()->setBody('<script>window.location.href = '
             . Mage::getUrl('*/*/review') . ';</script>');
     }
 

--- a/app/code/core/Mage/Tax/Block/Adminhtml/Frontend/Region/Updater.php
+++ b/app/code/core/Mage/Tax/Block/Adminhtml/Frontend/Region/Updater.php
@@ -20,7 +20,7 @@ class Mage_Tax_Block_Adminhtml_Frontend_Region_Updater extends Mage_Adminhtml_Bl
     {
         $html = parent::_getElementHtml($element);
 
-        $js = '<script type="text/javascript">
+        $js = '<script>
                var updater = new RegionUpdater("tax_defaults_country", "none", "tax_defaults_region", %s, "nullify");
                if(updater.lastCountryId) {
                    var tmpRegionId = document.getElementById("tax_defaults_region").value;

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Chooser.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Chooser.php
@@ -173,7 +173,7 @@ class Mage_Widget_Block_Adminhtml_Widget_Chooser extends Mage_Adminhtml_Block_Te
             . $this->quoteEscape($this->getLabel() ?: Mage::helper('widget')->__('Not Selected'))
             . '</label>
             <div id="' . $chooserId . 'advice-container" class="hidden"></div>
-            <script type="text/javascript">
+            <script>
                 var instantiateChooser = function() {
                     window.' . $chooserId . ' = new WysiwygWidget.chooser(
                         "' . $chooserId . '",

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Destination/Edit/Tab/General.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Destination/Edit/Tab/General.php
@@ -110,7 +110,7 @@ class Maho_FeedManager_Block_Adminhtml_Destination_Edit_Tab_General extends Mage
             : '';
 
         return <<<SCRIPT
-        <script type="text/javascript">
+        <script>
         (function() {
             // TODO: Add 'google_api', 'facebook_api' back when API upload is implemented
             var types = ['sftp', 'ftp'];

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping.php
@@ -276,7 +276,7 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping extends Mage_Adminh
 
         $transformerData = Mage::helper('core')->jsonEncode($data);
 
-        return '<script type="text/javascript">var TransformerData = ' . $transformerData . ';</script>';
+        return '<script>var TransformerData = ' . $transformerData . ';</script>';
     }
 
     /**

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Csv.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Csv.php
@@ -72,7 +72,7 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Csv extends Maho_Fe
         </div>
 
 
-        <script type="text/javascript">
+        <script>
         var CsvBuilder = {
             columns: ' . Mage::helper('core')->jsonEncode($columnsData) . ',
             sourceTypes: ' . Mage::helper('core')->jsonEncode($sourceTypes) . ',

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Json.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Json.php
@@ -79,7 +79,7 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Json extends Maho_F
         </div>
 
 
-        <script type="text/javascript">
+        <script>
         var JsonBuilder = {
             structure: ' . Mage::helper('core')->jsonEncode($structureData) . ',
             sourceTypes: ' . Mage::helper('core')->jsonEncode($sourceTypes) . ',

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Xml.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Xml.php
@@ -79,7 +79,7 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Xml extends Maho_Fe
         </div>
 
 
-        <script type="text/javascript">
+        <script>
         var XmlBuilder = {
             structure: ' . Mage::helper('core')->jsonEncode($structureData) . ',
             sourceTypes: ' . Mage::helper('core')->jsonEncode($sourceTypes) . ',

--- a/app/design/adminhtml/default/default/template/api/role_users_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/api/role_users_grid_js.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Api_Role_Grid_User $this */
 ?>
-<script type="text/javascript">
+<script>
 <?php $myBlock = $this->getLayout()->getBlock('roleUsersGrid'); ?>
 <?php if( is_object($myBlock) && $myBlock->getJsObjectName() ): ?>
     const checkBoxes = new Map();

--- a/app/design/adminhtml/default/default/template/api/roleinfo.phtml
+++ b/app/design/adminhtml/default/default/template/api/roleinfo.phtml
@@ -23,6 +23,6 @@
 <form action="<?= $this->getUrl('*/*/saverole') ?>" method="post" id="role_edit_form">
     <?= $this->getBlockHtml('formkey') ?>
 </form>
-<script type="text/javascript">
+<script>
     var roleForm = new varienForm('role_edit_form');
 </script>

--- a/app/design/adminhtml/default/default/template/api/user_roles_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/api/user_roles_grid_js.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Template $this */
 ?>
-<script type="text/javascript">
+<script>
 <?php $myBlock = $this->getLayout()->getBlock('user.roles.grid'); ?>
 <?php if(is_object($myBlock) && $myBlock->getJsObjectName()): ?>
     const radioBoxes = new Map();

--- a/app/design/adminhtml/default/default/template/api/userinfo.phtml
+++ b/app/design/adminhtml/default/default/template/api/userinfo.phtml
@@ -30,6 +30,6 @@
 <form action="<?= $this->getUrl('*/*/saveuser') ?>" method="post" id="user_edit_form">
     <?= $this->getBlockHtml('formkey') ?>
 </form>
-<script type="text/javascript">
+<script>
     var userForm = new varienForm('user_edit_form');
 </script>

--- a/app/design/adminhtml/default/default/template/api2/attribute/buttons.phtml
+++ b/app/design/adminhtml/default/default/template/api2/attribute/buttons.phtml
@@ -25,6 +25,6 @@
 <form action="<?= $this->getUrl('*/*/save') ?>" method="post" id="role_edit_form">
     <?= $this->getBlockHtml('formkey') ?>
 </form>
-<script type="text/javascript">
+<script>
     var roleForm = new varienForm('role_edit_form');
 </script>

--- a/app/design/adminhtml/default/default/template/api2/permissions/user/edit/tab/roles/js.phtml
+++ b/app/design/adminhtml/default/default/template/api2/permissions/user/edit/tab/roles/js.phtml
@@ -12,7 +12,7 @@
 /** @var Mage_Adminhtml_Block_Template $this */
 ?>
 
-<script type="text/javascript">
+<script>
 var activeRestRole = getActiveRestRole();
 
 function getActiveRestRole() {

--- a/app/design/adminhtml/default/default/template/api2/role/buttons.phtml
+++ b/app/design/adminhtml/default/default/template/api2/role/buttons.phtml
@@ -25,7 +25,7 @@
 <form action="<?= $this->getUrl('*/*/save') ?>" method="post" id="role_edit_form">
     <?= $this->getBlockHtml('formkey') ?>
 </form>
-<script type="text/javascript">
+<script>
 //<![CDATA[
     var roleForm = new varienForm('role_edit_form');
 //]]>

--- a/app/design/adminhtml/default/default/template/api2/role/users_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/api2/role/users_grid_js.phtml
@@ -12,7 +12,7 @@
 /** @var Mage_Adminhtml_Block_Template $this */
 ?>
 
-<script type="text/javascript">
+<script>
 <?php
     /** @var Mage_Api2_Block_Adminhtml_Roles_Tab_Users $myBlock */
     $myBlock = $this->getLayout()->getBlock('adminhtml.role.edit.tab.users');

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Bundle_Block_Adminhtml_Catalog_Product_Edit_Tab_Bundle $this */
 ?>
-<script type="text/javascript">
+<script>
 if(typeof Bundle=='undefined') {
     Bundle = {};
 }
@@ -47,7 +47,7 @@ if(typeof Bundle=='undefined') {
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 // re-bind form elements onchange
 varienWindowOnload();
 <?php if ($this->isReadonly()):?>

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Bundle_Block_Adminhtml_Catalog_Product_Edit_Tab_Bundle_Option $this */
 ?>
-<script type="text/javascript">
+<script>
 function createOptionTemplate(data) {
     const typeSelectHtml = `<?= $this->getTypeSelectHtml() ?>`.replace(/\{\{index\}\}/g, data.index);
     const requireSelectHtml = `<?= $this->getRequireSelectHtml() ?>`.replace(/\{\{index\}\}/g, data.index);
@@ -61,7 +61,7 @@ function createOptionTemplate(data) {
 
 <?= $this->getSelectionHtml() ?>
 
-<script type="text/javascript">
+<script>
 function changeInputType(oldObject, oType) {
     const newObject = document.createElement('input');
     newObject.type = oType;

--- a/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/product/edit/bundle/option/selection.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Bundle_Block_Adminhtml_Catalog_Product_Edit_Tab_Bundle_Option_Selection $this */
 ?>
-<script type="text/javascript">
+<script>
 const bundleTemplateBox = '<table class="border" cellpadding="0" cellspacing="0">' +
     '    <thead>' +
     '        <tr class="headings">' +

--- a/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/create/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/create/items/renderer.phtml
@@ -364,7 +364,7 @@
                         <?= Mage::helper('core/string')->truncate($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
                             ... <span id="<?= $_id = 'id' . uniqid()?>"><?= $_remainder ?></span>
-                            <script type="text/javascript">
+                            <script>
                             document.getElementById('<?= $_id ?>').style.display = 'none';
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseover', function(){document.getElementById('<?= $_id ?>').style.display = '';});
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseout',  function(){document.getElementById('<?= $_id ?>').style.display = 'none';});

--- a/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/creditmemo/view/items/renderer.phtml
@@ -298,7 +298,7 @@
                         <?= Mage::helper('core/string')->truncate($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
                             ... <span id="<?= $_id = 'id' . uniqid()?>"><?= $_remainder ?></span>
-                            <script type="text/javascript">
+                            <script>
                             document.getElementById('<?= $_id ?>').style.display = 'none';
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseover', function(){document.getElementById('<?= $_id ?>').style.display = '';});
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseout',  function(){document.getElementById('<?= $_id ?>').style.display = 'none';});

--- a/app/design/adminhtml/default/default/template/bundle/sales/invoice/create/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/invoice/create/items/renderer.phtml
@@ -352,7 +352,7 @@
                         <?= Mage::helper('core/string')->truncate($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
                             ... <span id="<?= $_id = 'id' . uniqid()?>"><?= $_remainder ?></span>
-                            <script type="text/javascript">
+                            <script>
                             document.getElementById('<?= $_id ?>').style.display = 'none';
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseover', function(){document.getElementById('<?= $_id ?>').style.display = '';});
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseout',  function(){document.getElementById('<?= $_id ?>').style.display = 'none';});

--- a/app/design/adminhtml/default/default/template/bundle/sales/invoice/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/invoice/view/items/renderer.phtml
@@ -297,7 +297,7 @@
                         <?= Mage::helper('core/string')->truncate($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
                             ... <span id="<?= $_id = 'id' . uniqid()?>"><?= $_remainder ?></span>
-                            <script type="text/javascript">
+                            <script>
                             document.getElementById('<?= $_id ?>').style.display = 'none';
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseover', function(){document.getElementById('<?= $_id ?>').style.display = '';});
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseout',  function(){document.getElementById('<?= $_id ?>').style.display = 'none';});

--- a/app/design/adminhtml/default/default/template/bundle/sales/order/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/order/view/items/renderer.phtml
@@ -367,7 +367,7 @@
                         <?= Mage::helper('core/string')->truncate($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
                             ... <span id="<?= $_id = 'id' . uniqid()?>"><?= $_remainder ?></span>
-                            <script type="text/javascript">
+                            <script>
                             document.getElementById('<?= $_id ?>').style.display = 'none';
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseover', function(){document.getElementById('<?= $_id ?>').style.display = '';});
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseout',  function(){document.getElementById('<?= $_id ?>').style.display = 'none';});

--- a/app/design/adminhtml/default/default/template/bundle/sales/shipment/create/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/shipment/create/items/renderer.phtml
@@ -77,7 +77,7 @@
                         <?= Mage::helper('core/string')->truncate($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
                             ... <span id="<?= $_id = 'id' . uniqid()?>"><?= $_remainder ?></span>
-                            <script type="text/javascript">
+                            <script>
                             document.getElementById('<?= $_id ?>').style.display = 'none';
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseover', function(){document.getElementById('<?= $_id ?>').style.display = '';});
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseout',  function(){document.getElementById('<?= $_id ?>').style.display = 'none';});

--- a/app/design/adminhtml/default/default/template/bundle/sales/shipment/view/items/renderer.phtml
+++ b/app/design/adminhtml/default/default/template/bundle/sales/shipment/view/items/renderer.phtml
@@ -77,7 +77,7 @@
                         <?= Mage::helper('core/string')->truncate($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
                             ... <span id="<?= $_id = 'id' . uniqid()?>"><?= $_remainder ?></span>
-                            <script type="text/javascript">
+                            <script>
                             document.getElementById('<?= $_id ?>').style.display = 'none';
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseover', function(){document.getElementById('<?= $_id ?>').style.display = '';});
                             document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseout',  function(){document.getElementById('<?= $_id ?>').style.display = 'none';});

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/js.phtml
@@ -9,7 +9,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<script type="text/javascript">
+<script>
 function saveAndContinueEdit(){
     disableElements('save');
     var activeTab = product_attribute_tabsJsTabs.activeTab.id;

--- a/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/add.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/attribute/set/toolbar/add.phtml
@@ -19,6 +19,6 @@
     </p>
 </div>
 <?= $this->getFormHtml() ?>
-<script type="text/javascript">
+<script>
     var addSet = new varienForm('<?= $this->getFormId() ?>');
 </script>

--- a/app/design/adminhtml/default/default/template/catalog/product/created.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/created.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Catalog_Product_Created $this */
 ?>
-<script type="text/javascript">
+<script>
 var added = false;
 function addProduct(closeAfter) {
     if(window.opener != null && !added) {

--- a/app/design/adminhtml/default/default/template/catalog/product/edit.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit.phtml
@@ -35,7 +35,7 @@
     <?= $this->getBlockHtml('formkey') ?>
     <div style="display:none"></div>
 </form>
-<script type="text/javascript">
+<script>
     const productForm = new varienForm('product_edit_form', '<?= $this->getValidationUrl() ?>');
     productForm._processValidationResult = function(response) {
         if (response.error) {

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/attribute.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/attribute.phtml
@@ -22,7 +22,7 @@
 <form action="<?= $this->getSaveUrl() ?>" method="post" id="attributes_edit_form" enctype="multipart/form-data">
     <?= $this->getBlockHtml('formkey') ?>
 </form>
-<script type="text/javascript">
+<script>
 var attributesForm = new varienForm('attributes_edit_form', '<?= $this->getValidationUrl() ?>');
 attributesForm._processValidationResult = function(response) {
 

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/inventory.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/inventory.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Action_Attribute_Tab_Inventory $this */
 ?>
-<script type="text/javascript">
+<script>
 function toggleValueElementsWithCheckbox(checkbox) {
     var td = checkbox.parentNode;
     var checkboxes = td.querySelectorAll('input[type="checkbox"]');

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/action/websites.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/action/websites.phtml
@@ -79,7 +79,7 @@
     <?php endforeach ?>
     </fieldset>
 </div>
-<script type="text/javascript">
+<script>
     const productWebsiteCheckboxes = document.querySelectorAll('.website-checkbox');
 
     productWebsiteCheckboxes.forEach(checkbox => {

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options.phtml
@@ -32,7 +32,7 @@
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 // re-bind form elements onchange
 varienWindowOnload();
 //show error message

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/option.phtml
@@ -13,7 +13,7 @@
 ?>
 <?= $this->getTemplatesHtml() ?>
 
-<script type="text/javascript">
+<script>
 //<![CDATA[
 var firstStepTemplate = '<div class="option-box" id="option_{{id}}">'+
             '<table id="<?= $this->getFieldId() ?>_{{id}}" class="option-header" cellpadding="0" cellspacing="0">'+

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/date.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/date.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Options_Type_Date $this */
 ?>
-<script type="text/javascript">
+<script>
 OptionTemplateDate = '<table class="border" cellpadding="0" cellspacing="0">'+
         '<tr class="headings">'+
             <?php if ($this->getCanReadPrice() !== false) : ?>

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/file.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/file.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Options_Type_File $this */
 ?>
-<script type="text/javascript">
+<script>
 OptionTemplateFile = '<table class="border" cellpadding="0" cellspacing="0">'+
         '<tr class="headings">'+
             <?php if ($this->getCanReadPrice() !== false) : ?>

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/select.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Options_Type_Select $this */
 ?>
-<script type="text/javascript">
+<script>
 OptionTemplateSelect = '<table class="border" cellpadding="0" cellspacing="0">'+
         '<input type="hidden" class="required-option-select-type-rows" name="validation_{{option_id}}_result" value="" >'+
         '<thead>'+

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/text.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/options/type/text.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Options_Type_Text $this */
 ?>
-<script type="text/javascript">
+<script>
 OptionTemplateText = '<table class="border" cellpadding="0" cellspacing="0">'+
         '<tr class="headings">'+
             <?php if ($this->getCanReadPrice() !== false) : ?>

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/price/group.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/price/group.phtml
@@ -46,7 +46,7 @@ $_showWebsite= $this->isMultiWebsites();
         </tfoot>
     </table>
 
-<script type="text/javascript">
+<script>
 var groupPriceRowTemplate = '<tr>'
     + '<td<?php if (!$_showWebsite): ?> style="display:none"<?php endif ?>>'
     + '<select class="<?= $_htmlClass ?> required-entry" name="<?= $_htmlName ?>[{{index}}][website_id]" id="group_price_row_{{index}}_website">'

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/price/tier.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/price/tier.phtml
@@ -48,7 +48,7 @@
         </tfoot>
     </table>
 
-<script type="text/javascript">
+<script>
 var tierPriceRowTemplate = '<tr>'
     + '<td<?php if (!$_showWebsite): ?> style="display:none"<?php endif ?>>'
     + '<select class="<?= $_htmlClass ?> required-entry" name="<?= $_htmlName ?>[{{index}}][website_id]" id="tier_price_row_{{index}}_website">'

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/serializer.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/serializer.phtml
@@ -14,7 +14,7 @@
 
 <?php $_id = 'id_' . md5(microtime()) ?>
 <input type="hidden" name="<?= $this->getInputElementName() ?>"  value="" id="<?= $_id ?>" />
-<script type="text/javascript">
+<script>
 // create serializer controller, that will syncronize grid checkboxes with hidden input
 new productLinksController('<?= $_id?>', <?= $this->getProductsJSON() ?>, <?= $this->getGridBlock()->getJsObjectName() ?>);
 </script>

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/super/config.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/super/config.phtml
@@ -124,7 +124,7 @@
     &nbsp;<?= Mage::helper('catalog')->__('Price') ?> <strong>'{{value}}'</strong>
 </div>
 <?= $this->getGridHtml() ?>
-<script type="text/javascript">
+<script>
 var superProduct = new Product.Configurable(<?= $this->getAttributesJson() ?>,<?= $this->getLinksJson() ?>,'<?= $this->getHtmlId() ?>_',<?= $this->getGridJsObject() ?>, <?= ( $this->isReadonly() ? 'true' : 'false') ?>);
 superProduct.createEmptyUrl = '<?= $this->getNewEmptyProductUrl() ?>';
 superProduct.createNormalUrl = '<?= $this->getNewProductUrl() ?>';

--- a/app/design/adminhtml/default/default/template/catalog/product/edit/websites.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/edit/websites.phtml
@@ -58,7 +58,7 @@
     </div>
     </fieldset>
 </div>
-<script type="text/javascript">
+<script>
     const productWebsiteCheckboxes = document.querySelectorAll('.website-checkbox');
 
     productWebsiteCheckboxes.forEach(checkbox => {

--- a/app/design/adminhtml/default/default/template/catalog/product/helper/gallery.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/helper/gallery.phtml
@@ -141,7 +141,7 @@
 <input type="hidden" id="<?= $this->getHtmlId() ?>_save_image"
        name="<?= $this->getElement()->getName() ?>[values]"
        value="<?= $this->escapeHtml($this->getImagesValuesJson()) ?>"/>
-<script type="text/javascript">
+<script>
 //<![CDATA[
 var <?= $this->getJsObjectName() ?> = new Product.Gallery('<?= $this->getHtmlId() ?>', <?= $this->getImageTypesJson() ?>);
 //]]>

--- a/app/design/adminhtml/default/default/template/catalog/product/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/js.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Catalog_Product_Edit_Js $this */
 ?>
-<script type="text/javascript">
+<script>
 document.addEventListener('DOMContentLoaded', () => {
     recalculateTax();
     registerTaxRecalcs();

--- a/app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/tab/inventory.phtml
@@ -35,7 +35,7 @@
             <?php $_checked = ($this->getFieldValue('use_config_manage_stock') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_manage_stock" name="<?= $this->getFieldSuffix() ?>[stock_data][use_config_manage_stock]" value="1" <?= $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?= $_readonly ?>/>
             <label for="inventory_use_config_manage_stock" class="normal"><?= Mage::helper('catalog')->__('Use Config Settings') ?></label>
-            <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements(document.getElementById('inventory_use_config_manage_stock'), document.getElementById('inventory_use_config_manage_stock').parentNode);</script><?php endif ?></td>
+            <?php if (!$this->isReadonly()):?><script>toggleValueElements(document.getElementById('inventory_use_config_manage_stock'), document.getElementById('inventory_use_config_manage_stock').parentNode);</script><?php endif ?></td>
             <td class="value scope-label"><?= Mage::helper('adminhtml')->__('[GLOBAL]') ?></td>
         </tr>
 
@@ -58,7 +58,7 @@
             <?php $_checked = ($this->getFieldValue('use_config_min_qty') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_min_qty" name="<?= $this->getFieldSuffix() ?>[stock_data][use_config_min_qty]" value="1" <?= $_checked ?> onclick="toggleValueElements(this, this.parentNode);" <?= $_readonly ?> />
             <label for="inventory_use_config_min_qty" class="normal"><?= Mage::helper('catalog')->__('Use Config Settings') ?></label>
-            <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements(document.getElementById('inventory_use_config_min_qty'), document.getElementById('inventory_use_config_min_qty').parentNode);</script><?php endif ?></td>
+            <?php if (!$this->isReadonly()):?><script>toggleValueElements(document.getElementById('inventory_use_config_min_qty'), document.getElementById('inventory_use_config_min_qty').parentNode);</script><?php endif ?></td>
             <td class="value scope-label"><?= Mage::helper('adminhtml')->__('[GLOBAL]') ?></td>
         </tr>
 
@@ -69,7 +69,7 @@
             <?php $_checked = ($this->getFieldValue('use_config_min_sale_qty') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_min_sale_qty" name="<?= $this->getFieldSuffix() ?>[stock_data][use_config_min_sale_qty]" value="1" <?= $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?= $_readonly ?> />
             <label for="inventory_use_config_min_sale_qty" class="normal"><?= Mage::helper('catalog')->__('Use Config Settings') ?></label>
-            <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements(document.getElementById('inventory_use_config_min_sale_qty'), document.getElementById('inventory_use_config_min_sale_qty').parentNode);</script><?php endif ?></td>
+            <?php if (!$this->isReadonly()):?><script>toggleValueElements(document.getElementById('inventory_use_config_min_sale_qty'), document.getElementById('inventory_use_config_min_sale_qty').parentNode);</script><?php endif ?></td>
             <td class="value scope-label"><?= Mage::helper('adminhtml')->__('[GLOBAL]') ?></td>
         </tr>
 
@@ -80,7 +80,7 @@
             <?php $_checked = ($this->getFieldValue('use_config_max_sale_qty') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_max_sale_qty" name="<?= $this->getFieldSuffix() ?>[stock_data][use_config_max_sale_qty]" value="1" <?= $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?= $_readonly ?> />
             <label for="inventory_use_config_max_sale_qty" class="normal"><?= Mage::helper('catalog')->__('Use Config Settings') ?></label>
-            <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements(document.getElementById('inventory_use_config_max_sale_qty'), document.getElementById('inventory_use_config_max_sale_qty').parentNode);</script><?php endif ?></td>
+            <?php if (!$this->isReadonly()):?><script>toggleValueElements(document.getElementById('inventory_use_config_max_sale_qty'), document.getElementById('inventory_use_config_max_sale_qty').parentNode);</script><?php endif ?></td>
             <td class="value scope-label"><?= Mage::helper('adminhtml')->__('[GLOBAL]') ?></td>
         </tr>
 
@@ -121,7 +121,7 @@
             <?php $_checked = ($this->getFieldValue('use_config_backorders') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_backorders" name="<?= $this->getFieldSuffix() ?>[stock_data][use_config_backorders]" value="1" <?= $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?= $_readonly ?> />
             <label for="inventory_use_config_backorders" class="normal"><?= Mage::helper('catalog')->__('Use Config Settings') ?></label>
-            <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements(document.getElementById('inventory_use_config_backorders'), document.getElementById('inventory_use_config_backorders').parentNode);</script><?php endif ?></td>
+            <?php if (!$this->isReadonly()):?><script>toggleValueElements(document.getElementById('inventory_use_config_backorders'), document.getElementById('inventory_use_config_backorders').parentNode);</script><?php endif ?></td>
             <td class="value scope-label"><?= Mage::helper('adminhtml')->__('[GLOBAL]') ?></td>
         </tr>
         <tr>
@@ -131,7 +131,7 @@
             <?php $_checked = ($this->getFieldValue('use_config_notify_stock_qty') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_notify_stock_qty" name="<?= $this->getFieldSuffix() ?>[stock_data][use_config_notify_stock_qty]" value="1" <?= $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?= $_readonly ?>/>
             <label for="inventory_use_config_notify_stock_qty" class="normal"><?= Mage::helper('catalog')->__('Use Config Settings') ?></label>
-            <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements(document.getElementById('inventory_use_config_notify_stock_qty'), document.getElementById('inventory_use_config_notify_stock_qty').parentNode);</script><?php endif ?></td>
+            <?php if (!$this->isReadonly()):?><script>toggleValueElements(document.getElementById('inventory_use_config_notify_stock_qty'), document.getElementById('inventory_use_config_notify_stock_qty').parentNode);</script><?php endif ?></td>
             <td class="value scope-label"><?= Mage::helper('adminhtml')->__('[GLOBAL]') ?></td>
         </tr>
 <?php endif ?>
@@ -146,7 +146,7 @@
             <?php $_checked = ($this->getFieldValue('use_config_enable_qty_increments') || $this->isNew()) ? 'checked="checked"' : '' ?>
             <input type="checkbox" id="inventory_use_config_enable_qty_increments" name="<?= $this->getFieldSuffix() ?>[stock_data][use_config_enable_qty_increments]" value="1" <?= $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?= $_readonly ?>/>
             <label for="inventory_use_config_enable_qty_increments" class="normal"><?= Mage::helper('catalog')->__('Use Config Settings') ?></label>
-            <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements(document.getElementById('inventory_use_config_enable_qty_increments'), document.getElementById('inventory_use_config_enable_qty_increments').parentNode);</script><?php endif ?></td>
+            <?php if (!$this->isReadonly()):?><script>toggleValueElements(document.getElementById('inventory_use_config_enable_qty_increments'), document.getElementById('inventory_use_config_enable_qty_increments').parentNode);</script><?php endif ?></td>
             <td class="value scope-label"><?= Mage::helper('adminhtml')->__('[GLOBAL]') ?></td>
         </tr>
         <tr>
@@ -156,7 +156,7 @@
                 <?php $_checked = ($this->getFieldValue('use_config_qty_increments') || $this->isNew()) ? 'checked="checked"' : '' ?>
                 <input type="checkbox" id="inventory_use_config_qty_increments" name="<?= $this->getFieldSuffix() ?>[stock_data][use_config_qty_increments]" value="1" <?= $_checked ?> onclick="toggleValueElements(this, this.parentNode);" class="checkbox" <?= $_readonly ?>/>
                 <label for="inventory_use_config_qty_increments" class="normal"><?= Mage::helper('catalog')->__('Use Config Settings') ?></label>
-                <?php if (!$this->isReadonly()):?><script type="text/javascript">toggleValueElements(document.getElementById('inventory_use_config_qty_increments'), document.getElementById('inventory_use_config_qty_increments').parentNode);</script><?php endif ?></td>
+                <?php if (!$this->isReadonly()):?><script>toggleValueElements(document.getElementById('inventory_use_config_qty_increments'), document.getElementById('inventory_use_config_qty_increments').parentNode);</script><?php endif ?></td>
             <td class="value scope-label"><?= Mage::helper('adminhtml')->__('[GLOBAL]') ?></td>
         </tr>
         <tr>
@@ -173,7 +173,7 @@
         </table>
     </fieldset>
 </div>
-<script type="text/javascript">
+<script>
     function changeManageStockOption() {
         const manageStockCheckbox = document.getElementById('inventory_use_config_manage_stock');
         const manageStockSelect = document.getElementById('inventory_manage_stock');

--- a/app/design/adminhtml/default/default/template/currencysymbol/grid.phtml
+++ b/app/design/adminhtml/default/default/template/currencysymbol/grid.phtml
@@ -70,7 +70,7 @@
         </div>
     </div>
 </form>
-<script type="text/javascript">
+<script>
     var currencySymbolsForm = new varienForm('currency_symbols_form');
 
     function toggleUseDefault(code, value)

--- a/app/design/adminhtml/default/default/template/customer/edit/js.phtml
+++ b/app/design/adminhtml/default/default/template/customer/edit/js.phtml
@@ -9,7 +9,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<script type="text/javascript">
+<script>
 function saveAndContinueEdit(urlTemplate) {
         var template = new Template(urlTemplate, Template.HANDLEBARS_PATTERN);
         var url = template.evaluate({tab_id:customer_info_tabsJsTabs.activeTab.id});

--- a/app/design/adminhtml/default/default/template/customer/sales/order/create/address/form/renderer/vat.phtml
+++ b/app/design/adminhtml/default/default/template/customer/sales/order/create/address/form/renderer/vat.phtml
@@ -33,7 +33,7 @@ $_validateButton = $this->getValidateButton();
             <?= $_validateButton->toHtml() ?>
         </div>
         <?php if (Mage::helper('customer')->isVatValidationEnabled()): ?>
-        <script type="text/javascript">
+        <script>
             document.addEventListener('DOMContentLoaded', function() {
                 var elm = document.getElementById('<?= $this->jsQuoteEscape($this->getVatFieldId()) ?>');
                 if (elm) {

--- a/app/design/adminhtml/default/default/template/customer/system/config/validatevat.phtml
+++ b/app/design/adminhtml/default/default/template/customer/system/config/validatevat.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Customer_System_Config_Validatevat $this */
 ?>
-<script type="text/javascript">
+<script>
     function validateVat() {
         var elem = document.getElementById('<?= $this->getHtmlId() ?>');
 

--- a/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
+++ b/app/design/adminhtml/default/default/template/customer/tab/addresses.phtml
@@ -101,7 +101,7 @@
         <?php endif ?>
     </div>
 
-<script type="text/javascript">
+<script>
 let deleteButtonId = <?= $_iterator ?>;
 
 class addressesModel {

--- a/app/design/adminhtml/default/default/template/customersegmentation/segment/sequence/form_scripts.phtml
+++ b/app/design/adminhtml/default/default/template/customersegmentation/segment/sequence/form_scripts.phtml
@@ -7,7 +7,7 @@
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 ?>
-<script type="text/javascript">
+<script>
 function toggleCouponFields(generateCoupon) {
     const couponFields = ['coupon_sales_rule_id', 'coupon_prefix', 'coupon_expires_days'];
     const display = generateCoupon == '1' ? '' : 'none';

--- a/app/design/adminhtml/default/default/template/dashboard/grid.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/grid.phtml
@@ -49,7 +49,7 @@ $numColumns = count($this->getColumns());
 </table>
 </div>
 <?php if($this->canDisplayContainer()): ?>
-<script type="text/javascript">
+<script>
 //<![CDATA[
     <?= $this->getJsObjectName() ?> = new varienGrid('<?= $this->getId() ?>', '<?= $this->getGridUrl() ?>', '<?= $this->getVarNamePage() ?>', '<?= $this->getVarNameSort() ?>', '<?= $this->getVarNameDir() ?>', '<?= $this->getVarNameFilter() ?>');
     <?= $this->getJsObjectName() ?>.useAjax = '<?= $this->getUseAjax() ?>';

--- a/app/design/adminhtml/default/default/template/dashboard/index.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/index.phtml
@@ -13,7 +13,7 @@
 ?>
 
 <?php if (is_array($this->getChild('diagrams')->getTabsIds())) : ?>
-<script type="text/javascript">
+<script>
 //<![CDATA[
 function loadChartJs() {
     return new Promise((resolve, reject) => {

--- a/app/design/adminhtml/default/default/template/dashboard/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/store/switcher.phtml
@@ -35,7 +35,7 @@
     <?php endforeach ?>
 </select>
 </p>
-<script type="text/javascript">
+<script>
 //<![CDATA[
     function switchStore(obj){
         if (obj.options[obj.selectedIndex].getAttribute('website') == 'true') {

--- a/app/design/adminhtml/default/default/template/directory/js/optional_zip_countries.phtml
+++ b/app/design/adminhtml/default/default/template/directory/js/optional_zip_countries.phtml
@@ -18,7 +18,7 @@
  * @var Mage_Adminhtml_Block_Template $this
  */
 ?>
-<script type="text/javascript">
+<script>
 //<![CDATA[
 optionalZipCountries = <?= $this->helper('directory')->getCountriesWithOptionalZip(true) ?>;
 //]]>

--- a/app/design/adminhtml/default/default/template/directory/region_import_dialog.phtml
+++ b/app/design/adminhtml/default/default/template/directory/region_import_dialog.phtml
@@ -10,7 +10,7 @@
 /** @var Mage_Core_Block_Template $this */
 ?>
 
-<script type="text/javascript">
+<script>
 function showRegionImportDialog() {
     const formHtml = `
         <form id="region-import-form" style="display: flex; flex-direction: column; gap: 15px;">

--- a/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/creditmemo/name.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/creditmemo/name.phtml
@@ -26,7 +26,7 @@
                 <?= Mage::helper('core/string')->truncate($_option['value'], 55, '', $_remainder) ?>
                 <?php if ($_remainder):?>
                     ... <span id="<?= $_id = 'id' . uniqid()?>"><?= $_remainder ?></span>
-                    <script type="text/javascript">
+                    <script>
                     document.getElementById('<?= $_id ?>').style.display = 'none';
                     document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseover', function(){document.getElementById('<?= $_id ?>').style.display = '';});
                     document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseout', function(){document.getElementById('<?= $_id ?>').style.display = 'none';});

--- a/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/invoice/name.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/invoice/name.phtml
@@ -26,7 +26,7 @@
                 <?= Mage::helper('core/string')->truncate($_option['value'], 55, '', $_remainder) ?>
                 <?php if ($_remainder):?>
                     ... <span id="<?= $_id = 'id' . uniqid()?>"><?= $_remainder ?></span>
-                    <script type="text/javascript">
+                    <script>
                     document.getElementById('<?= $_id ?>').style.display = 'none';
                     document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseover', function(){document.getElementById('<?= $_id ?>').style.display = '';});
                     document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseout', function(){document.getElementById('<?= $_id ?>').style.display = 'none';});

--- a/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/name.phtml
+++ b/app/design/adminhtml/default/default/template/downloadable/sales/items/column/downloadable/name.phtml
@@ -26,7 +26,7 @@
                 <?= Mage::helper('core/string')->truncate($_option['value'], 55, '', $_remainder) ?>
                 <?php if ($_remainder):?>
                     ... <span id="<?= $_id = 'id' . uniqid()?>"><?= $_remainder ?></span>
-                    <script type="text/javascript">
+                    <script>
                     document.getElementById('<?= $_id ?>').style.display = 'none';
                     document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseover', function(){document.getElementById('<?= $_id ?>').style.display = '';});
                     document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseout', function(){document.getElementById('<?= $_id ?>').style.display = 'none';});

--- a/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
+++ b/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
@@ -99,7 +99,7 @@
         <input type="hidden" id="option-count-check" value="" />
     </div>
 </div>
-<script type="text/javascript">
+<script>
 //<![CDATA[
 var optionDefaultInputType = 'radio';
 

--- a/app/design/adminhtml/default/default/template/forgotpassword.phtml
+++ b/app/design/adminhtml/default/default/template/forgotpassword.phtml
@@ -19,8 +19,8 @@
     <title><?= Mage::helper('adminhtml')->__('Log into Maho Admin Page') ?></title>
     <link type="text/css" rel="stylesheet" href="<?= $this->getSkinUrl('login.css') ?>" media="all" />
     <?= Mage::helper('page')->getFaviconHtml() ?>
-    <script type="text/javascript" src="<?= $this->getJsUrl('validation.js') ?>"></script>
-    <script type="text/javascript" src="<?= $this->getJsUrl('mage/adminhtml/form.js') ?>"></script>
+    <script src="<?= $this->getJsUrl('validation.js') ?>"></script>
+    <script src="<?= $this->getJsUrl('mage/adminhtml/form.js') ?>"></script>
 </head>
 <body id="page-login">
     <div class="login-container">
@@ -46,7 +46,7 @@
                 <p class="legal">Powered by Maho</p>
             </form>
             <div class="bottom"></div>
-            <script type="text/javascript">
+            <script>
                 var loginForm = new varienForm('loginForm');
             </script>
         </div>

--- a/app/design/adminhtml/default/default/template/giftmessage/popup.phtml
+++ b/app/design/adminhtml/default/default/template/giftmessage/popup.phtml
@@ -17,7 +17,7 @@
     <?= $this->getChildHtml() ?>
 </div>
 
-<script type="text/javascript">
+<script>
 _giftOptions = new GiftOptionsPopup();
 </script>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/importexport/export/form/after.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/export/form/after.phtml
@@ -23,8 +23,6 @@
         <button class="scalable" type="button" onclick="getFile();"><span><?= $this->__('Continue') ?></span></button>
     </div>
 </div>
-<script type="text/javascript">
-//<![CDATA[
+<script>
    document.getElementById('entity').selectedIndex = 0; // forced resetting entity selector after page refresh
-//]]>
 </script>

--- a/app/design/adminhtml/default/default/template/importexport/export/form/before.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/export/form/before.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Template $this */
 ?>
-<script type="text/javascript">
+<script>
 //<![CDATA[
     /**
      * Post form data and process response via AJAX.

--- a/app/design/adminhtml/default/default/template/importexport/import/form/before.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/import/form/before.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Template $this */
 ?>
-<script type="text/javascript">
+<script>
     /**
      * Name and ID for iframe for data POST-ing.
      *

--- a/app/design/adminhtml/default/default/template/importexport/import/frame/result.phtml
+++ b/app/design/adminhtml/default/default/template/importexport/import/frame/result.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_ImportExport_Block_Adminhtml_Import_Frame_Result $this */
 ?>
-<script type='text/javascript'>
+<script>
 //<![CDATA[
     top.editForm.postToFrameComplete(<?= $this->getResponseJson() ?>);
 //]]>

--- a/app/design/adminhtml/default/default/template/log/dashboard/devices_chart.phtml
+++ b/app/design/adminhtml/default/default/template/log/dashboard/devices_chart.phtml
@@ -39,7 +39,7 @@ $chartId = rand(100, 999);
             </div>
         </div>
 
-        <script type="text/javascript">
+        <script>
             window.chartsLoaded = window.chartsLoaded || false;
             function loadCharts(callback) {
                 if (window.chartsLoaded && window.Chart) {

--- a/app/design/adminhtml/default/default/template/login.phtml
+++ b/app/design/adminhtml/default/default/template/login.phtml
@@ -19,8 +19,8 @@
     <title><?= Mage::helper('adminhtml')->__('Log into Maho Admin Page') ?></title>
     <link type="text/css" rel="stylesheet" href="<?= $this->getSkinUrl('login.css') ?>" media="all" />
     <?= Mage::helper('page')->getFaviconHtml() ?>
-    <script type="text/javascript" src="<?= $this->getJsUrl('validation.js') ?>"></script>
-    <script type="text/javascript" src="<?= $this->getJsUrl('maho-passkey-tools.js') ?>"></script>
+    <script src="<?= $this->getJsUrl('validation.js') ?>"></script>
+    <script src="<?= $this->getJsUrl('maho-passkey-tools.js') ?>"></script>
 </head>
 <body id="page-login">
     <div class="login-container">

--- a/app/design/adminhtml/default/default/template/maho/feedmanager/dynamicrule/output-js.phtml
+++ b/app/design/adminhtml/default/default/template/maho/feedmanager/dynamicrule/output-js.phtml
@@ -9,7 +9,7 @@
  * @var Mage_Adminhtml_Block_Template $this
  */
 ?>
-<script type="text/javascript">
+<script>
 document.addEventListener('DOMContentLoaded', function() {
     const outputType = document.getElementById('rule_output_type');
     const outputValue = document.getElementById('rule_output_value');

--- a/app/design/adminhtml/default/default/template/newsletter/preview/iframeswitcher.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/preview/iframeswitcher.phtml
@@ -39,7 +39,7 @@
     </p>
 </div>
 
-<script type="text/javascript">
+<script>
 const previewForm = document.getElementById('preview_form');
 const previewIframe = document.getElementById('preview_iframe');
 

--- a/app/design/adminhtml/default/default/template/newsletter/preview/store.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/preview/store.phtml
@@ -36,7 +36,7 @@
         <?php endforeach ?>
     <?php endforeach ?>
 </select>
-<script type="text/javascript">
+<script>
 document.addEventListener('DOMContentLoaded', () => {
     const storeSwitcher = document.getElementById('store_switcher');
     if (storeSwitcher) {

--- a/app/design/adminhtml/default/default/template/newsletter/problem/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/problem/list.phtml
@@ -23,7 +23,7 @@
     <?= $this->getDeleteButtonHtml() ?>
 </div>
 <?php endif ?>
-<script type="text/javascript">
+<script>
     const problemController = {
         checkCheckboxes(controlCheckbox) {
             const problemGrid = document.getElementById('problemGrid');

--- a/app/design/adminhtml/default/default/template/newsletter/subscriber/list.phtml
+++ b/app/design/adminhtml/default/default/template/newsletter/subscriber/list.phtml
@@ -27,7 +27,7 @@
     <button class="scalable" onclick="subscriberController.addToQueue();"><span><?= Mage::helper('newsletter')->__('Add to Queue') ?></span></button>
 </div>
 <?php endif ?>
-<script type="text/javascript">
+<script>
     var subscriberController = {
         checkCheckboxes: function(controlCheckbox) {
             var elements = document.getElementById('subscriberGrid').getElementsByClassName('subscriberCheckbox');

--- a/app/design/adminhtml/default/default/template/notification/window.phtml
+++ b/app/design/adminhtml/default/default/template/notification/window.phtml
@@ -12,7 +12,7 @@
 /** @var Mage_Adminhtml_Block_Notification_Window $this */
 ?>
 <?php if ($this->canShow()): ?>
-<script type="text/javascript">
+<script>
     let messagePopupClosed = false;
     function openMessagePopup() {
         const height = document.documentElement.scrollHeight;

--- a/app/design/adminhtml/default/default/template/oauth/authorize/form/login.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/form/login.phtml
@@ -42,7 +42,7 @@
                         <input type="hidden" name="oauth_token" value="<?= $this->escapeHtml($this->getToken()) ?>"/>
                     </fieldset>
                 </form>
-                <script type="text/javascript">
+                <script>
                 //<![CDATA[
                      var loginForm = new varienForm('loginForm');
                 //]]>

--- a/app/design/adminhtml/default/default/template/oauth/authorize/head-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/head-simple.phtml
@@ -21,7 +21,7 @@
 <title><?= htmlspecialchars(html_entity_decode($this->getTitle())) ?></title>
 <?= Mage::helper('page')->getFaviconHtml() ?>
 
-<script type="text/javascript">
+<script>
     var BASE_URL = '<?= $this->getUrl('*') ?>';
     var SKIN_URL = '<?= $this->getSkinUrl() ?>';
     var FORM_KEY = '<?= $this->getFormKey() ?>';

--- a/app/design/adminhtml/default/default/template/page/footer.phtml
+++ b/app/design/adminhtml/default/default/template/page/footer.phtml
@@ -16,7 +16,7 @@
 <span>|</span>
 <?= $this->__('Interface Locale: %s', $this->getLanguageSelect()) ?>
 
-<script type="text/javascript">
+<script>
     function setInterfaceLanguage(evt) {
         const elem = evt.target;
         if (elem) {

--- a/app/design/adminhtml/default/default/template/page/head.phtml
+++ b/app/design/adminhtml/default/default/template/page/head.phtml
@@ -16,7 +16,7 @@
 <title><?= htmlspecialchars(html_entity_decode($this->getTitle())) ?></title>
 <?= Mage::helper('page')->getFaviconHtml() ?>
 
-<script type="text/javascript">
+<script>
     var BASE_URL = '<?= $this->getUrl('*') ?>';
     var SKIN_URL = '<?= $this->getSkinUrl() ?>';
     var FORM_KEY = '<?= $this->getFormKey() ?>';
@@ -25,7 +25,7 @@
 
 <?= $this->getCssJsHtml() ?>
 
-<script type="text/javascript">
+<script>
     Fieldset.addToPrefix(<?= Mage::helper('adminhtml')->getCurrentUserId() ?>);
 </script>
 

--- a/app/design/adminhtml/default/default/template/page/header.phtml
+++ b/app/design/adminhtml/default/default/template/page/header.phtml
@@ -25,7 +25,7 @@
             <?php $defSearch = $this->__('Global Record Search') ?>
             <input id="global_search" name="query" type="text" class="input-text" value="<?php if(!empty($query)): ?><?= $query ?><?php else: ?><?= $this->quoteEscape($defSearch) ?><?php endif ?>" onfocus="if(this.value=='<?= $this->quoteEscape($defSearch, true) ?>')this.value=''; " onblur="if(this.value=='')this.value='<?= $defSearch ?>';" autocomplete="off" />
             <div id="global_search_autocomplete" class="autocomplete" style="display:none"></div>
-            <script type="text/javascript">
+            <script>
                 document.getElementById('global_search').addEventListener('input', function() {
                     let query = this.value;
                     if (query.length < 2) {

--- a/app/design/adminhtml/default/default/template/page/js/translate.phtml
+++ b/app/design/adminhtml/default/default/template/page/js/translate.phtml
@@ -42,6 +42,6 @@ $_data = [
     'Please wait, loading...' => $this->__('Please wait, loading...')
 ];
 ?>
-<script type="text/javascript">
+<script>
     var Translator = new Translate(<?= Mage::helper('core')->jsonEncode($_data) ?>);
 </script>

--- a/app/design/adminhtml/default/default/template/paygate/form/cc.phtml
+++ b/app/design/adminhtml/default/default/template/paygate/form/cc.phtml
@@ -26,7 +26,7 @@
                     <p class="note"><?= $this->__('To cancel pending authorizations and release amounts that have already been processed during this payment, click Cancel.') ?></p>
                 </div>
                 <?= $this->showNoticeMessage($this->__('Please enter another credit card number to complete your purchase.')) ?>
-                    <script type="text/javascript">
+                    <script>
                     function cancelPaymentAuthorizations(){
                         mahoFetch('<?= $this->getAdminCancelUrl() ?>')
                         .then(response => {

--- a/app/design/adminhtml/default/default/template/payment/form/cc.phtml
+++ b/app/design/adminhtml/default/default/template/payment/form/cc.phtml
@@ -85,7 +85,7 @@
             </li>
             <li class="adv-container">&nbsp;</li>
         </ul>
-        <script type="text/javascript">
+        <script>
             var SSChecked<?= $_code ?> = function() {
                 var elm = document.getElementById('<?= $_code ?>_cc_type');
                 var ssDiv = document.getElementById('<?= $_code ?>_cc_type_ss_div');

--- a/app/design/adminhtml/default/default/template/permissions/role_users_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/role_users_grid_js.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Template $this */
 ?>
-<script type="text/javascript">
+<script>
 <?php $myBlock = $this->getLayout()->getBlock('roleUsersGrid'); ?>
 <?php if( is_object($myBlock) && $myBlock->getJsObjectName() ): ?>
     const checkBoxes = new Map(Object.entries(<?= $myBlock->_getUsers(true) ?>));

--- a/app/design/adminhtml/default/default/template/permissions/roleinfo.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/roleinfo.phtml
@@ -23,6 +23,6 @@
 <form action="<?= $this->getUrl('*/*/saverole') ?>" method="post" id="role_edit_form">
     <?= $this->getBlockHtml('formkey') ?>
 </form>
-<script type="text/javascript">
+<script>
     var roleForm = new varienForm('role_edit_form');
 </script>

--- a/app/design/adminhtml/default/default/template/permissions/user_roles_grid_js.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/user_roles_grid_js.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Template $this */
 ?>
-<script type="text/javascript">
+<script>
 <?php $myBlock = $this->getLayout()->getBlock('user.roles.grid'); ?>
 <?php if( is_object($myBlock) && $myBlock->getJsObjectName()): ?>
     const radioBoxes = new Map();

--- a/app/design/adminhtml/default/default/template/permissions/userinfo.phtml
+++ b/app/design/adminhtml/default/default/template/permissions/userinfo.phtml
@@ -30,6 +30,6 @@
 <form action="<?= $this->getUrl('*/*/saveuser') ?>" method="post" id="user_edit_form">
     <?= $this->getBlockHtml('formkey') ?>
 </form>
-<script type="text/javascript">
+<script>
     var userForm = new varienForm('user_edit_form');
 </script>

--- a/app/design/adminhtml/default/default/template/promo/fieldset.phtml
+++ b/app/design/adminhtml/default/default/template/promo/fieldset.phtml
@@ -24,7 +24,7 @@
     <?= $_element->getChildrenHtml() ?>
     </fieldset>
 </div>
-<script type="text/javascript">
+<script>
 var <?= $_element->getHtmlId() ?> = new VarienRulesForm('<?= $_element->getHtmlId() ?>', '<?= $this->getNewChildUrl() ?>');
 <?php if ($_element->getReadonly()): ?>
     <?= $_element->getHtmlId() ?>.setReadonly(true);

--- a/app/design/adminhtml/default/default/template/promo/js.phtml
+++ b/app/design/adminhtml/default/default/template/promo/js.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Promo_Catalog_Edit_Js $this */
 ?>
-<script type="text/javascript">
+<script>
 function hideShowSubproductOptions()
 {
     if (document.getElementById('rule_sub_is_enable').value == 1) {

--- a/app/design/adminhtml/default/default/template/rating/detailed.phtml
+++ b/app/design/adminhtml/default/default/template/rating/detailed.phtml
@@ -42,7 +42,7 @@
         </table>
         <input type="hidden" name="validate_rating" class="validate-rating" value="" />
     </div>
-<script type="text/javascript">
+<script>
     Validation.addAllThese(
     [
            ['validate-rating', '<?= $this->jsQuoteEscape(Mage::helper('rating')->__('Please select one of each ratings above')) ?>', function(v) {

--- a/app/design/adminhtml/default/default/template/report/grid.phtml
+++ b/app/design/adminhtml/default/default/template/report/grid.phtml
@@ -143,7 +143,7 @@ $numColumns = count($this->getColumns());
     </div>
 <?php if($this->canDisplayContainer()): ?>
 </div>
-<script type="text/javascript">
+<script>
     var <?= $this->getJsObjectName() ?> = new varienGrid('<?= $this->getId() ?>', '<?= $this->getGridUrl() ?>', '<?= $this->getVarNamePage() ?>', '<?= $this->getVarNameSort() ?>', '<?= $this->getVarNameDir() ?>', '<?= $this->getVarNameFilter() ?>');
     <?= $this->getJsObjectName() ?>.useAjax = '<?= $this->getUseAjax() ?>';
     <?php if($this->getDateFilterVisibility()):?>

--- a/app/design/adminhtml/default/default/template/report/grid/container.phtml
+++ b/app/design/adminhtml/default/default/template/report/grid/container.phtml
@@ -24,7 +24,7 @@
 <div>
     <?= $this->getGridHtml() ?>
 </div>
-<script type="text/javascript">
+<script>
     function filterFormSubmit() {
         const filterForm = document.getElementById('filter_form');
         if (!filterForm) return;

--- a/app/design/adminhtml/default/default/template/report/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/report/store/switcher.phtml
@@ -38,7 +38,7 @@
     <?php endforeach ?>
 </select>
 </p>
-<script type="text/javascript">
+<script>
     function switchStore(obj){
         if (obj.options[obj.selectedIndex].getAttribute('website') == 'true') {
             var selectionType = 'website';

--- a/app/design/adminhtml/default/default/template/report/store/switcher/enhanced.phtml
+++ b/app/design/adminhtml/default/default/template/report/store/switcher/enhanced.phtml
@@ -37,7 +37,7 @@
     <?php endforeach ?>
 </select>
 </p>
-<script type="text/javascript">
+<script>
     function switchStore(obj){
         var storeParam = obj.value ? 'store_ids/' + obj.value + '/' : '';
         if(obj.switchParams){

--- a/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
+++ b/app/design/adminhtml/default/default/template/resetforgottenpassword.phtml
@@ -19,8 +19,8 @@
     <title><?= Mage::helper('adminhtml')->__('Reset a Password') ?></title>
     <link type="text/css" rel="stylesheet" href="<?= $this->getSkinUrl('login.css') ?>" media="all" />
     <?= Mage::helper('page')->getFaviconHtml() ?>
-    <script type="text/javascript" src="<?= $this->getJsUrl('validation.js') ?>"></script>
-    <script type="text/javascript" src="<?= $this->getJsUrl('mage/adminhtml/form.js') ?>"></script>
+    <script src="<?= $this->getJsUrl('validation.js') ?>"></script>
+    <script src="<?= $this->getJsUrl('mage/adminhtml/form.js') ?>"></script>
 </head>
 <body id="page-login">
     <div class="login-container">
@@ -54,7 +54,7 @@
                 <p class="legal">Powered by Maho</p>
             </form>
             <div class="bottom"></div>
-            <script type="text/javascript">
+            <script>
                 var resetPasswordForm = new varienForm('reset-password-form');
             </script>
         </div>

--- a/app/design/adminhtml/default/default/template/sales/items/column/name.phtml
+++ b/app/design/adminhtml/default/default/template/sales/items/column/name.phtml
@@ -24,7 +24,7 @@
             <?php else: ?>
                 <?php $_option = $this->getFormattedOption($_option['value']); ?>
                 <?= $_option['value'] ?><?php if (isset($_option['remainder']) && $_option['remainder']): ?><span id="<?= $_dots = 'dots' . uniqid()?>"> ...</span><span id="<?= $_id = 'id' . uniqid() ?>"><?= $_option['remainder'] ?></span>
-                    <script type="text/javascript">
+                    <script>
                     document.getElementById('<?= $_id ?>').style.display = 'none';
                     document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseover', function(){document.getElementById('<?= $_id ?>').style.display = '';});
                     document.getElementById('<?= $_id ?>').parentElement.addEventListener('mouseover', function(){document.getElementById('<?= $_dots ?>').style.display = 'none';});

--- a/app/design/adminhtml/default/default/template/sales/order/comments/view.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/comments/view.phtml
@@ -46,7 +46,7 @@
         </li>
     <?php endforeach ?>
     </ul>
-<script type="text/javascript">
+<script>
 function submitComment() {
     submitAndReloadArea(document.getElementById('comments_block').parentNode, '<?= $this->getSubmitUrl() ?>')
 }

--- a/app/design/adminhtml/default/default/template/sales/order/create/billing/method/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/billing/method/form.phtml
@@ -35,7 +35,7 @@
     <?php endforeach ?>
     </dl>
 </div>
-<script type="text/javascript">order.setPaymentMethod('<?= $this->getSelectedMethodCode() ?>')</script>
+<script>order.setPaymentMethod('<?= $this->getSelectedMethodCode() ?>')</script>
 <?php else: ?>
     <div><?= Mage::helper('sales')->__('No Payment Methods') ?></div>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/sales/order/create/comment.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/comment.phtml
@@ -14,4 +14,4 @@
 <!--<h4 class="icon-head fieldset-legend <?= $this->getHeaderCssClass() ?>"><?= $this->getHeaderText() ?></h4>-->
 <label for="order-comment"><?= Mage::helper('sales')->__('Order Comments') ?></label><br />
 <textarea style="width:98%; height:8em;" id="order-comment" name="order[comment][customer_note]" rows="2" cols="15"><?= $this->getCommentNote() ?></textarea>
-<script type="text/javascript">order.commentFieldsBind('order-comment')</script>
+<script>order.commentFieldsBind('order-comment')</script>

--- a/app/design/adminhtml/default/default/template/sales/order/create/coupons/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/coupons/form.phtml
@@ -26,7 +26,7 @@
             <?php if($this->getCouponCode()): ?>
                 <p><strong><?= $this->escapeHtml($this->getCouponCode()) ?></strong> [<a href="#" onclick="order.applyCoupon(''); return false;" title="<?= Mage::helper('sales')->__('Remove Coupon Code') ?>"><?= Mage::helper('sales')->__('Remove') ?></a>]</p>
             <?php endif ?>
-            <script type="text/javascript">
+            <script>
                 order.overlay('shipping-method-overlay', <?php if ($this->getQuote()->isVirtual()): ?>false<?php else: ?>true<?php endif ?>);
                 order.overlay('address-shipping-overlay', <?php if ($this->getQuote()->isVirtual()): ?>false<?php else: ?>true<?php endif ?>);
             </script>

--- a/app/design/adminhtml/default/default/template/sales/order/create/data.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/data.phtml
@@ -20,7 +20,7 @@
     <?php endforeach ?>
 </select>
 </p>
-    <script type="text/javascript">
+    <script>
         order.setCurrencySymbol('<?= $this->jsQuoteEscape($this->getCurrencySymbol($this->getCurrentCurrencyCode())) ?>')
     </script>
 <table cellspacing="0" width="100%">

--- a/app/design/adminhtml/default/default/template/sales/order/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/form.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Sales_Order_Create_Form $this */
 ?>
-<script type="text/javascript">
+<script>
     var order = new AdminOrder(<?= $this->getOrderDataJson() ?>);
     order.setLoadBaseUrl('<?= $this->getLoadBlockUrl() ?>');
     var payment = {};

--- a/app/design/adminhtml/default/default/template/sales/order/create/form/account.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/form/account.phtml
@@ -18,5 +18,5 @@
     <div id="customer_account_fieds">
         <?= $this->getForm()->getHtml() ?>
     </div>
-    <script type="text/javascript">order.accountFieldsBind(document.getElementById('customer_account_fieds'))</script>
+    <script>order.accountFieldsBind(document.getElementById('customer_account_fieds'))</script>
 </div>

--- a/app/design/adminhtml/default/default/template/sales/order/create/form/address.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/form/address.phtml
@@ -17,7 +17,7 @@ if ($this->getIsShipping()):
     $_fieldsContainerId = 'order-shipping_address_fields';
     $_addressChoiceContainerId = 'order-shipping_address_choice';
 ?>
-    <script type="text/javascript">
+    <script>
     order.shippingAddressContainer = '<?= $_fieldsContainerId ?>';
     order.setAddresses(<?= $this->getAddressCollectionJson() ?>);
     </script>
@@ -25,7 +25,7 @@ if ($this->getIsShipping()):
     $_fieldsContainerId = 'order-billing_address_fields';
     $_addressChoiceContainerId = 'order-billing_address_choice';
 ?>
-    <script type="text/javascript">
+    <script>
     order.billingAddressContainer = '<?= $_fieldsContainerId ?>';
     </script>
 <?php endif ?>
@@ -70,7 +70,7 @@ if ($this->getIsShipping()):
     </div>
     <?php $hideElement = 'address-' . ($this->getIsShipping() ? 'shipping' : 'billing') . '-overlay'; ?>
     <div style="display:none;" id="<?= $hideElement ?>" class="overlay"><span><?= $this->__('Shipping address selection is not applicable') ?></span></div>
-    <script type="text/javascript">
+    <script>
         order.bindAddressFields('<?= $_fieldsContainerId ?>');
         order.bindAddressFields('<?= $_addressChoiceContainerId ?>');
         <?php if ($this->getIsShipping() && $this->getIsAsBilling()): ?>

--- a/app/design/adminhtml/default/default/template/sales/order/create/giftmessage.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/giftmessage.phtml
@@ -29,7 +29,7 @@
         </div>
     </div>
 </div>
-<script type="text/javascript">
+<script>
     order.giftmessageFieldsBind('order-giftmessage');
 </script>
 </div>

--- a/app/design/adminhtml/default/default/template/sales/order/create/items/grid.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/items/grid.phtml
@@ -413,6 +413,6 @@
     <br />
     <div id="order-coupons"><?= $this->getChildHtml() ?></div>
     <div class="clear"></div>
-    <script type="text/javascript">order.itemsOnchangeBind()</script>
+    <script>order.itemsOnchangeBind()</script>
 </div>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/js.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Template $this */
 ?>
-<script type="text/javascript">
+<script>
     order.sidebarHide();
     window.addEventListener('load', function() {
         if (window.productConfigure) {

--- a/app/design/adminhtml/default/default/template/sales/order/create/shipping/method/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/shipping/method/form.phtml
@@ -69,7 +69,7 @@
             </a>
         </div>
     <?php else: ?>
-        <script type="text/javascript">document.getElementById('order-shipping-method-choose').style.display = 'block';</script>
+        <script>document.getElementById('order-shipping-method-choose').style.display = 'block';</script>
     <?php endif ?>
 <?php elseif($this->getIsRateRequest()): ?>
     <strong><?= Mage::helper('sales')->__('Sorry, no quotes are available for this order at this time.') ?></strong>
@@ -82,7 +82,7 @@
     </div>
 <?php endif ?>
 <div style="display:none;" id="shipping-method-overlay" class="overlay"><span><?= $this->__('Shipping method selection is not applicable') ?></span></div>
-<script type="text/javascript">
+<script>
 order.overlay('shipping-method-overlay', <?php if ($this->getQuote()->isVirtual()): ?>false<?php else: ?>true<?php endif ?>);
 order.overlay('address-shipping-overlay', <?php if ($this->getQuote()->isVirtual()): ?>false<?php else: ?>true<?php endif ?>);
 </script>

--- a/app/design/adminhtml/default/default/template/sales/order/create/totals.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/create/totals.phtml
@@ -32,7 +32,7 @@
     <p><?= $this->getButtonHtml(Mage::helper('sales')->__('Submit Order'),'order.submit()','save') ?></p>
 </div>
 
-<script type="text/javascript">
+<script>
 (function() {
     const sendEmailCheckbox = document.getElementById('send_confirmation');
     if (sendEmailCheckbox) {

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/items.phtml
@@ -106,7 +106,7 @@
 </div>
 <div class="clear"></div>
 
-<script type="text/javascript">
+<script>
 const submitButtons = document.querySelectorAll('.submit-button');
 const updateButtons = document.querySelectorAll('.update-button');
 const fields = document.querySelectorAll('.qty-input');

--- a/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/totals/adjustments.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/creditmemo/create/totals/adjustments.phtml
@@ -46,7 +46,7 @@
             </button>
         </td>
     </tr>
-    <script type="text/javascript">
+    <script>
         Validation.addAllThese([
             ['not-negative-amount', '<?= $this->jsQuoteEscape($this->helper('sales')->__('Please enter positive number in this field.')) ?>', function(v) {
                 if (v.length) {

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/form.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/form.phtml
@@ -80,7 +80,7 @@
           <?= $this->getChildHtml('order_items') ?>
     </div>
 </form>
-<script type="text/javascript">
+<script>
     var createShipment = document.getElementById('invoice_do_shipment');
     if (createShipment) {
         createShipment.addEventListener('click', function(e){

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/items.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/items.phtml
@@ -133,7 +133,7 @@
     </tbody>
 </table>
 
-<script type="text/javascript">
+<script>
 const submitButtons = document.querySelectorAll('.submit-button');
 const updateButtons = document.querySelectorAll('.update-button');
 const enableSubmitButtons = <?= (int) !$this->getDisableSubmitButton() ?>;

--- a/app/design/adminhtml/default/default/template/sales/order/invoice/create/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/invoice/create/tracking.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Sales_Order_Invoice_Create_Tracking $this */
 ?>
-<script type="text/javascript">
+<script>
 var trackingControl;
 trackingControl = {
     index : 0,
@@ -87,6 +87,6 @@ trackingControl = {
     </tbody>
 </table>
 </div>
-<script type="text/javascript">
+<script>
 trackingControl.template = new Template('<tr>' + document.getElementById('track_row_template').innerHTML.replace(/__index__/g, '{{index}}') + '<\/tr>', Template.HANDLEBARS_PATTERN);
 </script>

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/create/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/create/tracking.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Sales_Order_Shipment_Create_Tracking $this */
 ?>
-<script type="text/javascript">
+<script>
 var trackingControl;
 trackingControl = {
     index : 0,
@@ -87,6 +87,6 @@ trackingControl = {
     </tbody>
 </table>
 </div>
-<script type="text/javascript">
+<script>
 trackingControl.template = new Template('<tr>' + document.getElementById('track_row_template').innerHTML.replace(/__index__/g, '{{index}}') + '<\/tr>', Template.HANDLEBARS_PATTERN);
 </script>

--- a/app/design/adminhtml/default/default/template/sales/order/shipment/view/tracking.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/shipment/view/tracking.phtml
@@ -59,7 +59,7 @@
 <?php endif ?>
 </table>
 </div>
-<script type="text/javascript">
+<script>
 function selectCarrier(elem) {
     var option = elem.options[elem.selectedIndex];
     document.getElementById('tracking_title').value = option.value && option.value != 'custom' ? option.text : '';

--- a/app/design/adminhtml/default/default/template/sales/order/view/history.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/history.phtml
@@ -63,7 +63,7 @@
         </li>
     <?php endforeach ?>
     </ul>
-    <script type="text/javascript">
+    <script>
         if (document.getElementById('order_status')) document.getElementById('order_status').textContent = '<?= $this->jsQuoteEscape($this->getOrder()->getStatusLabel()) ?>';
     </script>
 </div>

--- a/app/design/adminhtml/default/default/template/sales/order/view/info.phtml
+++ b/app/design/adminhtml/default/default/template/sales/order/view/info.phtml
@@ -167,7 +167,7 @@ $orderStoreDate = $this->formatDate($_order->getCreatedAtStoreDate(), 'medium', 
 <?php endif ?>
 
 <?php if ($_order->getCustomerIsGuest()): ?>
-<script type="text/javascript">
+<script>
 function updateGuestEmail() {
     const currentEmail = <?= Mage::helper('core')->jsonEncode($_order->getCustomerEmail()) ?>;
     const newEmail = prompt('<?= $this->__('Enter new email address:') ?>', currentEmail);

--- a/app/design/adminhtml/default/default/template/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher.phtml
@@ -38,7 +38,7 @@
     <?php endforeach ?>
 </select>
 </p>
-<script type="text/javascript">
+<script>
     function switchStore(obj) {
         var storeParam = obj.value ? 'store/' + obj.value + '/' : '';
         if (obj.switchParams) {

--- a/app/design/adminhtml/default/default/template/store/switcher/enhanced.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher/enhanced.phtml
@@ -40,7 +40,7 @@
 </select>
 </p>
 </div>
-<script type="text/javascript">
+<script>
 class varienStore {
     constructor(containerId, storeSwitcher, url, useAjax, useConfirm) {
         this.containerId = containerId;

--- a/app/design/adminhtml/default/default/template/system/cache/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/cache/edit.phtml
@@ -18,7 +18,7 @@
 <form action="<?= $this->getSaveUrl() ?>" method="post" id="config_edit_form" enctype="multipart/form-data">
     <?= $this->getBlockHtml('formkey') ?>
 
-    <script type="text/javascript">
+    <script>
     function setCacheAction(id, button)
     {
         document.getElementById(id).value = button.id;
@@ -79,6 +79,6 @@
         </fieldset>
     </div>
 </form>
-<script type="text/javascript">
+<script>
     var configForm = new varienForm('config_edit_form');
 </script>

--- a/app/design/adminhtml/default/default/template/system/config/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/edit.phtml
@@ -20,7 +20,7 @@
     <?= $this->getBlockHtml('formkey') ?>
     <?= $this->getChildHtml('form') ?>
 </form>
-<script type="text/javascript">
+<script>
 const configFormHandler = {
     validator: {
         options: {

--- a/app/design/adminhtml/default/default/template/system/config/form/field/array.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/form/field/array.phtml
@@ -52,7 +52,7 @@ $_colspan = $_colspan > 1 ? 'colspan="' . $_colspan . '"' : '';
     </button>
 </div>
 
-<script type="text/javascript">
+<script>
 const arrayRow<?= $_htmlId ?> = {
     template: new Template(
         '<tr id="#{_id}">'

--- a/app/design/adminhtml/default/default/template/system/config/js.phtml
+++ b/app/design/adminhtml/default/default/template/system/config/js.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Template $this */
 ?>
-<script type="text/javascript">
+<script>
 class OriginModel {
     constructor() {
         this.reload = false;

--- a/app/design/adminhtml/default/default/template/system/convert/profile/process.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/process.phtml
@@ -17,7 +17,7 @@
     img { margin-right:5px; }
     svg { margin-right:5px; }
 </style>
-<script type="text/javascript">
+<script>
     var FORM_KEY = "<?= $this->getFormKey() ?>";
 </script>
     <ul>
@@ -61,7 +61,7 @@
             </ul>
             <?php if ($batchId = $this->getBatchModel()->getId()):?>
                 <?php if ($this->getBatchModelHasAdapter()):?>
-                <script type="text/javascript">
+                <script>
                     var countOfStartedProfiles = 0;
                     var countOfUpdated = 0;
                     var countOfError = 0;
@@ -69,7 +69,7 @@
                     var totalRecords = <?= $this->getBatchItemsCount() ?>;
                     var config= <?= $this->getBatchConfigJson() ?>;
                 </script>
-                <script type="text/javascript">
+                <script>
                     function addImportData(data) {
                         importData.push(data);
                     }
@@ -230,7 +230,7 @@
                     }
                 </script>
                 <?php $importData = $this->getImportData();?>
-                <script type="text/javascript">
+                <script>
                     <?php foreach ($importData as  $importValue):?>
                     addImportData(<?= $this->jsonEncode($importValue) ?>);
                     <?php endforeach ?>
@@ -239,6 +239,6 @@
                 <?php endif ?>
             <?php endif ?>
             <?php if ($this->getShowFinished()):?>
-                <script type="text/javascript">document.getElementById('liFinished').style.display = 'block';</script>
+                <script>document.getElementById('liFinished').style.display = 'block';</script>
             <?php endif ?>
    <?php endif ?>

--- a/app/design/adminhtml/default/default/template/system/convert/profile/run.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/run.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_System_Convert_Profile_Edit_Tab_Run $this */
 ?>
-<script type="text/javascript">
+<script>
 function runProfile(popup)
 {
     var url = "<?= $this->getUrl('*/*/run', ['id' => $this->getProfileId()]) ?>";

--- a/app/design/adminhtml/default/default/template/system/convert/profile/wizard.phtml
+++ b/app/design/adminhtml/default/default/template/system/convert/profile/wizard.phtml
@@ -12,7 +12,7 @@
 /** @var Mage_Adminhtml_Block_System_Convert_Gui_Edit_Tab_Wizard $this */
 ?>
 
-<script type="text/javascript">
+<script>
 const profileImportOnly = ['profile_number_of_records', 'profile_decimal_separator'];
 
 function getElementById(id) {
@@ -529,7 +529,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 </div>
 
-<script type="text/javascript">
+<script>
 document.addEventListener('DOMContentLoaded', function() {
     document.querySelectorAll('.option-control').forEach(showOption);
     changeEntityType();

--- a/app/design/adminhtml/default/default/template/system/currency/rate/matrix.phtml
+++ b/app/design/adminhtml/default/default/template/system/currency/rate/matrix.phtml
@@ -56,6 +56,6 @@ $_rates = ( $_newRates ) ? $_newRates : $_oldRates;
     </table>
     </div>
 </form>
-<script type="text/javascript">
+<script>
     currencyForm = new varienForm('rateForm');
 </script>

--- a/app/design/adminhtml/default/default/template/system/design/edit.phtml
+++ b/app/design/adminhtml/default/default/template/system/design/edit.phtml
@@ -24,6 +24,6 @@
 <form action="<?= $this->getSaveUrl() ?>" method="post" id="design_edit_form">
     <?= $this->getBlockHtml('formkey') ?>
 </form>
-<script type="text/javascript">
+<script>
     var designForm = new varienForm('design_edit_form');
 </script>

--- a/app/design/adminhtml/default/default/template/system/shipping/applicable_country.phtml
+++ b/app/design/adminhtml/default/default/template/system/shipping/applicable_country.phtml
@@ -9,7 +9,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<script type="text/javascript">
+<script>
 class CountryModel {
     constructor() {
         this.reload = false;

--- a/app/design/adminhtml/default/default/template/system/variable/js.phtml
+++ b/app/design/adminhtml/default/default/template/system/variable/js.phtml
@@ -9,7 +9,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 ?>
-<script type="text/javascript">
+<script>
 function toggleValueElement(element) {
     var disabled = false;
     if (element.value == 1) {

--- a/app/design/adminhtml/default/default/template/tag/edit/container.phtml
+++ b/app/design/adminhtml/default/default/template/tag/edit/container.phtml
@@ -25,7 +25,7 @@
 
     <?= $this->getTagAssignAccordionHtml() ?>
 
-<script type="text/javascript">
+<script>
     function saveAndContinueEdit(url) {
         var tagForm = new varienForm('edit_form');
         tagForm.submit(url);
@@ -39,7 +39,7 @@
         <p class="content-buttons form-buttons"><?= $this->getButtonsHtml('footer') ?></p>
     </div>
 <?php endif ?>
-<script type="text/javascript">
+<script>
     var editForm = new varienForm('edit_form', '<?= $this->getValidationUrl() ?>');
 </script>
 <?= $this->getFormScripts() ?>

--- a/app/design/adminhtml/default/default/template/tax/class/page/edit.phtml
+++ b/app/design/adminhtml/default/default/template/tax/class/page/edit.phtml
@@ -19,6 +19,6 @@
     </p>
 </div>
 <?= $this->_getRenameFormHtml() ?>
-<script type="text/javascript">
+<script>
     var renameForm = new varienForm('<?= $this->_getRenameFormId() ?>');
 </script>

--- a/app/design/adminhtml/default/default/template/tax/importExport.phtml
+++ b/app/design/adminhtml/default/default/template/tax/importExport.phtml
@@ -28,7 +28,7 @@
                 <?= $this->getButtonHtml('Import Tax Rates', "this.form.submit()") ?>
             </fieldset>
         </form>
-        <script type="text/javascript">
+        <script>
             var importForm = new varienForm('import_form');
         </script>
     </div>

--- a/app/design/adminhtml/default/default/template/tax/rate/form.phtml
+++ b/app/design/adminhtml/default/default/template/tax/rate/form.phtml
@@ -15,6 +15,6 @@
     <?= $this->getFormHtml() ?>
 </div>
 <?= $this->getChildHtml('form_after') ?>
-<script type="text/javascript">
+<script>
 var updater = new RegionUpdater('tax_country_id', 'tax_region', 'tax_region_id', <?= Mage::helper('directory')->getRegionJsonByStore() ?>, 'disable');
 </script>

--- a/app/design/adminhtml/default/default/template/tax/toolbar/class/save.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/class/save.phtml
@@ -19,7 +19,7 @@
 </div>
 <?php if( $form ): ?>
 <?= $form->toHtml() ?>
-<script type="text/javascript">
+<script>
     var wigetForm = new varienForm('<?= $form->getForm()->getId() ?>');
 </script>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rate/save.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rate/save.phtml
@@ -26,7 +26,7 @@
 </div>
 <?php if( $form ): ?>
 <?= $form->toHtml() ?>
-<script type="text/javascript">
+<script>
     var wigetForm = new varienForm('<?= $form->getForm()->getId() ?>');
 </script>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/tax/toolbar/rule/save.phtml
+++ b/app/design/adminhtml/default/default/template/tax/toolbar/rule/save.phtml
@@ -20,7 +20,7 @@
 </div>
 <?php if( $form ): ?>
 <?= $form->toHtml() ?>
-<script type="text/javascript">
+<script>
     var wigetForm = new varienForm('<?= $form->getForm()->getId() ?>');
 </script>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/urlrewrite/edit.phtml
+++ b/app/design/adminhtml/default/default/template/urlrewrite/edit.phtml
@@ -24,7 +24,7 @@
 <?= $this->getChildHtml() ?>
 
 <?php if ($this->getChild('form')): ?>
-<script type="text/javascript">
+<script>
     var editForm = new varienForm('edit_form', '<?= $this->getValidationUrl() ?>');
 </script>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/usa/dhl/unitofmeasure.phtml
+++ b/app/design/adminhtml/default/default/template/usa/dhl/unitofmeasure.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Usa_Block_Adminhtml_Dhl_Unitofmeasure $this */
 ?>
-<script type="text/javascript">
+<script>
     function changeDimensions() {
         const dimensionUnitInch = '(<?= $this->getInch() ?>)';
         const dimensionUnitCm = '(<?= $this->getCm() ?>)';

--- a/app/design/adminhtml/default/default/template/weee/renderer/tax.phtml
+++ b/app/design/adminhtml/default/default/template/weee/renderer/tax.phtml
@@ -70,7 +70,7 @@
         </tbody>
     </table>
 
-<script type="text/javascript">
+<script>
     window.itemsCount = window.itemsCount ?? 0;
 
     const weeeTaxControl = {

--- a/app/design/adminhtml/default/default/template/widget/accordion.phtml
+++ b/app/design/adminhtml/default/default/template/widget/accordion.phtml
@@ -21,6 +21,6 @@
     <?= $this->getChildHtml($_item->getId()) ?>
 <?php endforeach ?>
 </dl>
-<script type="text/javascript">
+<script>
     tab_content_<?= $this->getHtmlId() ?>AccordionJs = new varienAccordion('tab_content_<?= $this->getHtmlId() ?>', '<?= $this->getShowOnlyOne() ?>');
 </script>

--- a/app/design/adminhtml/default/default/template/widget/form/container.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/container.phtml
@@ -34,7 +34,7 @@ $gridNav = $this->getGridNavigation();
         <p class="form-buttons"><?= $this->getButtonsHtml('footer') ?></p>
     </div>
 <?php endif ?>
-<script type="text/javascript">
+<script>
     editForm = new varienForm('edit_form', '<?= $this->getValidationUrl() ?>');
 </script>
 <?= $this->getFormScripts() ?>

--- a/app/design/adminhtml/default/default/template/widget/form/element/gallery.phtml
+++ b/app/design/adminhtml/default/default/template/widget/form/element/gallery.phtml
@@ -48,12 +48,12 @@
 <?php endif ?>
 
 <?php if ($i==0): ?>
-    <script type="text/javascript">document.getElementById("gallery_thead").style.visibility="hidden";</script>
+    <script>document.getElementById("gallery_thead").style.visibility="hidden";</script>
 <?php endif ?>
 
 </tbody></table>
 
-<script type="text/javascript">
+<script>
 //<![CDATA[
 id = 0;
 num_of_images = <?= $i ?>;

--- a/app/design/adminhtml/default/default/template/widget/grid.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid.phtml
@@ -178,7 +178,7 @@ $numColumns = count($this->getColumns());
 </div>
 <?php if($this->canDisplayContainer()): ?>
 </div>
-<script type="text/javascript">
+<script>
     globalThis.<?= $this->getJsObjectName() ?> = new varienGrid('<?= $this->getId() ?>', '<?= $this->getGridUrl() ?>', '<?= $this->getVarNamePage() ?>', '<?= $this->getVarNameSort() ?>', '<?= $this->getVarNameDir() ?>', '<?= $this->getVarNameFilter() ?>');
     <?= $this->getJsObjectName() ?>.useAjax = '<?= $this->getUseAjax() ?>';
     <?php if($this->getRowClickCallback()): ?>

--- a/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/massaction.phtml
@@ -81,7 +81,7 @@
 /** @var Mage_Adminhtml_Block_Widget_Grid $parent */
 $parent = $this->getParentBlock();
 if (!$parent->canDisplayContainer()): ?>
-<script type="text/javascript">
+<script>
     <?= $this->getJsObjectName() ?>.setGridIds('<?= $this->getGridIdsJson() ?>');
 </script>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/widget/grid/serializer.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid/serializer.phtml
@@ -14,7 +14,7 @@
 <?php $_id = 'id_' . md5(microtime()) ?>
 <?php $formId = $this->getFormId()?>
 <?php if (!empty($formId)) :?>
-<script type="text/javascript">
+<script>
     setTimeout(function() {
         var serializeInput  = document.createElement('input');
         serializeInput.type = 'hidden';
@@ -26,7 +26,7 @@
 </script>
 <?php else: ?>
 <input type="hidden" name="<?= $this->getInputElementName() ?>"  value="" id="<?= $_id ?>" />
-<script type="text/javascript">
+<script>
     new serializerController('<?= $_id?>', <?= $this->getDataAsJSON() ?>, <?= $this->getColumnInputNames(true) ?>, <?= $this->getGridBlock()->getJsObjectName() ?>, '<?= $this->getReloadParamName() ?>');
 </script>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
+++ b/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
@@ -20,7 +20,7 @@
             <div id="page_group_container"></div>
     </div>
 </div>
-<script type="text/javascript">
+<script>
 var pageGroupTemplate = '<div class="options-box page_group_container" id="page_group_container_{{id}}">'+
     '<div class="option-box">'+
         '<div class="option-title">'+

--- a/app/design/adminhtml/default/default/template/widget/instance/js.phtml
+++ b/app/design/adminhtml/default/default/template/widget/instance/js.phtml
@@ -11,7 +11,7 @@
 
 /** @var Mage_Adminhtml_Block_Template $this */
 ?>
-<script type="text/javascript">
+<script>
 /**
  * Get the value of a form element by ID or element reference
  * @param {string|HTMLElement} element

--- a/app/design/adminhtml/default/default/template/widget/tabs.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabs.phtml
@@ -29,7 +29,7 @@
     </li>
 <?php endforeach ?>
 </ul>
-<script type="text/javascript">
+<script>
     <?= $this->getJsObjectName() ?> = new varienTabs('<?= $this->getId() ?>', '<?= $this->getDestElementId() ?>', '<?= $this->getActiveTabId() ?>', <?= $this->getAllShadowTabs() ?>);
 </script>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/widget/tabshoriz.phtml
+++ b/app/design/adminhtml/default/default/template/widget/tabshoriz.phtml
@@ -28,7 +28,7 @@
     </li>
 <?php endforeach ?>
 </ul>
-<script type="text/javascript">
+<script>
 
     <?= $this->getId() ?>JsTabs = new varienTabs('<?= $this->getId() ?>', '<?= $this->getDestElementId() ?>', '<?= $this->getActiveTabId() ?>', <?= $this->getAllShadowTabs() ?>);
 </script>

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/option_tierprices.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/option_tierprices.phtml
@@ -178,7 +178,7 @@ if (Mage::helper('weee')->typeOfDisplay($_product, [1,2,4])) {
         <?php if ($_catalogHelper->isShowPriceOnGesture($_product)):?>
             <?php $popupId = 'msrp-popup-' . $_product->getId() . $this->helper('core')->getRandomString(20); ?>
             <a href="#" id="<?php echo($popupId);?>"><?= $this->__('Click for price') ?></a>
-            <script type="text/javascript">
+            <script>
             <?php
                 $addToCartUrl = $this->getProduct()->isSalable()
                     ? $this->getAddToCartUrlCustom($_product, ['qty' => $_price['price_qty']], false)

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/price.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/price.phtml
@@ -93,7 +93,7 @@ $canApplyMAP  = Mage::helper('catalog')->canApplyMsrp($_product);
 </div>
 <?php endif ?>
 <?php if($_product->isSaleable()): ?>
-<script type="text/javascript">
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         bundle.reloadPrice();
     });

--- a/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle.phtml
+++ b/app/design/frontend/base/default/template/bundle/catalog/product/view/type/bundle.phtml
@@ -14,7 +14,7 @@
 <?php $_product = $this->getProduct() ?>
 
 <?php if ($_product->isSaleable()): ?>
-    <script type="text/javascript">
+    <script>
         var skipTierPricePercentUpdate = true;
         var bundle = new Product.Bundle(<?= $this->getJsonConfig() ?>);
         var taxCalcMethod = "<?= Mage::helper('tax')->getConfig()->getAlgorithm($_product->getStore()) ?>";

--- a/app/design/frontend/base/default/template/catalog/msrp/popup.phtml
+++ b/app/design/frontend/base/default/template/catalog/msrp/popup.phtml
@@ -33,7 +33,7 @@
                 <button type="button" title="<?= $this->quoteEscape($this->__('Add to Cart')) ?>" class="button btn-cart" id="map-popup-button"><?= $this->__('Add to Cart') ?></button>
             </form>
         </div>
-        <script type="text/javascript">
+        <script>
             document.addEventListener("DOMContentLoaded", () => {
                 Catalog.Map.bindProductForm();
             });

--- a/app/design/frontend/base/default/template/catalog/product/compare/list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/compare/list.phtml
@@ -167,7 +167,7 @@
             <img src="<?= $this->getSkinUrl('images/loading.svg') ?>" alt="<?= $this->quoteEscape($this->__('Please wait...')) ?>" title="<?= $this->quoteEscape($this->__('Please wait...')) ?>" class="v-middle" /> <?= $this->__('Please wait...') ?>
         </span>
     </div>
-    <script type="text/javascript">
+    <script>
         function removeItem(url) {
             document.getElementById('compare-list-please-wait').style.display = 'block';
 
@@ -198,5 +198,5 @@
         }
     </script>
 <?php else: ?>
-    <script type="text/javascript">window.close();</script>
+    <script>window.close();</script>
 <?php endif ?>

--- a/app/design/frontend/base/default/template/catalog/product/gallery.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/gallery.phtml
@@ -40,7 +40,7 @@
         </div>
     <?php endif ?>
 </div>
-<script type="text/javascript">
+<script>
     window.addEventListener('load', function() {
         const image = document.getElementById('product-gallery-image');
         const dimensions = {

--- a/app/design/frontend/base/default/template/catalog/product/list/related.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list/related.phtml
@@ -47,7 +47,7 @@
         <?php endforeach ?>
         </ol>
     </div>
-    <script type="text/javascript">
+    <script>
         document.querySelectorAll('.related-checkbox').forEach(elem => {
             elem.addEventListener('click', addRelatedToProduct);
         });

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp.phtml
@@ -30,7 +30,7 @@
         <?php endif ?>
         <?php $helpLinkId = 'msrp-click-' . $_product->getId() . $this->helper('core')->getRandomString(20); ?>
         <a href="#" class="map-link" id="<?php echo($helpLinkId);?>"><?= $this->__('Click for price') ?></a>
-        <script type="text/javascript">
+        <script>
             <?php if ($this->helper('catalog')->isShowPriceOnGesture($_product)): ?>
                 var newLink = Catalog.Map.addHelpLink(
                     '<?= $helpLinkId ?>',

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp_item.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp_item.phtml
@@ -39,7 +39,7 @@
             <span id="<?= $priceElementId ?>" style="display:none"></span>
             <?php $popupId = 'msrp-popup-' . $_id . $_coreHelper->getRandomString(20); ?>
             <a href="#" id="<?php echo($popupId);?>"><?= $this->__('Click for price') ?></a>
-            <script type="text/javascript">
+            <script>
                 window.addEventListener('load', function() {
                     const priceElement = document.getElementById("<?= $priceElementId ?>");
                     const realPrice = <?= $this->getRealPriceJs($_product) ?>;
@@ -89,7 +89,7 @@
 
         <?php $helpLinkId = 'msrp-help-' . $_id . $_coreHelper->getRandomString(20); ?>
         <a href="#" id="<?php echo($helpLinkId);?>"><?= $this->__("What's this?") ?></a>
-        <script type="text/javascript">
+        <script>
             Catalog.Map.addHelpLink(
                 '<?= $helpLinkId ?>',
                 '<?= $this->jsQuoteEscape($this->__("What's this?")) ?>'

--- a/app/design/frontend/base/default/template/catalog/product/price_msrp_noform.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price_msrp_noform.phtml
@@ -30,7 +30,7 @@
         <?php endif ?>
         <?php $helpLinkId = 'msrp-click-' . $_product->getId() . $this->helper('core')->getRandomString(20); ?>
         <a href="#" class="map-link" id="<?php echo($helpLinkId);?>"><?= $this->__('Click for price') ?></a>
-        <script type="text/javascript">
+        <script>
             <?php if ($this->helper('catalog')->isShowPriceOnGesture($_product)): ?>
                 var productLink = {
                     url: "<?= $_product->isSalable() ? $this->getAddToCartUrlCustom($_product, [], false) : '' ?>",

--- a/app/design/frontend/base/default/template/catalog/product/view.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view.phtml
@@ -13,7 +13,7 @@
 ?>
 <?php $_helper = $this->helper('catalog/output'); ?>
 <?php $_product = $this->getProduct(); ?>
-<script type="text/javascript">
+<script>
     var optionsPrice = new Product.OptionsPrice(<?= $this->getJsonConfig() ?>);
 </script>
 <div id="messages_product_view"><?= $this->getMessagesBlock()->toHtml() ?></div>
@@ -96,7 +96,7 @@
                 <?= $this->getChildChildHtml('container2', '', true, true) ?>
             <?php endif ?>
         </form>
-        <script type="text/javascript">
+        <script>
             var productAddToCartForm = new VarienForm('product_addtocart_form');
             productAddToCartForm.submit = async function(button, url) {
                 if (!this.validator.validate()) {

--- a/app/design/frontend/base/default/template/catalog/product/view/tierprices.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/tierprices.phtml
@@ -176,7 +176,7 @@ if (Mage::helper('weee')->typeOfDisplay($_product, [1,2,4])) {
         <?php if ($_catalogHelper->isShowPriceOnGesture($_product)):?>
             <?php $popupId = 'msrp-popup-' . $_product->getId() . $this->helper('core')->getRandomString(20); ?>
             <a href="#" id="<?php echo($popupId);?>"><?= $this->__('Click for price') ?></a>
-            <script type="text/javascript">
+            <script>
             <?php
                     $addToCartUrl = $this->getProduct()->isSalable()
                         ? $this->getAddToCartUrlCustom($_product, ['qty' => $_price['price_qty']], false)

--- a/app/design/frontend/base/default/template/catalog/seo/sitemap.phtml
+++ b/app/design/frontend/base/default/template/catalog/seo/sitemap.phtml
@@ -22,7 +22,7 @@
     <p class="note-msg">
         <?= $this->__('There are no %s available.', $this->getItemsTitle()) ?>
     </p>
-    <script type="text/javascript">
+    <script>
         const sitemapTopLinks = document.getElementById('sitemap_top_links');
         if (sitemapTopLinks) {
             sitemapTopLinks.style.display = 'none';

--- a/app/design/frontend/base/default/template/cataloginventory/stockqty/composite.phtml
+++ b/app/design/frontend/base/default/template/cataloginventory/stockqty/composite.phtml
@@ -39,7 +39,7 @@
         <?php endforeach ?>
         </tbody>
     </table>
-    <script type="text/javascript">
+    <script>
         document.getElementById('<?= $this->getPlaceholderId() ?>').addEventListener('click', function(event){
             this.classList.toggle('expanded');
             document.getElementById('<?= $this->getDetailsPlaceholderId() ?>').classList.toggle('no-display');

--- a/app/design/frontend/base/default/template/catalogsearch/advanced/form.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/advanced/form.phtml
@@ -74,6 +74,6 @@
         <button type="submit" title="<?= $this->quoteEscape($this->__('Search')) ?>" class="button"><?= $this->__('Search') ?></button>
     </div>
 </form>
-<script type="text/javascript">
+<script>
     var dataForm = new VarienForm('form-validate', true);
 </script>

--- a/app/design/frontend/base/default/template/catalogsearch/form.mini.phtml
+++ b/app/design/frontend/base/default/template/catalogsearch/form.mini.phtml
@@ -21,7 +21,7 @@ $catalogSearchHelper =  $this->helper('catalogsearch');
     </div>
 
     <div id="search_autocomplete" class="search-autocomplete"></div>
-    <script type="text/javascript">
+    <script>
         var searchForm = new Varien.searchForm('search_mini_form', 'search', '');
         searchForm.initAutocomplete('<?= $catalogSearchHelper->getSuggestUrl() ?>', 'search_autocomplete');
     </script>

--- a/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
@@ -84,7 +84,7 @@ $_weeeAmount = $_item->getWeeeTaxAppliedAmount();
                 <?php $helpLinkId = 'cart-msrp-help-' . $_item->getId(); ?>
                 <a id="<?= $helpLinkId ?>" href="#" class="map-help-link"><?= $this->__("What's this?") ?></a>
 
-                <script type="text/javascript">
+                <script>
                     Catalog.Map.addHelpLink('<?= $helpLinkId ?>', "<?= $this->jsQuoteEscape($this->__("What's this?")) ?>");
                 </script>
 

--- a/app/design/frontend/base/default/template/checkout/cart/minicart.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/minicart.phtml
@@ -22,7 +22,7 @@
     <?= $this->getChildHtml('minicart_content') ?>
 </div>
 
-<script type="text/javascript">
+<script>
     // Initialize minicart globally if it doesn't exist
     document.addEventListener('DOMContentLoaded', function() {
         if (typeof window.minicart === 'undefined') {

--- a/app/design/frontend/base/default/template/checkout/cart/minicart/items.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/minicart/items.phtml
@@ -71,7 +71,7 @@ if(empty($_cartQty)) {
     <?php endif ?>
 </div>
 
-<script type="text/javascript">
+<script>
     if (typeof truncateOptions === 'function') truncateOptions();
     document.addEventListener('DOMContentLoaded', function() {
         window.minicart = new Minicart({

--- a/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
@@ -24,7 +24,7 @@
                     <select id="region_id" name="region_id" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" style="display:none;"<?= ($this->isStateProvinceRequired() ? ' class="validate-select"' : '') ?>>
                         <option value=""><?= $this->__('Please select region, state or province') ?></option>
                     </select>
-                    <script type="text/javascript">
+                    <script>
                         document.getElementById('region_id').setAttribute('defaultValue', "<?= $this->getEstimateRegionId() ?>");
                     </script>
                     <input type="text" id="region" name="region" value="<?= $this->escapeHtml($this->getEstimateRegion()) ?>" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="input-text" style="display:none;" />
@@ -46,7 +46,7 @@
                 </button>
             </div>
         </form>
-        <script type="text/javascript">
+        <script>
             new RegionUpdater('country', 'region', 'region_id', <?= Mage::helper('directory')->getRegionJsonByStore() ?>);
         </script>
 
@@ -54,7 +54,7 @@
             <?= $this->setTemplate('checkout/cart/shipping/rates.phtml')->toHtml() ?>
         </div>
 
-        <script type="text/javascript">
+        <script>
         (function() {
             const countriesWithOptionalZip = <?= $this->helper('directory')->getCountriesWithOptionalZip(true) ?>;
             const form = document.getElementById('shipping-zip-form');

--- a/app/design/frontend/base/default/template/checkout/onepage.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage.phtml
@@ -28,7 +28,7 @@
     </li>
 <?php endforeach ?>
 </ol>
-<script type="text/javascript">
+<script>
     const accordion = new Accordion('checkoutSteps', '.step-title', true);
     <?php if($this->getActiveStep()): ?>
     accordion.openSection('opc-<?= $this->getActiveStep() ?>');

--- a/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
@@ -82,7 +82,7 @@
                             <select id="billing:region_id" name="billing[region_id]" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="validate-select" style="display:none;">
                                 <option value=""><?= $this->__('Please select region, state or province') ?></option>
                             </select>
-                            <script type="text/javascript">
+                            <script>
                                 document.getElementById('billing:region_id').setAttribute('defaultValue', "<?= $this->getAddress()->getRegionId() ?>");
                             </script>
                             <input type="text" id="billing:region" name="billing[region]" value="<?= $this->escapeHtml($this->getAddress()->getRegion()) ?>"  title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('region') ?>" style="display:none;" />
@@ -173,7 +173,7 @@
     <?= $this->getBlockHtml('formkey') ?>
 </fieldset>
 </form>
-<script type="text/javascript">
+<script>
     var billing = new Billing('co-billing-form', '<?= $this->getUrl('checkout/onepage/getAddress') ?>address/', '<?= $this->getUrl('checkout/onepage/saveBilling') ?>');
     var billingForm = new VarienForm('co-billing-form');
 

--- a/app/design/frontend/base/default/template/checkout/onepage/payment.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/payment.phtml
@@ -12,7 +12,7 @@
 /** @var Mage_Checkout_Block_Onepage_Payment $this */
 ?>
 <?= $this->getChildChildHtml('before_form') ?>
-<script type="text/javascript">
+<script>
     var quoteBaseGrandTotal = <?= (float)$this->getQuoteBaseGrandTotal() ?>;
     var checkQuoteBaseGrandTotal = quoteBaseGrandTotal;
     var quoteGrandTotalClean = quoteBaseGrandTotal;
@@ -38,7 +38,7 @@
         <img src="<?= $this->getSkinUrl('images/loading.svg') ?>" alt="<?= $this->quoteEscape($this->__('Loading next step...')) ?>" title="<?= $this->quoteEscape($this->__('Loading next step...')) ?>" class="v-middle" /> <?= $this->__('Loading next step...') ?>
     </span>
 </div>
-<script type="text/javascript">
+<script>
     payment.currentMethod = "<?= $this->getChild('methods')->getSelectedMethodCode() ?>";
     function toggleToolTip(event) {
         let paymentToolTip = document.getElementById('payment-tool-tip');

--- a/app/design/frontend/base/default/template/checkout/onepage/payment/methods.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/payment/methods.phtml
@@ -44,7 +44,7 @@ $oneMethod = count($methods) <= 1;
     <?php endforeach ?>
 <?php endif ?>
 <?= $this->getChildChildHtml('additional') ?>
-<script type="text/javascript">
+<script>
 <?= $this->getChildChildHtml('scripts') ?>
 payment.init();
 <?php if (is_string($oneMethod)): ?>

--- a/app/design/frontend/base/default/template/checkout/onepage/review/info.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/review/info.phtml
@@ -49,7 +49,7 @@
     </table>
 </div>
 <?= $this->getChildHtml('items_after') ?>
-<script type="text/javascript">truncateOptions();</script>
+<script>truncateOptions();</script>
 <div id="checkout-review-submit">
     <?= $this->getChildHtml('agreements') ?>
     <div class="buttons-set" id="review-buttons-container">
@@ -59,7 +59,7 @@
             <img src="<?= $this->getSkinUrl('images/loading.svg') ?>" alt="<?= $this->quoteEscape($this->__('Submitting order information...')) ?>" title="<?= $this->quoteEscape($this->__('Submitting order information...')) ?>" class="v-middle" /> <?= $this->__('Submitting order information...') ?>
         </span>
     </div>
-    <script type="text/javascript">
+    <script>
         review = new Review(
             '<?= $this->getUrl('checkout/onepage/saveOrder') ?>',
             '<?= $this->getUrl('checkout/onepage/success') ?>',

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
@@ -73,7 +73,7 @@
                                 <select id="shipping:region_id" name="shipping[region_id]" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="validate-select" style="display:none;">
                                     <option value=""><?= $this->__('Please select region, state or province') ?></option>
                                 </select>
-                                <script type="text/javascript">
+                                <script>
                                     document.getElementById('shipping:region_id').setAttribute('defaultValue', "<?= $this->getAddress()->getRegionId() ?>");
                                 </script>
                                 <input type="text" id="shipping:region" name="shipping[region]" value="<?= $this->escapeHtml($this->getAddress()->getRegion()) ?>" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('region') ?>" style="display:none;" />
@@ -129,7 +129,7 @@
     </div>
     <?= $this->getBlockHtml('formkey') ?>
 </form>
-<script type="text/javascript">
+<script>
     var shipping = new Shipping('co-shipping-form', '<?= $this->getUrl('checkout/onepage/getAddress') ?>address/',
         '<?= $this->getUrl('checkout/onepage/saveShipping') ?>', '<?= $this->getUrl('checkout/onepage/shippingMethod') ?>');
     var shippingForm = new VarienForm('co-shipping-form');

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping_method.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping_method.phtml
@@ -13,7 +13,7 @@
 ?>
 <form id="co-shipping-method-form" action="">
     <div id="checkout-shipping-method-load"></div>
-    <script type="text/javascript">
+    <script>
         var shippingMethod = new ShippingMethod('co-shipping-method-form', "<?= $this->getUrl('checkout/onepage/saveShippingMethod') ?>");
     </script>
     <div id="onepage-checkout-shipping-method-additional-load"><?= $this->getChildHtml('additional') ?></div>

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping_method/available.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping_method/available.phtml
@@ -32,7 +32,7 @@
                         <input name="shipping_method" type="radio" value="<?= $_rate->getCode() ?>" id="s_method_<?= $_rate->getCode() ?>"<?php if($_rate->getCode()===$this->getAddressShippingMethod()) echo ' checked="checked"' ?> class="radio"/>
 
                         <?php if ($_rate->getCode() === $this->getAddressShippingMethod()): ?>
-                        <script type="text/javascript">
+                        <script>
                             lastPrice = <?= (float)$_rate->getPrice() ?>;
                         </script>
                         <?php endif ?>
@@ -60,7 +60,7 @@
         </dd>
     <?php endforeach ?>
     </dl>
-    <script type="text/javascript">
+    <script>
         <?php if (!empty($shippingCodePrice)): ?>
         var shippingCodePrice = {<?= implode(',',$shippingCodePrice) ?>};
         <?php endif ?>

--- a/app/design/frontend/base/default/template/checkout/onestep.phtml
+++ b/app/design/frontend/base/default/template/checkout/onestep.phtml
@@ -101,7 +101,7 @@ $isLoggedIn = $this->isCustomerLoggedIn();
 </div>
 
 <script src="<?= $this->getSkinUrl('js/mage/promocode.js') ?>"></script>
-<script type="text/javascript">
+<script>
     // Initialize the one-step checkout
     const onestepCheckout = new OneStepCheckout({
         progress: '<?= $this->getUrl('checkout/onepage/progress') ?>',

--- a/app/design/frontend/base/default/template/configurableswatches/catalog/media/js.phtml
+++ b/app/design/frontend/base/default/template/configurableswatches/catalog/media/js.phtml
@@ -12,7 +12,7 @@
 /** @var Mage_ConfigurableSwatches_Block_Catalog_Media_Js_Abstract $this */
 ?>
 
-<script type="text/javascript">
+<script>
     ConfigurableMediaImages.init('<?= $this->getImageType() ?>');
     <?php foreach ($this->getProductImageFallbacks() as $imageFallback): ?>
     ConfigurableMediaImages.setImageFallback(<?= $imageFallback['product']->getId() ?>, JSON.parse('<?= $imageFallback['image_fallback'] ?>'));

--- a/app/design/frontend/base/default/template/configurableswatches/catalog/product/list/price/js.phtml
+++ b/app/design/frontend/base/default/template/configurableswatches/catalog/product/list/price/js.phtml
@@ -12,6 +12,6 @@
  * @var Mage_ConfigurableSwatches_Block_Catalog_Product_List_Price $this
  */
 ?>
-<script type="text/javascript">
+<script>
     new ConfigurableSwatchPrices(<?= $this->getJsonConfig() ?>);
 </script>

--- a/app/design/frontend/base/default/template/configurableswatches/catalog/product/view/type/configurable/swatch-js.phtml
+++ b/app/design/frontend/base/default/template/configurableswatches/catalog/product/view/type/configurable/swatch-js.phtml
@@ -11,7 +11,7 @@
 /** @var Mage_Core_Block_Template $this */
 ?>
 <?php if ($this->getLayout()->getBlock('head')->getItems('skin_js/js/configurableswatches/swatches-product.js')): ?>
-    <script type="text/javascript">
+    <script>
         document.addEventListener('DOMContentLoaded', function() {
             new Product.ConfigurableSwatches(spConfig);
         });

--- a/app/design/frontend/base/default/template/contacts/form.phtml
+++ b/app/design/frontend/base/default/template/contacts/form.phtml
@@ -51,6 +51,6 @@
         <button type="submit" title="<?= $this->quoteEscape(Mage::helper('contacts')->__('Submit')) ?>" class="button"><?= Mage::helper('contacts')->__('Submit') ?></button>
     </div>
 </form>
-<script type="text/javascript">
+<script>
     var contactForm = new VarienForm('contactForm', true);
 </script>

--- a/app/design/frontend/base/default/template/customer/address/book.phtml
+++ b/app/design/frontend/base/default/template/customer/address/book.phtml
@@ -71,7 +71,7 @@
         </ol>
     </div>
 </div>
-<script type="text/javascript">
+<script>
     function deleteAddress(addressId) {
         if (confirm("<?= $this->jsQuoteEscape($this->__('Are you sure you want to delete this address?')) ?>")) {
             window.location = "<?= $this->getDeleteUrl() ?>id/" + addressId + "/";

--- a/app/design/frontend/base/default/template/customer/address/edit.phtml
+++ b/app/design/frontend/base/default/template/customer/address/edit.phtml
@@ -95,7 +95,7 @@
                         <select id="region_id" name="region_id" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="validate-select" style="display:none;">
                            <option value=""><?= $this->__('Please select region, state or province') ?></option>
                         </select>
-                        <script type="text/javascript">
+                        <script>
                             document.getElementById('region_id').defaultValue = "<?= $this->getAddress()->getRegionId() ?>";
                         </script>
                         <input type="text" id="region" name="region" value="<?= $this->escapeHtml($this->getAddress()->getRegion()) ?>"  title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('region') ?>" />
@@ -141,7 +141,7 @@
         <button type="submit" title="<?= $this->quoteEscape($this->__('Save Address')) ?>" class="button"><?= $this->__('Save Address') ?></button>
     </div>
 </form>
-<script type="text/javascript">
+<script>
     var dataForm = new VarienForm('form-validate', true);
     new RegionUpdater('country', 'region', 'region_id', <?= Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, 'zip');
 </script>

--- a/app/design/frontend/base/default/template/customer/form/confirmation.phtml
+++ b/app/design/frontend/base/default/template/customer/form/confirmation.phtml
@@ -34,6 +34,6 @@
         <button type="submit" title="<?= $this->quoteEscape($this->__('Submit')) ?>" class="button"><?= $this->__('Submit') ?></button>
     </div>
 </form>
-<script type="text/javascript">
+<script>
     var dataForm = new VarienForm('form-validate', true);
 </script>

--- a/app/design/frontend/base/default/template/customer/form/edit.phtml
+++ b/app/design/frontend/base/default/template/customer/form/edit.phtml
@@ -92,7 +92,7 @@
         <button type="submit" title="<?= $this->quoteEscape($this->__('Save')) ?>" class="button"><?= $this->__('Save') ?></button>
     </div>
 </form>
-<script type="text/javascript">
+<script>
     var dataForm = new VarienForm('form-validate', true);
     function setPasswordForm(arg) {
         const fieldset = document.querySelector('#password').closest('.fieldset');

--- a/app/design/frontend/base/default/template/customer/form/forgotpassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/forgotpassword.phtml
@@ -34,6 +34,6 @@
         </div>
     </form>
 </div>
-<script type="text/javascript">
+<script>
     var dataFormForgot = new VarienForm('form-validate-forgot', true);
 </script>

--- a/app/design/frontend/base/default/template/customer/form/login.phtml
+++ b/app/design/frontend/base/default/template/customer/form/login.phtml
@@ -93,7 +93,7 @@
         <?= $this->getChildHtml('forgotpassword_form') ?>
     </dialog>
 
-    <script type="text/javascript">
+    <script>
         var dataForm = new VarienForm('login-form', true);
 
         <?php if ($isMagicLinkEnabled && $magicLinkMode !== Mage_Customer_Model_Config_Registrationmode::MODE_NO_PASSWORD): ?>

--- a/app/design/frontend/base/default/template/customer/form/register.phtml
+++ b/app/design/frontend/base/default/template/customer/form/register.phtml
@@ -101,7 +101,7 @@
                         <select id="region_id_register" name="region_id" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="validate-select" style="display:none;">
                             <option value=""><?= $this->__('Please select region, state or province') ?></option>
                         </select>
-                        <script type="text/javascript">
+                        <script>
                             document.getElementById('region_id_register').setAttribute('defaultValue', "<?= $this->getFormData()->getRegionId() ?>");
                         </script>
                         <input type="text" id="region_register" name="region" value="<?= $this->escapeHtml($this->getRegion()) ?>" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('region') ?>" style="display:none;" />
@@ -172,7 +172,7 @@
         <input name="context" type="hidden" value="checkout" />
     <?php endif ?>
 </form>
-<script type="text/javascript">
+<script>
     var dataFormRegister = new VarienForm('form-validate-register', true);
     <?php if($this->getShowAddressFields()): ?>
     new RegionUpdater('country_register', 'region_register', 'region_id_register', <?= Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, 'zip_register');

--- a/app/design/frontend/base/default/template/customer/form/resetforgottenpassword.phtml
+++ b/app/design/frontend/base/default/template/customer/form/resetforgottenpassword.phtml
@@ -48,6 +48,6 @@
         <button type="submit" title="<?= $this->quoteEscape($this->__('Reset a Password')) ?>" class="button"><?= $this->__('Reset a Password') ?></button>
     </div>
 </form>
-<script type="text/javascript">
+<script>
     var dataForm = new VarienForm('form-validate', true);
 </script>

--- a/app/design/frontend/base/default/template/customer/logout.phtml
+++ b/app/design/frontend/base/default/template/customer/logout.phtml
@@ -15,7 +15,7 @@
     <h1><?= Mage::helper('customer')->__('You are now logged out') ?></h1>
 </div>
 <p><?= Mage::helper('customer')->__('You have logged out and will be redirected to our homepage in 5 seconds.') ?></p>
-<script type="text/javascript">
+<script>
     setTimeout(function() {
         location.href = '<?= $this->getUrl() ?>'
     }, 5000);

--- a/app/design/frontend/base/default/template/customer/widget/dob.phtml
+++ b/app/design/frontend/base/default/template/customer/widget/dob.phtml
@@ -66,6 +66,6 @@ NOTE: Regarding styles - if we leave it this way, we'll move it to boxes.css
 
     <div class="validation-advice" style="display:none;"></div>
 </div>
-<script type="text/javascript">
+<script>
     var customer_dob = new Varien.DOB('.customer-dob', <?= $this->isRequired() ? 'true' : 'false' ?>, '<?= $this->getDateFormat() ?>');
 </script>

--- a/app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
@@ -72,7 +72,7 @@ $_deleteUrl = $this->getDeleteUrlCustom(false);
             <?php $helpLinkId = 'cart-msrp-help-' . $_item->getId(); ?>
             <a id="<?= $helpLinkId ?>" href="#"
                class="map-help-link"><?= $this->__("What's this?") ?></a>
-            <script type="text/javascript">
+            <script>
                 Catalog.Map.addHelpLink('<?= $helpLinkId ?>', "<?= $this->jsQuoteEscape($this->__("What's this?")) ?>");
             </script>
         </span>

--- a/app/design/frontend/base/default/template/giftmessage/inline.phtml
+++ b/app/design/frontend/base/default/template/giftmessage/inline.phtml
@@ -12,7 +12,7 @@
 /** @var Mage_GiftMessage_Block_Message_Inline $this */
 ?>
 <?php if(!$this->getDontDisplayContainer()): ?>
-<script type="text/javascript">
+<script>
     if (!window.toogleVisibilityOnObjects) {
         var toogleVisibilityOnObjects = function(source, objects) {
             if (typeof source == 'string') {
@@ -182,7 +182,7 @@
                             </div>
                         </li>
                     </ul>
-                    <script type="text/javascript">
+                    <script>
                         toogleRequired('gift-message-whole-message', ['gift-message-whole-from','gift-message-whole-to']);
                     </script>
                 </div>
@@ -234,7 +234,7 @@
                                      </div>
                                  </li>
                              </ul>
-                             <script type="text/javascript">
+                             <script>
                                 toogleRequired('gift-message-<?= $_item->getId() ?>-message', ['gift-message-<?= $_item->getId() ?>-from','gift-message-<?= $_item->getId() ?>-to']);
                              </script>
                          </div>
@@ -246,7 +246,7 @@
              <?php endif ?>
         </div>
     </div>
-    <script type="text/javascript">
+    <script>
         toogleVisibilityOnObjects('allow_gift_messages', ['allow-gift-message-container']);
         toogleVisibilityOnObjects('allow_gift_messages_for_order', ['allow-gift-messages-for-order-container']);
         toogleVisibilityOnObjects('allow_gift_messages_for_items', ['allow-gift-messages-for-items-container']);

--- a/app/design/frontend/base/default/template/newsletter/subscribe.phtml
+++ b/app/design/frontend/base/default/template/newsletter/subscribe.phtml
@@ -25,7 +25,7 @@
             </div>
         </div>
     </form>
-    <script type="text/javascript">
+    <script>
         var newsletterSubscriberFormDetail = new VarienForm('newsletter-validate-detail');
     </script>
 </div>

--- a/app/design/frontend/base/default/template/page/html/cookienotice.phtml
+++ b/app/design/frontend/base/default/template/page/html/cookienotice.phtml
@@ -18,7 +18,7 @@
         <div class="actions"><button class="button" onclick="allowSaveCookie()"><?= $this->__('Allow') ?></button></div>
     </div>
 </div>
-<script type="text/javascript">
+<script>
     function allowSaveCookie() {
         Mage.Cookies.set('<?= Mage_Core_Helper_Cookie::IS_USER_ALLOWED_SAVE_COOKIE ?>', '<?= Mage::helper('core/cookie')->getAcceptedSaveCookiesWebsiteIds()?>', new Date(new Date().getTime() + <?= Mage::helper('core/cookie')->getCookieRestrictionLifetime() ?> * 1000));
         window.location.reload();

--- a/app/design/frontend/base/default/template/page/js/cookie.phtml
+++ b/app/design/frontend/base/default/template/page/js/cookie.phtml
@@ -17,7 +17,7 @@
  */
 ?>
 
-<script type="text/javascript">
+<script>
     Mage.Cookies.path   = '<?= $this->jsQuoteEscape($this->getPath()) ?>';
     Mage.Cookies.domain = '<?= $this->jsQuoteEscape($this->getDomain()) ?>';
 </script>

--- a/app/design/frontend/base/default/template/paygate/form/cc.phtml
+++ b/app/design/frontend/base/default/template/paygate/form/cc.phtml
@@ -27,7 +27,7 @@
         </div>
         <?= $this->showNoticeMessage($this->__('Please enter another credit card number to complete your purchase.')) ?>
 
-        <script type="text/javascript">
+        <script>
             var cancelButtonId = 'payment-button-cancel';
             var cancelButton = document.getElementById(cancelButtonId);
             cancelButton.onclick = null;

--- a/app/design/frontend/base/default/template/payment/form/cc.phtml
+++ b/app/design/frontend/base/default/template/payment/form/cc.phtml
@@ -106,7 +106,7 @@
             </li>
             <li class="adv-container">&nbsp;</li>
         </ul>
-        <script type="text/javascript">
+        <script>
             var SSChecked<?= $_code ?> = function() {
                 var elm = document.getElementById('<?= $_code ?>_cc_type');
                 var ssDiv = document.getElementById('<?= $_code ?>_cc_type_ss_div');

--- a/app/design/frontend/base/default/template/paypal/express/minicart/shortcut.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/minicart/shortcut.phtml
@@ -24,7 +24,7 @@
     <?php if ($this->getIsInCatalogProduct()): ?>
         <input type="hidden" id="pp_checkout_url" name="return_url" value="" />
     <?php endif ?>
-    <script type="text/javascript">
+    <script>
         document.getElementById('<?= $shortcutHtmlId ?>').addEventListener('click', function(event) {
             <?php if ($this->getConfirmationUrl()): ?>
             if (confirm('<?= $this->jsQuoteEscape($this->getConfirmationMessage()) ?>')) {

--- a/app/design/frontend/base/default/template/paypal/express/product/shortcut.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/product/shortcut.phtml
@@ -22,7 +22,7 @@
     <?php if ($this->getIsInCatalogProduct()): ?>
         <input type="hidden" id="pp_checkout_url" name="return_url" value="" />
     <?php endif ?>
-    <script type="text/javascript">
+    <script>
         document.getElementById('<?= $shortcutHtmlId ?>').addEventListener('click', function(event) {
             <?php if ($this->getConfirmationUrl()): ?>
             if (confirm('<?= $this->jsQuoteEscape($this->getConfirmationMessage()) ?>')) {

--- a/app/design/frontend/base/default/template/paypal/express/review.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review.phtml
@@ -97,7 +97,7 @@
         </span>
     </div>
 </form>
-<script type="text/javascript">
+<script>
     // submit buttons are not needed when submitting with ajax
     document.getElementById('review_submit').style.display = 'none';
     const shippingMethodSubmit = document.getElementById('update_shipping_method_submit');

--- a/app/design/frontend/base/default/template/paypal/express/review/address.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/review/address.phtml
@@ -76,7 +76,7 @@
                             <select id="<?= $prefix ?>:region_id" name="<?= $prefix ?>[region_id]" title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="validate-select" style="display:none;">
                                 <option value=""><?= $this->__('Please select region, state or province') ?></option>
                             </select>
-                            <script type="text/javascript">
+                            <script>
                                 document.getElementById('<?= $prefix ?>:region_id').setAttribute('defaultValue', "<?= $this->getAddress()->getRegionId() ?>");
                             </script>
                             <input type="text" id="<?= $prefix ?>:region" name="<?= $prefix ?>[region]" value="<?= $this->escapeHtml($this->getAddress()->getRegion()) ?>"  title="<?= $this->quoteEscape($this->__('State/Province')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('region') ?>" style="display:none;" />
@@ -127,12 +127,12 @@
      </li>
     </ul>
 </div>
-<script type="text/javascript">
+<script>
     var <?= $prefix ?>RegionUpdater = new RegionUpdater('<?= $prefix ?>:country_id', '<?= $prefix ?>:region', '<?= $prefix ?>:region_id', <?= Mage::helper('directory')->getRegionJsonByStore() ?>, undefined, '<?= $prefix ?>:postcode');
     <?= $prefix ?>RegionUpdater.update();
 </script>
 <?php if ($this->getShowAsShippingCheckbox()): ?>
-<script type="text/javascript">
+<script>
     OrderReviewController.prototype._copyShippingToBilling_parent = OrderReviewController.prototype._copyShippingToBilling;
     OrderReviewController.prototype._copyShippingToBilling = function (event) {
         this._copyShippingToBilling_parent(event);

--- a/app/design/frontend/base/default/template/paypal/express/shortcut.phtml
+++ b/app/design/frontend/base/default/template/paypal/express/shortcut.phtml
@@ -29,7 +29,7 @@
 <?php if ($this->getIsInCatalogProduct()): ?>
     <input type="hidden" id="pp_checkout_url" name="return_url" value="" />
 <?php endif ?>
-<script type="text/javascript">
+<script>
     document.getElementById('<?= $shortcutHtmlId ?>').addEventListener('click', function(event) {
         <?php if ($this->getConfirmationUrl()): ?>
         if (confirm('<?= $this->jsQuoteEscape($this->getConfirmationMessage()) ?>')) {

--- a/app/design/frontend/base/default/template/paypal/hss/form.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/form.phtml
@@ -22,7 +22,7 @@
         <input type="hidden" name="SECURETOKENID" value="<?= $this->getSecureTokenId() ?>" />
         <input type="hidden" name="MODE" value="<?= $this->isTestMode() ? 'TEST' : 'LIVE' ?>" />
     </form>
-    <script type="text/javascript">
+    <script>
         document.getElementById('token_form').submit();
     </script>
 </body>

--- a/app/design/frontend/base/default/template/paypal/hss/iframe.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/iframe.phtml
@@ -15,7 +15,7 @@
     <?= $this->__('Please do not refresh the page until you complete payment.') ?>
 </div>
 <iframe id="hss-iframe" style="display:none;" scrolling="no" frameborder="0" border="0" src="<?= $this->getFrameActionUrl() ?>" height="610" width="100%"></iframe>
-<script type="text/javascript">
+<script>
     const headers = document.querySelectorAll('#' + checkout.accordion.container.getAttribute('id') + ' .section');
     headers.forEach(header => {
         header.classList.remove('allow');

--- a/app/design/frontend/base/default/template/paypal/hss/js.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/js.phtml
@@ -12,7 +12,7 @@
 /** @var Mage_Paypal_Block_Iframe $this */
 ?>
 <div id="checkout-paypaliframe-load" class="authentication"></div>
-<script type="text/javascript">
+<script>
     Review.prototype.save = function() {
         if (checkout.loadWaiting !== false) return;
         checkout.setLoadWaiting('review');

--- a/app/design/frontend/base/default/template/paypal/hss/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/hss/redirect.phtml
@@ -16,7 +16,7 @@
 ?>
 <html>
 <head>
-    <script type="text/javascript">
+    <script>
         if (window.top == window.self) {
             window.location = "<?= $this->getUrl('checkout/cart') ?>";
         }

--- a/app/design/frontend/base/default/template/paypal/payflowadvanced/iframe.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowadvanced/iframe.phtml
@@ -16,7 +16,7 @@
 </div>
 <iframe id="payflow-advanced-iframe" style="display:none;" scrolling="no" frameborder="0"
         src="<?= $this->getFrameActionUrl() ?>" height="610" width="100%"></iframe>
-<script type="text/javascript">
+<script>
     const headers = document.querySelectorAll('#' + document.getElementById(checkout.accordion.container.getAttribute('id')) + ' .section');
     headers.forEach(header => {
         header.classList.remove('allow');

--- a/app/design/frontend/base/default/template/paypal/payflowadvanced/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowadvanced/redirect.phtml
@@ -15,7 +15,7 @@
 ?>
 <html>
 <head>
-    <script type="text/javascript">
+    <script>
         if (window.top == window.self) {
             window.location = "<?= $this->getUrl('checkout/cart') ?>";
         }

--- a/app/design/frontend/base/default/template/paypal/payflowlink/iframe.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowlink/iframe.phtml
@@ -15,7 +15,7 @@
 </div>
 <iframe id="payflow-link-iframe" style="display:none;" scrolling="no" frameborder="0" border="0"
         src="<?= $this->getFrameActionUrl() ?>" height="610" width="100%"></iframe>
-<script type="text/javascript">
+<script>
     const headers = document.querySelectorAll('#' + checkout.accordion.container.getAttribute('id') + ' .section');
     headers.forEach(header => {
         header.classList.remove('allow');

--- a/app/design/frontend/base/default/template/paypal/payflowlink/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/payflowlink/redirect.phtml
@@ -15,7 +15,7 @@
 ?>
 <html>
 <head>
-    <script type="text/javascript">
+    <script>
         if (window.top == window.self) {
             window.location = "<?= $this->getUrl('checkout/cart') ?>";
         }

--- a/app/design/frontend/base/default/template/sales/guest/form.phtml
+++ b/app/design/frontend/base/default/template/sales/guest/form.phtml
@@ -77,7 +77,7 @@
     </div>
 </form>
 
-<script type="text/javascript">
+<script>
     if (document.getElementById('quick_search_type_id').value === 'zip') {
         document.getElementById('oar-zip').style.display = 'block';
         document.getElementById('oar-email').style.display = 'none';

--- a/app/design/frontend/base/default/template/sales/order/creditmemo.phtml
+++ b/app/design/frontend/base/default/template/sales/order/creditmemo.phtml
@@ -13,7 +13,7 @@
 ?>
 <div class="order-items order-details">
 <?php if($this->canDisplayGiftmessage()): ?>
-    <script type="text/javascript">
+    <script>
         function giftMessageToogle(giftMessageIdentifier) {
             const link = document.getElementById('order-item-gift-message-link-' + giftMessageIdentifier);
             const container = document.getElementById('order-item-gift-message-' + giftMessageIdentifier);

--- a/app/design/frontend/base/default/template/sales/order/invoice.phtml
+++ b/app/design/frontend/base/default/template/sales/order/invoice.phtml
@@ -13,7 +13,7 @@
 ?>
 <div class="order-items order-details">
 <?php if($this->canDisplayGiftmessage()): ?>
-    <script type="text/javascript">
+    <script>
         function giftMessageToogle(giftMessageIdentifier) {
             const link = document.getElementById('order-item-gift-message-link-' + giftMessageIdentifier);
             const container = document.getElementById('order-item-gift-message-' + giftMessageIdentifier);

--- a/app/design/frontend/base/default/template/sales/order/print.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print.phtml
@@ -68,4 +68,4 @@
     </tbody>
         <?php endforeach ?>
 </table>
-<script type="text/javascript">window.print();</script>
+<script>window.print();</script>

--- a/app/design/frontend/base/default/template/sales/order/print/creditmemo.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print/creditmemo.phtml
@@ -81,4 +81,4 @@
     <?php endforeach ?>
 </table>
 <?php endforeach ?>
-<script type="text/javascript">window.print();</script>
+<script>window.print();</script>

--- a/app/design/frontend/base/default/template/sales/order/print/invoice.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print/invoice.phtml
@@ -77,4 +77,4 @@
         <?php endforeach ?>
     </table>
 <?php endforeach ?>
-<script type="text/javascript">window.print();</script>
+<script>window.print();</script>

--- a/app/design/frontend/base/default/template/sales/order/print/shipment.phtml
+++ b/app/design/frontend/base/default/template/sales/order/print/shipment.phtml
@@ -77,4 +77,4 @@
     </table>
 <?php endforeach ?>
 <?php endif ?>
-<script type="text/javascript">window.print();</script>
+<script>window.print();</script>

--- a/app/design/frontend/base/default/template/sales/order/shipment.phtml
+++ b/app/design/frontend/base/default/template/sales/order/shipment.phtml
@@ -13,7 +13,7 @@
 ?>
 <div class="order-items order-details">
 <?php if($this->canDisplayGiftmessage()): ?>
-    <script type="text/javascript">
+    <script>
         function giftMessageToogle(giftMessageIdentifier) {
             const link = document.getElementById('order-item-gift-message-link-' + giftMessageIdentifier);
             const container = document.getElementById('order-item-gift-message-' + giftMessageIdentifier);

--- a/app/design/frontend/base/default/template/sales/widget/guest/form.phtml
+++ b/app/design/frontend/base/default/template/sales/widget/guest/form.phtml
@@ -62,7 +62,7 @@
             </div>
         </div>
     </div>
-    <script type="text/javascript">
+    <script>
         if (document.getElementById('quick_search_type_id').value === 'zip') {
             document.getElementById('oar-zip').style.display = 'block';
             document.getElementById('oar-email').style.display = 'none';

--- a/app/design/frontend/base/default/template/tag/list.phtml
+++ b/app/design/frontend/base/default/template/tag/list.phtml
@@ -35,7 +35,7 @@
             </div>
         </form>
         <p class="note"><?= $this->__("Use spaces to separate tags. Use single quotes (') for phrases.") ?></p>
-        <script type="text/javascript">
+        <script>
             var addTagFormJs = new VarienForm('addTagForm');
             function submitTagForm() {
                 if (addTagFormJs.validator.validate()) {

--- a/app/design/frontend/base/default/template/wishlist/item/list.phtml
+++ b/app/design/frontend/base/default/template/wishlist/item/list.phtml
@@ -51,7 +51,7 @@
 <?php foreach ($columns as $column): ?>
     <?= $column->getAdditionalHtml() ?>
 <?php endforeach ?>
-<script type="text/javascript">
+<script>
 <?php foreach ($columns as $column): ?>
     <?= $column->getJs() ?>
 <?php endforeach ?>

--- a/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_item.phtml
+++ b/app/design/frontend/base/default/template/wishlist/render/item/price_msrp_item.phtml
@@ -39,7 +39,7 @@
             <span id="<?= $priceElementId ?>" style="display:none"></span>
             <?php $popupId = 'msrp-popup-' . $_id . $_coreHelper->getRandomString(20); ?>
             <a href="#" id="<?php echo($popupId);?>"><?= $this->__('Click for price') ?></a>
-            <script type="text/javascript">
+            <script>
                 window.addEventListener('load', function() {
                     const priceElement = document.getElementById("<?= $priceElementId ?>");
                     const realPrice = <?= $this->getRealPriceJs($_product) ?>;
@@ -88,7 +88,7 @@
 
         <?php $helpLinkId = 'msrp-help-' . $_id . $_coreHelper->getRandomString(20); ?>
         <a href="#" id="<?php echo($helpLinkId);?>"><?= $this->__("What's this?") ?></a>
-        <script type="text/javascript">
+        <script>
             Catalog.Map.addHelpLink(
                 '<?= $helpLinkId ?>',
                 '<?= $this->jsQuoteEscape($this->__("What's this?")) ?>'

--- a/app/design/frontend/base/default/template/wishlist/sharing.phtml
+++ b/app/design/frontend/base/default/template/wishlist/sharing.phtml
@@ -49,7 +49,7 @@
         <button type="submit" title="<?= $this->quoteEscape($this->__('Share Wishlist')) ?>" class="button"><?= $this->__('Share Wishlist') ?></button>
     </div>
 </form>
-<script type="text/javascript">
+<script>
     Validation.add('validate-emails',
         '<?= $this->jsQuoteEscape($this->__('Please enter a valid email addresses, separated by commas. For example johndoe@domain.com, johnsmith@domain.com.')) ?>',
         function (v) {

--- a/app/design/frontend/base/default/template/wishlist/view.phtml
+++ b/app/design/frontend/base/default/template/wishlist/view.phtml
@@ -44,7 +44,7 @@
             </div>
         </form>
 
-        <script type="text/javascript">
+        <script>
             const wishlistForm = new Validation(document.getElementById('wishlist-view-form'));
             const wishlistAllCartForm = new Validation(document.getElementById('wishlist-allcart-form'));
 

--- a/lib/Maho/Data/Form/Element/Gallery.php
+++ b/lib/Maho/Data/Form/Element/Gallery.php
@@ -72,7 +72,7 @@ class Gallery extends AbstractElement
             }
         }
         if ($i == 0) {
-            $html .= '<script type="text/javascript">document.getElementById("gallery_thead").style.visibility="hidden";</script>';
+            $html .= '<script>document.getElementById("gallery_thead").style.visibility="hidden";</script>';
         }
 
         $html .= '</tbody></table>';

--- a/lib/Maho/Data/Form/Element/Multiselect.php
+++ b/lib/Maho/Data/Form/Element/Multiselect.php
@@ -116,7 +116,7 @@ class Multiselect extends AbstractElement
 
         $result .= ($this->getNoSpan() === true) ? '' : '</span>' . "\n";
 
-        $result .= '<script type="text/javascript">' . "\n";
+        $result .= '<script>' . "\n";
         $result .= '   var ' . $this->getJsObjectName() . ' = {' . "\n";
         $result .= '     selectAll: function() { ' . "\n";
         $result .= '         var sel = document.getElementById("' . $this->getHtmlId() . '");' . "\n";


### PR DESCRIPTION
## Summary
- Removed all `type="text/javascript"` and `type='text/javascript'` attributes from `<script>` tags across 263 files (templates, blocks, helpers)
- Since HTML5, `text/javascript` is the default MIME type for `<script>` tags, making the attribute redundant and producing W3C validation warnings
- No behavioral change — purely cosmetic HTML cleanup

Closes #819

## Test plan
- [ ] Verify admin panel pages load correctly with inline and external scripts functioning
- [ ] Verify frontend pages load correctly (product pages, checkout, customer account)
- [ ] Run W3C HTML validator on sample pages to confirm warnings are resolved