### PR TITLE
Added HTML validation for WYSIWYG textarea mode

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
@@ -34,6 +34,16 @@ class Mage_Adminhtml_Block_Catalog_Helper_Form_Wysiwyg extends \Maho\Data\Form\E
                     'onclick'  => "catalogWysiwygEditor.open('$wysiwygUrl', '{$this->getHtmlId()}')",
                 ])->toHtml();
         }
+        if ($this->getEntityAttribute()->getIsWysiwygEnabled()) {
+            $validateUrl = Mage::getSingleton('adminhtml/url')->getUrl('*/cms_wysiwyg/validateHtml');
+            $html .= Mage::getSingleton('core/layout')
+                ->createBlock('adminhtml/widget_button', '', [
+                    'label'    => Mage::helper('cms')->__('Validate HTML'),
+                    'type'     => 'button',
+                    'class'    => 'validate-html',
+                    'onclick'  => "validateHtmlContent('{$this->getHtmlId()}', '$validateUrl');",
+                ])->toHtml();
+        }
         return $html;
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
@@ -41,6 +41,7 @@ class Mage_Adminhtml_Block_Catalog_Helper_Form_Wysiwyg extends \Maho\Data\Form\E
                     'label'    => Mage::helper('cms')->__('Validate HTML'),
                     'type'     => 'button',
                     'class'    => 'validate-html',
+                    'style'    => 'margin-left: 4px;',
                     'onclick'  => "validateHtmlContent('{$this->getHtmlId()}', '$validateUrl');",
                 ])->toHtml();
         }

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
@@ -31,6 +31,7 @@ class Mage_Adminhtml_Block_Catalog_Helper_Form_Wysiwyg extends \Maho\Data\Form\E
                     'type'     => 'button',
                     'disabled' => $this->getDisabled() || $this->getReadonly(),
                     'class'    => 'btn-wysiwyg',
+                    'style'    => 'margin-right: 4px;',
                     'onclick'  => "catalogWysiwygEditor.open('$wysiwygUrl', '{$this->getHtmlId()}')",
                 ])->toHtml();
         }
@@ -41,7 +42,6 @@ class Mage_Adminhtml_Block_Catalog_Helper_Form_Wysiwyg extends \Maho\Data\Form\E
                     'label'    => Mage::helper('cms')->__('Validate HTML'),
                     'type'     => 'button',
                     'class'    => 'validate-html',
-                    'style'    => 'margin-left: 4px;',
                     'onclick'  => "validateHtmlContent('{$this->getHtmlId()}', '$validateUrl');",
                 ])->toHtml();
         }

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2022-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2022-2025 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2025-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -17,6 +17,54 @@ class Mage_Adminhtml_Cms_WysiwygController extends Mage_Adminhtml_Controller_Act
      * @see Mage_Adminhtml_Controller_Action::_isAllowed()
      */
     public const ADMIN_RESOURCE = 'cms';
