### PR TITLE
Fix TIMESTAMP_INIT_UPDATE cross-engine parity (fixes #856)

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Dynamic/Rule.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Dynamic/Rule.php
@@ -74,7 +74,7 @@ class Mage_Catalog_Model_Resource_Category_Dynamic_Rule extends Mage_Core_Model_
     #[\Override]
     public function save(Mage_Core_Model_Abstract $rule)
     {
-        $now = Mage::getSingleton('core/date')->gmtDate();
+        $now = Mage::app()->getLocale()->formatDateForDb('now');
         $rule->setUpdatedAt($now);
         if (!$rule->getCreatedAt()) {
             $rule->setCreatedAt($now);

--- a/app/code/core/Mage/Catalog/sql/maho_setup/maho-25.6.0.php
+++ b/app/code/core/Mage/Catalog/sql/maho_setup/maho-25.6.0.php
@@ -40,7 +40,7 @@ $table = $installer->getConnection()
     ], 'Created At')
     ->addColumn('updated_at', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
         'nullable'  => false,
-        'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE,
+        'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
     ], 'Updated At')
     ->addIndex(
         $installer->getIdxName('catalog/category_dynamic_rule', ['category_id']),

--- a/app/code/core/Mage/Catalog/sql/maho_setup/maho-26.5.0.php
+++ b/app/code/core/Mage/Catalog/sql/maho_setup/maho-26.5.0.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @package    Mage_Catalog
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Catalog_Model_Resource_Setup $this */
+$installer = $this;
+$installer->startSetup();
+
+// Drop MySQL-only `ON UPDATE CURRENT_TIMESTAMP` clause on updated_at columns that were originally
+// declared with TIMESTAMP_INIT_UPDATE. Value is now managed explicitly in PHP via _beforeSave()
+// for cross-engine parity (see issue #856).
+if ($installer->getConnection() instanceof \Maho\Db\Adapter\Pdo\Mysql) {
+    $installer->getConnection()->modifyColumn(
+        $installer->getTable('catalog/category_dynamic_rule'),
+        'updated_at',
+        [
+            'type'     => Maho\Db\Ddl\Table::TYPE_TIMESTAMP,
+            'nullable' => false,
+            'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
+            'comment'  => 'Updated At',
+        ],
+    );
+}
+
+$installer->endSetup();

--- a/app/code/core/Mage/Core/Model/Flag.php
+++ b/app/code/core/Mage/Core/Model/Flag.php
@@ -51,7 +51,7 @@ class Mage_Core_Model_Flag extends Mage_Core_Model_Abstract
         }
 
         $this->setFlagCode($this->_flagCode);
-        $this->setLastUpdate(date(Maho\Db\Adapter\Pdo\Mysql::TIMESTAMP_FORMAT));
+        $this->setLastUpdate(Mage::app()->getLocale()->formatDateForDb('now'));
 
         return parent::_beforeSave();
     }

