### PR TITLE
Fixed cron cleanup immediately deleting errored/missed jobs

### DIFF
--- a/app/code/core/Mage/Cron/Model/Observer.php
+++ b/app/code/core/Mage/Cron/Model/Observer.php
@@ -300,9 +300,8 @@ class Mage_Cron_Model_Observer
 
         $now = Mage::getSingleton('core/date')->gmtTimestamp();
         foreach ($history->getIterator() as $record) {
-            if (empty($record->getExecutedAt())
-                || (strtotime($record->getExecutedAt()) < $now - $historyLifetimes[$record->getStatus()])
-            ) {
+            $referenceTime = $record->getExecutedAt() ?: $record->getScheduledAt();
+            if ($referenceTime && strtotime($referenceTime) < $now - $historyLifetimes[$record->getStatus()]) {
                 $record->delete();
             }
         }


### PR DESCRIPTION
## Summary

- Jobs that went to ERROR or MISSED status without an `executed_at` timestamp were being deleted immediately by `cleanup()`, because `empty($record->getExecutedAt())` short-circuited the history lifetime check
- This was triggered by the outer try/catch in `dispatch()` (added in 82d0fe1505) which sets ERROR status before `executed_at` is set, and by "too late" missed jobs where the exception is thrown before `executed_at` is set
- Now uses `scheduled_at` as fallback when `executed_at` is empty, so the configured failure history lifetime (default 600 minutes) is actually respected

## Test plan

- [ ] Configure a cron job that will error (e.g. invalid model reference)
- [ ] Run cron and verify the errored job stays visible in the Cron Jobs grid for the configured failure history lifetime
- [ ] Verify that MISSED jobs also persist in the grid according to the lifetime setting
- [ ] Verify that successfully completed jobs are still cleaned up after the success history lifetime