### PR TITLE
Hide PayLater messaging on out-of-stock product pages

### DIFF
--- a/app/code/core/Maho/Paypal/Block/Paylater/Message.php
+++ b/app/code/core/Maho/Paypal/Block/Paylater/Message.php
@@ -30,7 +30,7 @@ class Maho_Paypal_Block_Paylater_Message extends Mage_Core_Block_Template
 
         if ($isInCatalog) {
             $currentProduct = Mage::registry('current_product');
-            if ($currentProduct === null) {
+            if ($currentProduct === null || !$currentProduct->isSaleable()) {
                 $this->_shouldRender = false;
                 return $result;
             }


### PR DESCRIPTION
## Summary

- PayLater financing messages are now hidden on product pages when the product is not saleable (out of stock, disabled, etc.)
- The check is added in `Maho_Paypal_Block_Paylater_Message::_beforeToHtml()` alongside the existing null-product guard
- No template changes needed — the block simply returns empty HTML

## Root cause

In `catalog/product/view.phtml`, the `extra_buttons` block (which contains the PayLater message) is rendered outside the `isSaleable()` conditional for products without custom options, so it would display even when a product cannot be purchased.