### PR TITLE
Increased default cron schedule_ahead_for from 20 to 60 minutes

### DIFF
--- a/app/code/core/Mage/Cron/etc/config.xml
+++ b/app/code/core/Mage/Cron/etc/config.xml
@@ -42,7 +42,7 @@
         <system>
             <cron>
                 <schedule_generate_every>15</schedule_generate_every>
-                <schedule_ahead_for>20</schedule_ahead_for>
+                <schedule_ahead_for>60</schedule_ahead_for>
                 <schedule_lifetime>15</schedule_lifetime>
                 <history_cleanup_every>10</history_cleanup_every>
                 <history_success_lifetime>60</history_success_lifetime>


### PR DESCRIPTION
## Summary

- The default schedule_ahead_for of 20 minutes was too narrow -- hourly and daily cron jobs often had no pending schedules because the generation window did not overlap their next run time
- Increasing to 60 minutes ensures hourly jobs always have at least one pending schedule, and daily jobs are more likely to be pre-scheduled

## Test plan

- [ ] Verify that after a cron run, hourly jobs have pending schedules in the grid
- [ ] Verify that every-minute and every-5-minute jobs generate the expected ~60 and ~12 entries respectively