--- a/app/code/core/Mage/Core/sql/core_setup/install-1.6.0.0.php
+++ b/app/code/core/Mage/Core/sql/core_setup/install-1.6.0.0.php
@@ -716,7 +716,7 @@ $table = $installer->getConnection()
     ], 'Flag Data')
     ->addColumn('last_update', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
         'nullable'  => false,
-        'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE,
+        'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
     ], 'Date of Last Flag Update')
     ->addIndex(
         $installer->getIdxName('core/flag', ['last_update']),

--- a/app/code/core/Mage/Core/sql/maho_setup/maho-26.5.0.php
+++ b/app/code/core/Mage/Core/sql/maho_setup/maho-26.5.0.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @package    Mage_Core
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Core_Model_Resource_Setup $this */
+$installer = $this;
+$installer->startSetup();
+
+// Drop MySQL-only `ON UPDATE CURRENT_TIMESTAMP` clause on timestamp columns that were originally
+// declared with TIMESTAMP_INIT_UPDATE. Value is now managed explicitly in PHP (see Mage_Core_Model_Flag::_beforeSave)
+// for cross-engine parity (see issue #856).
+if ($installer->getConnection() instanceof \Maho\Db\Adapter\Pdo\Mysql) {
+    $installer->getConnection()->modifyColumn(
+        $installer->getTable('core/flag'),
+        'last_update',
+        [
+            'type'     => Maho\Db\Ddl\Table::TYPE_TIMESTAMP,
+            'nullable' => false,
+            'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
+            'comment'  => 'Date of Last Flag Update',
+        ],
+    );
+}
+
+$installer->endSetup();

--- a/app/code/core/Mage/Payment/Model/Restriction.php
+++ b/app/code/core/Mage/Payment/Model/Restriction.php
@@ -26,7 +26,7 @@ class Mage_Payment_Model_Restriction extends Mage_Core_Model_Abstract
     {
         parent::_beforeSave();
         $now = Mage::app()->getLocale()->formatDateForDb('now');
-        if (!$this->getId()) {
+        if ($this->isObjectNew() && !$this->getCreatedAt()) {
             $this->setCreatedAt($now);
         }
         $this->setUpdatedAt($now);

--- a/app/code/core/Mage/Payment/Model/Restriction.php
+++ b/app/code/core/Mage/Payment/Model/Restriction.php
@@ -21,6 +21,18 @@ class Mage_Payment_Model_Restriction extends Mage_Core_Model_Abstract
         $this->_init('payment/restriction');
     }
 
+    #[\Override]
+    protected function _beforeSave()
+    {
+        parent::_beforeSave();
+        $now = Mage::app()->getLocale()->formatDateForDb('now');
+        if (!$this->getId()) {
+            $this->setCreatedAt($now);
+        }
+        $this->setUpdatedAt($now);
+        return $this;
+    }
+
     /**
      * Validate payment method against restrictions
      */

--- a/app/code/core/Mage/Payment/sql/maho_setup/maho-25.5.0.php
+++ b/app/code/core/Mage/Payment/sql/maho_setup/maho-25.5.0.php
@@ -57,7 +57,7 @@ $table = $installer->getConnection()
     ], 'Created At')
     ->addColumn('updated_at', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
         'nullable'  => false,
-        'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE,
+        'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
     ], 'Updated At')
     ->addIndex(
         $installer->getIdxName('payment/restriction', ['status']),

--- a/app/code/core/Mage/Payment/sql/maho_setup/maho-26.5.0.php
+++ b/app/code/core/Mage/Payment/sql/maho_setup/maho-26.5.0.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @package    Mage_Payment
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Core_Model_Resource_Setup $this */
+$installer = $this;
+$installer->startSetup();
+
+// Drop MySQL-only `ON UPDATE CURRENT_TIMESTAMP` clause on updated_at columns that were originally
+// declared with TIMESTAMP_INIT_UPDATE. Value is now managed explicitly in PHP via _beforeSave()
+// for cross-engine parity (see issue #856).
+if ($installer->getConnection() instanceof \Maho\Db\Adapter\Pdo\Mysql) {
+    $installer->getConnection()->modifyColumn(
+        $installer->getTable('payment/restriction'),
+        'updated_at',
+        [
+            'type'     => Maho\Db\Ddl\Table::TYPE_TIMESTAMP,
+            'nullable' => false,
+            'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
+            'comment'  => 'Updated At',
+        ],
+    );
+}
+
+$installer->endSetup();

--- a/app/code/core/Maho/Blog/Model/Resource/Category.php
+++ b/app/code/core/Maho/Blog/Model/Resource/Category.php
@@ -179,7 +179,7 @@ class Maho_Blog_Model_Resource_Category extends Mage_Eav_Model_Entity_Abstract
     #[\Override]
     public function save(\Maho\DataObject $object)
     {
-        $now = Mage::app()->getLocale()->nowUtc();
+        $now = Mage::app()->getLocale()->formatDateForDb('now');
 
         if (!$object->getId()) {
             $object->setCreatedAt($now);

--- a/app/code/core/Maho/Blog/Model/Resource/Post.php
+++ b/app/code/core/Maho/Blog/Model/Resource/Post.php
@@ -209,7 +209,7 @@ class Maho_Blog_Model_Resource_Post extends Mage_Eav_Model_Entity_Abstract
     #[\Override]
     public function save(\Maho\DataObject $object)
     {
-        $now = Mage::app()->getLocale()->nowUtc();
+        $now = Mage::app()->getLocale()->formatDateForDb('now');
 
         if (!$object->getId()) {
             $object->setCreatedAt($now);

--- a/app/code/core/Maho/Blog/sql/blog_setup/install-1.0.0.php
+++ b/app/code/core/Maho/Blog/sql/blog_setup/install-1.0.0.php
@@ -80,7 +80,7 @@ $table = $installer->getConnection()
     ])
     ->addColumn('updated_at', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
         'nullable'  => false,
-        'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE,
+        'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
     ])
     ->addIndex(
         $installer->getIdxName('blog/post', ['entity_type_id']),

--- a/app/code/core/Maho/Blog/sql/blog_setup/upgrade-1.0.1-2.0.0.php
+++ b/app/code/core/Maho/Blog/sql/blog_setup/upgrade-1.0.1-2.0.0.php
@@ -98,7 +98,7 @@ $table = $connection
     ])
     ->addColumn('updated_at', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
         'nullable'  => false,
-        'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE,
+        'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
     ])
     ->addIndex(
         $installer->getIdxName('blog/category', ['entity_type_id']),

--- a/app/code/core/Maho/Blog/sql/maho_setup/maho-26.5.0.php
+++ b/app/code/core/Maho/Blog/sql/maho_setup/maho-26.5.0.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @package    Maho_Blog
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Core_Model_Resource_Setup $this */
+$installer = $this;
+$installer->startSetup();
+
+// Drop MySQL-only `ON UPDATE CURRENT_TIMESTAMP` clause on updated_at columns that were originally
+// declared with TIMESTAMP_INIT_UPDATE. Value is now managed explicitly in PHP via _beforeSave()
+// for cross-engine parity (see issue #856).
+if ($installer->getConnection() instanceof \Maho\Db\Adapter\Pdo\Mysql) {
+    $tables = [
+        'blog/post',
+        'blog/category',
+    ];
+    foreach ($tables as $alias) {
+        $table = $installer->getTable($alias);
+        if (!$installer->getConnection()->isTableExists($table)) {
+            continue;
+        }
+        $installer->getConnection()->modifyColumn(
+            $table,
+            'updated_at',
+            [
+                'type'     => Maho\Db\Ddl\Table::TYPE_TIMESTAMP,
+                'nullable' => false,
+                'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
+            ],
+        );
+    }
+}
+
+$installer->endSetup();

--- a/app/code/core/Maho/CatalogLinkRule/Model/Rule.php
+++ b/app/code/core/Maho/CatalogLinkRule/Model/Rule.php
@@ -28,6 +28,18 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
         $this->_init('cataloglinkrule/rule');
     }
 
