### PR TITLE
Prevent admin grid status badge wrapping in narrow columns

### DIFF
--- a/public/skin/adminhtml/default/default/base.css
+++ b/public/skin/adminhtml/default/default/base.css
@@ -4710,7 +4710,8 @@ dl.accordion dt.open a:after,div.collapseable a.open:after {
 
 .grid-severity-minor span,.grid-severity-major span,.grid-severity-critical span,.grid-severity-notice span {
     font: 400 12px/1.33 ui-sans-serif,system-ui,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
-    padding: 2px 10px
+    padding: 2px 10px;
+    white-space: nowrap
 }
 
 .grid-severity-minor span,.grid-severity-major span {


### PR DESCRIPTION
## Summary
- Admin grids render status labels via `.grid-severity-*` span badges (e.g. 'Reindex Required' on System > Index Management).
- When the containing column is narrower than the label, the text wraps inside the pill, producing a staircase-style visual where each word sits on its own line with a jagged coloured background.
- Fix: add `white-space: nowrap` to the badge span so it stays on a single line and the column widens to accommodate it instead.

## Before
On System > Index Management the Status column is fairly tight. 'Reindex Required' wrapped onto two lines and the red background broke across rows in an uneven staircase (see attached below).

<img width="2057" height="888" alt="image" src="https://github.com/user-attachments/assets/657ebed5-89c6-4923-9148-bf8074b565c1" />


## After
Badge stays as a single-line pill; column grows to fit the label.

<img width="2856" height="755" alt="image" src="https://github.com/user-attachments/assets/62764ea1-e991-4c2c-8f5c-4390ba4634c8" />


## Test plan
- [ ] Visit System > Index Management on a fresh install where one or more indexers need reindex.
- [ ] Confirm the red 'Reindex Required' badge renders as a single line, not wrapped.
- [ ] Spot-check other grids that use `.grid-severity-notice` / `.grid-severity-minor` / `.grid-severity-major` / `.grid-severity-critical` (e.g. System > Cache Management 'Invalidated', product grid visibility severities) to confirm no regression.