### PR TITLE
Changed default observer instantiation from `singleton` to `model`

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Compare/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Compare/Item.php
@@ -161,7 +161,7 @@ class Mage_Catalog_Model_Product_Compare_Item extends Mage_Core_Model_Abstract
      *
      * @return $this
      */
-    #[Maho\Config\Observer('customer_login', area: 'frontend', type: 'model')]
+    #[Maho\Config\Observer('customer_login', area: 'frontend')]
     public function bindCustomerLogin()
     {
         $this->_getResource()->updateCustomerFromVisitor($this);
@@ -175,7 +175,7 @@ class Mage_Catalog_Model_Product_Compare_Item extends Mage_Core_Model_Abstract
      *
      * @return $this
      */
-    #[Maho\Config\Observer('customer_logout', area: 'frontend', type: 'model')]
+    #[Maho\Config\Observer('customer_logout', area: 'frontend')]
     public function bindCustomerLogout(?\Maho\Event\Observer $observer = null)
     {
         $this->_getResource()->purgeVisitorByCustomer($this);

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Observer.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Observer.php
@@ -17,7 +17,7 @@ class Mage_Catalog_Model_Product_Option_Observer
      * @param \Maho\DataObject $observer
      * @return $this
      */
-    #[Maho\Config\Observer('sales_convert_quote_item_to_order_item', area: 'frontend', type: 'model')]
+    #[Maho\Config\Observer('sales_convert_quote_item_to_order_item', area: 'frontend')]
     public function copyQuoteFilesToOrderFiles($observer)
     {
         /** @var Mage_Sales_Model_Quote_Item $quoteItem */

--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -41,7 +41,7 @@ class Mage_CatalogInventory_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_product_load_after')]
+    #[Maho\Config\Observer('catalog_product_load_after', type: 'singleton')]
     public function addInventoryData($observer)
     {
         $product = $observer->getEvent()->getProduct();
@@ -62,7 +62,7 @@ class Mage_CatalogInventory_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_product_clear')]
+    #[Maho\Config\Observer('catalog_product_clear', type: 'singleton')]
     public function removeInventoryData($observer)
     {
         $product = $observer->getEvent()->getProduct();
@@ -82,7 +82,7 @@ class Mage_CatalogInventory_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_product_collection_load_after')]
+    #[Maho\Config\Observer('catalog_product_collection_load_after', type: 'singleton')]
     public function addStockStatusToCollection($observer)
     {
         /** @var Mage_Catalog_Model_Resource_Product_Collection $productCollection */
@@ -104,7 +104,7 @@ class Mage_CatalogInventory_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('sales_quote_item_collection_products_after_load')]
+    #[Maho\Config\Observer('sales_quote_item_collection_products_after_load', type: 'singleton')]
     public function addInventoryDataToCollection($observer)
     {
         $productCollection = $observer->getEvent()->getProductCollection();
@@ -118,7 +118,7 @@ class Mage_CatalogInventory_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_product_save_after')]
+    #[Maho\Config\Observer('catalog_product_save_after', type: 'singleton')]
     public function saveInventoryData($observer)
     {
         /** @var Mage_Catalog_Model_Product $product */
@@ -147,7 +147,7 @@ class Mage_CatalogInventory_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_model_product_duplicate')]
+    #[Maho\Config\Observer('catalog_model_product_duplicate', type: 'singleton')]
     public function copyInventoryData($observer)
     {
         /** @var Mage_Catalog_Model_Product $currentProduct */
@@ -290,7 +290,7 @@ class Mage_CatalogInventory_Model_Observer
      * @return $this
      * @throws Mage_Core_Exception
      */
-    #[Maho\Config\Observer('sales_quote_item_qty_set_after')]
+    #[Maho\Config\Observer('sales_quote_item_qty_set_after', type: 'singleton')]
     public function checkQuoteItemQty($observer)
     {
         /** @var Mage_Sales_Model_Quote_Item $quoteItem */
@@ -575,7 +575,7 @@ class Mage_CatalogInventory_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('checkout_submit_all_after')]
+    #[Maho\Config\Observer('checkout_submit_all_after', type: 'singleton')]
     public function checkoutAllSubmitAfter(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Sales_Model_Quote $quote */
@@ -595,7 +595,7 @@ class Mage_CatalogInventory_Model_Observer
      *
      * @return Mage_CatalogInventory_Model_Observer|void
      */
-    #[Maho\Config\Observer('sales_model_service_quote_submit_before')]
+    #[Maho\Config\Observer('sales_model_service_quote_submit_before', type: 'singleton')]
     public function subtractQuoteInventory(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Sales_Model_Quote $quote */
@@ -621,7 +621,7 @@ class Mage_CatalogInventory_Model_Observer
      * Revert quote items inventory data (cover not success order place case)
      * @param \Maho\Event\Observer $observer
      */
-    #[Maho\Config\Observer('sales_model_service_quote_submit_failure')]
+    #[Maho\Config\Observer('sales_model_service_quote_submit_failure', type: 'singleton')]
     public function revertQuoteInventory($observer)
     {
         /** @var Mage_Sales_Model_Quote $quote */
@@ -704,7 +704,7 @@ class Mage_CatalogInventory_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return $this
      */
-    #[Maho\Config\Observer('sales_model_service_quote_submit_success')]
+    #[Maho\Config\Observer('sales_model_service_quote_submit_success', type: 'singleton')]
     public function reindexQuoteInventory($observer)
     {
         // Reindex quote ids
@@ -760,7 +760,7 @@ class Mage_CatalogInventory_Model_Observer
      *
      * @param \Maho\Event\Observer $observer
      */
-    #[Maho\Config\Observer('sales_order_creditmemo_save_after')]
+    #[Maho\Config\Observer('sales_order_creditmemo_save_after', type: 'singleton')]
     public function refundOrderInventory($observer)
     {
         /** @var Mage_Sales_Model_Order_Creditmemo $creditmemo */
@@ -800,7 +800,7 @@ class Mage_CatalogInventory_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('sales_order_item_cancel')]
+    #[Maho\Config\Observer('sales_order_item_cancel', type: 'singleton')]
     public function cancelOrderItem($observer)
     {
         /** @var Mage_Sales_Model_Order_Item $item */
@@ -823,7 +823,7 @@ class Mage_CatalogInventory_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('admin_system_config_changed_section_cataloginventory')]
+    #[Maho\Config\Observer('admin_system_config_changed_section_cataloginventory', type: 'singleton')]
     public function updateItemsStockUponConfigChange($observer)
     {
         Mage::getResourceSingleton('cataloginventory/stock')->updateSetOutOfStock();
@@ -886,9 +886,9 @@ class Mage_CatalogInventory_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_product_prepare_index_select')]
-    #[Maho\Config\Observer('prepare_catalog_product_index_select')]
-    #[Maho\Config\Observer('prepare_product_children_id_list_select')]
+    #[Maho\Config\Observer('catalog_product_prepare_index_select', type: 'singleton')]
+    #[Maho\Config\Observer('prepare_catalog_product_index_select', type: 'singleton')]
+    #[Maho\Config\Observer('prepare_product_children_id_list_select', type: 'singleton')]
     public function prepareCatalogProductIndexSelect(\Maho\Event\Observer $observer)
     {
         $select     = $observer->getEvent()->getSelect();
@@ -935,9 +935,9 @@ class Mage_CatalogInventory_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @throws Exception
      */
-    #[Maho\Config\Observer('end_index_events_cataloginventory_stock_item_save')]
-    #[Maho\Config\Observer('end_process_event_cataloginventory_stock_item_save')]
-    #[Maho\Config\Observer('after_reindex_process_cataloginventory_stock', area: 'adminhtml')]
+    #[Maho\Config\Observer('end_index_events_cataloginventory_stock_item_save', type: 'singleton')]
+    #[Maho\Config\Observer('end_process_event_cataloginventory_stock_item_save', type: 'singleton')]
+    #[Maho\Config\Observer('after_reindex_process_cataloginventory_stock', area: 'adminhtml', type: 'singleton')]
     public function reindexProductsMassAction($observer): void
     {
         Mage::getSingleton('index/indexer')->indexEvents(
@@ -952,7 +952,7 @@ class Mage_CatalogInventory_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_block_product_status_display')]
+    #[Maho\Config\Observer('catalog_block_product_status_display', type: 'singleton')]
     public function displayProductStatusInfo($observer)
     {
         $info = $observer->getEvent()->getStatus();

--- a/app/code/core/Mage/CatalogRule/Model/Observer.php
+++ b/app/code/core/Mage/CatalogRule/Model/Observer.php
@@ -33,7 +33,7 @@ class Mage_CatalogRule_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_product_save_commit_after', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_product_save_commit_after', area: 'adminhtml', type: 'singleton')]
     public function applyAllRulesOnProduct($observer)
     {
         /** @var Mage_Catalog_Model_Product $product */
@@ -54,7 +54,7 @@ class Mage_CatalogRule_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_product_save_before', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_product_save_before', area: 'adminhtml', type: 'singleton')]
     public function loadProductRules($observer)
     {
         /** @var Mage_Catalog_Model_Product $product */
@@ -74,7 +74,7 @@ class Mage_CatalogRule_Model_Observer
      *
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_product_import_after', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_product_import_after', area: 'adminhtml', type: 'singleton')]
     public function applyAllRules($observer)
     {
         /** @var Mage_CatalogRule_Model_Resource_Rule $resource */
@@ -92,7 +92,7 @@ class Mage_CatalogRule_Model_Observer
      *
      * @return  $this
      */
-    #[Maho\Config\Observer('sales_quote_collect_totals_before', area: 'frontend', id: 'preload_price_rules')]
+    #[Maho\Config\Observer('sales_quote_collect_totals_before', area: 'frontend', type: 'singleton', id: 'preload_price_rules')]
     public function preloadPriceRules(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Sales_Model_Quote $quote */
@@ -128,7 +128,7 @@ class Mage_CatalogRule_Model_Observer
      *
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_product_get_final_price', area: 'frontend')]
+    #[Maho\Config\Observer('catalog_product_get_final_price', area: 'frontend', type: 'singleton')]
     public function processFrontFinalPrice($observer)
     {
         /** @var Mage_Catalog_Model_Product $product */
@@ -176,8 +176,8 @@ class Mage_CatalogRule_Model_Observer
      *
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_product_get_final_price', area: 'adminhtml')]
-    #[Maho\Config\Observer('catalog_product_get_final_price', area: 'crontab')]
+    #[Maho\Config\Observer('catalog_product_get_final_price', area: 'adminhtml', type: 'singleton')]
+    #[Maho\Config\Observer('catalog_product_get_final_price', area: 'crontab', type: 'singleton')]
     public function processAdminFinalPrice($observer)
     {
         /** @var Mage_Catalog_Model_Product $product */
@@ -219,7 +219,7 @@ class Mage_CatalogRule_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_product_type_configurable_price')]
+    #[Maho\Config\Observer('catalog_product_type_configurable_price', type: 'singleton')]
     public function catalogProductTypeConfigurablePrice(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Product $product */
@@ -270,7 +270,7 @@ class Mage_CatalogRule_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('prepare_catalog_product_price_index_table')]
+    #[Maho\Config\Observer('prepare_catalog_product_price_index_table', type: 'singleton')]
     public function prepareCatalogProductPriceIndexTable(\Maho\Event\Observer $observer)
     {
         $select             = $observer->getEvent()->getSelect();
@@ -359,7 +359,7 @@ class Mage_CatalogRule_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_entity_attribute_save_after', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_entity_attribute_save_after', area: 'adminhtml', type: 'singleton')]
     public function catalogAttributeSaveAfter(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Entity_Attribute $attribute */
@@ -376,7 +376,7 @@ class Mage_CatalogRule_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_entity_attribute_delete_after', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_entity_attribute_delete_after', area: 'adminhtml', type: 'singleton')]
     public function catalogAttributeDeleteAfter(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Entity_Attribute $attribute */
@@ -392,7 +392,7 @@ class Mage_CatalogRule_Model_Observer
      * @return $this
      * @throws Mage_Core_Model_Store_Exception
      */
-    #[Maho\Config\Observer('prepare_catalog_product_collection_prices', area: 'frontend')]
+    #[Maho\Config\Observer('prepare_catalog_product_collection_prices', area: 'frontend', type: 'singleton')]
     public function prepareCatalogProductCollectionPrices(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Resource_Product_Collection $collection */
@@ -440,7 +440,7 @@ class Mage_CatalogRule_Model_Observer
     /**
      * Create catalog rule relations for imported products
      */
-    #[Maho\Config\Observer('catalog_product_import_finish_before', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_product_import_finish_before', area: 'adminhtml', type: 'singleton')]
     public function createCatalogRulesRelations(\Maho\Event\Observer $observer)
     {
         /** @var Mage_ImportExport_Model_Import_Entity_Product $adapter */

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -1403,15 +1403,14 @@ class Mage_Core_Model_App
                 switch ($obs['type']) {
                     case 'disabled':
                         break;
-                    case 'object':
-                    case 'model':
+                    case 'singleton':
                         $method = $obs['method'];
-                        $object = Mage::getModel($obs['model']);
+                        $object = Mage::getSingleton($obs['model']);
                         $this->_callObserverMethod($object, $method, $observer, $obsName);
                         break;
                     default:
                         $method = $obs['method'];
-                        $object = Mage::getSingleton($obs['model']);
+                        $object = Mage::getModel($obs['model']);
                         $this->_callObserverMethod($object, $method, $observer, $obsName);
                         break;
                 }

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1214,11 +1214,10 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
                         Mage::getSingleton((string) $observer->class),
                         (string) $observer->method,
                     ],
-                    'object', 'model' => [
+                    default => [
                         Mage::getModel((string) $observer->class),
                         (string) $observer->method,
                     ],
-                    default => [$observer->getClassName(), (string) $observer->method],
                 };
 
                 $args = (array) $observer->args;

--- a/app/code/core/Mage/GiftMessage/Model/Observer.php
+++ b/app/code/core/Mage/GiftMessage/Model/Observer.php
@@ -17,8 +17,8 @@ class Mage_GiftMessage_Model_Observer extends \Maho\DataObject
      *
      * @return $this
      */
-    #[Maho\Config\Observer('sales_convert_quote_item_to_order_item', area: 'adminhtml', type: 'model')]
-    #[Maho\Config\Observer('sales_convert_quote_item_to_order_item', area: 'frontend', type: 'model')]
+    #[Maho\Config\Observer('sales_convert_quote_item_to_order_item', area: 'adminhtml')]
+    #[Maho\Config\Observer('sales_convert_quote_item_to_order_item', area: 'frontend')]
     public function salesEventConvertQuoteItemToOrderItem(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Sales_Model_Order_Item $orderItem */
@@ -42,8 +42,8 @@ class Mage_GiftMessage_Model_Observer extends \Maho\DataObject
      *
      * @return $this
      */
-    #[Maho\Config\Observer('sales_convert_quote_address_to_order', area: 'adminhtml', type: 'model')]
-    #[Maho\Config\Observer('sales_convert_quote_address_to_order', area: 'frontend', type: 'model')]
+    #[Maho\Config\Observer('sales_convert_quote_address_to_order', area: 'adminhtml')]
+    #[Maho\Config\Observer('sales_convert_quote_address_to_order', area: 'frontend')]
     public function salesEventConvertQuoteAddressToOrder(\Maho\Event\Observer $observer)
     {
         if ($observer->getEvent()->getAddress()->getGiftMessageId()) {
@@ -58,8 +58,8 @@ class Mage_GiftMessage_Model_Observer extends \Maho\DataObject
      *
      * @return $this
      */
-    #[Maho\Config\Observer('sales_convert_quote_to_order', area: 'adminhtml', type: 'model')]
-    #[Maho\Config\Observer('sales_convert_quote_to_order', area: 'frontend', type: 'model')]
+    #[Maho\Config\Observer('sales_convert_quote_to_order', area: 'adminhtml')]
+    #[Maho\Config\Observer('sales_convert_quote_to_order', area: 'frontend')]
     public function salesEventConvertQuoteToOrder(\Maho\Event\Observer $observer)
     {
         $observer->getEvent()->getOrder()
@@ -72,7 +72,7 @@ class Mage_GiftMessage_Model_Observer extends \Maho\DataObject
      *
      * @return $this
      */
-    #[Maho\Config\Observer('checkout_controller_onepage_save_shipping_method', area: 'frontend', type: 'model')]
+    #[Maho\Config\Observer('checkout_controller_onepage_save_shipping_method', area: 'frontend')]
     public function checkoutEventCreateGiftMessage(\Maho\Event\Observer $observer)
     {
         $giftMessages = $observer->getEvent()->getRequest()->getParam('giftmessage');
@@ -133,8 +133,8 @@ class Mage_GiftMessage_Model_Observer extends \Maho\DataObject
      *
      * @return $this
      */
-    #[Maho\Config\Observer('sales_convert_order_to_quote', area: 'adminhtml', type: 'model')]
-    #[Maho\Config\Observer('sales_convert_order_to_quote', area: 'frontend', type: 'model')]
+    #[Maho\Config\Observer('sales_convert_order_to_quote', area: 'adminhtml')]
+    #[Maho\Config\Observer('sales_convert_order_to_quote', area: 'frontend')]
     public function salesEventOrderToQuote(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Sales_Model_Order $order */
@@ -163,7 +163,7 @@ class Mage_GiftMessage_Model_Observer extends \Maho\DataObject
      *
      * @return $this
      */
-    #[Maho\Config\Observer('sales_convert_order_item_to_quote_item', area: 'adminhtml', type: 'model')]
+    #[Maho\Config\Observer('sales_convert_order_item_to_quote_item', area: 'adminhtml')]
     public function salesEventOrderItemToQuoteItem(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Sales_Model_Order_Item $orderItem */

--- a/app/code/core/Mage/Review/Model/Observer.php
+++ b/app/code/core/Mage/Review/Model/Observer.php
@@ -17,7 +17,7 @@ class Mage_Review_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('tag_tag_product_collection_load_after', area: 'frontend', type: 'model')]
+    #[Maho\Config\Observer('tag_tag_product_collection_load_after', area: 'frontend')]
     public function tagProductCollectionLoadAfter(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Tag_Model_Resource_Product_Collection $collection */
@@ -50,7 +50,7 @@ class Mage_Review_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_block_product_list_collection', area: 'frontend', type: 'model')]
+    #[Maho\Config\Observer('catalog_block_product_list_collection', area: 'frontend')]
     public function catalogBlockProductCollectionBeforeToHtml(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Resource_Product_Collection $productCollection */

--- a/app/code/core/Mage/Tag/Model/Tag.php
+++ b/app/code/core/Mage/Tag/Model/Tag.php
@@ -191,8 +191,8 @@ class Mage_Tag_Model_Tag extends Mage_Core_Model_Abstract
      * @param \Maho\Event\Observer $observer
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_controller_product_save_visibility_changed', area: 'adminhtml', type: 'model')]
-    #[Maho\Config\Observer('catalog_controller_product_delete', area: 'adminhtml', type: 'model')]
+    #[Maho\Config\Observer('catalog_controller_product_save_visibility_changed', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_controller_product_delete', area: 'adminhtml')]
     public function productEventAggregate($observer)
     {
         $this->_getProductEventTagsCollection($observer)->walk('aggregate');
@@ -205,7 +205,7 @@ class Mage_Tag_Model_Tag extends Mage_Core_Model_Abstract
      * @param \Maho\Event\Observer $observer
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_product_delete_before', area: 'adminhtml', type: 'model')]
+    #[Maho\Config\Observer('catalog_product_delete_before', area: 'adminhtml')]
     public function productDeleteEventAction($observer)
     {
         $this->_getResource()->decrementProducts($this->_getProductEventTagsCollection($observer)->getAllIds());

--- a/app/code/core/Mage/Weee/Model/Observer.php
+++ b/app/code/core/Mage/Weee/Model/Observer.php
@@ -64,7 +64,7 @@ class Mage_Weee_Model_Observer extends Mage_Core_Model_Abstract
      *
      * @return  Mage_Weee_Model_Observer
      */
-    #[Maho\Config\Observer('catalog_prepare_price_select', type: 'model')]
+    #[Maho\Config\Observer('catalog_prepare_price_select')]
     public function prepareCatalogIndexSelect(\Maho\Event\Observer $observer)
     {
         $storeId = (int) $observer->getEvent()->getStoreId();
@@ -168,7 +168,7 @@ class Mage_Weee_Model_Observer extends Mage_Core_Model_Abstract
      *
      * @return  Mage_Weee_Model_Observer
      */
-    #[Maho\Config\Observer('adminhtml_product_attribute_types', area: 'adminhtml', type: 'model')]
+    #[Maho\Config\Observer('adminhtml_product_attribute_types', area: 'adminhtml')]
     public function addWeeeTaxAttributeType(\Maho\Event\Observer $observer)
     {
         // adminhtml_product_attribute_types
@@ -203,7 +203,7 @@ class Mage_Weee_Model_Observer extends Mage_Core_Model_Abstract
      *
      * @return  Mage_Weee_Model_Observer
      */
-    #[Maho\Config\Observer('catalog_entity_attribute_save_before', type: 'model')]
+    #[Maho\Config\Observer('catalog_entity_attribute_save_before')]
     public function assignBackendModelToAttribute(\Maho\Event\Observer $observer)
     {
         $backendModel = Mage_Weee_Model_Attribute_Backend_Weee_Tax::getBackendModelName();

--- a/app/code/core/Maho/AdminActivityLog/Model/Observer.php
+++ b/app/code/core/Maho/AdminActivityLog/Model/Observer.php
@@ -45,7 +45,7 @@ class Maho_AdminActivityLog_Model_Observer
         return $this->_currentActionGroupId;
     }
 
-    #[Maho\Config\Observer('admin_user_authenticate_after', area: 'adminhtml', id: 'adminactivitylog_login_success')]
+    #[Maho\Config\Observer('admin_user_authenticate_after', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_login_success')]
     public function logAdminLogin(\Maho\Event\Observer $observer): void
     {
         try {
@@ -62,7 +62,7 @@ class Maho_AdminActivityLog_Model_Observer
         }
     }
 
-    #[Maho\Config\Observer('admin_session_user_logout', area: 'adminhtml', id: 'adminactivitylog_logout')]
+    #[Maho\Config\Observer('admin_session_user_logout', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_logout')]
     public function logAdminLogout(\Maho\Event\Observer $observer): void
     {
         try {
@@ -79,7 +79,7 @@ class Maho_AdminActivityLog_Model_Observer
         }
     }
 
-    #[Maho\Config\Observer('admin_session_user_login_failed', area: 'adminhtml', id: 'adminactivitylog_login_failed')]
+    #[Maho\Config\Observer('admin_session_user_login_failed', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_login_failed')]
     public function logAdminLoginFailed(\Maho\Event\Observer $observer): void
     {
         try {
@@ -99,8 +99,8 @@ class Maho_AdminActivityLog_Model_Observer
         }
     }
 
-    #[Maho\Config\Observer('model_save_before', area: 'adminhtml', id: 'adminactivitylog_save_before')]
-    #[Maho\Config\Observer('model_delete_before', area: 'adminhtml', id: 'adminactivitylog_delete_before')]
+    #[Maho\Config\Observer('model_save_before', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_save_before')]
+    #[Maho\Config\Observer('model_delete_before', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_delete_before')]
     public function logAdminActivityBefore(\Maho\Event\Observer $observer): void
     {
         try {
@@ -130,7 +130,7 @@ class Maho_AdminActivityLog_Model_Observer
         }
     }
 
-    #[Maho\Config\Observer('model_save_after', area: 'adminhtml', id: 'adminactivitylog_save_after')]
+    #[Maho\Config\Observer('model_save_after', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_save_after')]
     public function logAdminActivityAfter(\Maho\Event\Observer $observer): void
     {
         try {
@@ -214,7 +214,7 @@ class Maho_AdminActivityLog_Model_Observer
         }
     }
 
-    #[Maho\Config\Observer('model_delete_after', area: 'adminhtml', id: 'adminactivitylog_delete_after')]
+    #[Maho\Config\Observer('model_delete_after', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_delete_after')]
     public function logAdminDelete(\Maho\Event\Observer $observer): void
     {
         try {
@@ -247,7 +247,7 @@ class Maho_AdminActivityLog_Model_Observer
         }
     }
 
-    #[Maho\Config\Observer('controller_action_predispatch_adminhtml', area: 'adminhtml', id: 'adminactivitylog_page_visit')]
+    #[Maho\Config\Observer('controller_action_predispatch_adminhtml', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_page_visit')]
     public function logPageVisit(\Maho\Event\Observer $observer): void
     {
         try {
@@ -329,7 +329,7 @@ class Maho_AdminActivityLog_Model_Observer
         return array_diff_key($data, array_flip($this->ignoreFields));
     }
 
-    #[Maho\Config\Observer('controller_action_postdispatch_adminhtml', area: 'adminhtml', id: 'adminactivitylog_mass_action')]
+    #[Maho\Config\Observer('controller_action_postdispatch_adminhtml', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_mass_action')]
     public function logMassAction(\Maho\Event\Observer $observer): void
     {
         if (!Mage::helper('adminactivitylog')->shouldLogMassActions()) {
@@ -466,7 +466,7 @@ class Maho_AdminActivityLog_Model_Observer
         Mage::helper('adminactivitylog')->cleanOldLogs();
     }
 
-    #[Maho\Config\Observer('encryption_key_regenerated', id: 'adminactivitylog_recrypt_data')]
+    #[Maho\Config\Observer('encryption_key_regenerated', type: 'singleton', id: 'adminactivitylog_recrypt_data')]
     public function encryptionKeyRegenerated(\Maho\Event\Observer $observer): void
     {
         /** @var \Symfony\Component\Console\Output\OutputInterface $output */

--- a/lib/Maho/Config/Observer.php
+++ b/lib/Maho/Config/Observer.php
@@ -29,7 +29,7 @@ readonly class Observer
     /**
      * @param string  $event    Event name to observe (e.g. 'catalog_product_save_after')
      * @param string  $area     Area scope: 'global' (default), 'frontend', 'adminhtml', 'crontab', 'install'
-     * @param string  $type     Instantiation type: 'singleton' (default, shared instance) or 'model' (new instance per dispatch)
+     * @param string  $type     Instantiation type: 'model' (default, new instance per dispatch) or 'singleton' (shared instance)
      * @param ?string $id       Observer identifier, auto-generated if omitted. Set explicitly when other code references this observer by id.
      * @param ?string $replaces The `id` of another observer on the same event/area to disable and replace.
      *                          Accepts either the explicit id, the class name, or the class alias format
@@ -39,7 +39,7 @@ readonly class Observer
     public function __construct(
         public string $event,
         public string $area = 'global',
-        public string $type = 'singleton',
+        public string $type = 'model',
         public ?string $id = null,
         public ?string $replaces = null,
     ) {}


### PR DESCRIPTION
## Summary

- Changed the default `type` parameter on `#[Maho\Config\Observer]` from `'singleton'` (shared instance) to `'model'` (fresh instance per dispatch)
- Updated dispatch logic in `App.php` and `Config.php` to default to `getModel()` instead of `getSingleton()`
- Added explicit `type: 'singleton'` to the 3 observer classes that rely on shared state across dispatches: `AdminActivityLog`, `CatalogRule`, `CatalogInventory`
- Removed now-redundant `type: 'model'` from ~21 observer declarations that were explicitly setting what is now the default

## Rationale

A fresh instance per dispatch is the safer default — no risk of leaked state between event handlers. Several observer classes extend `DataObject` or `Mage_Core_Model_Abstract` which carry mutable state, making shared instances a subtle bug vector.

An audit of all 54 observer classes confirmed only 3 rely on singleton state across dispatches, and those are now explicitly opted in.

## Test plan

- [x] `composer dump-autoload` compiles successfully
- [x] Compiled attributes show 199 model / 44 singleton — singletons only from the 3 expected classes
- [x] `vendor/bin/php-cs-fixer fix --dry-run` — 0 issues
- [x] `vendor/bin/phpstan analyze` — 0 errors
- [x] `composer test` — 1845 tests passed

Closes #818