### PR TITLE
Fix admin login TypeError when admin_user.extra is non-string (PHP 8)

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -14779,12 +14779,6 @@ parameters:
 			path: app/code/core/Mage/ImportExport/Model/Import/Entity/Abstract.php
 
 		-
-			rawMessage: 'Parameter #1 $str of method Mage_Core_Helper_UnserializeArray::unserialize() expects string, array given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/ImportExport/Model/Import/Entity/Customer.php
-
-		-
 			rawMessage: 'Method Mage_ImportExport_Model_Import_Entity_Product::_filterRowData() has no return type specified.'
 			identifier: missingType.return
 			count: 1

--- a/app/code/core/Mage/Admin/Model/Resource/User.php
+++ b/app/code/core/Mage/Admin/Model/Resource/User.php
@@ -446,7 +446,11 @@ class Mage_Admin_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstrac
         try {
             $unsterilizedData = Mage::helper('core/unserializeArray')->unserialize($user->getExtra());
             $user->setExtra($unsterilizedData);
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
+            // Catch Throwable, not Exception — PHP 8's TypeError extends
+            // Error (not Exception), and the helper called above can throw
+            // TypeError (json_validate requires string) on a re-load where
+            // setExtra(array) was already called by a previous pass.
             $user->setExtra(false);
         }
         return $user;

--- a/app/code/core/Mage/Core/Helper/UnserializeArray.php
+++ b/app/code/core/Mage/Core/Helper/UnserializeArray.php
@@ -13,9 +13,9 @@
 class Mage_Core_Helper_UnserializeArray extends Mage_Core_Helper_Abstract
 {
     /**
-     * @param string $str
-     * @return array
-     * @throws Exception
+     * @param mixed $str  Serialized string, JSON string, or already-decoded value (passed through)
+     * @return mixed      Decoded array for serialized/JSON input; input unchanged for non-string input
+     * @throws Exception  When string input cannot be decoded
      * @SuppressWarnings("PHPMD.ErrorControlOperator")
      */
     public function unserialize($str)

--- a/app/code/core/Mage/Core/Helper/UnserializeArray.php
+++ b/app/code/core/Mage/Core/Helper/UnserializeArray.php
@@ -22,6 +22,14 @@ class Mage_Core_Helper_UnserializeArray extends Mage_Core_Helper_Abstract
     {
         $str ??= '';
 
+        // Pass through if the value has already been decoded upstream
+        // (e.g., a previous _afterLoad pass did setExtra(array), and the
+        // model still holds the array on a re-load). json_validate()
+        // requires string — a non-string fatals with TypeError otherwise.
+        if (!is_string($str)) {
+            return $str;
+        }
+
         if (json_validate($str)) {
             return Mage::helper('core')->jsonDecode($str);
         }

--- a/tests/Backend/Unit/Core/Helper/UnserializeArrayTest.php
+++ b/tests/Backend/Unit/Core/Helper/UnserializeArrayTest.php
@@ -100,6 +100,37 @@ describe('UnserializeArray helper with JSON scalar edge cases', function () {
 });
 
 /**
+ * Non-string input passes through unchanged. This protects callers like
+ * Mage_Admin_Model_Resource_User::_unserializeExtraData where _afterLoad
+ * can run twice on the same model — the second pass sees the already-decoded
+ * array, and json_validate() would fatal with TypeError on non-string input.
+ */
+describe('UnserializeArray helper passthrough for already-decoded input', function () {
+    beforeEach(function () {
+        $this->helper = Mage::helper('core/unserializeArray');
+    });
+
+    it('returns array input unchanged', function () {
+        $decoded = ['configState' => ['foo' => '1']];
+        expect($this->helper->unserialize($decoded))->toBe($decoded);
+    });
+
+    it('returns int input unchanged', function () {
+        expect($this->helper->unserialize(42))->toBe(42);
+    });
+
+    it('returns bool input unchanged', function () {
+        expect($this->helper->unserialize(true))->toBeTrue();
+        expect($this->helper->unserialize(false))->toBeFalse();
+    });
+
+    it('returns object input unchanged', function () {
+        $obj = (object) ['a' => 1];
+        expect($this->helper->unserialize($obj))->toBe($obj);
+    });
+});
+
+/**
  * Tests that the Serialized config backend handles the same JSON scalar
  * edge cases safely, since it uses UnserializeArray under the hood.
  */


### PR DESCRIPTION
## Summary

Admin login fatals with `TypeError: json_validate(): Argument #1 ($json) must be of type string, array given` when `admin_user.extra` is non-empty and the user is reloaded mid-request.

`Mage_Admin_Model_Resource_User::_unserializeExtraData` wraps the helper call in `catch (Exception $e)` — but PHP 8's `TypeError` extends `Error`, not `Exception`. So when `Mage_Core_Helper_UnserializeArray::unserialize()` calls `json_validate()` on a non-string, the `TypeError` escapes the catch and surfaces as a fatal.

The non-string case happens on a re-load:
1. `_afterLoad` runs, calls `_unserializeExtraData`, which decodes the JSON string and writes it back via `setExtra($array)`.
2. On a subsequent re-load (e.g. `Mage_Admin_Model_User::reload()` during admin pre-dispatch), the same `_afterLoad` → `_unserializeExtraData` flow runs.
3. But now `$user->getExtra()` is the already-decoded array, and the helper's `json_validate()` fatals.

## Stack trace

```
Fatal error: Uncaught TypeError: json_validate(): Argument #1 (\$json) must be of type string, array given
  in /app/app/code/core/Mage/Core/Helper/UnserializeArray.php:25
Stack trace:
#0 .../UnserializeArray.php(25): json_validate(Array)
#1 .../Resource/User.php(447): unserialize(Array)
#2 .../Resource/User.php(151): _unserializeExtraData(Object(Mage_Admin_Model_User))
#3 .../Resource/Db/Abstract.php(366): _afterLoad(Object(Mage_Admin_Model_User))
#4 .../Model/Abstract.php(279): load(NULL)
#5 .../Admin/Model/User.php(600): reload()
#6 .../Admin/Model/Observer.php(45): actionPreDispatchAdmin(Object(Maho\Event\Observer))
...
```

## Reproduction

1. Populate `admin_user.extra` with a JSON string. The standard way this happens organically: open any admin config page (System → Configuration → ...), expand/collapse a section, save. Maho persists the open/closed state into `admin_user.extra` as `{\"configState\":{...}}`.
2. Log out, log back in. The first request after login triggers `Mage_Admin_Model_User::reload()` via the admin pre-dispatch observer, which re-runs `_afterLoad` on the now-decoded array → fatal.

## Fix

Two-part, belt-and-braces:

1. **`UnserializeArray::unserialize()`** passes non-string input through unchanged. If a caller hands the helper an already-decoded value, returning it as-is is the right behaviour (the contract is "give me the deserialised form"). Avoids the `TypeError` at the source.

2. **`_unserializeExtraData()`** now catches `\Throwable` instead of `Exception`, so any future `TypeError` / `ValueError` / etc. from the helper or the underlying decoder won't escape and fatal the admin auth flow.

Either fix alone closes the bug; together they're belt-and-braces.

## Test plan

- [ ] Populate `admin_user.extra` with `{\"configState\":{\"foo\":\"1\"}}`.
- [ ] Log out, log back in. Should reach the dashboard, not fatal.
- [ ] Verify `_unserializeExtraData` still produces a usable `extra` array on the model (open a config page, toggle a section, confirm state persists across requests).