### PR TITLE
Fix admin_user.created being auto-updated on every login

### DIFF
--- a/app/code/core/Mage/Admin/etc/config.xml
+++ b/app/code/core/Mage/Admin/etc/config.xml
@@ -12,7 +12,7 @@
 <config>
     <modules>
         <Mage_Admin>
-            <version>1.6.1.5</version>
+            <version>1.6.1.6</version>
         </Mage_Admin>
     </modules>
     <global>

--- a/app/code/core/Mage/Admin/sql/admin_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/install-1.6.0.0.php
@@ -163,6 +163,7 @@ $table = $installer->getConnection()
     ], 'User Password')
     ->addColumn('created', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
         'nullable'  => false,
+        'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
     ], 'User Created Time')
     ->addColumn('modified', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
     ], 'User Modified Time')

--- a/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.5-1.6.1.6.php
+++ b/app/code/core/Mage/Admin/sql/admin_setup/upgrade-1.6.1.5-1.6.1.6.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @package    Mage_Admin
+ * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Fix admin_user.created column: remove legacy MySQL ON UPDATE CURRENT_TIMESTAMP.
+ *
+ * The original install DDL (install-1.6.0.0.php) declared the `created` column as
+ * TIMESTAMP NOT NULL without an explicit default. On MySQL servers running with
+ * `explicit_defaults_for_timestamp = OFF` (the pre-8.0 default), MySQL silently
+ * applied its legacy "first TIMESTAMP NOT NULL column in a table" rule and
+ * auto-added `DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`.
+ *
+ * Effect: every time an admin user row was updated (e.g. on login via
+ * Mage_Admin_Model_Resource_User::recordLogin()), MySQL auto-bumped `created`
+ * to NOW(), destroying the record of when the user was actually created.
+ *
+ * This is a classic Magento-1/OpenMage inheritance bug. It breaks security
+ * monitoring use cases that depend on a stable account-creation timestamp
+ * (password rotation policies, dormant-account detection, audit trails).
+ *
+ * Fix: explicitly redefine the column with DEFAULT CURRENT_TIMESTAMP only
+ * (no ON UPDATE). Existing row values are preserved — MODIFY COLUMN only
+ * changes the column metadata, not the stored data.
+ */
+
+/** @var Mage_Core_Model_Resource_Setup $this */
+$installer = $this;
+$installer->startSetup();
+
+$installer->getConnection()->modifyColumn(
+    $installer->getTable('admin/user'),
+    'created',
+    [
+        'type'     => Maho\Db\Ddl\Table::TYPE_TIMESTAMP,
+        'nullable' => false,
+        'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
+        'comment'  => 'User Created Time',
+    ],
+);
+
+$installer->endSetup();

--- a/lib/Maho/Db/Adapter/Pdo/Pgsql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Pgsql.php
@@ -1610,8 +1610,7 @@ class Pgsql extends AbstractPdoAdapter
                         $qualifiedTable,
                         $quotedColumn,
                     ));
-                } elseif ($default === \Maho\Db\Ddl\Table::TIMESTAMP_INIT
-                    || $default === \Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE) {
+                } elseif ($default === \Maho\Db\Ddl\Table::TIMESTAMP_INIT) {
                     $this->raw_query(sprintf(
                         'ALTER TABLE %s ALTER COLUMN %s SET DEFAULT CURRENT_TIMESTAMP',
                         $qualifiedTable,

--- a/lib/Maho/Db/Adapter/Pdo/Pgsql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Pgsql.php
@@ -1610,6 +1610,13 @@ class Pgsql extends AbstractPdoAdapter
                         $qualifiedTable,
                         $quotedColumn,
                     ));
+                } elseif ($default === \Maho\Db\Ddl\Table::TIMESTAMP_INIT
+                    || $default === \Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE) {
+                    $this->raw_query(sprintf(
+                        'ALTER TABLE %s ALTER COLUMN %s SET DEFAULT CURRENT_TIMESTAMP',
+                        $qualifiedTable,
+                        $quotedColumn,
+                    ));
                 } else {
                     $this->raw_query(sprintf(
                         'ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s',


### PR DESCRIPTION
## Summary

`Mage_Admin` install DDL declares `admin_user.created` as `TIMESTAMP NOT NULL` with no explicit default. On MySQL servers running with `explicit_defaults_for_timestamp = OFF` (the pre-8.0 default, still common on upgraded installs and some managed DB providers), MySQL silently applies its legacy "first TIMESTAMP NOT NULL column in a table" rule and auto-adds `DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`.

Result: every time an admin user row is updated (most commonly by `Mage_Admin_Model_Resource_User::recordLogin()` which issues `UPDATE admin_user SET logdate=?, lognum=? WHERE user_id=?` on every successful login), MySQL auto-bumps `created` to `NOW()`, destroying the original account-creation timestamp.

This has been silently broken since Magento 1 and was inherited by OpenMage and Maho.

## Reproduction

```sql
SHOW CREATE TABLE admin_user;
-- `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
```

Log in as any admin, then:

```sql
SELECT username, created, modified, logdate FROM admin_user;
-- `created` now equals `logdate` (both NOW())
-- `modified` is older (it's only touched on model save, not on recordLogin's direct UPDATE)
```

## Why it matters

`admin_user.created` is the stable "this account was created at X" timestamp. Breaking it undermines:

- **Password rotation / expiry policies** — "force reset after 90 days of account age" becomes meaningless because every account looks 0 days old after last login.
- **Dormant-account detection** — auditors expect `created` + `logdate` to tell a story; when they're always equal, the signal is lost.
- **Incident investigation** — after a breach, "when was this backdoor admin user actually created?" is answered with "right now, apparently" on every install with this bug.
- **Compliance audit trails** — SOC 2 / ISO 27001 rely on stable account-creation records.

## Fix

1. **Install DDL** — add an explicit `'default' => TIMESTAMP_INIT` so new installs get `DEFAULT CURRENT_TIMESTAMP` (no `ON UPDATE`) regardless of the server's `explicit_defaults_for_timestamp` setting.

2. **Upgrade script 1.6.1.5 → 1.6.1.6** — issues `MODIFY COLUMN` to correct existing installs. Existing `created` values are preserved (MODIFY changes column metadata, not stored data).

## Before / after

```sql
-- before
`created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP

-- after
`created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
```

## Test plan

- [x] Verified on 3 separate MySQL 8 installs (same RDS cluster, different DBs — two had the `ON UPDATE` clause from legacy config, one had `0000-00-00` from modern config, upgrade script fixed all three).
- [x] Confirmed `ALTER TABLE ... MODIFY COLUMN` preserves existing row values.
- [ ] Install a fresh Maho from this branch on a MySQL 8 host with `explicit_defaults_for_timestamp = OFF` and verify `admin_user.created` renders as `DEFAULT CURRENT_TIMESTAMP` only.
- [ ] Log in as an admin, confirm `created` doesn't change while `logdate` does.

## Scope note

This PR fixes `admin_user.created` only. A follow-up audit of other Maho tables using the same `TIMESTAMP NOT NULL` pattern without an explicit default may be warranted — happy to do that as a separate PR if maintainers agree on the approach.