+
+    /**
+     * Validate HTML fragment via the W3C Nu validator
+     */
+    public function validateHtmlAction(): void
+    {
+        $html = $this->getRequest()->getPost('html', '');
+
+        $prefix = "<!DOCTYPE html>\n<html lang=\"en\">\n<head><meta charset=\"utf-8\"><title>v</title></head>\n<body>\n";
+        $suffix = "\n</body>\n</html>";
+        $prefixLines = substr_count($prefix, "\n");
+
+        try {
+            $client = \Symfony\Component\HttpClient\HttpClient::create(['timeout' => 15]);
+            $response = $client->request('POST', 'https://validator.w3.org/nu/?out=json', [
+                'headers' => ['Content-Type' => 'text/html; charset=utf-8'],
+                'body' => $prefix . $html . $suffix,
+            ]);
+
+            $result = json_decode($response->getContent(), true);
+            $messages = [];
+
+            foreach ($result['messages'] ?? [] as $msg) {
+                if (isset($msg['firstLine'])) {
+                    $msg['firstLine'] -= $prefixLines;
+                }
+                if (isset($msg['lastLine'])) {
+                    $msg['lastLine'] -= $prefixLines;
+                }
+                if (($msg['lastLine'] ?? 1) < 1) {
+                    continue;
+                }
+                $messages[] = $msg;
+            }
+
+            $this->getResponse()
+                ->setHeader('Content-Type', 'application/json', true)
+                ->setBody(Mage::helper('core')->jsonEncode(['messages' => $messages]));
+        } catch (\Exception $e) {
+            Mage::logException($e);
+            $this->getResponse()
+                ->setHeader('Content-Type', 'application/json', true)
+                ->setBody(Mage::helper('core')->jsonEncode([
+                    'error' => true,
+                    'message' => Mage::helper('cms')->__('Could not reach the HTML validator service.'),
+                ]));
+        }
+    }
 
     /**
      * Template directives callback

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
@@ -24,6 +24,7 @@ class Mage_Adminhtml_Cms_WysiwygController extends Mage_Adminhtml_Controller_Act
     public function validateHtmlAction(): void
     {
         $html = $this->getRequest()->getPost('html', '');
+        $html = preg_replace('/\{\{[^{}]*\}\}/', '', $html);
 
         $prefix = "<!DOCTYPE html>\n<html lang=\"en\">\n<head><meta charset=\"utf-8\"><title>v</title></head>\n<body>\n";
         $suffix = "\n</body>\n</html>";

--- a/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
+++ b/app/code/core/Mage/Cms/Model/Wysiwyg/Config.php
@@ -64,6 +64,7 @@ class Mage_Cms_Model_Wysiwyg_Config extends \Maho\DataObject
             'no_display'                    => false,
             'translator'                    => Mage::helper('cms'),
             'directives_url'                => Mage::getSingleton('adminhtml/url')->getUrl('*/cms_wysiwyg/directive'),
+            'validate_html_url'             => Mage::getSingleton('adminhtml/url')->getUrl('*/cms_wysiwyg/validateHtml'),
             'width'                         => '100%',
             'plugins'                       => [],
         ]);

--- a/lib/Maho/Data/Form/Element/Editor.php
+++ b/lib/Maho/Data/Form/Element/Editor.php
@@ -69,7 +69,7 @@ class Editor extends Textarea
 
         }
         // Display only buttons to additional features
-        if ($this->getConfig('widget_window_url') || $this->getConfig('plugins') || $this->getConfig('add_images')) {
+        if ($this->getConfig('widget_window_url') || $this->getConfig('plugins') || $this->getConfig('add_images') || $this->getConfig('validate_html_url')) {
             $html = $this->_getButtonsHtml() . parent::getElementHtml();
             $html = $this->_wrapIntoContainer($html);
             return $html;
@@ -166,6 +166,15 @@ class Editor extends Textarea
                 }
                 $buttonsHtml .= $this->_getButtonHtml($buttonOptions);
             }
+        }
+
+        if ($this->getConfig('validate_html_url')) {
+            $url = $this->getConfig('validate_html_url');
+            $buttonsHtml .= $this->_getButtonHtml([
+                'title'     => $this->translate('Validate HTML'),
+                'onclick'   => "validateHtmlContent('{$this->getHtmlId()}', '$url');",
+                'class'     => 'validate-html plugin' . ($visible ? '' : ' no-display'),
+            ]);
         }
 
         return $buttonsHtml;

--- a/public/js/mage/adminhtml/tools.js
+++ b/public/js/mage/adminhtml/tools.js
@@ -619,3 +619,75 @@ function xssFilter(str) {
     // Filter out comment nodes to prevent their text from leaking as visible content
     return Array.from(safeNodes).filter(n => n.nodeType !== Node.COMMENT_NODE).map(n => n.outerHTML || n.textContent).join('');
 }
