### PR TITLE
Sync Stock Availability with Qty (fixes #851)

### DIFF
--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -745,7 +745,7 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
                 !$this->_getData('is_in_stock')
                 && Mage::getStoreConfigFlag(self::XML_PATH_SYNC_AVAIL_WITH_QTY)
             ) {
-                $this->setIsInStock(true);
+                $this->setIsInStock(1);
             }
 
             // if qty is below notify qty, update the low stock date to today date otherwise set null

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -84,6 +84,7 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
     public const XML_PATH_GLOBAL                = 'cataloginventory/options/';
     public const XML_PATH_CAN_SUBTRACT          = 'cataloginventory/options/can_subtract';
     public const XML_PATH_CAN_BACK_IN_STOCK     = 'cataloginventory/options/can_back_in_stock';
+    public const XML_PATH_SYNC_AVAIL_WITH_QTY   = 'cataloginventory/options/sync_stock_availability_with_qty';
 
     public const XML_PATH_ITEM                  = 'cataloginventory/item_options/';
     public const XML_PATH_MIN_QTY               = 'cataloginventory/item_options/min_qty';
@@ -740,6 +741,11 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
             if (!$this->verifyStock()) {
                 $this->setIsInStock(false)
                     ->setStockStatusChangedAutomaticallyFlag(true);
+            } elseif (
+                !$this->_getData('is_in_stock')
+                && Mage::getStoreConfigFlag(self::XML_PATH_SYNC_AVAIL_WITH_QTY)
+            ) {
+                $this->setIsInStock(true);
             }
 
             // if qty is below notify qty, update the low stock date to today date otherwise set null

--- a/app/code/core/Mage/CatalogInventory/etc/config.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/config.xml
@@ -130,6 +130,7 @@
             <options>
                 <can_subtract>1</can_subtract>
                 <can_back_in_stock>1</can_back_in_stock>
+                <sync_stock_availability_with_qty>1</sync_stock_availability_with_qty>
                 <show_out_of_stock>0</show_out_of_stock>
                 <stock_threshold_qty>0</stock_threshold_qty>
                 <display_product_stock_status>1</display_product_stock_status>

--- a/app/code/core/Mage/CatalogInventory/etc/system.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/system.xml
@@ -43,6 +43,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </can_back_in_stock>
+                        <sync_stock_availability_with_qty translate="label comment">
+                            <label>Sync Stock Availability with Qty</label>
+                            <comment>When enabled, products automatically return to In Stock as soon as Qty rises above the threshold.</comment>
+                            <frontend_type>boolean</frontend_type>
+                            <sort_order>2</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </sync_stock_availability_with_qty>
                         <show_out_of_stock translate="label comment">
                             <label>Display Out of Stock Products</label>
                             <comment>Products will still be shown by direct product URLs.</comment>

--- a/app/locale/en_US/Mage_CatalogInventory.csv
+++ b/app/locale/en_US/Mage_CatalogInventory.csv
@@ -46,6 +46,7 @@
 "Some of the products cannot be ordered in the requested quantity.","Some of the products cannot be ordered in the requested quantity."
 "Stock Options","Stock Options"
 "Stock Status","Stock Status"
+"Sync Stock Availability with Qty","Sync Stock Availability with Qty"
 "The maximum quantity allowed for purchase is %s.","The maximum quantity allowed for purchase is %s."
 "The minimum quantity allowed for purchase is %s.","The minimum quantity allowed for purchase is %s."
 "The requested quantity for ""%s"" is not available.","The requested quantity for ""%s"" is not available."
@@ -61,3 +62,4 @@
 "Update","Update"
 "Update product stock data","Update product stock data"
 "Update the Product","Update the Product"
+"When enabled, products automatically return to In Stock as soon as Qty rises above the threshold.","When enabled, products automatically return to In Stock as soon as Qty rises above the threshold."