+    #[\Override]
+    protected function _beforeSave()
+    {
+        parent::_beforeSave();
+        $now = Mage::app()->getLocale()->formatDateForDb('now');
+        if (!$this->getId()) {
+            $this->setCreatedAt($now);
+        }
+        $this->setUpdatedAt($now);
+        return $this;
+    }
+
     public function hasConditionsSerialized(): bool
     {
         return $this->hasData('source_conditions_serialized');

--- a/app/code/core/Maho/CatalogLinkRule/Model/Rule.php
+++ b/app/code/core/Maho/CatalogLinkRule/Model/Rule.php
@@ -33,7 +33,7 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
     {
         parent::_beforeSave();
         $now = Mage::app()->getLocale()->formatDateForDb('now');
-        if (!$this->getId()) {
+        if ($this->isObjectNew() && !$this->getCreatedAt()) {
             $this->setCreatedAt($now);
         }
         $this->setUpdatedAt($now);

--- a/app/code/core/Maho/CatalogLinkRule/sql/cataloglinkrule_setup/install-1.0.0.php
+++ b/app/code/core/Maho/CatalogLinkRule/sql/cataloglinkrule_setup/install-1.0.0.php
@@ -68,7 +68,7 @@ $table->addColumn('rule_id', Table::TYPE_INTEGER, null, [
 ], 'Created At')
 ->addColumn('updated_at', Table::TYPE_TIMESTAMP, null, [
     'nullable' => false,
-    'default'  => Table::TIMESTAMP_INIT_UPDATE,
+    'default'  => Table::TIMESTAMP_INIT,
 ], 'Updated At')
 ->addIndex(
     $installer->getIdxName('cataloglinkrule/rule', ['is_active', 'priority', 'link_type_id']),

--- a/app/code/core/Maho/CatalogLinkRule/sql/maho_setup/maho-26.5.0.php
+++ b/app/code/core/Maho/CatalogLinkRule/sql/maho_setup/maho-26.5.0.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @package    Maho_CatalogLinkRule
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+use Maho\Db\Ddl\Table;
+
+/** @var Mage_Core_Model_Resource_Setup $this */
+$installer = $this;
+$installer->startSetup();
+
+// Drop MySQL-only `ON UPDATE CURRENT_TIMESTAMP` clause on updated_at columns that were originally
+// declared with TIMESTAMP_INIT_UPDATE. Value is now managed explicitly in PHP via _beforeSave()
+// for cross-engine parity (see issue #856).
+if ($installer->getConnection() instanceof \Maho\Db\Adapter\Pdo\Mysql) {
+    $installer->getConnection()->modifyColumn(
+        $installer->getTable('cataloglinkrule/rule'),
+        'updated_at',
+        [
+            'type'     => Table::TYPE_TIMESTAMP,
+            'nullable' => false,
+            'default'  => Table::TIMESTAMP_INIT,
+            'comment'  => 'Updated At',
+        ],
+    );
+}
+
+$installer->endSetup();

--- a/app/code/core/Maho/CustomerSegmentation/Model/EmailSequence.php
+++ b/app/code/core/Maho/CustomerSegmentation/Model/EmailSequence.php
@@ -247,6 +247,12 @@ class Maho_CustomerSegmentation_Model_EmailSequence extends Mage_Core_Model_Abst
             }
         }
 
+        $now = Mage::app()->getLocale()->formatDateForDb('now');
+        if ($this->isObjectNew() && !$this->getCreatedAt()) {
+            $this->setCreatedAt($now);
+        }
+        $this->setUpdatedAt($now);
+
         return $this;
     }
 

--- a/app/code/core/Maho/CustomerSegmentation/Model/Segment.php
+++ b/app/code/core/Maho/CustomerSegmentation/Model/Segment.php
@@ -330,6 +330,12 @@ class Maho_CustomerSegmentation_Model_Segment extends Mage_Rule_Model_Abstract
             }
         }
 