+
+async function validateHtmlContent(textareaId, url) {
+    const textarea = document.getElementById(textareaId);
+    if (!textarea) {
+        return;
+    }
+
+    const html = textarea.value.trim();
+    if (!html) {
+        Dialog.info('<p>There is no HTML content to validate.</p>', { title: 'HTML Validation', width: 500 });
+        return;
+    }
+
+    try {
+        const result = await mahoFetch(url, {
+            method: 'POST',
+            body: new URLSearchParams({ html }),
+        });
+
+        const messages = result.messages ?? [];
+
+        if (messages.length === 0) {
+            Dialog.info('<p class="validate-ok">No errors or warnings found.</p>', { title: 'HTML Validation', width: 500 });
+            return;
+        }
+
+        const errors = messages.filter(m => m.type === 'error');
+        const warnings = messages.filter(m => m.type !== 'error');
+        const summary = [];
+        if (errors.length) summary.push(`${errors.length} error${errors.length > 1 ? 's' : ''}`);
+        if (warnings.length) summary.push(`${warnings.length} warning${warnings.length > 1 ? 's' : ''}`);
+
+        const items = messages.map(msg => {
+            const isError = msg.type === 'error';
+            const label = isError ? 'Error' : 'Warning';
+            const line = msg.lastLine ? ` — line ${msg.lastLine}` : '';
+            let extractHtml = '';
+
+            if (msg.extract) {
+                if (msg.hiliteStart !== undefined && msg.hiliteLength) {
+                    const before = escapeHtml(msg.extract.substring(0, msg.hiliteStart));
+                    const hilite = escapeHtml(msg.extract.substring(msg.hiliteStart, msg.hiliteStart + msg.hiliteLength));
+                    const after = escapeHtml(msg.extract.substring(msg.hiliteStart + msg.hiliteLength));
+                    extractHtml = `<pre>${before}<mark>${hilite}</mark>${after}</pre>`;
+                } else {
+                    extractHtml = `<pre>${escapeHtml(msg.extract)}</pre>`;
+                }
+            }
+
+            return `<div class="${isError ? 'error-msg' : 'warning-msg'}">
+                <strong>${label}${line}:</strong> ${escapeHtml(msg.message ?? '')}
+                ${extractHtml}
+            </div>`;
+        }).join('');
+
+        const content = `
+            <style>
+                .dialog-content .error-msg,
+                .dialog-content .warning-msg { background-image: none !important; background-position: 0 !important; padding-left: 12px !important; }
+                .dialog-content .error-msg pre,
+                .dialog-content .warning-msg pre { margin: 6px 0 0; padding: 6px; background: #f5f5f5; border-radius: 3px; font-size: 12px; white-space: pre-wrap; overflow-x: auto; }
+                .dialog-content .error-msg mark { background: #fecaca; padding: 1px 2px; border-radius: 2px; }
+                .dialog-content .warning-msg mark { background: #fed7aa; padding: 1px 2px; border-radius: 2px; }
+            </style>
+            <p>${summary.join(' and ')} found:</p>
+            ${items}`;
+
+        Dialog.info(content, { title: 'HTML Validation', width: 600 });
+    } catch (e) {
+        Dialog.alert(`<p>${escapeHtml(e.message ?? 'Could not reach the HTML validator service.')}</p>`, { title: 'HTML Validation', width: 500 });
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a **"Validate HTML"** button on editor textareas when TipTap is disabled or toggled to source mode
- Sends content to the W3C Nu validator (`validator.w3.org/nu/`) via a backend proxy to avoid CORS
- Wraps the HTML fragment in a minimal document skeleton and adjusts line numbers in the response
- Displays validation results (errors/warnings with highlighted source extracts) in a Maho Dialog

## Changes

- `WysiwygController.php` — new `validateHtmlAction()` backend proxy
- `Wysiwyg/Config.php` — adds `validate_html_url` to editor config
- `Editor.php` — renders the "Validate HTML" plugin button (last in the row)
- `tools.js` — `validateHtmlContent()` function for the client-side logic

Closes #776

## Test plan

- [ ] Set WYSIWYG to "Enabled by Default", toggle to source mode → "Validate HTML" button should appear
- [ ] Set WYSIWYG to "Disabled by Default" → button should appear next to textarea
- [ ] Set WYSIWYG to "Disabled Completely" → button should appear next to textarea
- [ ] Click "Validate HTML" with valid HTML → dialog shows "No errors or warnings found"
- [ ] Click "Validate HTML" with invalid HTML (e.g. unclosed tags, `<br/>`) → dialog shows errors/warnings with highlighted extracts
- [ ] Click "Validate HTML" with empty textarea → dialog shows "no content" message
- [ ] Verify button is hidden when TipTap editor is active