### PR TITLE
Fixed TipTap WYSIWYG appending trailing empty `<p></p>` on save

### DIFF
--- a/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
@@ -128,11 +128,13 @@ class tiptapWysiwygSetup {
     }
 
     convertToPlain(content) {
-        // ProseMirror's schema requires a trailing block node, so editor.getHTML()
-        // always emits a trailing <p></p>. Strip empty trailing paragraphs so they
-        // don't leak into saved content.
+        // ProseMirror's schema requires the cursor to live inside a block node, so
+        // editor.getHTML() emits a trailing empty <p></p> that's just "where the
+        // cursor is parked" — not content. Strip a single trailing empty paragraph
+        // so it doesn't leak into saved content. User-authored blank lines (a
+        // second Enter beyond the cursor's home paragraph) survive.
         const doc = new DOMParser().parseFromString(content, 'text/html');
-        while (doc.body.lastElementChild?.tagName === 'P'
+        if (doc.body.lastElementChild?.tagName === 'P'
             && doc.body.lastElementChild.innerHTML.trim() === '') {
             doc.body.lastElementChild.remove();
         }

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
@@ -128,6 +128,16 @@ class tiptapWysiwygSetup {
     }
 
     convertToPlain(content) {
+        // ProseMirror's schema requires a trailing block node, so editor.getHTML()
+        // always emits a trailing <p></p>. Strip empty trailing paragraphs so they
+        // don't leak into saved content.
+        const doc = new DOMParser().parseFromString(content, 'text/html');
+        while (doc.body.lastElementChild?.tagName === 'P'
+            && doc.body.lastElementChild.innerHTML.trim() === '') {
+            doc.body.lastElementChild.remove();
+        }
+        content = doc.body.innerHTML;
+
         // TipTap generates minified HTML, so when switching to the plain editor beautify it
         content = html_beautify(content, { indent_size: 4 });
 


### PR DESCRIPTION
## Summary
ProseMirror's schema requires the cursor to live inside a block node, so `editor.getHTML()` always emits a trailing empty `<p></p>` — that paragraph is just "where the cursor is parked," not content. It was leaking into saved CMS blocks/pages via `convertToPlain()`.

The fix strips **a single** trailing empty `<p>` inside `convertToPlain()` (the choke point used by both the form-submit sync and the WYSIWYG→plain toggle). Stripping just one preserves user-authored trailing blank lines: a user who really wants whitespace at the bottom presses Enter twice — one paragraph is the cursor's home (stripped), the other is intent (kept).

Conservative match (`innerHTML.trim() === ''`): `<p><br></p>`, `<p>&nbsp;</p>`, and other intentionally-non-empty paragraphs are not touched. Old DB content with the spurious trailing `<p></p>` is cleaned up on the next save.

Fixes #872.

## Test plan
- [ ] Empty editor → save → field is empty (was `<p></p>` before).
- [ ] Type "Hello" then save (no Enter) → saved as `<p>Hello</p>`.
- [ ] Type "Hello" + Enter (one trailing blank in editor) → saved as `<p>Hello</p>` (the cursor's home is stripped).
- [ ] Type "Hello" + Enter + Enter (intentional blank line below) → saved as `<p>Hello</p><p></p>` (one blank survives).
- [ ] Content ending in heading/list/table → no spurious trailing `<p></p>`.
- [ ] Toggle WYSIWYG ↔ HTML repeatedly → no growing tail of empty paragraphs.
- [ ] Trailing widget directive (`{{widget ...}}`) still works.