### PR TITLE
Fix validateSerializedObject crashing on JSON attribute values (#840)

### DIFF
--- a/app/code/core/Mage/Core/Helper/String.php
+++ b/app/code/core/Mage/Core/Helper/String.php
@@ -574,6 +574,11 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
             return true;
         }
 
+        // JSON cannot encode PHP objects — unserialize() must never run on it
+        if (json_validate($str)) {
+            return true;
+        }
+
         if (!unserialize($str, ['allowed_classes' => false])) {
             return false;
         }

--- a/tests/Backend/Unit/Core/Helper/StringSerializationTest.php
+++ b/tests/Backend/Unit/Core/Helper/StringSerializationTest.php
@@ -322,3 +322,25 @@ describe('isSerializedArrayOrObject detects both JSON and legacy formats', funct
         expect($this->helper->isSerializedArrayOrObject(''))->toBeFalse();
     });
 });
+
+describe('validateSerializedObject does not call unserialize on JSON', function () {
+    beforeEach(function () {
+        $this->helper = Mage::helper('core/string');
+    });
+
+    it('passes JSON object without error', function () {
+        expect($this->helper->validateSerializedObject('{"394953":"468","394954":"273"}'))->toBeTrue();
+    });
+
+    it('passes JSON array without error', function () {
+        expect($this->helper->validateSerializedObject('[1,2,3]'))->toBeTrue();
+    });
+
+    it('passes valid PHP-serialized array', function () {
+        expect($this->helper->validateSerializedObject(serialize(['key' => 'val'])))->toBeTrue();
+    });
+
+    it('passes plain string', function () {
+        expect($this->helper->validateSerializedObject('just a string'))->toBeTrue();
+    });
+});


### PR DESCRIPTION
## Summary

`validateSerializedObject` was calling `unserialize()` on any value that `isSerializedArrayOrObject` returned `true` for — including valid JSON objects and arrays. Since `unserialize()` always fails on JSON, this threw a warning-turned-exception on every EAV attribute whose value was stored as JSON (e.g. `media_gallery_swatches`), crashing the admin product validate endpoint and silently redirecting to the dashboard instead of saving.

The suggested fix in #840 patches `isSerializedArrayOrObject` to return `false` for JSON, but that would break `Mage_Sales_Model_Quote_Item` (lines 521–522) and `Mage_Dataflow`, which rely on that method returning `true` for JSON so `UnserializeArray::unserialize()` is called to decode it.

The correct fix is in `validateSerializedObject` itself: skip `unserialize()` when the value is valid JSON. JSON cannot encode PHP objects, so the `allowed_classes` security check has no target there anyway.

## Changes

- `app/code/core/Mage/Core/Helper/String.php`: skip `unserialize()` in `validateSerializedObject` when value is valid JSON
- `tests/Backend/Unit/Core/Helper/StringSerializationTest.php`: add test cases for `validateSerializedObject` with JSON input

## Test plan

- [ ] `composer test -- --testsuite=Backend` passes
- [ ] Admin product save works for products with JSON-valued EAV attributes (e.g. `media_gallery_swatches`)

Fixes #840

Co-authored-by: postadelmaga <postadelmaga@users.noreply.github.com>