### PR TITLE
Return JSON error on invalid form key in cart AJAX actions

### DIFF
--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -966,7 +966,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
         if (!$this->_validateFormKey()) {
             $this->getResponse()->setBodyJson([
                 'success' => 0,
-                'error' => $this->__('Invalid form key'),
+                'error' => $this->__('Invalid form key. Please refresh the page.'),
             ]);
             return;
         }
@@ -1001,7 +1001,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
         if (!$this->_validateFormKey()) {
             $this->getResponse()->setBodyJson([
                 'success' => 0,
-                'error' => $this->__('Invalid form key'),
+                'error' => $this->__('Invalid form key. Please refresh the page.'),
             ]);
             return;
         }

--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -964,7 +964,11 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
     public function ajaxDeleteAction(): void
     {
         if (!$this->_validateFormKey()) {
-            Mage::throwException('Invalid form key');
+            $this->getResponse()->setBodyJson([
+                'success' => 0,
+                'error' => $this->__('Invalid form key'),
+            ]);
+            return;
         }
         $id = (int) $this->getRequest()->getParam('id');
         $result = [];
@@ -995,7 +999,11 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
     public function ajaxUpdateAction(): void
     {
         if (!$this->_validateFormKey()) {
-            Mage::throwException('Invalid form key');
+            $this->getResponse()->setBodyJson([
+                'success' => 0,
+                'error' => $this->__('Invalid form key'),
+            ]);
+            return;
         }
         $id = (int) $this->getRequest()->getParam('id');
         $qty = $this->getRequest()->getParam('qty');


### PR DESCRIPTION
## Summary

- `ajaxDeleteAction()` and `ajaxUpdateAction()` in `CartController` were calling `Mage::throwException()` when the form key was invalid, causing an unhandled exception (500 error) instead of a graceful response
- Now they return a proper JSON response (`{"success": 0, "error": "Invalid form key"}`) matching the existing error format used by these endpoints

## Test plan

- [ ] Call `/checkout/cart/ajaxDelete` with an invalid or missing form key and verify a JSON error response is returned instead of an exception
- [ ] Call `/checkout/cart/ajaxUpdate` with an invalid or missing form key and verify the same
- [ ] Verify normal minicart delete and update operations still work correctly with a valid form key