### PR TITLE
Stub empty summary on zero-review products to eliminate N+1 queries

### DIFF
--- a/app/code/core/Mage/Review/Model/Review.php
+++ b/app/code/core/Mage/Review/Model/Review.php
@@ -190,6 +190,13 @@ class Mage_Review_Model_Review extends Mage_Core_Model_Abstract
             }
         }
 
+        $emptySummary = Mage::getModel('review/review_summary');
+        foreach ($collection->getItems() as $item) {
+            if (!$item->hasData('rating_summary')) {
+                $item->setRatingSummary($emptySummary);
+            }
+        }
+
         return $this;
     }
 

--- a/app/code/core/Mage/Review/Model/Review.php
+++ b/app/code/core/Mage/Review/Model/Review.php
@@ -190,10 +190,9 @@ class Mage_Review_Model_Review extends Mage_Core_Model_Abstract
             }
         }
 
-        $emptySummary = Mage::getModel('review/review_summary');
         foreach ($collection->getItems() as $item) {
             if (!$item->hasData('rating_summary')) {
-                $item->setRatingSummary($emptySummary);
+                $item->setRatingSummary(Mage::getModel('review/review_summary'));
             }
         }
 


### PR DESCRIPTION
## Summary

- Fixes #825
- `appendSummary()` now stubs an empty `review/review_summary` model on products not matched by the batch query
- Prevents `Mage_Review_Block_Helper::getSummaryHtml()` from firing individual SELECT queries for each zero-review product (~1000 redundant queries on a typical 36-product category page)

## Test plan

- [ ] Load a category page containing products with and without reviews
- [ ] Verify zero-review products still render without a rating badge (no visual change)
- [ ] Verify reviewed products still display correct rating summaries
- [ ] Confirm query log no longer shows per-product `review_entity_summary` SELECT queries for zero-review products