### PR TITLE
Fixed admin order create: sidebar serialization adding unchecked items

### DIFF
--- a/public/js/mage/adminhtml/sales.js
+++ b/public/js/mage/adminhtml/sales.js
@@ -720,8 +720,15 @@ class AdminOrder
         if (this.collectElementsValue) {
             var elems = document.getElementById(this.getAreaId('sidebar')).querySelectorAll('input');
             for (var i=0; i < elems.length; i++) {
-                if (elems[i].value) {
-                    data[elems[i].name] = elems[i].value;
+                var el = elems[i];
+                if (!el.name) continue;
+                // Checkboxes/radios always have a .value attribute regardless
+                // of whether the user ticked them. Skip them when not :checked
+                // so unticked sidebar items don't get auto-added to the order.
+                if ((el.type === 'checkbox' || el.type === 'radio')) {
+                    if (el.checked && el.value) data[el.name] = el.value;
+                } else if (el.value) {
+                    data[el.name] = el.value;
                 }
             }
         }


### PR DESCRIPTION
## Summary

`AdminOrder.sidebarApplyChanges()` walks every `<input>` in the sidebar and writes name/value to the request payload when `el.value` is truthy. For checkboxes that condition is always true — browsers populate `.value` with the HTML attribute regardless of the user's tick state — so every checkbox in every sidebar widget (Cart, Wishlist, Last Ordered Items, Recently Viewed, Compared, etc.) gets serialized and submitted on "Update Changes".

## Reproducer

1. Sales → New Order, pick a customer with prior orders / wishlist / recently viewed items
2. Tick a single product in any sidebar widget
3. Click Update Changes
4. The whole sidebar's contents land in the order, not just the ticked one


https://github.com/user-attachments/assets/51a46fa3-9fd5-4203-8455-6c4efb55c93c



## Fix

Branch on `el.type` — only include checkboxes/radios when `el.checked` is also true. Plain inputs keep their existing behaviour.

```diff
-                if (elems[i].value) {
-                    data[elems[i].name] = elems[i].value;
+                var el = elems[i];
+                if (!el.name) continue;
+                if ((el.type === 'checkbox' || el.type === 'radio')) {
+                    if (el.checked && el.value) data[el.name] = el.value;
+                } else if (el.value) {
+                    data[el.name] = el.value;
                 }
```

## Test plan

- [x] Reproduced bug on dev with Recently Viewed (13 items): ticking 1 box submitted all 14 sidebar entries
- [x] Verified fix on dev: ticking 1 box submits only that one
- [ ] Reviewer to confirm against fresh `main` clone