### PR TITLE
Fix utcDate() html5 path ignoring store timezone

### DIFF
--- a/app/code/core/Mage/Core/Model/Locale.php
+++ b/app/code/core/Mage/Core/Model/Locale.php
@@ -675,15 +675,19 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
     {
         // Special handling for HTML5 native input formats
         if ($format === 'html5' && is_string($date)) {
+            // Parse date in store timezone so midnight/time values are correct for the store
+            $storeTimezone = Mage::app()->getStore($store)->getConfig(self::XML_PATH_DEFAULT_TIMEZONE);
+            $storeTz = new DateTimeZone($storeTimezone);
+
             if (preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/', $date)) {
                 // datetime-local format - validate the datetime
-                $dateTime = DateTime::createFromFormat(self::HTML5_DATETIME_FORMAT, substr($date, 0, 16));
+                $dateTime = DateTime::createFromFormat(self::HTML5_DATETIME_FORMAT, substr($date, 0, 16), $storeTz);
                 if ($dateTime === false || $dateTime->format(self::HTML5_DATETIME_FORMAT) !== substr($date, 0, 16)) {
                     return null;
                 }
             } elseif (preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
                 // date format - validate the date
-                $dateTime = DateTime::createFromFormat(self::DATE_FORMAT, $date);
+                $dateTime = DateTime::createFromFormat(self::DATE_FORMAT, $date, $storeTz);
                 if ($dateTime === false || $dateTime->format(self::DATE_FORMAT) !== $date) {
                     return null;
                 }
@@ -693,10 +697,6 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
             } else {
                 return null;
             }
-
-            // Set to store timezone first
-            $storeTimezone = Mage::app()->getStore($store)->getConfig(self::XML_PATH_DEFAULT_TIMEZONE);
-            $dateTime->setTimezone(new DateTimeZone($storeTimezone));
 
             // Convert to UTC
             $dateTime->setTimezone(new DateTimeZone(self::DEFAULT_TIMEZONE));


### PR DESCRIPTION
## Summary
- utcDate() with format=html5 was parsing dates in UTC instead of the store timezone, causing admin grid date filters to return wrong results for non-UTC stores
- DateTime::createFromFormat() without a timezone arg defaults to UTC, making the subsequent setTimezone(store) then setTimezone(UTC) calls a no-op round-trip
- Now passes the store timezone directly to createFromFormat() so dates are interpreted correctly before converting to UTC

Example: store in Australia/Sydney (UTC+10), filtering for 2026-04-16:
- **Before**: WHERE created_at >= '2026-04-16 00:00:00' (UTC midnight — wrong)
- **After**: WHERE created_at >= '2026-04-15 14:00:00' (AEST midnight converted to UTC — correct)

Fixes #769

## Test plan
- [ ] Set store timezone to a non-UTC timezone (e.g. Australia/Sydney)
- [ ] Create an order at a time that falls on different dates in UTC vs store timezone
- [ ] Filter the orders grid by today date and confirm the order appears
- [ ] Repeat with datetime-local filter on a grid that supports time filtering