### PR TITLE
Fixed TipTap stripping directives with single-quoted attributes

### DIFF
--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
@@ -40,8 +40,8 @@ const parseDirective = (directiveStr) => {
         }
         // Handle normal key="value" format
         else {
-            for (const match of trimmedAttr.matchAll(/([\w\-]+)="(.*?)"/g)) {
-                directiveObj.params[match[1]] = match[2];
+            for (const match of trimmedAttr.matchAll(/([\w\-]+)=(["'])(.*?)\2/g)) {
+                directiveObj.params[match[1]] = match[3];
             }
         }
     }


### PR DESCRIPTION
## Summary
- `parseDirective` in the TipTap extension only matched `key="value"` pairs, so directives written with single quotes (e.g. `{{config path='trans_email/ident_support/email'}}` or `{{skin url='images/logo.svg'}}`) lost their params during the editor round-trip and were re-rendered as just `{{config}}` / `{{skin}}`.
- Updated the regex to `([\w\-]+)=(["'])(.*?)\2` so it accepts either quote style, with a backreference ensuring the opening and closing quotes match.

## Notes
- Standalone directives written with single quotes get normalized to double quotes on save (the canonical form `renderDirective` always emits). Magento parses both, so behavior is preserved.
- Directives embedded inside double-quoted HTML attributes (e.g. `<a href="mailto:{{config path='...'}}">`) were not affected by the bug — they go through the `inAttribute` escape path in `setup.js` and never hit `parseDirective`. They continue to work and preserve their original quote style.

Fixes #871

## Test plan
- [ ] Open the WYSIWYG editor and add `{{config path='trans_email/ident_support/email'}}` in source mode, switch to visual and back — directive is preserved (with double quotes).
- [ ] Same with `{{skin url='images/logo.svg'}}`.
- [ ] Verify `<a href="mailto:{{config path='trans_email/ident_sales/email'}}">` still round-trips correctly.
- [ ] Verify existing double-quoted directives (`{{config path="..."}}`) still parse and render correctly.