--- a/tests/Backend/Unit/CatalogInventory/Model/Stock/SyncAvailabilityWithQtyTest.php
+++ b/tests/Backend/Unit/CatalogInventory/Model/Stock/SyncAvailabilityWithQtyTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @package    Mage_CatalogInventory
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+uses(Tests\MahoBackendTestCase::class);
+
+const SYNC_AVAIL_PATH = 'cataloginventory/options/sync_stock_availability_with_qty';
+
+/**
+ * @param array<string, mixed> $overrides
+ */
+function makeStockItemForSyncTest(array $overrides = []): Mage_CatalogInventory_Model_Stock_Item
+{
+    $item = Mage::getModel('cataloginventory/stock_item');
+    $item->addData([
+        'type_id'                => 'simple',
+        'qty'                    => 5,
+        'min_qty'                => 0,
+        'use_config_min_qty'     => 0,
+        'backorders'             => Mage_CatalogInventory_Model_Stock::BACKORDERS_NO,
+        'use_config_backorders'  => 0,
+        'manage_stock'           => 1,
+        'use_config_manage_stock' => 0,
+        'is_in_stock'            => 1,
+    ]);
+    $item->addData($overrides);
+    return $item;
+}
+
+function invokeStockItemBeforeSave(Mage_CatalogInventory_Model_Stock_Item $item): void
+{
+    $method = new ReflectionMethod($item, '_beforeSave');
+    $method->setAccessible(true);
+    $method->invoke($item);
+}
+
+describe('Stock Item _beforeSave: existing qty → out-of-stock behavior is unchanged', function () {
+    it('flips to out of stock when qty drops to 0 (flag irrelevant)', function () {
+        Mage::app()->getStore()->setConfig(SYNC_AVAIL_PATH, 0);
+
+        $item = makeStockItemForSyncTest(['qty' => 0, 'is_in_stock' => 1]);
+        invokeStockItemBeforeSave($item);
+
+        expect((int) $item->getData('is_in_stock'))->toBe(0)
+            ->and((int) $item->getStockStatusChangedAutomatically())->toBe(1);
+    });
+
+    it('flips to out of stock when qty drops at or below min_qty', function () {
+        $item = makeStockItemForSyncTest(['qty' => 2, 'min_qty' => 5, 'is_in_stock' => 1]);
+        invokeStockItemBeforeSave($item);
+
+        expect((int) $item->getData('is_in_stock'))->toBe(0);
+    });
+
+    it('does not flip to out of stock when backorders are enabled even with qty 0', function () {
+        $item = makeStockItemForSyncTest([
+            'qty'        => 0,
+            'is_in_stock' => 1,
+            'backorders' => Mage_CatalogInventory_Model_Stock::BACKORDERS_YES_NONOTIFY,
+        ]);
+        invokeStockItemBeforeSave($item);
+
+        expect((int) $item->getData('is_in_stock'))->toBe(1);
+    });
+});
+
+describe('Stock Item _beforeSave: qty → in-stock sync (gated by config)', function () {
+    it('flips back to in stock when flag is on and qty rises above min_qty', function () {
+        Mage::app()->getStore()->setConfig(SYNC_AVAIL_PATH, 1);
+
+        $item = makeStockItemForSyncTest([
+            'qty'                         => 10,
+            'is_in_stock'                 => 0,
+            'stock_status_changed_auto'   => 1,
+        ]);
+        invokeStockItemBeforeSave($item);
+
+        expect((int) $item->getData('is_in_stock'))->toBe(1)
+            ->and((int) $item->getStockStatusChangedAutomatically())->toBe(0);
+    });
+
+    it('does NOT flip back when flag is off even if qty is positive', function () {
+        Mage::app()->getStore()->setConfig(SYNC_AVAIL_PATH, 0);
+
+        $item = makeStockItemForSyncTest(['qty' => 10, 'is_in_stock' => 0]);
+        invokeStockItemBeforeSave($item);
+
+        expect((int) $item->getData('is_in_stock'))->toBe(0);
+    });
+
+    it('does not flip back when qty is still at or below min_qty', function () {
+        Mage::app()->getStore()->setConfig(SYNC_AVAIL_PATH, 1);
+
+        $item = makeStockItemForSyncTest(['qty' => 3, 'min_qty' => 5, 'is_in_stock' => 0]);
+        invokeStockItemBeforeSave($item);
+
+        expect((int) $item->getData('is_in_stock'))->toBe(0);
+    });
+
+    it('leaves already-in-stock items alone with flag on', function () {
+        Mage::app()->getStore()->setConfig(SYNC_AVAIL_PATH, 1);
+
+        $item = makeStockItemForSyncTest(['qty' => 10, 'is_in_stock' => 1]);
+        invokeStockItemBeforeSave($item);
+
+        expect((int) $item->getData('is_in_stock'))->toBe(1);
+    });
+
+    it('with flag on, qty goes 5 → 0 → 10 round-trips is_in_stock', function () {
+        Mage::app()->getStore()->setConfig(SYNC_AVAIL_PATH, 1);
+
+        // Step 1: qty drops to 0, auto-flip out
+        $item = makeStockItemForSyncTest(['qty' => 0, 'is_in_stock' => 1]);
+        invokeStockItemBeforeSave($item);
+        expect((int) $item->getData('is_in_stock'))->toBe(0)
+            ->and((int) $item->getStockStatusChangedAutomatically())->toBe(1);
+
+        // Step 2: qty rises to 10, auto-flip back in
+        $item->setQty(10);
+        // clear transient flag so the next save re-evaluates cleanly
+        $item->unsetData('stock_status_changed_automatically_flag');
+        invokeStockItemBeforeSave($item);
+        expect((int) $item->getData('is_in_stock'))->toBe(1)
+            ->and((int) $item->getStockStatusChangedAutomatically())->toBe(0);
+    });
+});
+
+describe('Stock Item _beforeSave: non-qty product types are untouched', function () {
+    it('does not auto-flip for grouped products even when flag is on', function () {
+        Mage::app()->getStore()->setConfig(SYNC_AVAIL_PATH, 1);
+
+        $item = makeStockItemForSyncTest([
+            'type_id'     => 'grouped',
+            'qty'         => 10,
+            'is_in_stock' => 0,
+        ]);
+        invokeStockItemBeforeSave($item);
+
+        expect((int) $item->getData('is_in_stock'))->toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds a new Stock Options setting **"Sync Stock Availability with Qty"** (default on) that symmetrizes the existing auto-flip: when Qty rises back above `min_qty`, Stock Availability is returned to **In Stock** on the next save.
- Previously, Qty dropping to 0 auto-flipped products to Out of Stock, but Qty returning to a positive value never flipped them back — forcing merchants to toggle the status manually (issue #851).
- Covers admin edit, admin mass actions, REST/SOAP API, and the order-cancel path.

## Out of scope

- **CSV import** (`Mage_ImportExport`): the importer uses a direct-SQL `insertOnDuplicate` path that bypasses the stock item model entirely, so `_beforeSave()` is not invoked. The importer has a pre-existing asymmetry where `is_in_stock` is not derived from Qty at all (neither direction). Addressing it is unrelated to #851 and deserves a separate PR.

## Test plan

- [x] `composer test -- --testsuite=Backend --filter=SyncAvailabilityWithQty` → 9 passed
- [ ] Manual check: create product with Qty 5 / In Stock, save Qty 0 → Out of Stock, save Qty 10 → In Stock
- [ ] Manual check: disable the new setting, save Qty 10 on an Out-of-Stock product → stays Out of Stock (respects flag)
- [ ] Manual check: verify no regression on the existing "Qty → 0 flips to Out of Stock" path