### PR TITLE
Skip attribute-based observers and cron jobs for disabled modules

### DIFF
--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -1364,6 +1364,9 @@ class Mage_Core_Model_App
                 }
 
                 foreach (Maho::getCompiledAttributes()['observers'][$area][$eventName] ?? [] as $entry) {
+                    if (!empty($entry['module']) && !Mage::helper('core')->isModuleEnabled($entry['module'])) {
+                        continue;
+                    }
                     $observers[$entry['name']] = [
                         'type'   => $entry['type'],
                         'model'  => $entry['alias'],

--- a/app/code/core/Mage/Cron/Helper/Data.php
+++ b/app/code/core/Mage/Cron/Helper/Data.php
@@ -52,6 +52,9 @@ class Mage_Cron_Helper_Data extends Mage_Core_Helper_Abstract
         }
 
         foreach (Maho::getCompiledAttributes()['crontab'] ?? [] as $jobCode => $jobDef) {
+            if (!empty($jobDef['module']) && !$this->isModuleEnabled($jobDef['module'])) {
+                continue;
+            }
             $configPath = $jobDef['config_path'] ?? '';
             $result[$jobCode] = [
                 'job_code' => $jobCode,

--- a/app/code/core/Mage/Cron/Model/Observer.php
+++ b/app/code/core/Mage/Cron/Model/Observer.php
@@ -95,6 +95,9 @@ class Mage_Cron_Model_Observer
 
             try {
                 if (isset($compiledJobs[$jobCode])) {
+                    if (!empty($compiledJobs[$jobCode]['module']) && !Mage::helper('core')->isModuleEnabled($compiledJobs[$jobCode]['module'])) {
+                        continue;
+                    }
                     $this->_processCompiledJob($schedule, $compiledJobs[$jobCode]);
                     continue;
                 }
@@ -146,6 +149,9 @@ class Mage_Cron_Model_Observer
                 continue;
             }
             if (!$cronHelper->isJobEnabled($jobCode)) {
+                continue;
+            }
+            if (!empty($jobDef['module']) && !Mage::helper('core')->isModuleEnabled($jobDef['module'])) {
                 continue;
             }
             $schedule = $this->_getAlwaysJobSchedule($jobCode);
@@ -449,6 +455,9 @@ class Mage_Cron_Model_Observer
 
         foreach (Maho::getCompiledAttributes()['crontab'] ?? [] as $jobCode => $jobDef) {
             if (!$cronHelper->isJobEnabled($jobCode)) {
+                continue;
+            }
+            if (!empty($jobDef['module']) && !Mage::helper('core')->isModuleEnabled($jobDef['module'])) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary

- Add runtime module-active guard for `#[Observer]` attributes in `Mage_Core_Model_App::dispatchEvent()` — skip observers whose module is disabled via `app/etc/modules/*.xml`
- Add the same guard for `#[CronJob]` attributes in all three cron dispatch points (scheduled jobs, always-run jobs, and schedule generation)
- Companion change in maho-composer-plugin v4.0.18 adds `module` field to compiled crontab entries (matching observers and routes)

Fixes #843

## Test plan

- [ ] Disable a core module (e.g. `Mage_Bundle`) in `app/etc/modules/Mage_Bundle.xml`
- [ ] Run `composer dump-autoload`
- [ ] Verify product pages render without fatal errors from disabled module observers
- [ ] Verify disabled module cron jobs don't appear in admin cron listing and don't execute

Co-Authored-By: postadelmaga <postadelmaga@users.noreply.github.com>