### PR TITLE
Tax RuleController: log caught exceptions and avoid singleton load

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
@@ -19,6 +19,14 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
     public const ADMIN_RESOURCE = 'sales/tax/rules';
 
     /**
+     * @inheritDoc
+     */
+    protected function _construct()
+    {
+        $this->setUsedModuleName('Mage_Tax');
+    }
+
+    /**
      * Index action
      *
      * @return $this
@@ -59,7 +67,7 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
             if (!$ruleModel->getId()) {
                 Mage::getSingleton('adminhtml/session')->unsRuleData();
                 Mage::getSingleton('adminhtml/session')
-                    ->addError(Mage::helper('tax')->__('This rule no longer exists.'));
+                    ->addError($this->__('This rule no longer exists.'));
                 $this->_redirect('*/*/');
                 return;
             }
@@ -76,8 +84,8 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
 
         $this->_initAction()
             ->_addBreadcrumb(
-                $taxRuleId ? Mage::helper('tax')->__('Edit Rule') : Mage::helper('tax')->__('New Rule'),
-                $taxRuleId ? Mage::helper('tax')->__('Edit Rule') : Mage::helper('tax')->__('New Rule'),
+                $taxRuleId ? $this->__('Edit Rule') : $this->__('New Rule'),
+                $taxRuleId ? $this->__('Edit Rule') : $this->__('New Rule'),
             )
             ->_addContent($this->getLayout()->createBlock('adminhtml/tax_rule_edit')
                 ->setData('action', $this->getUrl('*/tax_rule/save')))
@@ -109,7 +117,7 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
             }
 
             $ruleModel->save();
-            $session->addSuccess(Mage::helper('tax')->__('The tax rule has been saved.'));
+            $session->addSuccess($this->__('The tax rule has been saved.'));
 
             if ($this->getRequest()->getParam('back')) {
                 return $this->_redirect('*/*/edit', ['rule' => $ruleModel->getId()]);
@@ -119,7 +127,7 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
         } catch (Mage_Core_Exception $e) {
             $session->addException($e, $e->getMessage());
         } catch (Exception $e) {
-            $session->addException($e, Mage::helper('tax')->__('An error occurred while saving this tax rule.'));
+            $session->addException($e, $this->__('An error occurred while saving this tax rule.'));
         }
 
         Mage::getSingleton('adminhtml/session')->setRuleData($postData);
@@ -150,7 +158,7 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
         if (count($existingRules) > 0) {
             $ruleCodes = implode(',', $existingRules);
             $session->addError(
-                Mage::helper('tax')->__('Rules (%s) already exist for the specified Tax Rate, Customer Tax Class and Product Tax Class combinations', $ruleCodes),
+                $this->__('Rules (%s) already exist for the specified Tax Rate, Customer Tax Class and Product Tax Class combinations', $ruleCodes),
             );
             return false;
         }
@@ -166,7 +174,7 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
         $ruleModel = Mage::getSingleton('tax/calculation_rule')
             ->load($ruleId);
         if (!$ruleModel->getId()) {
-            Mage::getSingleton('adminhtml/session')->addError(Mage::helper('tax')->__('This rule no longer exists'));
+            Mage::getSingleton('adminhtml/session')->addError($this->__('This rule no longer exists'));
             $this->_redirect('*/*/');
             return;
         }
@@ -175,7 +183,7 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
             $ruleModel->delete();
 
             Mage::getSingleton('adminhtml/session')
-                ->addSuccess(Mage::helper('tax')->__('The tax rule has been deleted.'));
+                ->addSuccess($this->__('The tax rule has been deleted.'));
             $this->_redirect('*/*/');
 
             return;
@@ -183,7 +191,7 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
             Mage::getSingleton('adminhtml/session')->addException($e, $e->getMessage());
         } catch (Exception $e) {
             Mage::getSingleton('adminhtml/session')
-                ->addException($e, Mage::helper('tax')->__('An error occurred while deleting this tax rule.'));
+                ->addException($e, $this->__('An error occurred while deleting this tax rule.'));
         }
 
         $this->_redirectReferer();
@@ -198,8 +206,8 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
     {
         $this->loadLayout()
             ->_setActiveMenu('sales/tax/rules')
-            ->_addBreadcrumb(Mage::helper('tax')->__('Tax'), Mage::helper('tax')->__('Tax'))
-            ->_addBreadcrumb(Mage::helper('tax')->__('Tax Rules'), Mage::helper('tax')->__('Tax Rules'))
+            ->_addBreadcrumb($this->__('Tax'), $this->__('Tax'))
+            ->_addBreadcrumb($this->__('Tax Rules'), $this->__('Tax Rules'))
         ;
         return $this;
     }

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Adminhtml
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -95,7 +95,7 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
         }
 
         $ruleId = (int) $this->getRequest()->getParam('tax_calculation_rule_id');
-        $ruleModel = Mage::getSingleton('tax/calculation_rule')->load($ruleId);
+        $ruleModel = Mage::getModel('tax/calculation_rule')->load($ruleId);
         $ruleModel->setData($postData);
         $ruleModel->setCalculateSubtotal($this->getRequest()->getParam('calculate_subtotal', 0));
 
@@ -117,9 +117,9 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
 
             return $this->_redirect('*/*/');
         } catch (Mage_Core_Exception $e) {
-            $session->addError($e->getMessage());
+            $session->addException($e, $e->getMessage());
         } catch (Exception $e) {
-            $session->addError(Mage::helper('tax')->__('An error occurred while saving this tax rule.'));
+            $session->addException($e, Mage::helper('tax')->__('An error occurred while saving this tax rule.'));
         }
 
         Mage::getSingleton('adminhtml/session')->setRuleData($postData);
@@ -180,10 +180,10 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
 
             return;
         } catch (Mage_Core_Exception $e) {
-            Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
+            Mage::getSingleton('adminhtml/session')->addException($e, $e->getMessage());
         } catch (Exception $e) {
             Mage::getSingleton('adminhtml/session')
-                ->addError(Mage::helper('tax')->__('An error occurred while deleting this tax rule.'));
+                ->addException($e, Mage::helper('tax')->__('An error occurred while deleting this tax rule.'));
         }
 
         $this->_redirectReferer();


### PR DESCRIPTION
## Summary
- `setUsedModuleName('Mage_Tax')` in `_construct()` so `$this->__()` resolves against the Mage_Tax locale, then replace the verbose `Mage::helper('tax')->__('...')` calls with `$this->__('...')`. All affected strings already exist in `app/locale/en_US/Mage_Tax.csv`.
- Use `Mage::getModel('tax/calculation_rule')` instead of `Mage::getSingleton(...)` when loading the rule for save — a singleton retains state across calls and risks leaking data between operations.
- Replace `addError($e->getMessage())` with `addException($e, $msg)` in `saveAction` and `deleteAction` catch blocks so the underlying exception is also written to `exception.log` (user-visible message is unchanged).

Inspired by OpenMage/magento-lts#5525 — thanks to @Hanmac for the original work. Skipped the `_getSession()` migration to stay consistent with Maho's prevailing `Mage::getXXX(...)` accessor style.

## Test plan
- [ ] Save a new tax rule — success message appears
- [ ] Save a tax rule with a duplicate (rate / customer class / product class) — duplicate-error message appears, rule is not created
- [ ] Trigger a save error (e.g. force a DB exception) — generic error appears in admin, full exception is logged to `var/log/exception.log`
- [ ] Delete an existing tax rule — success message appears
- [ ] Delete a non-existent rule (manipulated id) — "rule no longer exists" message appears
- [ ] Verify breadcrumbs / title / messages all render in English (no untranslated keys)