### PR TITLE
Fix configurable product pricing inputs rendering with spurious single quotes

### DIFF
--- a/public/js/mage/adminhtml/product.js
+++ b/public/js/mage/adminhtml/product.js
@@ -282,10 +282,10 @@ Product.Configurable = class {
         /* Generation templates */
         this.addAttributeTemplate = this.createTemplateFunction(
             document.getElementById(idPrefix + 'attribute_template').innerHTML.replace(/__id__/g,
-            "'{{html_id}}'").replace(/ template no-display/g, ''));
+            '{{html_id}}').replace(/ template no-display/g, ''));
         this.addValueTemplate = this.createTemplateFunction(
             document.getElementById(idPrefix + 'value_template').innerHTML.replace(/__id__/g,
-            "'{{html_id}}'").replace(/ template no-display/g, ''));
+            '{{html_id}}').replace(/ template no-display/g, ''));
         this.pricingValueTemplate = this.createTemplateFunction(document.getElementById(idPrefix + 'simple_pricing').innerHTML);
         this.pricingValueViewTemplate = this.createTemplateFunction(document.getElementById(idPrefix + 'simple_pricing_view').innerHTML);
 


### PR DESCRIPTION
## Summary

- The `__id__` placeholder in `Product.Configurable` templates was replaced with `'{{html_id}}'` (surrounding quotes included), causing literal `'` characters to appear in rendered `id` attributes and adjacent output after template evaluation
- Removing the surrounding quotes from the two `.replace(/__id__/g, ...)` calls lets `HANDLEBARS_PATTERN` work correctly without a custom regex
- Intentional display quotes in text content (e.g. `<strong>'{{label}}'</strong>`) are preserved: the leading `'` is the natural "before" character consumed and re-emitted by the pattern, and the trailing `'` is a plain literal — both survive unchanged

Fixes #838

## Test plan

- [ ] Open a configurable product in the admin
- [ ] Go to the _Super product attributes configuration_ tab
- [ ] Verify pricing inputs show clean values (e.g. `10`, not `'10'`)
- [ ] Verify generated element IDs contain no spurious single quotes