### PR TITLE
Consolidate 'adminhtml' config area into 'admin'

### DIFF
--- a/app/code/core/Mage/Admin/Model/Observer.php
+++ b/app/code/core/Mage/Admin/Model/Observer.php
@@ -19,7 +19,7 @@ class Mage_Admin_Model_Observer
      *
      * @param \Maho\Event\Observer $observer
      */
-    #[Maho\Config\Observer('controller_action_predispatch', area: 'adminhtml', id: 'auth')]
+    #[Maho\Config\Observer('controller_action_predispatch', area: 'admin', id: 'auth')]
     public function actionPreDispatchAdmin($observer)
     {
         /** @var Mage_Admin_Model_Session $session */

--- a/app/code/core/Mage/Admin/etc/config.xml
+++ b/app/code/core/Mage/Admin/etc/config.xml
@@ -73,7 +73,7 @@
             </emails>
         </admin>
     </default>
-    <adminhtml>
+    <admin>
         <layout>
             <updates>
                 <admin>
@@ -81,5 +81,5 @@
                 </admin>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
 </config>

--- a/app/code/core/Mage/AdminNotification/Model/Observer.php
+++ b/app/code/core/Mage/AdminNotification/Model/Observer.php
@@ -15,7 +15,7 @@ class Mage_AdminNotification_Model_Observer
     /**
      * Predispath admin action controller
      */
-    #[Maho\Config\Observer('controller_action_predispatch', area: 'adminhtml')]
+    #[Maho\Config\Observer('controller_action_predispatch', area: 'admin')]
     public function preDispatch(\Maho\Event\Observer $observer)
     {
         if (Mage::getSingleton('admin/session')->isLoggedIn()) {

--- a/app/code/core/Mage/AdminNotification/etc/config.xml
+++ b/app/code/core/Mage/AdminNotification/etc/config.xml
@@ -44,7 +44,7 @@
             </adminnotification_setup>
         </resources>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_AdminNotification>
@@ -61,7 +61,7 @@
                 </adminnotification>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
     <default>
         <system>
             <adminnotification>

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Search/Grid.php
@@ -93,7 +93,7 @@ class Mage_Adminhtml_Block_Sales_Order_Create_Search_Grid extends Mage_Adminhtml
             ->addAttributeToSelect('gift_message_available')
             ->addStoreFilter()
             ->addAttributeToFilter('type_id', array_keys(
-                Mage::getConfig()->getNode('adminhtml/sales/order/create/available_product_types')->asArray(),
+                Mage::getConfig()->getNode('admin/sales/order/create/available_product_types')->asArray(),
             ))
             ->addAttributeToFilter('status', [
                 'in' => Mage::getSingleton('catalog/product_status')->getSaleableStatusIds(),

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Sidebar/Abstract.php
@@ -114,7 +114,7 @@ class Mage_Adminhtml_Block_Sales_Order_Create_Sidebar_Abstract extends Mage_Admi
         $items = [];
         $collection = $this->getItemCollection();
         if ($collection) {
-            $productTypes = Mage::getConfig()->getNode('adminhtml/sales/order/create/available_product_types')->asArray();
+            $productTypes = Mage::getConfig()->getNode('admin/sales/order/create/available_product_types')->asArray();
             if (is_array($collection)) {
                 $items = $collection;
             } else {

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View.php
@@ -46,7 +46,7 @@ class Mage_Adminhtml_Block_Sales_Order_View extends Mage_Adminhtml_Block_Widget_
             $nonEditableTypes = array_keys($this->getOrder()->getResource()->aggregateProductsByTypes(
                 $order->getId(),
                 array_keys(Mage::getConfig()
-                    ->getNode('adminhtml/sales/order/create/available_product_types')
+                    ->getNode('admin/sales/order/create/available_product_types')
                     ->asArray()),
                 false,
             ));

--- a/app/code/core/Mage/Adminhtml/Controller/Action.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Action.php
@@ -57,7 +57,7 @@ class Mage_Adminhtml_Controller_Action extends Mage_Core_Controller_Varien_Actio
      *
      * @var string
      */
-    protected $_currentArea = Mage_Core_Model_App_Area::AREA_ADMINHTML;
+    protected $_currentArea = Mage_Core_Model_App_Area::AREA_ADMIN;
 
     /**
      * Namespace for session.

--- a/app/code/core/Mage/Adminhtml/Helper/Sales.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Sales.php
@@ -79,7 +79,7 @@ class Mage_Adminhtml_Helper_Sales extends Mage_Core_Helper_Abstract
      */
     public function applySalableProductTypesFilter($collection)
     {
-        $productTypes = Mage::getConfig()->getNode('adminhtml/sales/order/create/available_product_types')->asArray();
+        $productTypes = Mage::getConfig()->getNode('admin/sales/order/create/available_product_types')->asArray();
         $productTypes = array_keys($productTypes);
         foreach ($collection->getItems() as $key => $item) {
             if ($item instanceof Mage_Catalog_Model_Product) {

--- a/app/code/core/Mage/Adminhtml/Model/Observer.php
+++ b/app/code/core/Mage/Adminhtml/Model/Observer.php
@@ -12,7 +12,7 @@
 
 class Mage_Adminhtml_Model_Observer
 {
-    #[Maho\Config\Observer('controller_action_layout_generate_blocks_before', area: 'adminhtml')]
+    #[Maho\Config\Observer('controller_action_layout_generate_blocks_before', area: 'admin')]
     public function displayBootupWarnings($observer)
     {
         $bootupWarnings = Mage::registry('bootup_warnings') ?? [];
@@ -21,7 +21,7 @@ class Mage_Adminhtml_Model_Observer
         }
     }
 
-    #[Maho\Config\Observer('core_locale_set_locale', area: 'adminhtml')]
+    #[Maho\Config\Observer('core_locale_set_locale', area: 'admin')]
     public function bindLocale($observer)
     {
         if ($locale = $observer->getEvent()->getLocale()) {

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
@@ -287,7 +287,7 @@ class Mage_Adminhtml_Model_Sales_Order_Create extends \Maho\DataObject implement
         $this->initRuleData();
 
         $itemsCollection = $order->getItemsCollection(
-            array_keys(Mage::getConfig()->getNode('adminhtml/sales/order/create/available_product_types')->asArray()),
+            array_keys(Mage::getConfig()->getNode('admin/sales/order/create/available_product_types')->asArray()),
             true,
         );
 

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Observer.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Observer.php
@@ -16,7 +16,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_Admin_Observer
      *
      * @param \Maho\Event\Observer $observer
      */
-    #[Maho\Config\Observer('admin_system_config_changed_section_admin', area: 'adminhtml')]
+    #[Maho\Config\Observer('admin_system_config_changed_section_admin', area: 'admin')]
     public function afterCustomUrlChanged($observer)
     {
         if (is_null(Mage::registry('custom_admin_path_redirect'))) {

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Observer.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Admin/Observer.php
@@ -6,6 +6,7 @@
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2022-2025 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
@@ -173,7 +173,7 @@ class Mage_Adminhtml_Catalog_Product_Action_AttributeController extends Mage_Adm
                     'products' => $productIds,
                 ]);
 
-                $notice = Mage::getConfig()->getNode('adminhtml/messages/website_chnaged_indexers/label');
+                $notice = Mage::getConfig()->getNode('admin/messages/website_chnaged_indexers/label');
                 if ($notice) {
                     $this->_getSession()->addNotice($this->__((string) $notice, $this->getUrl('adminhtml/process/list')));
                 }

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
@@ -173,7 +173,7 @@ class Mage_Adminhtml_Catalog_Product_Action_AttributeController extends Mage_Adm
                     'products' => $productIds,
                 ]);
 
-                $notice = Mage::getConfig()->getNode('admin/messages/website_chnaged_indexers/label');
+                $notice = Mage::getConfig()->getNode('admin/messages/website_changed_indexers/label');
                 if ($notice) {
                     $this->_getSession()->addNotice($this->__((string) $notice, $this->getUrl('adminhtml/process/list')));
                 }

--- a/app/code/core/Mage/Adminhtml/controllers/IndexController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/IndexController.php
@@ -104,7 +104,7 @@ class Mage_Adminhtml_IndexController extends Mage_Adminhtml_Controller_Action
      */
     public function globalSearchAction(): void
     {
-        $searchModules = Mage::getConfig()->getNode('adminhtml/global_search');
+        $searchModules = Mage::getConfig()->getNode('admin/global_search');
         $items = [];
 
         if (!Mage::getStoreConfigFlag('admin/global_search/enable') || !Mage::getSingleton('admin/session')->isAllowed('admin/global_search')) {

--- a/app/code/core/Mage/Adminhtml/etc/config.xml
+++ b/app/code/core/Mage/Adminhtml/etc/config.xml
@@ -61,8 +61,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-    <adminhtml>
+    
         <global_search>
             <products>
                 <class>adminhtml/search_catalog</class>
@@ -122,7 +121,7 @@
                 <label><![CDATA[Please refresh "Catalog URL Rewrites" and "Product Attributes" in System -&gt; <a href="%s">Index Management</a>]]></label>
             </website_chnaged_indexers>
         </messages>
-    </adminhtml>
+    </admin>
     <default>
         <system>
             <media_storage_configuration>

--- a/app/code/core/Mage/Adminhtml/etc/config.xml
+++ b/app/code/core/Mage/Adminhtml/etc/config.xml
@@ -117,9 +117,9 @@
             </order>
         </sales>
         <messages>
-            <website_chnaged_indexers translate="label" module="catalog">
+            <website_changed_indexers translate="label" module="catalog">
                 <label><![CDATA[Please refresh "Catalog URL Rewrites" and "Product Attributes" in System -&gt; <a href="%s">Index Management</a>]]></label>
-            </website_chnaged_indexers>
+            </website_changed_indexers>
         </messages>
     </admin>
     <default>

--- a/app/code/core/Mage/Api/Controller/Action.php
+++ b/app/code/core/Mage/Api/Controller/Action.php
@@ -20,7 +20,7 @@ class Mage_Api_Controller_Action extends Mage_Core_Controller_Front_Action
     #[\Override]
     public function preDispatch()
     {
-        $this->getLayout()->setArea('adminhtml');
+        $this->getLayout()->setArea('admin');
         Mage::app()->setCurrentStore('admin');
         $this->setFlag('', self::FLAG_NO_START_SESSION, 1); // Do not start standard session
         parent::preDispatch();

--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -17,7 +17,7 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
     public function __construct()
     {
         set_error_handler([$this, 'handlePhpError'], E_ALL);
-        Mage::app()->loadAreaPart(Mage_Core_Model_App_Area::AREA_ADMINHTML, Mage_Core_Model_App_Area::PART_EVENTS);
+        Mage::app()->loadAreaPart(Mage_Core_Model_App_Area::AREA_ADMIN, Mage_Core_Model_App_Area::PART_EVENTS);
     }
 
     /**

--- a/app/code/core/Mage/Api/etc/config.xml
+++ b/app/code/core/Mage/Api/etc/config.xml
@@ -94,7 +94,7 @@
             </modules>
         </translate>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Api>
@@ -104,7 +104,7 @@
                 </Mage_Api>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <default>
         <api>
             <config>

--- a/app/code/core/Mage/Api2/Model/Observer.php
+++ b/app/code/core/Mage/Api2/Model/Observer.php
@@ -39,7 +39,7 @@ class Mage_Api2_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_entity_attribute_save_after', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_entity_attribute_save_after', area: 'admin')]
     public function catalogAttributeSaveAfter(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Resource_Eav_Attribute $attribute */

--- a/app/code/core/Mage/Api2/etc/config.xml
+++ b/app/code/core/Mage/Api2/etc/config.xml
@@ -163,8 +163,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-    <adminhtml>
+    
         <layout>
             <updates>
                 <api2>
@@ -172,5 +171,5 @@
                 </api2>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
 </config>

--- a/app/code/core/Mage/Authorizenet/etc/config.xml
+++ b/app/code/core/Mage/Authorizenet/etc/config.xml
@@ -28,25 +28,6 @@
         </helpers>
     </global>
 
-    <adminhtml>
-        <translate>
-            <modules>
-                <Mage_Authorizenet>
-                    <files>
-                        <default>Mage_Authorizenet.csv</default>
-                    </files>
-                </Mage_Authorizenet>
-            </modules>
-        </translate>
-        <layout>
-            <updates>
-                <authorizenet>
-                    <file>authorizenet.xml</file>
-                </authorizenet>
-            </updates>
-        </layout>
-    </adminhtml>
-
     <frontend>
         <translate>
             <modules>
@@ -85,5 +66,22 @@
                 </args>
             </adminhtml>
         </routers>
+    
+        <translate>
+            <modules>
+                <Mage_Authorizenet>
+                    <files>
+                        <default>Mage_Authorizenet.csv</default>
+                    </files>
+                </Mage_Authorizenet>
+            </modules>
+        </translate>
+        <layout>
+            <updates>
+                <authorizenet>
+                    <file>authorizenet.xml</file>
+                </authorizenet>
+            </updates>
+        </layout>
     </admin>
 </config>

--- a/app/code/core/Mage/Bundle/Model/Observer.php
+++ b/app/code/core/Mage/Bundle/Model/Observer.php
@@ -18,7 +18,7 @@ class Mage_Bundle_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_product_prepare_save', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_product_prepare_save', area: 'admin')]
     public function prepareProductSave($observer)
     {
         /** @var Mage_Core_Controller_Request_Http $request */
@@ -129,7 +129,7 @@ class Mage_Bundle_Model_Observer
      * @return $this
      */
     #[Maho\Config\Observer('sales_convert_quote_item_to_order_item', area: 'frontend')]
-    #[Maho\Config\Observer('sales_convert_quote_item_to_order_item', area: 'adminhtml')]
+    #[Maho\Config\Observer('sales_convert_quote_item_to_order_item', area: 'admin')]
     public function appendBundleSelectionData($observer)
     {
         /** @var Mage_Sales_Model_Order_Item $orderItem */
@@ -169,7 +169,7 @@ class Mage_Bundle_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_model_product_duplicate', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_model_product_duplicate', area: 'admin')]
     public function duplicateProduct($observer)
     {
         /** @var Mage_Catalog_Model_Product $product */
@@ -232,8 +232,8 @@ class Mage_Bundle_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_product_edit_action', area: 'adminhtml')]
-    #[Maho\Config\Observer('catalog_product_new_action', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_product_edit_action', area: 'admin')]
+    #[Maho\Config\Observer('catalog_product_new_action', area: 'admin')]
     public function setAttributeTabBlock($observer)
     {
         /** @var Mage_Catalog_Model_Product $product */

--- a/app/code/core/Mage/Bundle/etc/config.xml
+++ b/app/code/core/Mage/Bundle/etc/config.xml
@@ -189,8 +189,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-    <adminhtml>
+    
         <translate>
             <modules>
                 <Mage_Bundle>
@@ -216,5 +215,5 @@
                 </create>
             </order>
         </sales>
-    </adminhtml>
+    </admin>
 </config>

--- a/app/code/core/Mage/Catalog/Model/Observer.php
+++ b/app/code/core/Mage/Catalog/Model/Observer.php
@@ -153,7 +153,7 @@ class Mage_Catalog_Model_Observer
     /**
      * Checking whether the using static urls in WYSIWYG allowed event
      */
-    #[Maho\Config\Observer('cms_wysiwyg_images_static_urls_allowed', area: 'adminhtml')]
+    #[Maho\Config\Observer('cms_wysiwyg_images_static_urls_allowed', area: 'admin')]
     public function catalogCheckIsUsingStaticUrlsAllowed(\Maho\Event\Observer $observer)
     {
         $storeId = $observer->getEvent()->getData('store_id');
@@ -282,7 +282,7 @@ class Mage_Catalog_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('adminhtml_product_attribute_types', area: 'adminhtml')]
+    #[Maho\Config\Observer('adminhtml_product_attribute_types', area: 'admin')]
     public function addFileAttributeType(\Maho\Event\Observer $observer)
     {
         $response = $observer->getEvent()->getResponse();
@@ -313,7 +313,7 @@ class Mage_Catalog_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('adminhtml_catalog_product_edit_element_types', area: 'adminhtml')]
+    #[Maho\Config\Observer('adminhtml_catalog_product_edit_element_types', area: 'admin')]
     public function addFileElementType(\Maho\Event\Observer $observer)
     {
         $response = $observer->getEvent()->getResponse();

--- a/app/code/core/Mage/Catalog/etc/config.xml
+++ b/app/code/core/Mage/Catalog/etc/config.xml
@@ -203,6 +203,16 @@
                 </required_options>
             </catalog_product_dataflow>
         </fieldsets>
+    
+        <translate>
+            <modules>
+                <Mage_Catalog>
+                    <files>
+                        <default>Mage_Catalog.csv</default>
+                    </files>
+                </Mage_Catalog>
+            </modules>
+        </translate>
     </admin>
     <global>
         <models>
@@ -613,17 +623,6 @@
             </catalog_product>
         </eav_attributes>
     </global>
-    <adminhtml>
-        <translate>
-            <modules>
-                <Mage_Catalog>
-                    <files>
-                        <default>Mage_Catalog.csv</default>
-                    </files>
-                </Mage_Catalog>
-            </modules>
-        </translate>
-    </adminhtml>
     <frontend>
         <routers>
             <catalog>
@@ -728,8 +727,8 @@
                 <background_color>#ffffff</background_color>
             </product_image>
             <seo>
-                <product_url_suffix></product_url_suffix>
-                <category_url_suffix></category_url_suffix>
+                <product_url_suffix/>
+                <category_url_suffix/>
                 <product_use_categories>1</product_use_categories>
                 <save_rewrites_history>1</save_rewrites_history>
                 <title_separator>-</title_separator>

--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -937,7 +937,7 @@ class Mage_CatalogInventory_Model_Observer
      */
     #[Maho\Config\Observer('end_index_events_cataloginventory_stock_item_save', type: 'singleton')]
     #[Maho\Config\Observer('end_process_event_cataloginventory_stock_item_save', type: 'singleton')]
-    #[Maho\Config\Observer('after_reindex_process_cataloginventory_stock', area: 'adminhtml', type: 'singleton')]
+    #[Maho\Config\Observer('after_reindex_process_cataloginventory_stock', area: 'admin', type: 'singleton')]
     public function reindexProductsMassAction($observer): void
     {
         Mage::getSingleton('index/indexer')->indexEvents(

--- a/app/code/core/Mage/CatalogInventory/etc/config.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/config.xml
@@ -114,7 +114,7 @@
             </modules>
         </translate>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_CatalogInventory>
@@ -124,7 +124,7 @@
                 </Mage_CatalogInventory>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <default>
         <cataloginventory>
             <options>

--- a/app/code/core/Mage/CatalogRule/Model/Observer.php
+++ b/app/code/core/Mage/CatalogRule/Model/Observer.php
@@ -33,7 +33,7 @@ class Mage_CatalogRule_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_product_save_commit_after', area: 'adminhtml', type: 'singleton')]
+    #[Maho\Config\Observer('catalog_product_save_commit_after', area: 'admin', type: 'singleton')]
     public function applyAllRulesOnProduct($observer)
     {
         /** @var Mage_Catalog_Model_Product $product */
@@ -54,7 +54,7 @@ class Mage_CatalogRule_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_product_save_before', area: 'adminhtml', type: 'singleton')]
+    #[Maho\Config\Observer('catalog_product_save_before', area: 'admin', type: 'singleton')]
     public function loadProductRules($observer)
     {
         /** @var Mage_Catalog_Model_Product $product */
@@ -74,7 +74,7 @@ class Mage_CatalogRule_Model_Observer
      *
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_product_import_after', area: 'adminhtml', type: 'singleton')]
+    #[Maho\Config\Observer('catalog_product_import_after', area: 'admin', type: 'singleton')]
     public function applyAllRules($observer)
     {
         /** @var Mage_CatalogRule_Model_Resource_Rule $resource */
@@ -176,7 +176,7 @@ class Mage_CatalogRule_Model_Observer
      *
      * @return  $this
      */
-    #[Maho\Config\Observer('catalog_product_get_final_price', area: 'adminhtml', type: 'singleton')]
+    #[Maho\Config\Observer('catalog_product_get_final_price', area: 'admin', type: 'singleton')]
     #[Maho\Config\Observer('catalog_product_get_final_price', area: 'crontab', type: 'singleton')]
     public function processAdminFinalPrice($observer)
     {
@@ -359,7 +359,7 @@ class Mage_CatalogRule_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_entity_attribute_save_after', area: 'adminhtml', type: 'singleton')]
+    #[Maho\Config\Observer('catalog_entity_attribute_save_after', area: 'admin', type: 'singleton')]
     public function catalogAttributeSaveAfter(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Entity_Attribute $attribute */
@@ -376,7 +376,7 @@ class Mage_CatalogRule_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_entity_attribute_delete_after', area: 'adminhtml', type: 'singleton')]
+    #[Maho\Config\Observer('catalog_entity_attribute_delete_after', area: 'admin', type: 'singleton')]
     public function catalogAttributeDeleteAfter(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Entity_Attribute $attribute */
@@ -440,7 +440,7 @@ class Mage_CatalogRule_Model_Observer
     /**
      * Create catalog rule relations for imported products
      */
-    #[Maho\Config\Observer('catalog_product_import_finish_before', area: 'adminhtml', type: 'singleton')]
+    #[Maho\Config\Observer('catalog_product_import_finish_before', area: 'admin', type: 'singleton')]
     public function createCatalogRulesRelations(\Maho\Event\Observer $observer)
     {
         /** @var Mage_ImportExport_Model_Import_Entity_Product $adapter */

--- a/app/code/core/Mage/CatalogRule/etc/config.xml
+++ b/app/code/core/Mage/CatalogRule/etc/config.xml
@@ -80,7 +80,7 @@
             </modules>
         </translate>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_CatalogRule>
@@ -90,5 +90,5 @@
                 </Mage_CatalogRule>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
 </config>

--- a/app/code/core/Mage/CatalogSearch/etc/config.xml
+++ b/app/code/core/Mage/CatalogSearch/etc/config.xml
@@ -91,7 +91,7 @@
             </updates>
         </layout>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_CatalogSearch>
@@ -108,7 +108,7 @@
                 </catalogsearch>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
     <default>
         <catalog>
             <seo>

--- a/app/code/core/Mage/Checkout/etc/config.xml
+++ b/app/code/core/Mage/Checkout/etc/config.xml
@@ -181,7 +181,7 @@
             </updates>
         </layout>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Checkout>
@@ -191,7 +191,7 @@
                 </Mage_Checkout>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <default>
         <checkout>
             <options>

--- a/app/code/core/Mage/Cms/Block/Widget/Block.php
+++ b/app/code/core/Mage/Cms/Block/Widget/Block.php
@@ -100,6 +100,6 @@ class Mage_Cms_Block_Widget_Block extends Mage_Core_Block_Template implements Ma
      */
     public function isRequestFromAdminArea()
     {
-        return $this->getRequest()->getRouteName() === Mage_Core_Model_App_Area::AREA_ADMINHTML;
+        return $this->getRequest()->getRouteName() === 'adminhtml';
     }
 }

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
@@ -74,9 +74,9 @@ class Mage_Cms_Model_Wysiwyg_Config extends \Maho\DataObject
                 'add_images'               => true,
                 'files_browser_window_url' => Mage::getSingleton('adminhtml/url')->getUrl('*/cms_wysiwyg_images/index'),
                 'files_browser_window_width'
-                    => (int) Mage::getConfig()->getNode('adminhtml/cms/browser/window_width'),
+                    => (int) Mage::getConfig()->getNode('admin/cms/browser/window_width'),
                 'files_browser_window_height'
-                    => (int) Mage::getConfig()->getNode('adminhtml/cms/browser/window_height'),
+                    => (int) Mage::getConfig()->getNode('admin/cms/browser/window_height'),
             ]);
         }
 

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Images/Storage.php
@@ -412,7 +412,7 @@ class Mage_Cms_Model_Wysiwyg_Images_Storage extends \Maho\DataObject
     public function getConfig()
     {
         if (!$this->_config) {
-            $this->_config = Mage::getConfig()->getNode('cms/browser', 'adminhtml');
+            $this->_config = Mage::getConfig()->getNode('cms/browser', 'admin');
         }
 
         return $this->_config;

--- a/app/code/core/Mage/Cms/etc/config.xml
+++ b/app/code/core/Mage/Cms/etc/config.xml
@@ -43,7 +43,7 @@
             </updates>
         </layout>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Cms>
@@ -104,7 +104,7 @@
                 <resize_height>75</resize_height>
             </browser>
         </cms>
-    </adminhtml>
+    </admin>
     <global>
         <models>
             <cms>

--- a/app/code/core/Mage/ConfigurableSwatches/etc/config.xml
+++ b/app/code/core/Mage/ConfigurableSwatches/etc/config.xml
@@ -69,7 +69,7 @@
         </product>
     </frontend>
 
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_ConfigurableSwatches>
@@ -79,7 +79,7 @@
                 </Mage_ConfigurableSwatches>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
 
     <default>
         <configswatches>

--- a/app/code/core/Mage/Contacts/etc/config.xml
+++ b/app/code/core/Mage/Contacts/etc/config.xml
@@ -65,7 +65,7 @@
             </email>
         </template>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Contacts>
@@ -75,7 +75,7 @@
                 </Mage_Contacts>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <default>
         <contacts>
             <contacts>

--- a/app/code/core/Mage/Core/Model/App/Area.php
+++ b/app/code/core/Mage/Core/Model/App/Area.php
@@ -14,7 +14,10 @@ class Mage_Core_Model_App_Area
 {
     public const AREA_GLOBAL   = 'global';
     public const AREA_FRONTEND = 'frontend';
-    public const AREA_ADMINHTML = 'adminhtml';
+    public const AREA_ADMIN    = 'admin';
+
+    /** @deprecated Since 26.5 Use AREA_ADMIN instead */
+    public const AREA_ADMINHTML = self::AREA_ADMIN;
 
     public const PART_CONFIG   = 'config';
     public const PART_EVENTS   = 'events';

--- a/app/code/core/Mage/Core/Model/App/Emulation.php
+++ b/app/code/core/Mage/Core/Model/App/Emulation.php
@@ -108,7 +108,7 @@ class Mage_Core_Model_App_Emulation extends \Maho\DataObject
         if (is_null($storeId)) {
             $newTranslateInline = false;
         } else {
-            if ($area == Mage_Core_Model_App_Area::AREA_ADMINHTML) {
+            if ($area == Mage_Core_Model_App_Area::AREA_ADMIN) {
                 $newTranslateInline = Mage::getStoreConfigFlag('dev/translate_inline/active_admin', $storeId);
             } else {
                 $newTranslateInline = Mage::getStoreConfigFlag('dev/translate_inline/active', $storeId);
@@ -208,7 +208,7 @@ class Mage_Core_Model_App_Emulation extends \Maho\DataObject
      */
     protected function _restoreInitialLocale(
         $initialLocaleCode,
-        $initialArea = Mage_Core_Model_App_Area::AREA_ADMINHTML,
+        $initialArea = Mage_Core_Model_App_Area::AREA_ADMIN,
     ) {
         $currentLocaleCode = $this->_app->getLocale()->getLocaleCode();
         if ($currentLocaleCode != $initialLocaleCode) {

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -366,6 +366,8 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         $resourceConfig = sprintf('config.%s.xml', $this->_getResourceConnectionModel('core'));
         $this->loadModulesConfiguration(['config.xml', $resourceConfig], $this);
 
+        $this->_migrateAdminhtmlConfig();
+
         // Prevent local.xml directives overwriting
         if ($this->_isLocalConfigLoaded) {
             $this->extend($this->_refLocalConfigObject);
@@ -374,6 +376,28 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         $this->applyExtends();
         \Maho\Profiler::stop('config/load-modules');
         return $this;
+    }
+
+    protected function _migrateAdminhtmlConfig(): void
+    {
+        $adminhtmlNode = $this->getNode('adminhtml');
+        if ($adminhtmlNode === false || !$adminhtmlNode->hasChildren()) {
+            return;
+        }
+
+        Mage::log(
+            'Deprecated: <adminhtml> config section detected. Third-party modules should migrate to <admin>.',
+            Mage::LOG_NOTICE,
+        );
+
+        $adminNode = $this->getNode('admin');
+        if ($adminNode === false) {
+            $this->getNode()->addChild('admin');
+            $adminNode = $this->getNode('admin');
+        }
+
+        $adminNode->extend($adminhtmlNode);
+        unset($this->getNode()->adminhtml);
     }
 
     /**
@@ -1020,7 +1044,8 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
                     if ($mergeModel->loadFile($configFile)) {
                         $this->_makeEventsLowerCase(Mage_Core_Model_App_Area::AREA_GLOBAL, $mergeModel);
                         $this->_makeEventsLowerCase(Mage_Core_Model_App_Area::AREA_FRONTEND, $mergeModel);
-                        $this->_makeEventsLowerCase(Mage_Core_Model_App_Area::AREA_ADMINHTML, $mergeModel);
+                        $this->_makeEventsLowerCase(Mage_Core_Model_App_Area::AREA_ADMIN, $mergeModel);
+                        $this->_makeEventsLowerCase('adminhtml', $mergeModel);
 
                         $mergeToObject->extend($mergeModel, true);
                     }

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -89,7 +89,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      * @var array
      */
     protected $_cacheSections = [
-        'adminhtml' => 0,
+        'admin'     => 0,
         'crontab'   => 0,
         'install'   => 0,
         'stores'    => 1,
@@ -734,6 +734,13 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
                 }
             }
             $path = $scope . ($scopeCode ? '/' . $scopeCode : '') . (empty($path) ? '' : '/' . $path);
+        }
+
+        /**
+         * Backward compatibility: redirect adminhtml/ paths to admin/
+         */
+        if ($path !== null && str_starts_with($path, 'adminhtml/')) {
+            $path = 'admin/' . substr($path, 10);
         }
 
         /**

--- a/app/code/core/Mage/Core/Model/Design/Fallback.php
+++ b/app/code/core/Mage/Core/Model/Design/Fallback.php
@@ -75,6 +75,7 @@ class Mage_Core_Model_Design_Fallback
      */
     public function getFallbackScheme($area, $package, $theme)
     {
+        $area = Mage_Core_Model_Design_Package::areaToDesignDir($area);
         $cacheKey = $area . '/' . $package . '/' . $theme;
 
         if (!isset($this->_cachedSchemes[$cacheKey])) {

--- a/app/code/core/Mage/Core/Model/Design/Package.php
+++ b/app/code/core/Mage/Core/Model/Design/Package.php
@@ -128,6 +128,14 @@ class Mage_Core_Model_Design_Package
         return $this;
     }
 
+    public static function areaToDesignDir(string $area): string
+    {
+        return match ($area) {
+            'admin' => 'adminhtml',
+            default => $area,
+        };
+    }
+
     /**
      * Retrieve package area
      *
@@ -309,8 +317,9 @@ class Mage_Core_Model_Design_Package
     public function getBaseDir(array $params)
     {
         $this->updateParamDefaults($params);
+        $areaDir = self::areaToDesignDir($params['_area']);
         return (empty($params['_relative']) ? Mage::getBaseDir('design') . DS : '') .
-            $params['_area'] . DS . $params['_package'] . DS . $params['_theme'] . DS . $params['_type'];
+            $areaDir . DS . $params['_package'] . DS . $params['_theme'] . DS . $params['_type'];
     }
 
     /**
@@ -320,8 +329,9 @@ class Mage_Core_Model_Design_Package
     {
         $params['_type'] = 'skin';
         $this->updateParamDefaults($params);
+        $areaDir = self::areaToDesignDir($params['_area']);
         return (empty($params['_relative']) ? Mage::getBaseDir('skin') . DS : '') .
-            $params['_area'] . DS . $params['_package'] . DS . $params['_theme'];
+            $areaDir . DS . $params['_package'] . DS . $params['_theme'];
     }
 
     /**
@@ -331,8 +341,9 @@ class Mage_Core_Model_Design_Package
     {
         $params['_type'] = 'locale';
         $this->updateParamDefaults($params);
+        $areaDir = self::areaToDesignDir($params['_area']);
         return (empty($params['_relative']) ? Mage::getBaseDir('design') . DS : '') .
-            $params['_area'] . DS . $params['_package'] . DS . $params['_theme'] . DS . 'locale' . DS .
+            $areaDir . DS . $params['_package'] . DS . $params['_theme'] . DS . 'locale' . DS .
             Mage::app()->getLocale()->getLocaleCode();
     }
 
@@ -343,7 +354,8 @@ class Mage_Core_Model_Design_Package
     {
         $params['_type'] = 'skin';
         $this->updateParamDefaults($params);
-        $urlPath = $params['_area'] . '/' . $params['_package'] . '/' . $params['_theme'] . '/';
+        $areaDir = self::areaToDesignDir($params['_area']);
+        $urlPath = $areaDir . '/' . $params['_package'] . '/' . $params['_theme'] . '/';
         // Prevent XSS through malformed configuration
         $urlPath = htmlspecialchars($urlPath, ENT_HTML5 | ENT_QUOTES, 'UTF-8');
         return Mage::getBaseUrl('skin', isset($params['_secure']) ? (bool) $params['_secure'] : null) . $urlPath;

--- a/app/code/core/Mage/Core/Model/Domainpolicy.php
+++ b/app/code/core/Mage/Core/Model/Domainpolicy.php
@@ -71,7 +71,7 @@ class Mage_Core_Model_Domainpolicy
 
         // Add X-Frame-Options header (existing functionality)
         $policy = null;
-        if ($action->getLayout()->getArea() === Mage_Core_Model_App_Area::AREA_ADMINHTML) {
+        if ($action->getLayout()->getArea() === Mage_Core_Model_App_Area::AREA_ADMIN) {
             $policy = $this->getBackendPolicy();
         } elseif ($action->getLayout()->getArea() === Mage_Core_Model_App_Area::AREA_FRONTEND) {
             $policy = $this->getFrontendPolicy();

--- a/app/code/core/Mage/Core/Model/Observer.php
+++ b/app/code/core/Mage/Core/Model/Observer.php
@@ -27,8 +27,8 @@ class Mage_Core_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('clean_cache_by_tags', area: 'adminhtml')]
-    #[Maho\Config\Observer('admin_system_config_changed_section_catalog', area: 'adminhtml')]
+    #[Maho\Config\Observer('clean_cache_by_tags', area: 'admin')]
+    #[Maho\Config\Observer('admin_system_config_changed_section_catalog', area: 'admin')]
     public function cleanCacheByTags(\Maho\Event\Observer $observer)
     {
         /** @var array $tags */

--- a/app/code/core/Mage/Core/Model/Pdf/Trait.php
+++ b/app/code/core/Mage/Core/Model/Pdf/Trait.php
@@ -101,9 +101,9 @@ trait Mage_Core_Model_Pdf_Trait
 
     protected function getCssContent(): string
     {
-        // Ensure we're in adminhtml design area for CSS loading
+        // Ensure we're in admin design area for CSS loading
         $originalArea = Mage::getDesign()->getArea();
-        Mage::getDesign()->setArea('adminhtml');
+        Mage::getDesign()->setArea('admin');
 
         try {
             $cssPath = Mage::getDesign()->getTemplateFilename('sales/order/pdf/pdf.css', [

--- a/app/code/core/Mage/Core/Model/Translate.php
+++ b/app/code/core/Mage/Core/Model/Translate.php
@@ -92,7 +92,7 @@ class Mage_Core_Model_Translate
         $this->setConfig([self::CONFIG_KEY_AREA => $area]);
 
         $this->_translateInline = Mage::getSingleton('core/translate_inline')
-            ->isAllowed($area === Mage_Core_Model_App_Area::AREA_ADMINHTML ? 'admin' : null);
+            ->isAllowed($area === Mage_Core_Model_App_Area::AREA_ADMIN ? 'admin' : null);
 
         if (!$forceReload) {
             if ($this->_canUseCache()) {

--- a/app/code/core/Mage/Core/Model/Translate/Inline.php
+++ b/app/code/core/Mage/Core/Model/Translate/Inline.php
@@ -123,7 +123,7 @@ class Mage_Core_Model_Translate_Inline
         }
 
         if (is_null($this->_isAllowed)) {
-            if (Mage::getDesign()->getArea() === Mage_Core_Model_App_Area::AREA_ADMINHTML) {
+            if (Mage::getDesign()->getArea() === Mage_Core_Model_App_Area::AREA_ADMIN) {
                 $active = Mage::getStoreConfigFlag('dev/translate_inline/active_admin', $store);
             } else {
                 $active = Mage::getStoreConfigFlag('dev/translate_inline/active', $store);
@@ -153,7 +153,7 @@ class Mage_Core_Model_Translate_Inline
         /** @var Mage_Core_Model_Resource_Translate_String $resource */
         $resource = Mage::getResourceModel('core/translate_string');
         foreach ($translate as $t) {
-            if (Mage::getDesign()->getArea() === Mage_Core_Model_App_Area::AREA_ADMINHTML) {
+            if (Mage::getDesign()->getArea() === Mage_Core_Model_App_Area::AREA_ADMIN) {
                 $storeId = 0;
             } elseif (empty($t['perstore'])) {
                 $resource->deleteTranslate($t['original'], null, false);
@@ -197,7 +197,7 @@ class Mage_Core_Model_Translate_Inline
     public function processResponseBody(&$body)
     {
         if (!$this->isAllowed()) {
-            if (Mage::getDesign()->getArea() === Mage_Core_Model_App_Area::AREA_ADMINHTML) {
+            if (Mage::getDesign()->getArea() === Mage_Core_Model_App_Area::AREA_ADMIN) {
                 $this->stripInlineTranslations($body);
             }
             return $this;

--- a/app/code/core/Mage/Core/Model/Variable/Observer.php
+++ b/app/code/core/Mage/Core/Model/Variable/Observer.php
@@ -17,7 +17,7 @@ class Mage_Core_Model_Variable_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('cms_wysiwyg_config_prepare', area: 'adminhtml')]
+    #[Maho\Config\Observer('cms_wysiwyg_config_prepare', area: 'admin')]
     public function prepareWysiwygPluginConfig(\Maho\Event\Observer $observer)
     {
         $config = $observer->getEvent()->getConfig();

--- a/app/code/core/Mage/Core/etc/config.xml
+++ b/app/code/core/Mage/Core/etc/config.xml
@@ -190,7 +190,7 @@
             </updates>
         </layout>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Core>
@@ -200,7 +200,7 @@
                 </Mage_Core>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <install>
         <translate>
             <modules>
@@ -279,7 +279,7 @@
                 </allowed_resources>
                 <ignored_resources>.svn,.htaccess</ignored_resources>
                 <loaded_modules>
-                    <Mage_Core />
+                    <Mage_Core/>
                 </loaded_modules>
             </media_storage_configuration>
         </system>
@@ -429,7 +429,7 @@
             <!-- Additional email for notifications -->
             <additional_notification_emails>
                 <!-- On creating a new admin user. You can specify several emails separated by commas. -->
-                <admin_user_create></admin_user_create>
+                <admin_user_create/>
             </additional_notification_emails>
         </general>
     </default>

--- a/app/code/core/Mage/Cron/Model/Observer.php
+++ b/app/code/core/Mage/Cron/Model/Observer.php
@@ -32,7 +32,7 @@ class Mage_Cron_Model_Observer
     /**
      * Check if cron is running and warn admin users if not
      */
-    #[Maho\Config\Observer('controller_action_predispatch', area: 'adminhtml', id: 'cron_status_check')]
+    #[Maho\Config\Observer('controller_action_predispatch', area: 'admin', id: 'cron_status_check')]
     public function checkCronStatus(\Maho\Event\Observer $observer): void
     {
         if (!Mage::getSingleton('admin/session')->isLoggedIn()) {

--- a/app/code/core/Mage/Cron/etc/config.xml
+++ b/app/code/core/Mage/Cron/etc/config.xml
@@ -60,8 +60,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-    <adminhtml>
+    
         <translate>
             <modules>
                 <Mage_Cron>
@@ -71,5 +70,5 @@
                 </Mage_Cron>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
 </config>

--- a/app/code/core/Mage/CurrencySymbol/etc/config.xml
+++ b/app/code/core/Mage/CurrencySymbol/etc/config.xml
@@ -44,9 +44,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-
-    <adminhtml>
+    
         <layout>
             <updates>
                 <currencysymbol>
@@ -63,5 +61,5 @@
                 </Mage_CurrencySymbol>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
 </config>

--- a/app/code/core/Mage/Customer/etc/config.xml
+++ b/app/code/core/Mage/Customer/etc/config.xml
@@ -180,6 +180,16 @@
                 </fax>
             </customer_dataflow>
         </fieldsets>
+    
+        <translate>
+            <modules>
+                <Mage_Customer>
+                    <files>
+                        <default>Mage_Customer.csv</default>
+                    </files>
+                </Mage_Customer>
+            </modules>
+        </translate>
     </admin>
     <global>
         <fieldsets>
@@ -426,17 +436,6 @@
             </email>
         </template>
     </global>
-    <adminhtml>
-        <translate>
-            <modules>
-                <Mage_Customer>
-                    <files>
-                        <default>Mage_Customer.csv</default>
-                    </files>
-                </Mage_Customer>
-            </modules>
-        </translate>
-    </adminhtml>
     <frontend>
         <secure_url>
             <customer>/customer/</customer>

--- a/app/code/core/Mage/Dataflow/etc/config.xml
+++ b/app/code/core/Mage/Dataflow/etc/config.xml
@@ -56,7 +56,7 @@
             </dataflow_setup>
         </resources>
     </global>
-    <adminhtml>
+    <admin>
         <layout>
             <updates>
                 <dataflow>
@@ -64,5 +64,5 @@
                 </dataflow>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
 </config>

--- a/app/code/core/Mage/Directory/etc/config.xml
+++ b/app/code/core/Mage/Directory/etc/config.xml
@@ -119,8 +119,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-    <adminhtml>
+    
         <translate>
             <modules>
                 <Mage_Directory>
@@ -137,7 +136,7 @@
                 </directory>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
     <default>
         <system>
             <currency>

--- a/app/code/core/Mage/Downloadable/Model/Observer.php
+++ b/app/code/core/Mage/Downloadable/Model/Observer.php
@@ -20,7 +20,7 @@ class Mage_Downloadable_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return  Mage_Downloadable_Model_Observer
      */
-    #[Maho\Config\Observer('catalog_product_prepare_save', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_product_prepare_save', area: 'admin')]
     public function prepareProductSave($observer)
     {
         $request = $observer->getEvent()->getRequest();
@@ -39,7 +39,7 @@ class Mage_Downloadable_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('sales_order_item_save_commit_after', area: 'adminhtml')]
+    #[Maho\Config\Observer('sales_order_item_save_commit_after', area: 'admin')]
     #[Maho\Config\Observer('sales_order_item_save_commit_after', area: 'frontend')]
     public function saveDownloadableOrderItem(\Maho\Event\Observer $observer)
     {
@@ -146,7 +146,7 @@ class Mage_Downloadable_Model_Observer
      * @param \Maho\Event\Observer $observer
      * @return $this
      */
-    #[Maho\Config\Observer('sales_order_save_commit_after', area: 'adminhtml')]
+    #[Maho\Config\Observer('sales_order_save_commit_after', area: 'admin')]
     #[Maho\Config\Observer('sales_order_save_commit_after', area: 'frontend')]
     public function setLinkStatus($observer)
     {

--- a/app/code/core/Mage/Downloadable/etc/config.xml
+++ b/app/code/core/Mage/Downloadable/etc/config.xml
@@ -170,33 +170,6 @@
             </creditmemo>
         </pdf>
     </global>
-    <adminhtml>
-        <translate>
-            <modules>
-                <Mage_Downloadable>
-                    <files>
-                        <default>Mage_Downloadable.csv</default>
-                    </files>
-                </Mage_Downloadable>
-            </modules>
-        </translate>
-        <sales>
-            <order>
-                <create>
-                    <available_product_types>
-                        <downloadable/>
-                    </available_product_types>
-                </create>
-            </order>
-        </sales>
-        <layout>
-            <updates>
-                <downloadable>
-                    <file>downloadable.xml</file>
-                </downloadable>
-            </updates>
-        </layout>
-    </adminhtml>
     <frontend>
         <routers>
             <downloadable>
@@ -287,6 +260,32 @@
                 </args>
             </adminhtml>
         </routers>
+    
+        <translate>
+            <modules>
+                <Mage_Downloadable>
+                    <files>
+                        <default>Mage_Downloadable.csv</default>
+                    </files>
+                </Mage_Downloadable>
+            </modules>
+        </translate>
+        <sales>
+            <order>
+                <create>
+                    <available_product_types>
+                        <downloadable/>
+                    </available_product_types>
+                </create>
+            </order>
+        </sales>
+        <layout>
+            <updates>
+                <downloadable>
+                    <file>downloadable.xml</file>
+                </downloadable>
+            </updates>
+        </layout>
     </admin>
     <default>
         <catalog>

--- a/app/code/core/Mage/Eav/etc/config.xml
+++ b/app/code/core/Mage/Eav/etc/config.xml
@@ -100,7 +100,7 @@
         <eav_attributes>
         </eav_attributes>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Eav>
@@ -110,7 +110,7 @@
                 </Mage_Eav>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <frontend>
         <translate>
             <modules>

--- a/app/code/core/Mage/GiftMessage/Model/Observer.php
+++ b/app/code/core/Mage/GiftMessage/Model/Observer.php
@@ -17,7 +17,7 @@ class Mage_GiftMessage_Model_Observer extends \Maho\DataObject
      *
      * @return $this
      */
-    #[Maho\Config\Observer('sales_convert_quote_item_to_order_item', area: 'adminhtml')]
+    #[Maho\Config\Observer('sales_convert_quote_item_to_order_item', area: 'admin')]
     #[Maho\Config\Observer('sales_convert_quote_item_to_order_item', area: 'frontend')]
     public function salesEventConvertQuoteItemToOrderItem(\Maho\Event\Observer $observer)
     {
@@ -42,7 +42,7 @@ class Mage_GiftMessage_Model_Observer extends \Maho\DataObject
      *
      * @return $this
      */
-    #[Maho\Config\Observer('sales_convert_quote_address_to_order', area: 'adminhtml')]
+    #[Maho\Config\Observer('sales_convert_quote_address_to_order', area: 'admin')]
     #[Maho\Config\Observer('sales_convert_quote_address_to_order', area: 'frontend')]
     public function salesEventConvertQuoteAddressToOrder(\Maho\Event\Observer $observer)
     {
@@ -58,7 +58,7 @@ class Mage_GiftMessage_Model_Observer extends \Maho\DataObject
      *
      * @return $this
      */
-    #[Maho\Config\Observer('sales_convert_quote_to_order', area: 'adminhtml')]
+    #[Maho\Config\Observer('sales_convert_quote_to_order', area: 'admin')]
     #[Maho\Config\Observer('sales_convert_quote_to_order', area: 'frontend')]
     public function salesEventConvertQuoteToOrder(\Maho\Event\Observer $observer)
     {
@@ -133,7 +133,7 @@ class Mage_GiftMessage_Model_Observer extends \Maho\DataObject
      *
      * @return $this
      */
-    #[Maho\Config\Observer('sales_convert_order_to_quote', area: 'adminhtml')]
+    #[Maho\Config\Observer('sales_convert_order_to_quote', area: 'admin')]
     #[Maho\Config\Observer('sales_convert_order_to_quote', area: 'frontend')]
     public function salesEventOrderToQuote(\Maho\Event\Observer $observer)
     {
@@ -163,7 +163,7 @@ class Mage_GiftMessage_Model_Observer extends \Maho\DataObject
      *
      * @return $this
      */
-    #[Maho\Config\Observer('sales_convert_order_item_to_quote_item', area: 'adminhtml')]
+    #[Maho\Config\Observer('sales_convert_order_item_to_quote_item', area: 'admin')]
     public function salesEventOrderItemToQuoteItem(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Sales_Model_Order_Item $orderItem */

--- a/app/code/core/Mage/GiftMessage/etc/config.xml
+++ b/app/code/core/Mage/GiftMessage/etc/config.xml
@@ -66,7 +66,7 @@
             </gift_messages>
         </sales>
     </default>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_GiftMessage>
@@ -83,7 +83,7 @@
                 </giftmessage>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
     <frontend>
         <routers>
             <giftmessage>

--- a/app/code/core/Mage/GoogleAnalytics/etc/config.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/config.xml
@@ -58,7 +58,7 @@
             </updates>
         </layout>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_GoogleAnalytics>
@@ -68,5 +68,5 @@
                 </Mage_GoogleAnalytics>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
 </config>

--- a/app/code/core/Mage/ImportExport/etc/config.xml
+++ b/app/code/core/Mage/ImportExport/etc/config.xml
@@ -116,8 +116,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-    <adminhtml>
+    
         <translate>
             <modules>
                 <Mage_ImportExport>
@@ -134,7 +133,7 @@
                 </importexport>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
     <default>
         <system>
             <export_csv>

--- a/app/code/core/Mage/Index/etc/config.xml
+++ b/app/code/core/Mage/Index/etc/config.xml
@@ -71,8 +71,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-    <adminhtml>
+    
         <layout>
             <updates>
                 <index>
@@ -89,5 +88,5 @@
                 </Mage_Index>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
 </config>

--- a/app/code/core/Mage/Log/Model/Resource/Visitor/Online.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor/Online.php
@@ -107,7 +107,6 @@ class Mage_Log_Model_Resource_Visitor_Online extends Mage_Core_Model_Resource_Db
 
             foreach ($visitors as $visitorData) {
                 unset($visitorData['last_url_id']);
-                $visitorData['remote_addr'] ??= 0;
 
                 $writeAdapter->insertForce($this->getMainTable(), $visitorData);
             }

--- a/app/code/core/Mage/Log/Model/Resource/Visitor/Online.php
+++ b/app/code/core/Mage/Log/Model/Resource/Visitor/Online.php
@@ -107,6 +107,7 @@ class Mage_Log_Model_Resource_Visitor_Online extends Mage_Core_Model_Resource_Db
 
             foreach ($visitors as $visitorData) {
                 unset($visitorData['last_url_id']);
+                $visitorData['remote_addr'] ??= 0;
 
                 $writeAdapter->insertForce($this->getMainTable(), $visitorData);
             }

--- a/app/code/core/Mage/Log/etc/config.xml
+++ b/app/code/core/Mage/Log/etc/config.xml
@@ -112,7 +112,7 @@
             </email>
         </template>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Log>
@@ -122,7 +122,7 @@
                 </Mage_Log>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <default>
         <log>
             <visitor>

--- a/app/code/core/Mage/Newsletter/etc/config.xml
+++ b/app/code/core/Mage/Newsletter/etc/config.xml
@@ -80,7 +80,7 @@
             <tempate_filter>newsletter/template_filter</tempate_filter>
         </newsletter>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Newsletter>
@@ -97,7 +97,7 @@
                 </newsletter>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
     <frontend>
         <routers>
             <newsletter>

--- a/app/code/core/Mage/Oauth/Block/Authorize/Abstract.php
+++ b/app/code/core/Mage/Oauth/Block/Authorize/Abstract.php
@@ -77,7 +77,7 @@ abstract class Mage_Oauth_Block_Authorize_Abstract extends Mage_Core_Block_Templ
         //load base template from admin area
         $params = [
             '_relative' => true,
-            '_area'     => 'adminhtml',
+            '_area'     => 'admin',
             '_package'  => 'default',
         ];
         return Mage::getDesign()->getTemplateFilename($this->getTemplate(), $params);

--- a/app/code/core/Mage/Oauth/etc/config.xml
+++ b/app/code/core/Mage/Oauth/etc/config.xml
@@ -74,8 +74,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-    <adminhtml>
+    
         <translate>
             <modules>
                 <Mage_Oauth>
@@ -92,7 +91,7 @@
                 </oauth>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
     <frontend>
         <routers>
             <oauth>

--- a/app/code/core/Mage/Page/etc/config.xml
+++ b/app/code/core/Mage/Page/etc/config.xml
@@ -81,7 +81,7 @@
             </updates>
         </layout>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Page>
@@ -91,7 +91,7 @@
                 </Mage_Page>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <install>
         <translate>
             <modules>
@@ -106,16 +106,16 @@
     <default>
         <design>
             <head translate="default_description" module="page">
-                <default_title></default_title>
-                <default_description></default_description>
-                <default_keywords></default_keywords>
-                <default_robots></default_robots>
+                <default_title/>
+                <default_description/>
+                <default_keywords/>
+                <default_robots/>
                 <default_media_type>text/html</default_media_type>
                 <default_charset>utf-8</default_charset>
             </head>
             <header translate="welcome" module="page">
                 <logo_src>images/logo.svg</logo_src>
-                <logo_alt></logo_alt>
+                <logo_alt/>
                 <logo_src_small>images/logo.svg</logo_src_small>
                 <welcome>Welcome!</welcome>
             </header>

--- a/app/code/core/Mage/Paygate/etc/config.xml
+++ b/app/code/core/Mage/Paygate/etc/config.xml
@@ -38,17 +38,6 @@
             </paygate_setup>
         </resources>
     </global>
-    <adminhtml>
-        <translate>
-            <modules>
-                <Mage_Paygate>
-                    <files>
-                        <default>Mage_Paygate.csv</default>
-                    </files>
-                </Mage_Paygate>
-            </modules>
-        </translate>
-    </adminhtml>
     <frontend>
         <secure_url>
             <authorizenet_paygate>/paygate/authorizenet_payment</authorizenet_paygate>
@@ -82,6 +71,16 @@
                 </args>
             </adminhtml>
         </routers>
+    
+        <translate>
+            <modules>
+                <Mage_Paygate>
+                    <files>
+                        <default>Mage_Paygate.csv</default>
+                    </files>
+                </Mage_Paygate>
+            </modules>
+        </translate>
     </admin>
 
     <default>

--- a/app/code/core/Mage/Payment/etc/config.xml
+++ b/app/code/core/Mage/Payment/etc/config.xml
@@ -110,7 +110,17 @@
             </updates>
         </layout>
     </frontend>
-    <adminhtml>
+    <admin>
+        <routers>
+            <adminhtml>
+                <args>
+                    <modules>
+                        <payment before="Mage_Adminhtml">Mage_Payment_Adminhtml</payment>
+                    </modules>
+                </args>
+            </adminhtml>
+        </routers>
+    
         <translate>
             <modules>
                 <Mage_Payment>
@@ -127,17 +137,6 @@
                 </payment_adminhtml>
             </updates>
         </layout>
-    </adminhtml>
-    <admin>
-        <routers>
-            <adminhtml>
-                <args>
-                    <modules>
-                        <payment before="Mage_Adminhtml">Mage_Payment_Adminhtml</payment>
-                    </modules>
-                </args>
-            </adminhtml>
-        </routers>
     </admin>
     <default>
         <payment>

--- a/app/code/core/Mage/Paypal/Model/Observer.php
+++ b/app/code/core/Mage/Paypal/Model/Observer.php
@@ -91,7 +91,7 @@ class Mage_Paypal_Model_Observer
     /**
      * Load country dependent PayPal solutions system configuration
      */
-    #[Maho\Config\Observer('adminhtml_init_system_config', area: 'adminhtml')]
+    #[Maho\Config\Observer('adminhtml_init_system_config', area: 'admin')]
     public function loadCountryDependentSolutionsConfig(\Maho\Event\Observer $observer)
     {
         $countryCode = Mage::helper('paypal')->getConfigurationCountryCode();

--- a/app/code/core/Mage/Paypal/etc/config.xml
+++ b/app/code/core/Mage/Paypal/etc/config.xml
@@ -119,17 +119,6 @@
             <paypal_express_callbackshippingoptions>paypal/express/callbackshippingoptions</paypal_express_callbackshippingoptions>
         </secure_url>
     </frontend>
-    <adminhtml>
-        <translate>
-            <modules>
-                <Mage_Paypal>
-                    <files>
-                        <default>Mage_Paypal.csv</default>
-                    </files>
-                </Mage_Paypal>
-            </modules>
-        </translate>
-    </adminhtml>
     <default>
         <paypal>
             <bncode>Magento_Cart_Community</bncode>
@@ -277,5 +266,15 @@
                 </args>
             </adminhtml>
         </routers>
+    
+        <translate>
+            <modules>
+                <Mage_Paypal>
+                    <files>
+                        <default>Mage_Paypal.csv</default>
+                    </files>
+                </Mage_Paypal>
+            </modules>
+        </translate>
     </admin>
 </config>

--- a/app/code/core/Mage/PaypalUk/etc/config.xml
+++ b/app/code/core/Mage/PaypalUk/etc/config.xml
@@ -79,7 +79,7 @@
             </updates>
         </layout>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_PaypalUk>
@@ -89,7 +89,7 @@
                 </Mage_PaypalUk>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <default>
         <payment>
             <paypaluk_express>

--- a/app/code/core/Mage/ProductAlert/etc/config.xml
+++ b/app/code/core/Mage/ProductAlert/etc/config.xml
@@ -70,7 +70,7 @@
             </email>
         </template>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_ProductAlert>
@@ -80,7 +80,7 @@
                 </Mage_ProductAlert>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <frontend>
         <translate>
             <modules>

--- a/app/code/core/Mage/Rating/Model/Observer.php
+++ b/app/code/core/Mage/Rating/Model/Observer.php
@@ -17,7 +17,7 @@ class Mage_Rating_Model_Observer
      *
      * @return Mage_Rating_Model_Observer
      */
-    #[Maho\Config\Observer('catalog_product_delete_after_done', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_product_delete_after_done', area: 'admin')]
     public function processProductAfterDeleteEvent(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Product $eventProduct */

--- a/app/code/core/Mage/Rating/etc/config.xml
+++ b/app/code/core/Mage/Rating/etc/config.xml
@@ -72,7 +72,7 @@
             </modules>
         </translate>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Rating>
@@ -82,5 +82,5 @@
                 </Mage_Rating>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
 </config>

--- a/app/code/core/Mage/Reports/etc/config.xml
+++ b/app/code/core/Mage/Reports/etc/config.xml
@@ -57,7 +57,7 @@
             </reports_setup>
         </resources>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Reports>
@@ -67,7 +67,7 @@
                 </Mage_Reports>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <frontend>
         <translate>
             <modules>

--- a/app/code/core/Mage/Review/Model/Observer.php
+++ b/app/code/core/Mage/Review/Model/Observer.php
@@ -33,7 +33,7 @@ class Mage_Review_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_product_delete_after_done', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_product_delete_after_done', area: 'admin')]
     public function processProductAfterDeleteEvent(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Product $eventProduct */

--- a/app/code/core/Mage/Review/etc/config.xml
+++ b/app/code/core/Mage/Review/etc/config.xml
@@ -58,7 +58,7 @@
             </review>
         </blocks>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Review>
@@ -68,7 +68,7 @@
                 </Mage_Review>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <frontend>
         <routers>
             <review>

--- a/app/code/core/Mage/Rss/Helper/Data.php
+++ b/app/code/core/Mage/Rss/Helper/Data.php
@@ -110,7 +110,7 @@ class Mage_Rss_Helper_Data extends Mage_Core_Helper_Abstract
             $emulationModel = Mage::getModel('core/app_emulation');
             // Emulate admin environment to disable using flat model - otherwise we won't get global stats
             // for all stores
-            $emulationModel->startEnvironmentEmulation(0, Mage_Core_Model_App_Area::AREA_ADMINHTML);
+            $emulationModel->startEnvironmentEmulation(0, Mage_Core_Model_App_Area::AREA_ADMIN);
         }
     }
 

--- a/app/code/core/Mage/Rss/Helper/Data.php
+++ b/app/code/core/Mage/Rss/Helper/Data.php
@@ -6,6 +6,7 @@
  * @package    Mage_Rss
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
  * @copyright  Copyright (c) 2021-2025 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 

--- a/app/code/core/Mage/Rss/controllers/CatalogController.php
+++ b/app/code/core/Mage/Rss/controllers/CatalogController.php
@@ -87,11 +87,11 @@ class Mage_Rss_CatalogController extends Mage_Rss_Controller_Abstract
     {
         $action = strtolower($this->getRequest()->getActionName());
         if ($action == 'notifystock' && $this->isFeedEnable('catalog/notifystock')) {
-            $this->_currentArea = Mage_Core_Model_App_Area::AREA_ADMINHTML;
+            $this->_currentArea = Mage_Core_Model_App_Area::AREA_ADMIN;
             Mage::helper('rss')->authAdmin('catalog/products');
         }
         if ($action == 'review' && $this->isFeedEnable('catalog/review')) {
-            $this->_currentArea = Mage_Core_Model_App_Area::AREA_ADMINHTML;
+            $this->_currentArea = Mage_Core_Model_App_Area::AREA_ADMIN;
             Mage::helper('rss')->authAdmin('catalog/reviews_ratings');
         }
         return parent::preDispatch();

--- a/app/code/core/Mage/Rss/controllers/OrderController.php
+++ b/app/code/core/Mage/Rss/controllers/OrderController.php
@@ -64,7 +64,7 @@ class Mage_Rss_OrderController extends Mage_Rss_Controller_Abstract
     {
         $action = strtolower($this->getRequest()->getActionName());
         if ($action == 'new' && $this->isFeedEnable('order/new')) {
-            $this->_currentArea = Mage_Core_Model_App_Area::AREA_ADMINHTML;
+            $this->_currentArea = Mage_Core_Model_App_Area::AREA_ADMIN;
             Mage::helper('rss')->authAdmin('sales/order');
         }
         return parent::preDispatch();

--- a/app/code/core/Mage/Rss/etc/config.xml
+++ b/app/code/core/Mage/Rss/etc/config.xml
@@ -38,7 +38,7 @@
             </rss_setup>
         </resources>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Rss>
@@ -55,7 +55,7 @@
                 </rss>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
     <frontend>
         <translate>
             <modules>

--- a/app/code/core/Mage/Rule/etc/config.xml
+++ b/app/code/core/Mage/Rule/etc/config.xml
@@ -31,7 +31,7 @@
             </rule>
         </blocks>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Rule>
@@ -41,7 +41,7 @@
                 </Mage_Rule>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <frontend>
         <translate>
             <modules>

--- a/app/code/core/Mage/Sales/Model/Observer.php
+++ b/app/code/core/Mage/Sales/Model/Observer.php
@@ -82,7 +82,7 @@ class Mage_Sales_Model_Observer
      * @throws Exception
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_product_delete_before', area: 'adminhtml', id: 'sales_quote_observer')]
+    #[Maho\Config\Observer('catalog_product_delete_before', area: 'admin', id: 'sales_quote_observer')]
     public function substractQtyFromQuotes(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Product $product */
@@ -96,7 +96,7 @@ class Mage_Sales_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalogrule_after_apply', area: 'adminhtml', id: 'sales_quote_observer')]
+    #[Maho\Config\Observer('catalogrule_after_apply', area: 'admin', id: 'sales_quote_observer')]
     public function markQuotesRecollectOnCatalogRules(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Product $product */
@@ -126,7 +126,7 @@ class Mage_Sales_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_product_save_after', area: 'adminhtml', id: 'sales_quote')]
+    #[Maho\Config\Observer('catalog_product_save_after', area: 'admin', id: 'sales_quote')]
     public function catalogProductSaveAfter(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Product $product */
@@ -145,7 +145,7 @@ class Mage_Sales_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_product_status_update', area: 'adminhtml', id: 'sales_quote')]
+    #[Maho\Config\Observer('catalog_product_status_update', area: 'admin', id: 'sales_quote')]
     public function catalogProductStatusUpdate(\Maho\Event\Observer $observer)
     {
         $status     = $observer->getEvent()->getStatus();
@@ -243,7 +243,7 @@ class Mage_Sales_Model_Observer
      *
      * @param \Maho\Event\Observer $observer
      */
-    #[Maho\Config\Observer('catalog_product_edit_form_render_recurring', area: 'adminhtml', id: 'payment')]
+    #[Maho\Config\Observer('catalog_product_edit_form_render_recurring', area: 'admin', id: 'payment')]
     public function prepareProductEditFormRecurringProfile($observer)
     {
         // replace the element of recurring payment profile field with a form
@@ -273,7 +273,7 @@ class Mage_Sales_Model_Observer
      *
      * @param \Maho\Event\Observer $observer
      */
-    #[Maho\Config\Observer('payment_method_is_active', area: 'adminhtml', id: 'sales_billing_agreement')]
+    #[Maho\Config\Observer('payment_method_is_active', area: 'admin', id: 'sales_billing_agreement')]
     public function restrictAdminBillingAgreementUsage($observer)
     {
         $methodInstance = $observer->getEvent()->getMethodInstance();
@@ -290,7 +290,7 @@ class Mage_Sales_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('customer_save_after', area: 'adminhtml', id: 'customer')]
+    #[Maho\Config\Observer('customer_save_after', area: 'admin', id: 'customer')]
     public function customerSaveAfter(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Customer_Model_Customer $customer */

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
@@ -61,14 +61,14 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends \Maho\DataObject
     protected function _getLayout(): Mage_Core_Model_Layout
     {
         if (!$this->_layout) {
-            // Ensure we're using adminhtml design area for PDF layouts
+            // Ensure we're using admin design area for PDF layouts
             $originalArea = Mage::getDesign()->getArea();
-            Mage::getDesign()->setArea('adminhtml');
+            Mage::getDesign()->setArea('admin');
 
             $this->_layout = Mage::getSingleton('core/layout');
 
             // Restore original area if it was different
-            if ($originalArea !== 'adminhtml') {
+            if ($originalArea !== 'admin') {
                 Mage::getDesign()->setArea($originalArea);
             }
         }
@@ -99,9 +99,9 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends \Maho\DataObject
         $html = '';
         $isFirst = true;
 
-        // Set adminhtml design area for template/block loading
+        // Set admin design area for template/block loading
         $originalArea = Mage::getDesign()->getArea();
-        Mage::getDesign()->setArea('adminhtml');
+        Mage::getDesign()->setArea('admin');
 
         try {
             foreach ($documents as $document) {
@@ -140,7 +140,7 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends \Maho\DataObject
             }
         } finally {
             // Restore original area even if exceptions occur
-            if ($originalArea !== 'adminhtml') {
+            if ($originalArea !== 'admin') {
                 Mage::getDesign()->setArea($originalArea);
             }
         }

--- a/app/code/core/Mage/Sales/etc/config.xml
+++ b/app/code/core/Mage/Sales/etc/config.xml
@@ -1401,7 +1401,7 @@
                 <discount translate="title">
                     <title>Discount</title>
                     <source_field>discount_amount</source_field>
-                    <amount_prefix></amount_prefix>
+                    <amount_prefix/>
                     <title_source_field>discount_description</title_source_field>
                     <font_size>7</font_size>
                     <display_zero>0</display_zero>
@@ -1440,17 +1440,17 @@
         <layout>
             <sales_pdf_invoice>
                 <reference name="sales.pdf.invoice">
-                    <block type="sales/order_pdf_invoice" name="sales.pdf.invoice" template="sales/order/pdf/invoice/default.phtml" />
+                    <block type="sales/order_pdf_invoice" name="sales.pdf.invoice" template="sales/order/pdf/invoice/default.phtml"/>
                 </reference>
             </sales_pdf_invoice>
             <sales_pdf_shipment>
                 <reference name="sales.pdf.shipment">
-                    <block type="sales/order_pdf_shipment" name="sales.pdf.shipment" template="sales/order/pdf/shipment/default.phtml" />
+                    <block type="sales/order_pdf_shipment" name="sales.pdf.shipment" template="sales/order/pdf/shipment/default.phtml"/>
                 </reference>
             </sales_pdf_shipment>
             <sales_pdf_creditmemo>
                 <reference name="sales.pdf.creditmemo">
-                    <block type="sales/order_pdf_creditmemo" name="sales.pdf.creditmemo" template="sales/order/pdf/creditmemo/default.phtml" />
+                    <block type="sales/order_pdf_creditmemo" name="sales.pdf.creditmemo" template="sales/order/pdf/creditmemo/default.phtml"/>
                 </reference>
             </sales_pdf_creditmemo>
         </layout>
@@ -1491,7 +1491,7 @@
             </updates>
         </layout>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Sales>
@@ -1508,7 +1508,7 @@
                 </sales>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
     <default>
         <sales>
             <totals_sort>

--- a/app/code/core/Mage/SalesRule/Model/Observer.php
+++ b/app/code/core/Mage/SalesRule/Model/Observer.php
@@ -202,7 +202,7 @@ class Mage_SalesRule_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_entity_attribute_save_after', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_entity_attribute_save_after', area: 'admin')]
     public function catalogAttributeSaveAfter(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Entity_Attribute $attribute */
@@ -220,7 +220,7 @@ class Mage_SalesRule_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_entity_attribute_delete_after', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_entity_attribute_delete_after', area: 'admin')]
     public function catalogAttributeDeleteAfter(\Maho\Event\Observer $observer)
     {
         /** @var Mage_Catalog_Model_Entity_Attribute $attribute */

--- a/app/code/core/Mage/SalesRule/etc/config.xml
+++ b/app/code/core/Mage/SalesRule/etc/config.xml
@@ -119,7 +119,7 @@
             </coupon>
         </salesrule>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_SalesRule>
@@ -129,7 +129,7 @@
                 </Mage_SalesRule>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <frontend>
         <translate>
             <modules>

--- a/app/code/core/Mage/Shipping/etc/config.xml
+++ b/app/code/core/Mage/Shipping/etc/config.xml
@@ -72,7 +72,7 @@
             </shipping>
         </sales>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Shipping>
@@ -82,7 +82,7 @@
                 </Mage_Shipping>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <frontend>
         <translate>
             <modules>

--- a/app/code/core/Mage/Sitemap/etc/config.xml
+++ b/app/code/core/Mage/Sitemap/etc/config.xml
@@ -47,7 +47,7 @@
             </email>
         </template>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Sitemap>
@@ -57,7 +57,7 @@
                 </Mage_Sitemap>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <default>
         <sitemap>
             <page>

--- a/app/code/core/Mage/Tag/Model/Tag.php
+++ b/app/code/core/Mage/Tag/Model/Tag.php
@@ -191,8 +191,8 @@ class Mage_Tag_Model_Tag extends Mage_Core_Model_Abstract
      * @param \Maho\Event\Observer $observer
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_controller_product_save_visibility_changed', area: 'adminhtml')]
-    #[Maho\Config\Observer('catalog_controller_product_delete', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_controller_product_save_visibility_changed', area: 'admin')]
+    #[Maho\Config\Observer('catalog_controller_product_delete', area: 'admin')]
     public function productEventAggregate($observer)
     {
         $this->_getProductEventTagsCollection($observer)->walk('aggregate');
@@ -205,7 +205,7 @@ class Mage_Tag_Model_Tag extends Mage_Core_Model_Abstract
      * @param \Maho\Event\Observer $observer
      * @return $this
      */
-    #[Maho\Config\Observer('catalog_product_delete_before', area: 'adminhtml')]
+    #[Maho\Config\Observer('catalog_product_delete_before', area: 'admin')]
     public function productDeleteEventAction($observer)
     {
         $this->_getResource()->decrementProducts($this->_getProductEventTagsCollection($observer)->getAllIds());

--- a/app/code/core/Mage/Tag/etc/config.xml
+++ b/app/code/core/Mage/Tag/etc/config.xml
@@ -97,7 +97,7 @@
             <tag_customer>/tag/customer/</tag_customer>
         </secure_url>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Tag>
@@ -114,7 +114,7 @@
                 </tag>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
     <default>
         <catalog>
             <tags>

--- a/app/code/core/Mage/Tax/etc/config.xml
+++ b/app/code/core/Mage/Tax/etc/config.xml
@@ -169,7 +169,7 @@
             </totals>
         </pdf>
     </global>
-    <adminhtml>
+    <admin>
         <layout>
             <updates>
                 <tax>
@@ -186,7 +186,7 @@
                 </Mage_Tax>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <frontend>
         <translate>
             <modules>

--- a/app/code/core/Mage/Uploader/etc/config.xml
+++ b/app/code/core/Mage/Uploader/etc/config.xml
@@ -32,7 +32,7 @@
             </uploader>
         </models>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Uploader>
@@ -42,7 +42,7 @@
                 </Mage_Uploader>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <frontend>
         <translate>
             <modules>

--- a/app/code/core/Mage/Usa/etc/config.xml
+++ b/app/code/core/Mage/Usa/etc/config.xml
@@ -54,7 +54,7 @@
             </tax>
         </sales>
     </global>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Usa>
@@ -64,7 +64,7 @@
                 </Mage_Usa>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <frontend>
         <translate>
             <modules>
@@ -162,7 +162,7 @@
                 <shipment_requesttype>0</shipment_requesttype>
                 <handling/>
                 <machinable>true</machinable>
-                <methods></methods>
+                <methods/>
                 <model>usa/shipping_carrier_usps</model>
                 <size>REGULAR</size>
                 <title>United States Postal Service</title>

--- a/app/code/core/Mage/Weee/Model/Observer.php
+++ b/app/code/core/Mage/Weee/Model/Observer.php
@@ -17,7 +17,7 @@ class Mage_Weee_Model_Observer extends Mage_Core_Model_Abstract
      *
      * @return  Mage_Weee_Model_Observer
      */
-    #[Maho\Config\Observer('adminhtml_catalog_product_edit_prepare_form', area: 'adminhtml')]
+    #[Maho\Config\Observer('adminhtml_catalog_product_edit_prepare_form', area: 'admin')]
     public function setWeeeRendererInForm(\Maho\Event\Observer $observer)
     {
         //adminhtml_catalog_product_edit_prepare_form
@@ -43,7 +43,7 @@ class Mage_Weee_Model_Observer extends Mage_Core_Model_Abstract
      *
      * @return  Mage_Weee_Model_Observer
      */
-    #[Maho\Config\Observer('adminhtml_catalog_product_form_prepare_excluded_field_list', area: 'adminhtml')]
+    #[Maho\Config\Observer('adminhtml_catalog_product_form_prepare_excluded_field_list', area: 'admin')]
     public function updateExcludedFieldList(\Maho\Event\Observer $observer)
     {
         //adminhtml_catalog_product_form_prepare_excluded_field_list
@@ -168,7 +168,7 @@ class Mage_Weee_Model_Observer extends Mage_Core_Model_Abstract
      *
      * @return  Mage_Weee_Model_Observer
      */
-    #[Maho\Config\Observer('adminhtml_product_attribute_types', area: 'adminhtml')]
+    #[Maho\Config\Observer('adminhtml_product_attribute_types', area: 'admin')]
     public function addWeeeTaxAttributeType(\Maho\Event\Observer $observer)
     {
         // adminhtml_product_attribute_types
@@ -231,7 +231,7 @@ class Mage_Weee_Model_Observer extends Mage_Core_Model_Abstract
      *
      * @return Mage_Weee_Model_Observer
      */
-    #[Maho\Config\Observer('adminhtml_catalog_product_edit_element_types', area: 'adminhtml')]
+    #[Maho\Config\Observer('adminhtml_catalog_product_edit_element_types', area: 'admin')]
     public function updateElementTypes(\Maho\Event\Observer $observer)
     {
         $response = $observer->getEvent()->getResponse();

--- a/app/code/core/Mage/Widget/Model/Observer.php
+++ b/app/code/core/Mage/Widget/Model/Observer.php
@@ -17,7 +17,7 @@ class Mage_Widget_Model_Observer
      *
      * @return $this
      */
-    #[Maho\Config\Observer('cms_wysiwyg_config_prepare', area: 'adminhtml')]
+    #[Maho\Config\Observer('cms_wysiwyg_config_prepare', area: 'admin')]
     public function prepareWidgetsPluginConfig(\Maho\Event\Observer $observer)
     {
         $config = $observer->getEvent()->getConfig();

--- a/app/code/core/Mage/Widget/etc/config.xml
+++ b/app/code/core/Mage/Widget/etc/config.xml
@@ -66,7 +66,17 @@
             </related_cache_types>
         </widget>
     </global>
-    <adminhtml>
+    <admin>
+        <routers>
+            <adminhtml>
+                <args>
+                    <modules>
+                        <widget before="Mage_Adminhtml">Mage_Widget_Adminhtml</widget>
+                    </modules>
+                </args>
+            </adminhtml>
+        </routers>
+    
         <translate>
             <modules>
                 <Mage_Widget>
@@ -83,16 +93,5 @@
                 </widget>
             </updates>
         </layout>
-    </adminhtml>
-    <admin>
-        <routers>
-            <adminhtml>
-                <args>
-                    <modules>
-                        <widget before="Mage_Adminhtml">Mage_Widget_Adminhtml</widget>
-                    </modules>
-                </args>
-            </adminhtml>
-        </routers>
     </admin>
 </config>

--- a/app/code/core/Mage/Wishlist/etc/config.xml
+++ b/app/code/core/Mage/Wishlist/etc/config.xml
@@ -98,7 +98,7 @@
             <wishlist>/wishlist/</wishlist>
         </secure_url>
     </frontend>
-    <adminhtml>
+    <admin>
         <translate>
             <modules>
                 <Mage_Wishlist>
@@ -108,7 +108,7 @@
                 </Mage_Wishlist>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <default>
         <wishlist>
             <general>

--- a/app/code/core/Maho/AdminActivityLog/Model/Observer.php
+++ b/app/code/core/Maho/AdminActivityLog/Model/Observer.php
@@ -45,7 +45,7 @@ class Maho_AdminActivityLog_Model_Observer
         return $this->_currentActionGroupId;
     }
 
-    #[Maho\Config\Observer('admin_user_authenticate_after', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_login_success')]
+    #[Maho\Config\Observer('admin_user_authenticate_after', area: 'admin', type: 'singleton', id: 'adminactivitylog_login_success')]
     public function logAdminLogin(\Maho\Event\Observer $observer): void
     {
         try {
@@ -62,7 +62,7 @@ class Maho_AdminActivityLog_Model_Observer
         }
     }
 
-    #[Maho\Config\Observer('admin_session_user_logout', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_logout')]
+    #[Maho\Config\Observer('admin_session_user_logout', area: 'admin', type: 'singleton', id: 'adminactivitylog_logout')]
     public function logAdminLogout(\Maho\Event\Observer $observer): void
     {
         try {
@@ -79,7 +79,7 @@ class Maho_AdminActivityLog_Model_Observer
         }
     }
 
-    #[Maho\Config\Observer('admin_session_user_login_failed', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_login_failed')]
+    #[Maho\Config\Observer('admin_session_user_login_failed', area: 'admin', type: 'singleton', id: 'adminactivitylog_login_failed')]
     public function logAdminLoginFailed(\Maho\Event\Observer $observer): void
     {
         try {
@@ -99,8 +99,8 @@ class Maho_AdminActivityLog_Model_Observer
         }
     }
 
-    #[Maho\Config\Observer('model_save_before', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_save_before')]
-    #[Maho\Config\Observer('model_delete_before', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_delete_before')]
+    #[Maho\Config\Observer('model_save_before', area: 'admin', type: 'singleton', id: 'adminactivitylog_save_before')]
+    #[Maho\Config\Observer('model_delete_before', area: 'admin', type: 'singleton', id: 'adminactivitylog_delete_before')]
     public function logAdminActivityBefore(\Maho\Event\Observer $observer): void
     {
         try {
@@ -130,7 +130,7 @@ class Maho_AdminActivityLog_Model_Observer
         }
     }
 
-    #[Maho\Config\Observer('model_save_after', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_save_after')]
+    #[Maho\Config\Observer('model_save_after', area: 'admin', type: 'singleton', id: 'adminactivitylog_save_after')]
     public function logAdminActivityAfter(\Maho\Event\Observer $observer): void
     {
         try {
@@ -214,7 +214,7 @@ class Maho_AdminActivityLog_Model_Observer
         }
     }
 
-    #[Maho\Config\Observer('model_delete_after', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_delete_after')]
+    #[Maho\Config\Observer('model_delete_after', area: 'admin', type: 'singleton', id: 'adminactivitylog_delete_after')]
     public function logAdminDelete(\Maho\Event\Observer $observer): void
     {
         try {
@@ -247,7 +247,7 @@ class Maho_AdminActivityLog_Model_Observer
         }
     }
 
-    #[Maho\Config\Observer('controller_action_predispatch_adminhtml', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_page_visit')]
+    #[Maho\Config\Observer('controller_action_predispatch_adminhtml', area: 'admin', type: 'singleton', id: 'adminactivitylog_page_visit')]
     public function logPageVisit(\Maho\Event\Observer $observer): void
     {
         try {
@@ -329,7 +329,7 @@ class Maho_AdminActivityLog_Model_Observer
         return array_diff_key($data, array_flip($this->ignoreFields));
     }
 
-    #[Maho\Config\Observer('controller_action_postdispatch_adminhtml', area: 'adminhtml', type: 'singleton', id: 'adminactivitylog_mass_action')]
+    #[Maho\Config\Observer('controller_action_postdispatch_adminhtml', area: 'admin', type: 'singleton', id: 'adminactivitylog_mass_action')]
     public function logMassAction(\Maho\Event\Observer $observer): void
     {
         if (!Mage::helper('adminactivitylog')->shouldLogMassActions()) {

--- a/app/code/core/Maho/AdminActivityLog/etc/config.xml
+++ b/app/code/core/Maho/AdminActivityLog/etc/config.xml
@@ -62,8 +62,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-    <adminhtml>
+    
         <layout>
             <updates>
                 <adminactivitylog>
@@ -71,7 +70,7 @@
                 </adminactivitylog>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
     <default>
         <admin>
             <adminactivitylog>

--- a/app/code/core/Maho/Blog/etc/config.xml
+++ b/app/code/core/Maho/Blog/etc/config.xml
@@ -113,8 +113,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-    <adminhtml>
+    
         <layout>
             <updates>
                 <blog>
@@ -131,7 +130,7 @@
                 </Maho_Blog>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <frontend>
         <routers>
             <blog>

--- a/app/code/core/Maho/Captcha/Model/Observer.php
+++ b/app/code/core/Maho/Captcha/Model/Observer.php
@@ -36,8 +36,8 @@ class Maho_Captcha_Model_Observer
         $this->failedVerification($controller, $isAjax);
     }
 
-    #[Maho\Config\Observer('admin_user_authenticate_before', area: 'adminhtml')]
-    #[Maho\Config\Observer('controller_action_predispatch_adminhtml_index_forgotpassword', area: 'adminhtml')]
+    #[Maho\Config\Observer('admin_user_authenticate_before', area: 'admin')]
+    #[Maho\Config\Observer('controller_action_predispatch_adminhtml_index_forgotpassword', area: 'admin')]
     public function verifyAdmin(\Maho\Event\Observer $observer): void
     {
         $helper = Mage::helper('captcha');

--- a/app/code/core/Maho/Captcha/etc/config.xml
+++ b/app/code/core/Maho/Captcha/etc/config.xml
@@ -54,7 +54,7 @@
             </modules>
         </translate>
     </frontend>
-    <adminhtml>
+    <admin>
         <layout>
             <updates>
                 <captcha>
@@ -71,7 +71,7 @@
                 </Maho_Captcha>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <default>
         <admin>
             <captcha>

--- a/app/code/core/Maho/CatalogLinkRule/etc/config.xml
+++ b/app/code/core/Maho/CatalogLinkRule/etc/config.xml
@@ -54,7 +54,17 @@
         </blocks>
     </global>
 
-    <adminhtml>
+    <admin>
+        <routers>
+            <adminhtml>
+                <args>
+                    <modules>
+                        <Maho_CatalogLinkRule before="Mage_Adminhtml">Maho_CatalogLinkRule_Adminhtml</Maho_CatalogLinkRule>
+                    </modules>
+                </args>
+            </adminhtml>
+        </routers>
+    
         <layout>
             <updates>
                 <cataloglinkrule>
@@ -71,18 +81,6 @@
                 </Maho_CatalogLinkRule>
             </modules>
         </translate>
-    </adminhtml>
-
-    <admin>
-        <routers>
-            <adminhtml>
-                <args>
-                    <modules>
-                        <Maho_CatalogLinkRule before="Mage_Adminhtml">Maho_CatalogLinkRule_Adminhtml</Maho_CatalogLinkRule>
-                    </modules>
-                </args>
-            </adminhtml>
-        </routers>
     </admin>
 
     <default>

--- a/app/code/core/Maho/ContentVersion/etc/config.xml
+++ b/app/code/core/Maho/ContentVersion/etc/config.xml
@@ -58,8 +58,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-    <adminhtml>
+    
         <layout>
             <updates>
                 <contentversion>
@@ -67,7 +66,7 @@
                 </contentversion>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
     <default>
         <general>
             <contentversion>

--- a/app/code/core/Maho/CustomerSegmentation/etc/config.xml
+++ b/app/code/core/Maho/CustomerSegmentation/etc/config.xml
@@ -73,8 +73,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-    <adminhtml>
+    
         <layout>
             <updates>
                 <customersegmentation>
@@ -91,7 +90,7 @@
                 </Maho_CustomerSegmentation>
             </modules>
         </translate>
-    </adminhtml>
+    </admin>
     <default>
         <customer>
             <customer_segments>

--- a/app/code/core/Maho/FeedManager/Model/Notifier.php
+++ b/app/code/core/Maho/FeedManager/Model/Notifier.php
@@ -129,7 +129,7 @@ class Maho_FeedManager_Model_Notifier
         // Send email
         /** @var Mage_Core_Model_Email_Template $emailTemplate */
         $emailTemplate = Mage::getModel('core/email_template');
-        $emailTemplate->setDesignConfig(['area' => 'adminhtml', 'store' => $storeId]);
+        $emailTemplate->setDesignConfig(['area' => 'admin', 'store' => $storeId]);
 
         $emailTemplate->sendTransactional(
             'feedmanager_feed_failure',

--- a/app/code/core/Maho/FeedManager/etc/config.xml
+++ b/app/code/core/Maho/FeedManager/etc/config.xml
@@ -87,9 +87,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-
-    <adminhtml>
+    
         <translate>
             <modules>
                 <Maho_FeedManager>
@@ -106,7 +104,7 @@
                 </feedmanager>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
 
     <default>
         <feedmanager>

--- a/app/code/core/Maho/Giftcard/Model/Observer.php
+++ b/app/code/core/Maho/Giftcard/Model/Observer.php
@@ -763,7 +763,7 @@ class Maho_Giftcard_Model_Observer
     /**
      * Process gift card in admin order create
      */
-    #[Maho\Config\Observer('adminhtml_sales_order_create_process_data_before', area: 'adminhtml', id: 'giftcard_process_admin_order')]
+    #[Maho\Config\Observer('adminhtml_sales_order_create_process_data_before', area: 'admin', id: 'giftcard_process_admin_order')]
     public function processAdminOrderGiftcard(Maho\Event\Observer $observer): void
     {
         /** @var Mage_Core_Controller_Request_Http $requestModel */

--- a/app/code/core/Maho/Giftcard/etc/config.xml
+++ b/app/code/core/Maho/Giftcard/etc/config.xml
@@ -179,6 +179,14 @@
                 </args>
             </adminhtml>
         </routers>
+    
+        <layout>
+            <updates>
+                <giftcard>
+                    <file>giftcard.xml</file>
+                </giftcard>
+            </updates>
+        </layout>
     </admin>
 
     <frontend>
@@ -199,14 +207,4 @@
             </updates>
         </layout>
     </frontend>
-
-    <adminhtml>
-        <layout>
-            <updates>
-                <giftcard>
-                    <file>giftcard.xml</file>
-                </giftcard>
-            </updates>
-        </layout>
-    </adminhtml>
 </config>

--- a/app/code/core/Maho/Intelligence/Model/Lsp/Handler/Definition.php
+++ b/app/code/core/Maho/Intelligence/Model/Lsp/Handler/Definition.php
@@ -136,7 +136,7 @@ class Maho_Intelligence_Model_Lsp_Handler_Definition
 
         $file = $designPackage->getTemplateFilename($templatePath, ['_area' => 'frontend']);
         if (!file_exists($file)) {
-            $file = $designPackage->getTemplateFilename($templatePath, ['_area' => 'adminhtml']);
+            $file = $designPackage->getTemplateFilename($templatePath, ['_area' => 'admin']);
         }
 
         return file_exists($file) ? $this->fileLocation($file) : null;

--- a/app/code/core/Maho/Intelligence/Model/Lsp/Handler/Hover.php
+++ b/app/code/core/Maho/Intelligence/Model/Lsp/Handler/Hover.php
@@ -248,7 +248,7 @@ class Maho_Intelligence_Model_Lsp_Handler_Hover
         $markdown = "**Layout handle**: `{$handle}`\n\n";
 
         $frontendHandles = $this->registry->get('layout', 'getHandles', ['frontend']);
-        $adminhtmlHandles = $this->registry->get('layout', 'getHandles', ['adminhtml']);
+        $adminhtmlHandles = $this->registry->get('layout', 'getHandles', ['admin']);
 
         $info = $frontendHandles[$handle] ?? $adminhtmlHandles[$handle] ?? null;
         if ($info !== null) {

--- a/app/code/core/Maho/Intelligence/Model/Provider/Event.php
+++ b/app/code/core/Maho/Intelligence/Model/Provider/Event.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 class Maho_Intelligence_Model_Provider_Event
 {
-    private const AREAS = ['global', 'frontend', 'adminhtml', 'crontab'];
+    private const AREAS = ['global', 'frontend', 'admin', 'crontab'];
 
     private ?array $cachedEvents = null;
 

--- a/app/code/core/Maho/Paypal/Model/Observer.php
+++ b/app/code/core/Maho/Paypal/Model/Observer.php
@@ -63,7 +63,7 @@ class Maho_Paypal_Model_Observer
         $output->writeln($result ? 'OK' : '<comment>SKIPPED</comment>');
     }
 
-    #[Maho\Config\Observer('adminhtml_init_system_config', area: 'adminhtml')]
+    #[Maho\Config\Observer('adminhtml_init_system_config', area: 'admin')]
     public function addDeprecationNotice(\Maho\DataObject $observer): void
     {
         /** @var Maho_Paypal_Model_Config $config */

--- a/app/code/core/Maho/Paypal/etc/config.xml
+++ b/app/code/core/Maho/Paypal/etc/config.xml
@@ -106,9 +106,7 @@
                 </args>
             </adminhtml>
         </routers>
-    </admin>
-
-    <adminhtml>
+    
         <translate>
             <modules>
                 <Maho_Paypal>
@@ -125,7 +123,7 @@
                 </maho_paypal>
             </updates>
         </layout>
-    </adminhtml>
+    </admin>
 
     <default>
         <maho_paypal>

--- a/app/design/adminhtml/default/default/template/oauth/authorize/button-simple.phtml
+++ b/app/design/adminhtml/default/default/template/oauth/authorize/button-simple.phtml
@@ -15,7 +15,7 @@
  *
  * @var Mage_Oauth_Block_Authorize_ButtonBaseAbstract $this
  */
-$logo = $this->getSkinUrl('images/logo-large.gif', ['_area' => 'adminhtml', '_package' => 'default']);
+$logo = $this->getSkinUrl('images/logo-large.gif', ['_area' => 'admin', '_package' => 'default']);
 ?>
 <div class="login-container">
     <div class="login-box">

--- a/composer.lock
+++ b/composer.lock
@@ -1223,16 +1223,16 @@
         },
         {
             "name": "mahocommerce/maho-composer-plugin",
-            "version": "v4.0.9",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MahoCommerce/maho-composer-plugin.git",
-                "reference": "dbcaf42e2313ad4ea2faed3fd81e2510c913a836"
+                "reference": "38660ac322f15f48ea3426e40fe6ee6321f701df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MahoCommerce/maho-composer-plugin/zipball/dbcaf42e2313ad4ea2faed3fd81e2510c913a836",
-                "reference": "dbcaf42e2313ad4ea2faed3fd81e2510c913a836",
+                "url": "https://api.github.com/repos/MahoCommerce/maho-composer-plugin/zipball/38660ac322f15f48ea3426e40fe6ee6321f701df",
+                "reference": "38660ac322f15f48ea3426e40fe6ee6321f701df",
                 "shasum": ""
             },
             "require": {
@@ -1265,9 +1265,9 @@
             "description": "Extension for Composer to copy assets and enable autoloading for Maho projects.",
             "support": {
                 "issues": "https://github.com/MahoCommerce/maho-composer-plugin/issues",
-                "source": "https://github.com/MahoCommerce/maho-composer-plugin/tree/v4.0.9"
+                "source": "https://github.com/MahoCommerce/maho-composer-plugin/tree/4.0.10"
             },
-            "time": "2026-04-12T20:13:44+00:00"
+            "time": "2026-04-13T14:01:37+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/lib/Maho/Config/Observer.php
+++ b/lib/Maho/Config/Observer.php
@@ -28,7 +28,7 @@ readonly class Observer
 {
     /**
      * @param string  $event    Event name to observe (e.g. 'catalog_product_save_after')
-     * @param string  $area     Area scope: 'global' (default), 'frontend', 'adminhtml', 'crontab', 'install'
+     * @param string  $area     Area scope: 'global' (default), 'frontend', 'admin', 'crontab', 'install'
      * @param string  $type     Instantiation type: 'model' (default, new instance per dispatch) or 'singleton' (shared instance)
      * @param ?string $id       Observer identifier, auto-generated if omitted. Set explicitly when other code references this observer by id.
      * @param ?string $replaces The `id` of another observer on the same event/area to disable and replace.

--- a/public/api.php
+++ b/public/api.php
@@ -23,7 +23,7 @@ if (!Mage::isInstalled()) {
 Mage::$headersSentThrowsException = false;
 Mage::init('admin');
 Mage::app()->loadAreaPart(Mage_Core_Model_App_Area::AREA_GLOBAL, Mage_Core_Model_App_Area::PART_EVENTS);
-Mage::app()->loadAreaPart(Mage_Core_Model_App_Area::AREA_ADMINHTML, Mage_Core_Model_App_Area::PART_EVENTS);
+Mage::app()->loadAreaPart(Mage_Core_Model_App_Area::AREA_ADMIN, Mage_Core_Model_App_Area::PART_EVENTS);
 
 // query parameter "type" is set by .htaccess rewrite rule
 $apiAlias = Mage::app()->getRequest()->getParam('type');

--- a/tests/Backend/Unit/Core/Model/App/AreaConsolidationTest.php
+++ b/tests/Backend/Unit/Core/Model/App/AreaConsolidationTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+uses(Tests\MahoBackendTestCase::class);
+
+it('defines AREA_ADMIN as the primary constant', function () {
+    expect(Mage_Core_Model_App_Area::AREA_ADMIN)->toBe('admin');
+});
+
+it('aliases AREA_ADMINHTML to AREA_ADMIN', function () {
+    expect(Mage_Core_Model_App_Area::AREA_ADMINHTML)->toBe(Mage_Core_Model_App_Area::AREA_ADMIN);
+    expect(Mage_Core_Model_App_Area::AREA_ADMINHTML)->toBe('admin');
+});
+
+it('loads admin area events and translate config from the admin section', function () {
+    $config = Mage::getConfig();
+
+    $layoutUpdates = $config->getNode('admin/layout/updates');
+    expect($layoutUpdates)->not->toBeFalse('Layout updates should exist under admin/');
+
+    $translate = $config->getNode('admin/translate/modules');
+    expect($translate)->not->toBeFalse('Translate modules should exist under admin/');
+
+    $adminhtmlNode = $config->getNode('adminhtml');
+    $hasChildren = $adminhtmlNode !== false && $adminhtmlNode->hasChildren();
+    expect($hasChildren)->toBeFalse('No <adminhtml> section should remain in merged config');
+});
+
+it('has no adminhtml area key in compiled attributes', function () {
+    $compiled = Maho::getCompiledAttributes();
+
+    expect($compiled['observers'])->not->toHaveKey('adminhtml');
+    expect($compiled['observers'])->toHaveKey('admin');
+    expect($compiled['observers']['admin'])->not->toBeEmpty();
+});
+
+it('resolves admin area observers from compiled attributes', function () {
+    $compiled = Maho::getCompiledAttributes();
+    $adminObservers = $compiled['observers']['admin'];
+
+    // The admin auth observer should be registered under the admin area
+    expect($adminObservers)->toHaveKey('controller_action_predispatch');
+
+    $predispatchObservers = array_column($adminObservers['controller_action_predispatch'], 'name');
+    expect($predispatchObservers)->toContain('auth');
+});
+
+it('merges third-party adminhtml config into admin via compat shim', function () {
+    // Use a standalone Mage_Core_Model_Config so we don't pollute the global config
+    $config = new Mage_Core_Model_Config();
+    $config->loadString('<config><admin><routers/></admin></config>');
+
+    // Simulate a third-party module with <adminhtml> section
+    $thirdParty = new Mage_Core_Model_Config();
+    $thirdParty->loadString('
+        <config>
+            <adminhtml>
+                <events>
+                    <test_compat_event>
+                        <observers>
+                            <test_observer>
+                                <class>catalog/observer</class>
+                                <method>testMethod</method>
+                            </test_observer>
+                        </observers>
+                    </test_compat_event>
+                </events>
+            </adminhtml>
+        </config>
+    ');
+
+    $config->extend($thirdParty, true);
+
+    // Run the migration shim
+    $ref = new ReflectionMethod($config, '_migrateAdminhtmlConfig');
+    $ref->invoke($config);
+
+    // The event should now be accessible under admin/events
+    $eventConfig = $config->getNode('admin/events/test_compat_event/observers/test_observer');
+    expect($eventConfig)->not->toBeFalse('Third-party adminhtml event should be merged into admin');
+    expect((string) $eventConfig->class)->toBe('catalog/observer');
+
+    // The adminhtml node should be cleaned up
+    $adminhtmlNode = $config->getNode('adminhtml');
+    $hasChildren = $adminhtmlNode !== false && $adminhtmlNode->hasChildren();
+    expect($hasChildren)->toBeFalse('adminhtml node should be removed after migration');
+});
+
+it('shim preserves existing admin config when merging adminhtml', function () {
+    $config = new Mage_Core_Model_Config();
+    $config->loadString('
+        <config>
+            <admin>
+                <routers>
+                    <adminhtml>
+                        <use>admin</use>
+                    </adminhtml>
+                </routers>
+            </admin>
+            <adminhtml>
+                <translate>
+                    <modules>
+                        <ThirdParty><files><default>ThirdParty.csv</default></files></ThirdParty>
+                    </modules>
+                </translate>
+            </adminhtml>
+        </config>
+    ');
+
+    $ref = new ReflectionMethod($config, '_migrateAdminhtmlConfig');
+    $ref->invoke($config);
+
+    // Existing admin content should be preserved
+    expect((string) $config->getNode('admin/routers/adminhtml/use'))->toBe('admin');
+
+    // Merged content should be present
+    $csvNode = $config->getNode('admin/translate/modules/ThirdParty/files/default');
+    expect($csvNode)->not->toBeFalse();
+    expect((string) $csvNode)->toBe('ThirdParty.csv');
+});
+
+it('shim is a no-op when no adminhtml section exists', function () {
+    $config = new Mage_Core_Model_Config();
+    $config->loadString('<config><admin><routers/></admin></config>');
+
+    $ref = new ReflectionMethod($config, '_migrateAdminhtmlConfig');
+    $ref->invoke($config);
+
+    // Should not crash, admin section should be untouched
+    expect($config->getNode('admin/routers'))->not->toBeFalse();
+});
+
+it('maps admin area to adminhtml design directory', function () {
+    expect(Mage_Core_Model_Design_Package::areaToDesignDir('admin'))->toBe('adminhtml');
+    expect(Mage_Core_Model_Design_Package::areaToDesignDir('frontend'))->toBe('frontend');
+
+    $designPackage = Mage::getSingleton('core/design_package');
+    $designPackage->setArea('admin');
+
+    $baseDir = $designPackage->getBaseDir([
+        '_area' => 'admin',
+        '_package' => 'default',
+        '_theme' => 'default',
+        '_type' => 'template',
+    ]);
+    expect($baseDir)->toContain(DIRECTORY_SEPARATOR . 'adminhtml' . DIRECTORY_SEPARATOR);
+    expect($baseDir)->not->toContain(DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR . 'default');
+});
+
+it('resolves skin URLs with adminhtml directory for admin area', function () {
+    $designPackage = Mage::getSingleton('core/design_package');
+    $designPackage->setArea('admin');
+
+    $skinDir = $designPackage->getSkinBaseDir([
+        '_area' => 'admin',
+        '_package' => 'default',
+        '_theme' => 'default',
+    ]);
+    expect($skinDir)->toContain(DIRECTORY_SEPARATOR . 'adminhtml' . DIRECTORY_SEPARATOR);
+});
+
+it('resolves locale directory with adminhtml directory for admin area', function () {
+    $designPackage = Mage::getSingleton('core/design_package');
+    $designPackage->setArea('admin');
+
+    $localeDir = $designPackage->getLocaleBaseDir([
+        '_area' => 'admin',
+        '_package' => 'default',
+        '_theme' => 'default',
+    ]);
+    expect($localeDir)->toContain(DIRECTORY_SEPARATOR . 'adminhtml' . DIRECTORY_SEPARATOR);
+});
+
+it('resolves theme inheritance config through design directory mapping', function () {
+    $fallback = new Mage_Core_Model_Design_Fallback();
+    $scheme = $fallback->getFallbackScheme('admin', 'default', 'default');
+
+    expect($scheme)->toBeArray();
+    expect($scheme)->not->toBeEmpty();
+});
+
+it('preserves admin routers config after consolidation', function () {
+    $config = Mage::getConfig();
+
+    $routers = $config->getNode('admin/routers/adminhtml');
+    expect($routers)->not->toBeFalse('Admin routers should exist under admin/routers');
+    expect((string) $routers->use)->toBe('admin');
+    expect((string) $routers->args->frontName)->not->toBeEmpty();
+});
+
+it('reads admin event config from the admin config node', function () {
+    $config = Mage::getConfig();
+
+    // getEventConfig reads from {area}/events — should work with 'admin'
+    $eventConfig = $config->getEventConfig('admin', 'controller_action_predispatch');
+    if ($eventConfig !== false && $eventConfig !== null) {
+        expect($eventConfig)->toBeInstanceOf(Mage_Core_Model_Config_Element::class);
+    }
+
+    // 'adminhtml' area should have no events in the config (all migrated to 'admin')
+    $adminhtmlEvents = $config->getNode('adminhtml/events');
+    expect($adminhtmlEvents)->toBeFalse('No events should remain under adminhtml/');
+});


### PR DESCRIPTION
Closes #814

## Summary

- Merges the two confusingly named top-level config areas — `<admin>` (routers, fieldsets) and `<adminhtml>` (events, layout, translate) — into a single `<admin>` area
- Adds `AREA_ADMIN` as the primary constant; `AREA_ADMINHTML` is deprecated and aliased to `AREA_ADMIN`
- Renames `<adminhtml>` to `<admin>` in all 60 config.xml files, merging children where both sections existed
- Updates all ~67 observer PHP attributes from `area: 'adminhtml'` to `area: 'admin'`
- Updates all PHP code referencing the admin area (constants, `setArea()`, design config arrays)

## Backward compatibility for third-party modules

- **XML config**: A compatibility shim in `Config::_migrateAdminhtmlConfig()` auto-merges any `<adminhtml>` content into `<admin>` at config load time, with a deprecation log notice
- **PHP observer attributes**: The `AttributeCompiler` in `maho-composer-plugin` normalizes `area: 'adminhtml'` → `'admin'` at compile time (separate PR needed for the plugin repo)
- **Design paths**: `Package::areaToDesignDir()` maps area code `'admin'` to filesystem directory `'adminhtml'`, so templates/skins/layouts resolve correctly without renaming directories
- **Route names**: The router name `'adminhtml'` (from `<admin><routers><adminhtml>`) is unchanged — code checking `getRouteName()` uses the literal string, not the area constant

## Note

The `AttributeCompiler` change in `vendor/mahocommerce/maho-composer-plugin/` needs a separate PR to that repo.

## Test plan

- [x] All 1845 tests pass
- [x] PHPStan clean (no errors)
- [x] php-cs-fixer clean
- [x] `composer dump-autoload` compiles attributes correctly under `'admin'` area
- [ ] Manual: verify admin panel loads, login, dashboard, product edit, system config
- [ ] Manual: verify PDF generation renders with admin theme