+        $now = Mage::app()->getLocale()->formatDateForDb('now');
+        if ($this->isObjectNew() && !$this->getCreatedAt()) {
+            $this->setCreatedAt($now);
+        }
+        $this->setUpdatedAt($now);
+
         return $this;
     }
 

--- a/app/code/core/Maho/CustomerSegmentation/sql/customersegmentation_setup/install-1.0.0.php
+++ b/app/code/core/Maho/CustomerSegmentation/sql/customersegmentation_setup/install-1.0.0.php
@@ -59,7 +59,7 @@ if (!$installer->getConnection()->isTableExists($installer->getTable('customerse
         ], 'Created At')
         ->addColumn('updated_at', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
             'nullable'  => false,
-            'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE,
+            'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
         ], 'Updated At')
         ->addColumn('matched_customers_count', Maho\Db\Ddl\Table::TYPE_INTEGER, null, [
             'unsigned'  => true,
@@ -124,7 +124,7 @@ if (!$installer->getConnection()->isTableExists($installer->getTable('customerse
         ], 'Added to Segment At')
         ->addColumn('updated_at', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
             'nullable'  => false,
-            'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE,
+            'default'   => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
         ], 'Updated At')
         ->addIndex(
             $installer->getIdxName('customersegmentation/segment_customer', ['segment_id', 'customer_id', 'website_id']),

--- a/app/code/core/Maho/CustomerSegmentation/sql/customersegmentation_setup/upgrade-1.0.0-1.1.0.php
+++ b/app/code/core/Maho/CustomerSegmentation/sql/customersegmentation_setup/upgrade-1.0.0-1.1.0.php
@@ -100,7 +100,7 @@ if (!$installer->getConnection()->isTableExists($installer->getTable('customer_s
         ], 'Created At')
         ->addColumn('updated_at', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
             'nullable' => false,
-            'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE,
+            'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
         ], 'Updated At')
         ->addIndex(
             'unique_segment_trigger_step',

--- a/app/code/core/Maho/CustomerSegmentation/sql/maho_setup/maho-26.5.0.php
+++ b/app/code/core/Maho/CustomerSegmentation/sql/maho_setup/maho-26.5.0.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @package    Maho_CustomerSegmentation
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Core_Model_Resource_Setup $this */
+$installer = $this;
+$installer->startSetup();
+
+// Drop MySQL-only `ON UPDATE CURRENT_TIMESTAMP` clause on updated_at columns that were originally
+// declared with TIMESTAMP_INIT_UPDATE. Value is now managed explicitly in PHP via _beforeSave()
+// for cross-engine parity (see issue #856).
+if ($installer->getConnection() instanceof \Maho\Db\Adapter\Pdo\Mysql) {
+    $tables = [
+        'customersegmentation/segment',
+        'customersegmentation/segment_customer',
+        'customersegmentation/emailSequence',
+    ];
+    foreach ($tables as $alias) {
+        $table = $installer->getTable($alias);
+        if (!$installer->getConnection()->isTableExists($table)) {
+            continue;
+        }
+        $installer->getConnection()->modifyColumn(
+            $table,
+            'updated_at',
+            [
+                'type'     => Maho\Db\Ddl\Table::TYPE_TIMESTAMP,
+                'nullable' => false,
+                'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
+                'comment'  => 'Updated At',
+            ],
+        );
+    }
+}
+
+$installer->endSetup();

--- a/app/code/core/Maho/FeedManager/Model/Destination.php
+++ b/app/code/core/Maho/FeedManager/Model/Destination.php
@@ -235,7 +235,7 @@ class Maho_FeedManager_Model_Destination extends Mage_Core_Model_Abstract
             $this->setData('config', Mage::helper('core')->encryptIdempotent($config));
         }
 
-        $now = Mage::app()->getLocale()->nowUtc();
+        $now = Mage::app()->getLocale()->formatDateForDb('now');
         if (!$this->getCreatedAt()) {
             $this->setCreatedAt($now);
         }

--- a/app/code/core/Maho/FeedManager/Model/DynamicRule.php
+++ b/app/code/core/Maho/FeedManager/Model/DynamicRule.php
@@ -286,7 +286,7 @@ class Maho_FeedManager_Model_DynamicRule extends Mage_Core_Model_Abstract
     {
         parent::_beforeSave();
 
-        $now = Mage::app()->getLocale()->nowUtc();
+        $now = Mage::app()->getLocale()->formatDateForDb('now');
         if (!$this->getCreatedAt()) {
             $this->setCreatedAt($now);
         }

--- a/app/code/core/Maho/FeedManager/Model/Feed.php
+++ b/app/code/core/Maho/FeedManager/Model/Feed.php
@@ -162,7 +162,7 @@ class Maho_FeedManager_Model_Feed extends Mage_Rule_Model_Abstract
             $this->setFilename($filename);
         }
 
-        $now = Mage::app()->getLocale()->nowUtc();
+        $now = Mage::app()->getLocale()->formatDateForDb('now');
         if (!$this->getCreatedAt()) {
             $this->setCreatedAt($now);
         }

--- a/app/code/core/Maho/FeedManager/sql/feedmanager_setup/install-1.0.0.php
+++ b/app/code/core/Maho/FeedManager/sql/feedmanager_setup/install-1.0.0.php
@@ -55,7 +55,7 @@ $table = $connection
     ], 'Created At')
     ->addColumn('updated_at', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
         'nullable' => false,
-        'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE,
+        'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
     ], 'Updated At')
     ->addIndex(
         $installer->getIdxName('feedmanager/destination', ['type']),
@@ -263,7 +263,7 @@ $table = $connection
     ], 'Created At')
     ->addColumn('updated_at', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
         'nullable' => false,
-        'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE,
+        'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
     ], 'Updated At')
     ->addIndex(
         $installer->getIdxName('feedmanager/feed', ['platform']),
@@ -508,7 +508,7 @@ $table = $connection
     ], 'Created At')
     ->addColumn('updated_at', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
         'nullable' => false,
-        'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE,
+        'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
     ], 'Updated At')
     ->addIndex(
         $installer->getIdxName('feedmanager/dynamic_rule', ['code'], 'unique'),

--- a/app/code/core/Maho/FeedManager/sql/maho_setup/maho-26.5.0.php
+++ b/app/code/core/Maho/FeedManager/sql/maho_setup/maho-26.5.0.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @package    Maho_FeedManager
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Core_Model_Resource_Setup $this */
+$installer = $this;
+$installer->startSetup();
+
+// Drop MySQL-only `ON UPDATE CURRENT_TIMESTAMP` clause on updated_at columns that were originally
+// declared with TIMESTAMP_INIT_UPDATE. Value is now managed explicitly in PHP via _beforeSave()
+// for cross-engine parity (see issue #856).
+if ($installer->getConnection() instanceof \Maho\Db\Adapter\Pdo\Mysql) {
+    $tables = [
+        'feedmanager/destination',
+        'feedmanager/feed',
+        'feedmanager/dynamic_rule',
+    ];
+    foreach ($tables as $alias) {
+        $installer->getConnection()->modifyColumn(
+            $installer->getTable($alias),
+            'updated_at',
+            [
+                'type'     => Maho\Db\Ddl\Table::TYPE_TIMESTAMP,
+                'nullable' => false,
+                'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
+                'comment'  => 'Updated At',
+            ],
+        );
+    }
+}
+
+$installer->endSetup();

--- a/app/code/core/Maho/Paypal/Model/Vault/Token.php
+++ b/app/code/core/Maho/Paypal/Model/Vault/Token.php
@@ -23,7 +23,7 @@ class Maho_Paypal_Model_Vault_Token extends Mage_Core_Model_Abstract
     {
         parent::_beforeSave();
         $now = Mage::app()->getLocale()->formatDateForDb('now');
-        if (!$this->getId()) {
+        if ($this->isObjectNew() && !$this->getCreatedAt()) {
             $this->setCreatedAt($now);
         }
         $this->setUpdatedAt($now);

--- a/app/code/core/Maho/Paypal/Model/Vault/Token.php
+++ b/app/code/core/Maho/Paypal/Model/Vault/Token.php
@@ -18,6 +18,18 @@ class Maho_Paypal_Model_Vault_Token extends Mage_Core_Model_Abstract
         $this->_init('maho_paypal/vault_token');
     }
 
+    #[\Override]
+    protected function _beforeSave()
+    {
+        parent::_beforeSave();
+        $now = Mage::app()->getLocale()->formatDateForDb('now');
+        if (!$this->getId()) {
+            $this->setCreatedAt($now);
+        }
+        $this->setUpdatedAt($now);
+        return $this;
+    }
+
     public function getDisplayLabel(): string
     {
         if ($this->getLabel()) {

--- a/app/code/core/Maho/Paypal/sql/maho_paypal_setup/install-1.0.0.php
+++ b/app/code/core/Maho/Paypal/sql/maho_paypal_setup/install-1.0.0.php
@@ -122,7 +122,7 @@ $vaultTable = $connection
     ], 'Created At')
     ->addColumn('updated_at', Maho\Db\Ddl\Table::TYPE_TIMESTAMP, null, [
         'nullable' => false,
-        'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE,
+        'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
     ], 'Updated At')
     ->addIndex(
         $installer->getIdxName('maho_paypal/vault_token', ['paypal_token_id_hash'], Maho\Db\Adapter\AdapterInterface::INDEX_TYPE_UNIQUE),

--- a/app/code/core/Maho/Paypal/sql/maho_setup/maho-26.5.0.php
+++ b/app/code/core/Maho/Paypal/sql/maho_setup/maho-26.5.0.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @package    Maho_Paypal
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Core_Model_Resource_Setup $this */
+$installer = $this;
+$installer->startSetup();
+
+// Drop MySQL-only `ON UPDATE CURRENT_TIMESTAMP` clause on updated_at columns that were originally
+// declared with TIMESTAMP_INIT_UPDATE. Value is now managed explicitly in PHP via _beforeSave()
+// for cross-engine parity (see issue #856).
+if ($installer->getConnection() instanceof \Maho\Db\Adapter\Pdo\Mysql) {
+    $installer->getConnection()->modifyColumn(
+        $installer->getTable('maho_paypal/vault_token'),
+        'updated_at',
+        [
+            'type'     => Maho\Db\Ddl\Table::TYPE_TIMESTAMP,
+            'nullable' => false,
+            'default'  => Maho\Db\Ddl\Table::TIMESTAMP_INIT,
+            'comment'  => 'Updated At',
+        ],
+    );
+}
+
+$installer->endSetup();

--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -2415,7 +2415,13 @@ class Mysql extends AbstractPdoAdapter
                 $cDefault = new \Maho\Db\Expr('CURRENT_TIMESTAMP');
             } elseif ($cDefault == \Maho\Db\Ddl\Table::TIMESTAMP_UPDATE) {
                 $cDefault = new \Maho\Db\Expr('0 ON UPDATE CURRENT_TIMESTAMP');
-            } elseif ($cDefault == \Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE) {
+            } elseif ($cDefault == 'TIMESTAMP_INIT_UPDATE') {
+                // Compared by value rather than the constant so PHPStan doesn't flag the
+                // adapter itself as using the deprecated symbol.
+                @trigger_error(
+                    'TIMESTAMP_INIT_UPDATE is deprecated because it is MySQL-only; use TIMESTAMP_INIT plus an explicit _beforeSave() that sets updated_at for cross-engine parity.',
+                    E_USER_DEPRECATED,
+                );
                 $cDefault = new \Maho\Db\Expr('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP');
             } elseif ($cNullable && !$cDefault) {
                 $cDefault = new \Maho\Db\Expr('NULL');

--- a/lib/Maho/Db/Adapter/Pdo/Pgsql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Pgsql.php
@@ -2340,7 +2340,13 @@ class Pgsql extends AbstractPdoAdapter
         if ($ddlType == \Maho\Db\Ddl\Table::TYPE_TIMESTAMP) {
             if ($cDefault === null) {
                 $cDefault = new \Maho\Db\Expr('NULL');
-            } elseif ($cDefault == \Maho\Db\Ddl\Table::TIMESTAMP_INIT || $cDefault == \Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE) {
+            } elseif ($cDefault == \Maho\Db\Ddl\Table::TIMESTAMP_INIT) {
+                $cDefault = new \Maho\Db\Expr('CURRENT_TIMESTAMP');
+            } elseif ($cDefault == 'TIMESTAMP_INIT_UPDATE') {
+                @trigger_error(
+                    'TIMESTAMP_INIT_UPDATE is deprecated because it is MySQL-only (PgSQL has no equivalent on-update syntax); use TIMESTAMP_INIT plus an explicit _beforeSave() that sets updated_at for cross-engine parity.',
+                    E_USER_DEPRECATED,
+                );
                 $cDefault = new \Maho\Db\Expr('CURRENT_TIMESTAMP');
             } elseif ($cNullable && !$cDefault) {
                 $cDefault = new \Maho\Db\Expr('NULL');

--- a/lib/Maho/Db/Adapter/Pdo/Sqlite.php
+++ b/lib/Maho/Db/Adapter/Pdo/Sqlite.php
@@ -2236,7 +2236,13 @@ class Sqlite extends AbstractPdoAdapter
         if ($ddlType == \Maho\Db\Ddl\Table::TYPE_TIMESTAMP) {
             if ($cDefault === null) {
                 $cDefault = new \Maho\Db\Expr('NULL');
-            } elseif ($cDefault == \Maho\Db\Ddl\Table::TIMESTAMP_INIT || $cDefault == \Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE) {
+            } elseif ($cDefault == \Maho\Db\Ddl\Table::TIMESTAMP_INIT) {
+                $cDefault = new \Maho\Db\Expr('CURRENT_TIMESTAMP');
+            } elseif ($cDefault == 'TIMESTAMP_INIT_UPDATE') {
+                @trigger_error(
+                    'TIMESTAMP_INIT_UPDATE is deprecated because it is MySQL-only (SQLite has no equivalent on-update syntax); use TIMESTAMP_INIT plus an explicit _beforeSave() that sets updated_at for cross-engine parity.',
+                    E_USER_DEPRECATED,
+                );
                 $cDefault = new \Maho\Db\Expr('CURRENT_TIMESTAMP');
             } elseif ($cNullable && !$cDefault) {
                 $cDefault = new \Maho\Db\Expr('NULL');

--- a/lib/Maho/Db/Ddl/Table.php
+++ b/lib/Maho/Db/Ddl/Table.php
@@ -53,7 +53,12 @@ class Table
     public const MAX_VARBINARY_SIZE    = 2147483648;
 
     /**
-     * Default values for timestampses - fill with current timestamp on inserting record, on changing and both cases
+     * Default values for timestamp columns: fill with current timestamp on insert, on update, or both.
+     *
+     * @deprecated TIMESTAMP_INIT_UPDATE is MySQL-only. PgSQL and SQLite silently downgrade it to
+     * plain CURRENT_TIMESTAMP (no on-update auto-bump). Use TIMESTAMP_INIT plus an explicit
+     * _beforeSave() that calls setUpdatedAt(Mage::app()->getLocale()->formatDateForDb('now'))
+     * for cross-engine parity.
      */
     public const TIMESTAMP_INIT_UPDATE = 'TIMESTAMP_INIT_UPDATE';
     public const TIMESTAMP_INIT        = 'TIMESTAMP_INIT';

--- a/tests/Backend/Integration/Db/TimestampAutoBumpTest.php
+++ b/tests/Backend/Integration/Db/TimestampAutoBumpTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class)->group('backend', 'db', 'timestamp');
+
+// Regression for #856: MySQL-only ON UPDATE CURRENT_TIMESTAMP silently downgraded to plain
+// CURRENT_TIMESTAMP on PgSQL/SQLite, so updated_at never auto-bumped on those engines.
+// The fix moves the bump into PHP _beforeSave(); these tests prove it works regardless
+// of engine, since the test suite runs against whichever DB is configured.
+
+describe('timestamp auto-bump', function () {
+    test('payment/restriction stamps created_at and bumps updated_at on save', function () {
+        $resource = Mage::getSingleton('core/resource');
+        $conn = $resource->getConnection('core_write');
+        $table = $resource->getTableName('payment/restriction');
+
+        $model = Mage::getModel('payment/restriction');
+        $model->setName('Parity Test');
+        $model->setStatus(1);
+        $model->setPaymentMethods('checkmo');
+        $model->save();
+
+        $id = (int) $model->getId();
+        expect($id)->toBeGreaterThan(0);
+        expect($model->getCreatedAt())->toMatch('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/');
+        expect($model->getUpdatedAt())->toMatch('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/');
+
+        $originalCreatedAt = $model->getCreatedAt();
+        $stale = '2020-01-01 00:00:00';
+
+        // Overwrite updated_at directly in the DB so the second save must visibly advance it.
+        $conn->update($table, ['updated_at' => $stale], ['restriction_id = ?' => $id]);
+
+        $reloaded = Mage::getModel('payment/restriction')->load($id);
+        expect($reloaded->getUpdatedAt())->toBe($stale);
+
+        $reloaded->setName('Parity Test Updated');
+        $reloaded->save();
+
+        $final = Mage::getModel('payment/restriction')->load($id);
+        expect($final->getUpdatedAt())->not->toBe($stale);
+        expect($final->getCreatedAt())->toBe($originalCreatedAt);
+
+        $final->delete();
+    });
+
+    test('core/flag stamps last_update on save and bumps it on re-save', function () {
+        $resource = Mage::getSingleton('core/resource');
+        $conn = $resource->getConnection('core_write');
+        $table = $resource->getTableName('core/flag');
+
+        $flagCode = 'timestamp_auto_bump_' . uniqid();
+        $flag = Mage::getModel('core/flag', ['flag_code' => $flagCode]);
+        $flag->setFlagData(['step' => 1]);
+        $flag->save();
+
+        $id = (int) $flag->getId();
+        expect($id)->toBeGreaterThan(0);
+        expect($flag->getLastUpdate())->toMatch('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/');
+
+        $stale = '2020-01-01 00:00:00';
+        $conn->update($table, ['last_update' => $stale], ['flag_id = ?' => $id]);
+
+        $reloaded = Mage::getModel('core/flag', ['flag_code' => $flagCode])->loadSelf();
+        expect($reloaded->getLastUpdate())->toBe($stale);
+
+        $reloaded->setFlagData(['step' => 2]);
+        $reloaded->save();
+
+        $final = Mage::getModel('core/flag', ['flag_code' => $flagCode])->loadSelf();
+        expect($final->getLastUpdate())->not->toBe($stale);
+
+        $final->delete();
+    });
+});


### PR DESCRIPTION
## Summary

- `TIMESTAMP_INIT_UPDATE` is a MySQL-only sentinel (emits `DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`). PgSQL and SQLite adapters silently downgrade it to plain `CURRENT_TIMESTAMP`, so `updated_at` auto-bump never fires on those engines.
- Move the update-on-save responsibility into PHP (`_beforeSave()`) so all 13 affected columns behave identically across MySQL / MariaDB / PgSQL / SQLite.
- Deprecate the constant with `@deprecated` PHPDoc + runtime `E_USER_DEPRECATED` notice (emitted by all 3 adapters) so third-party modules keep working but get a migration signal.

## What changed

**Schema (13 columns across 11 scripts)** — replace `TIMESTAMP_INIT_UPDATE` with `TIMESTAMP_INIT` in:
`core_flag.last_update`, `payment_restriction.updated_at`, `catalog_category_dynamic_rule.updated_at`, `cataloglinkrule_rule.updated_at`, `feedmanager_destination/feed/dynamic_rule.updated_at`, `customersegmentation_segment/segment_customer.updated_at`, `customer_segment_email_sequence.updated_at`, `blog_post/category.updated_at`, `maho_paypal_vault_token.updated_at`.

**Models (5)** — add/update `_beforeSave()` to set `updated_at` via `Mage::app()->getLocale()->formatDateForDb('now')`: `Mage_Payment_Model_Restriction`, `Maho_CatalogLinkRule_Model_Rule`, `Maho_Paypal_Model_Vault_Token`, `Maho_CustomerSegmentation_Model_Segment`, `Maho_CustomerSegmentation_Model_EmailSequence`. Also fix 6 existing models to use `formatDateForDb('now')` per CLAUDE.md.

**Migrations (7 new `maho-26.5.0.php` scripts)** — use `modifyColumn()` guarded by `instanceof \Maho\Db\Adapter\Pdo\Mysql` to drop the `ON UPDATE CURRENT_TIMESTAMP` clause on existing MySQL installs. PgSQL/SQLite never emitted the clause so the migration is a no-op there.

**Deprecation** — `@deprecated` PHPDoc on `Maho\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE`, runtime `E_USER_DEPRECATED` notice in the Mysql/Pgsql/Sqlite adapter branches. Sentinel still functional for backwards compat.

## Out of scope — follow-up #857

The related audit of `TYPE_TIMESTAMP` columns without explicit defaults (~124 columns exposed to MySQL's `explicit_defaults_for_timestamp=OFF` quirk) is deferred to #857.

## Test plan

- [x] `vendor/bin/php-cs-fixer fix` — clean
- [x] `vendor/bin/phpstan analyze` — clean
- [x] `composer test` — 1928 passed, 1 risky, 1 skipped
- [ ] Manual MySQL: `SELECT TABLE_NAME, COLUMN_NAME, EXTRA FROM information_schema.columns WHERE TABLE_SCHEMA = DATABASE() AND EXTRA LIKE '%on update%'` should return empty after migration
- [ ] Save-cycle: edit & save a blog post, feed, customer segment, payment restriction on PgSQL/SQLite — confirm `updated_at` bumps via PHP

Fixes #856