### PR TITLE
Cleared 67 PHPStan baseline entries and fixed underlying issues

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -73,12 +73,6 @@ parameters:
 			path: app/Mage.php
 
 		-
-			rawMessage: Right side of && is always false.
-			identifier: booleanAnd.rightAlwaysFalse
-			count: 1
-			path: app/Mage.php
-
-		-
 			rawMessage: 'Method Mage_Admin_Model_Acl_Assert_Ip::_isCleanIP() should return bool|null but return statement is missing.'
 			identifier: return.missing
 			count: 1
@@ -5074,12 +5068,6 @@ parameters:
 			path: app/code/core/Mage/Adminhtml/controllers/Catalog/Product/SetController.php
 
 		-
-			rawMessage: Ternary operator condition is always true.
-			identifier: ternary.alwaysTrue
-			count: 1
-			path: app/code/core/Mage/Adminhtml/controllers/Catalog/Product/SetController.php
-
-		-
 			rawMessage: 'Method Mage_Adminhtml_Catalog_ProductController::_filterStockData() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -5404,12 +5392,6 @@ parameters:
 			path: app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
 
 		-
-			rawMessage: Right side of && is always true.
-			identifier: booleanAnd.rightAlwaysTrue
-			count: 1
-			path: app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
-
-		-
 			rawMessage: 'Method Mage_Adminhtml_Sales_Order_InvoiceController::_getItemQtys() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -5434,24 +5416,6 @@ parameters:
 			path: app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
 
 		-
-			rawMessage: Result of && is always false.
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
-
-		-
-			rawMessage: 'Undefined variable: $shippingResponse'
-			identifier: variable.undefined
-			count: 1
-			path: app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
-
-		-
-			rawMessage: 'Variable $shippingResponse in isset() is never defined.'
-			identifier: isset.variable
-			count: 1
-			path: app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
-
-		-
 			rawMessage: 'Method Mage_Adminhtml_Sales_Order_ShipmentController::_getItemQtys() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -5460,12 +5424,6 @@ parameters:
 		-
 			rawMessage: 'Method Mage_Adminhtml_Sales_Order_ShipmentController::printLabelAction() has no return type specified.'
 			identifier: missingType.return
-			count: 1
-			path: app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
-
-		-
-			rawMessage: Negated boolean expression is always false.
-			identifier: booleanNot.alwaysFalse
 			count: 1
 			path: app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
 
@@ -6364,12 +6322,6 @@ parameters:
 			path: app/code/core/Mage/Bundle/Model/Product/Price.php
 
 		-
-			rawMessage: Left side of && is always true.
-			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
-			path: app/code/core/Mage/Bundle/Model/Product/Type.php
-
-		-
 			rawMessage: 'Parameter #1 $index of method Maho\DataObject::getProduct() expects int|string|null, Mage_Catalog_Model_Product|null given.'
 			identifier: argument.type
 			count: 1
@@ -6808,12 +6760,6 @@ parameters:
 			path: app/code/core/Mage/Catalog/Helper/Product.php
 
 		-
-			rawMessage: Ternary operator condition is always true.
-			identifier: ternary.alwaysTrue
-			count: 1
-			path: app/code/core/Mage/Catalog/Helper/Product.php
-
-		-
 			rawMessage: 'Method Mage_Catalog_Helper_Product_Compare::_getUrlCustomParams() has parameter $url with no type specified.'
 			identifier: missingType.parameter
 			count: 1
@@ -6914,12 +6860,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: app/code/core/Mage/Catalog/Model/Api2/Product/Image/Rest/Admin/V1.php
-
-		-
-			rawMessage: If condition is always false.
-			identifier: if.alwaysFalse
-			count: 2
-			path: app/code/core/Mage/Catalog/Model/Api2/Product/Rest.php
 
 		-
 			rawMessage: 'Method Mage_Catalog_Model_Api2_Product_Rest::_applyCategoryFilter() has no return type specified.'
@@ -7269,12 +7209,6 @@ parameters:
 				since 26.5 Flat Catalog will be removed in a future version
 			'''
 			identifier: method.deprecatedClass
-			count: 1
-			path: app/code/core/Mage/Catalog/Model/Category.php
-
-		-
-			rawMessage: Left side of && is always true.
-			identifier: booleanAnd.leftAlwaysTrue
 			count: 1
 			path: app/code/core/Mage/Catalog/Model/Category.php
 
@@ -8371,12 +8305,6 @@ parameters:
 			path: app/code/core/Mage/Catalog/Model/Resource/Abstract.php
 
 		-
-			rawMessage: Right side of || is always true.
-			identifier: booleanOr.rightAlwaysTrue
-			count: 1
-			path: app/code/core/Mage/Catalog/Model/Resource/Abstract.php
-
-		-
 			rawMessage: 'Parameter #1 $object of method Mage_Catalog_Model_Resource_Attribute::_clearUselessAttributeValues() expects Mage_Catalog_Model_Resource_Eav_Attribute, Mage_Eav_Model_Entity_Attribute given.'
 			identifier: argument.type
 			count: 1
@@ -8810,12 +8738,6 @@ parameters:
 			identifier: assign.propertyType
 			count: 1
 			path: app/code/core/Mage/Catalog/Model/Resource/Product/Link/Collection.php
-
-		-
-			rawMessage: Left side of && is always true.
-			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
-			path: app/code/core/Mage/Catalog/Model/Resource/Product/Link/Product/Collection.php
 
 		-
 			rawMessage: 'Method Mage_Catalog_Model_Resource_Product_Option::_construct() has no return type specified.'
@@ -10153,12 +10075,6 @@ parameters:
 			path: app/code/core/Mage/Checkout/Model/Cart/Api.php
 
 		-
-			rawMessage: Negated boolean expression is always false.
-			identifier: booleanNot.alwaysFalse
-			count: 1
-			path: app/code/core/Mage/Checkout/Model/Cart/Coupon/Api.php
-
-		-
 			rawMessage: 'Parameter #1 $value of method Mage_Sales_Model_Quote_Address::setCollectShippingRates() expects int, true given.'
 			identifier: argument.type
 			count: 1
@@ -10677,12 +10593,6 @@ parameters:
 		-
 			rawMessage: 'Method Mage_Core_Block_Messages::setMessagesSecondLevelTagName() has no return type specified.'
 			identifier: missingType.return
-			count: 1
-			path: app/code/core/Mage/Core/Block/Messages.php
-
-		-
-			rawMessage: Ternary operator condition is always true.
-			identifier: ternary.alwaysTrue
 			count: 1
 			path: app/code/core/Mage/Core/Block/Messages.php
 
@@ -11455,27 +11365,9 @@ parameters:
 			path: app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
 
 		-
-			rawMessage: Result of && is always false.
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
-
-		-
-			rawMessage: 'Variable $alias in isset() always exists and is always null.'
-			identifier: isset.variable
-			count: 1
-			path: app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
-
-		-
 			rawMessage: Variable $alias might not be defined.
 			identifier: variable.undefined
 			count: 3
-			path: app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
-
-		-
-			rawMessage: 'Variable $columnsToSelect in isset() always exists and is not nullable.'
-			identifier: isset.variable
-			count: 1
 			path: app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
 
 		-
@@ -11555,12 +11447,6 @@ parameters:
 			identifier: assign.propertyType
 			count: 1
 			path: app/code/core/Mage/Core/Model/Resource/Setup.php
-
-		-
-			rawMessage: Negated boolean expression is always false.
-			identifier: booleanNot.alwaysFalse
-			count: 1
-			path: app/code/core/Mage/Core/Model/Resource/Setup/Query/Modifier.php
 
 		-
 			rawMessage: 'Method Mage_Core_Model_Resource_Store::_construct() has no return type specified.'
@@ -12793,21 +12679,9 @@ parameters:
 			path: app/code/core/Mage/Dataflow/Model/Convert/Adapter/Interface.php
 
 		-
-			rawMessage: If condition is always false.
-			identifier: if.alwaysFalse
-			count: 1
-			path: app/code/core/Mage/Dataflow/Model/Convert/Adapter/Io.php
-
-		-
 			rawMessage: 'Method Mage_Dataflow_Model_Convert_Adapter_Io::getResource() has parameter $forWrite with no type specified.'
 			identifier: missingType.parameter
 			count: 1
-			path: app/code/core/Mage/Dataflow/Model/Convert/Adapter/Io.php
-
-		-
-			rawMessage: Negated boolean expression is always true.
-			identifier: booleanNot.alwaysTrue
-			count: 2
 			path: app/code/core/Mage/Dataflow/Model/Convert/Adapter/Io.php
 
 		-
@@ -13659,12 +13533,6 @@ parameters:
 		-
 			rawMessage: 'Method Mage_Dataflow_Model_Profile::_parseGuiData() has no return type specified.'
 			identifier: missingType.return
-			count: 1
-			path: app/code/core/Mage/Dataflow/Model/Profile.php
-
-		-
-			rawMessage: Right side of && is always true.
-			identifier: booleanAnd.rightAlwaysTrue
 			count: 1
 			path: app/code/core/Mage/Dataflow/Model/Profile.php
 
@@ -14719,20 +14587,8 @@ parameters:
 			path: app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
 
 		-
-			rawMessage: Negated boolean expression is always true.
-			identifier: booleanNot.alwaysTrue
-			count: 1
-			path: app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
-
-		-
 			rawMessage: 'Parameter #2 $callback of function array_filter expects (callable(mixed): bool)|null, Closure(mixed): int<0, max> given.'
 			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
-
-		-
-			rawMessage: Result of || is always true.
-			identifier: booleanOr.alwaysTrue
 			count: 1
 			path: app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
 
@@ -16099,12 +15955,6 @@ parameters:
 			path: app/code/core/Mage/Paypal/Model/Cart.php
 
 		-
-			rawMessage: Left side of && is always true.
-			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
-			path: app/code/core/Mage/Paypal/Model/Cart.php
-
-		-
 			rawMessage: 'Method Mage_Paypal_Model_Cart::_applyHiddenTaxWorkaround() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -16149,12 +15999,6 @@ parameters:
 		-
 			rawMessage: 'Method Mage_Paypal_Model_Config::isMethodSupportedForCountry() has parameter $method with no type specified.'
 			identifier: missingType.parameter
-			count: 1
-			path: app/code/core/Mage/Paypal/Model/Config.php
-
-		-
-			rawMessage: Negated boolean expression is always true.
-			identifier: booleanNot.alwaysTrue
 			count: 1
 			path: app/code/core/Mage/Paypal/Model/Config.php
 
@@ -18469,12 +18313,6 @@ parameters:
 			path: app/code/core/Mage/Sales/Model/Quote/Address.php
 
 		-
-			rawMessage: Right side of && is always true.
-			identifier: booleanAnd.rightAlwaysTrue
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Quote/Address.php
-
-		-
 			rawMessage: Property Mage_Sales_Model_Quote_Address_Item::$_quote has no type specified.
 			identifier: missingType.property
 			count: 1
@@ -18533,12 +18371,6 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: app/code/core/Mage/Sales/Model/Quote/Address/Total/Nominal/Shipping.php
-
-		-
-			rawMessage: Negated boolean expression is always true.
-			identifier: booleanNot.alwaysTrue
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
 
 		-
 			rawMessage: 'Parameter #1 $value of method Mage_Sales_Model_Quote_Address::setFreeMethodWeight() expects int, float given.'
@@ -19039,12 +18871,6 @@ parameters:
 			path: app/code/core/Mage/Sales/Model/Service/Quote.php
 
 		-
-			rawMessage: Negated boolean expression is always true.
-			identifier: booleanNot.alwaysTrue
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Service/Quote.php
-
-		-
 			rawMessage: 'Parameter #1 $message of static method Mage::throwException() expects string, array given.'
 			identifier: argument.type
 			count: 1
@@ -19061,12 +18887,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: app/code/core/Mage/Sales/Model/Service/Quote.php
-
-		-
-			rawMessage: Negated boolean expression is always false.
-			identifier: booleanNot.alwaysFalse
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Status/List.php
 
 		-
 			rawMessage: 'Method Mage_Sales_DownloadController::_validateFilePath() has no return type specified.'
@@ -19125,12 +18945,6 @@ parameters:
 		-
 			rawMessage: 'Method Mage_SalesRule_Model_Resource_Coupon::_construct() has no return type specified.'
 			identifier: missingType.return
-			count: 1
-			path: app/code/core/Mage/SalesRule/Model/Resource/Coupon.php
-
-		-
-			rawMessage: Negated boolean expression is always false.
-			identifier: booleanNot.alwaysFalse
 			count: 1
 			path: app/code/core/Mage/SalesRule/Model/Resource/Coupon.php
 
@@ -19279,12 +19093,6 @@ parameters:
 			path: app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
 
 		-
-			rawMessage: Left side of && is always true.
-			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
-			path: app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
-
-		-
 			rawMessage: 'Method Mage_Shipping_Model_Carrier_Abstract::_debug() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -19299,12 +19107,6 @@ parameters:
 		-
 			rawMessage: 'Method Mage_Shipping_Model_Carrier_Abstract::debugData() has no return type specified.'
 			identifier: missingType.return
-			count: 1
-			path: app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
-
-		-
-			rawMessage: Negated boolean expression is always false.
-			identifier: booleanNot.alwaysFalse
 			count: 1
 			path: app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
 
@@ -19714,12 +19516,6 @@ parameters:
 			path: app/code/core/Mage/Tax/Helper/Data.php
 
 		-
-			rawMessage: If condition is always false.
-			identifier: if.alwaysFalse
-			count: 3
-			path: app/code/core/Mage/Tax/Helper/Data.php
-
-		-
 			rawMessage: 'Parameter #1 $shippingAddress of method Mage_Tax_Model_Calculation::getRateRequest() expects Mage_Sales_Model_Quote_Address|false|null, Mage_Customer_Model_Address|null given.'
 			identifier: argument.type
 			count: 2
@@ -19734,12 +19530,6 @@ parameters:
 		-
 			rawMessage: 'Parameter #2 $format of method Mage_Core_Model_Store::convertPrice() expects bool, string|null given.'
 			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Tax/Helper/Data.php
-
-		-
-			rawMessage: Right side of && is always false.
-			identifier: booleanAnd.rightAlwaysFalse
 			count: 1
 			path: app/code/core/Mage/Tax/Helper/Data.php
 
@@ -20446,12 +20236,6 @@ parameters:
 			path: app/code/core/Mage/Weee/Model/Resource/Tax.php
 
 		-
-			rawMessage: Right side of && is always true.
-			identifier: booleanAnd.rightAlwaysTrue
-			count: 1
-			path: app/code/core/Mage/Weee/Model/Resource/Tax.php
-
-		-
 			rawMessage: 'Method Mage_Core_Model_Abstract::_init() invoked with 2 parameters, 1 required.'
 			identifier: arguments.count
 			count: 1
@@ -20980,12 +20764,6 @@ parameters:
 			path: app/design/adminhtml/default/default/template/system/autocomplete.phtml
 
 		-
-			rawMessage: Negated boolean expression is always true.
-			identifier: booleanNot.alwaysTrue
-			count: 2
-			path: app/design/adminhtml/default/default/template/system/store/tree.phtml
-
-		-
 			rawMessage: 'Call to deprecated method getSaveUrl() of class Mage_Adminhtml_Block_Tag_Edit.'
 			identifier: method.deprecated
 			count: 1
@@ -21184,18 +20962,6 @@ parameters:
 			path: app/design/frontend/base/default/template/catalog/product/list/toolbar.phtml
 
 		-
-			rawMessage: Left side of && is always true.
-			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
-			path: app/design/frontend/base/default/template/catalog/product/price.phtml
-
-		-
-			rawMessage: Ternary operator condition is always true.
-			identifier: ternary.alwaysTrue
-			count: 1
-			path: app/design/frontend/base/default/template/catalog/product/price.phtml
-
-		-
 			rawMessage: Variable $_weeeTaxAttributes might not be defined.
 			identifier: variable.undefined
 			count: 9
@@ -21230,12 +20996,6 @@ parameters:
 			identifier: method.notFound
 			count: 1
 			path: app/design/frontend/base/default/template/checkout/cart/minicart/items.phtml
-
-		-
-			rawMessage: Ternary operator condition is always true.
-			identifier: ternary.alwaysTrue
-			count: 1
-			path: app/design/frontend/base/default/template/checkout/onepage/progress/shipping.phtml
 
 		-
 			rawMessage: 'Parameter #1 $amount of method Mage_Checkout_Block_Total_Nominal::formatPrice() expects float, string given.'
@@ -21758,12 +21518,6 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: lib/Maho/Convert/Exception.php
-
-		-
-			rawMessage: Left side of && is always true.
-			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
-			path: lib/Maho/Convert/Mapper/Column.php
 
 		-
 			rawMessage: 'Method Maho\Convert\Mapper\Column::map() has no return type specified.'
@@ -23298,18 +23052,6 @@ parameters:
 		-
 			rawMessage: Property Maho\Simplexml\Config::$_xpathExtends has no type specified.
 			identifier: missingType.property
-			count: 1
-			path: lib/Maho/Simplexml/Config.php
-
-		-
-			rawMessage: Result of && is always false.
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: lib/Maho/Simplexml/Config.php
-
-		-
-			rawMessage: 'Strict comparison using === between mixed and false will always evaluate to false.'
-			identifier: identical.alwaysFalse
 			count: 1
 			path: lib/Maho/Simplexml/Config.php
 

--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -2659,12 +2659,6 @@ parameters:
 			path: app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
 
 		-
-			rawMessage: 'Parameter #1 $array (array{non-empty-string, non-empty-string}) of array_values is already a list, call has no effect.'
-			identifier: arrayValues.list
-			count: 1
-			path: app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
-
-		-
 			rawMessage: 'Parameter #1 $element of method Mage_Adminhtml_Block_System_Config_Form::_prepareGroupComment() expects Mage_Core_Model_Config_Element, Maho\Simplexml\Element given.'
 			identifier: argument.type
 			count: 1
@@ -3843,12 +3837,6 @@ parameters:
 		-
 			rawMessage: 'Method Mage_Adminhtml_Block_Widget_Tabs::bindShadowTabs() has no return type specified.'
 			identifier: missingType.return
-			count: 1
-			path: app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
-
-		-
-			rawMessage: 'PHPDoc tag @param references unknown parameter: $tabNId'
-			identifier: parameter.notFound
 			count: 1
 			path: app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
 
@@ -5500,18 +5488,6 @@ parameters:
 			path: app/code/core/Mage/Adminhtml/controllers/Sales/OrderController.php
 
 		-
-			rawMessage: 'Call to $this->getLayout()->createBlock(''adminhtml/sales'', ''sales'') resulted in invalid type Mage_Adminhtml_Block_Sales.'
-			identifier: mage.invalidType
-			count: 1
-			path: app/code/core/Mage/Adminhtml/controllers/SalesController.php
-
-		-
-			rawMessage: 'Parameter #1 $block of method Mage_Adminhtml_Controller_Action::_addContent() expects Mage_Core_Block_Abstract, false given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Adminhtml/controllers/SalesController.php
-
-		-
 			rawMessage: 'Parameter #1 $value of method Mage_Admin_Model_User::setPasskeyCredentialIdHash() expects string, null given.'
 			identifier: argument.type
 			count: 1
@@ -7114,12 +7090,6 @@ parameters:
 			path: app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
 
 		-
-			rawMessage: 'Strict comparison using !== between mixed and 0 will always evaluate to true.'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
-
-		-
 			rawMessage: 'Method Mage_Catalog_Model_Api2_Product_Website_Rest::_delete() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -7450,20 +7420,8 @@ parameters:
 			path: app/code/core/Mage/Catalog/Model/Config.php
 
 		-
-			rawMessage: 'Call to Mage::getResourceSingleton(''catalog_entity/convert'') resulted in invalid type bool(false).'
-			identifier: mage.invalidType
-			count: 1
-			path: app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
-
-		-
 			rawMessage: 'Call to an undefined method Mage_Eav_Model_Entity_Abstract::getStoreId().'
 			identifier: method.notFound
-			count: 1
-			path: app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
-
-		-
-			rawMessage: 'Cannot call method addProductToStore() on false.'
-			identifier: method.nonObject
 			count: 1
 			path: app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
 
@@ -8569,12 +8527,6 @@ parameters:
 			path: app/code/core/Mage/Catalog/Model/Resource/Product.php
 
 		-
-			rawMessage: 'Call to function is_array() with non-empty-array will always evaluate to true.'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: app/code/core/Mage/Catalog/Model/Resource/Product.php
-
-		-
 			rawMessage: 'Method Mage_Catalog_Model_Resource_Product_Action::_construct() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -8975,12 +8927,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: app/code/core/Mage/Catalog/Model/Resource/Url.php
-
-		-
-			rawMessage: 'Loose comparison using == between true and true will always evaluate to true.'
-			identifier: equal.alwaysTrue
-			count: 2
-			path: app/code/core/Mage/Catalog/Model/Url.php
 
 		-
 			rawMessage: 'Method Mage_Catalog_Model_Url::_addCategoryUrlPath() has no return type specified.'
@@ -9539,12 +9485,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: app/code/core/Mage/CatalogInventory/Model/Stock.php
-
-		-
-			rawMessage: 'Call to function is_numeric() with int will always evaluate to true.'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
 
 		-
 			rawMessage: 'Method Mage_Sales_Model_Quote_Item::setMessage() invoked with 1 parameter, 0 required.'
@@ -10897,12 +10837,6 @@ parameters:
 			path: app/code/core/Mage/Core/Controller/Varien/Front.php
 
 		-
-			rawMessage: 'Comparison operation ">" between int<0, 100> and 100 is always false.'
-			identifier: greater.alwaysFalse
-			count: 1
-			path: app/code/core/Mage/Core/Controller/Varien/Front.php
-
-		-
 			rawMessage: 'Method Mage_Core_Controller_Varien_Front::_checkBaseUrl() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -11313,12 +11247,6 @@ parameters:
 		-
 			rawMessage: 'Call to an undefined method SimpleXMLElement::getAttribute().'
 			identifier: method.notFound
-			count: 1
-			path: app/code/core/Mage/Core/Model/Layout.php
-
-		-
-			rawMessage: 'Call to function is_object() with object will always evaluate to true.'
-			identifier: function.alreadyNarrowedType
 			count: 1
 			path: app/code/core/Mage/Core/Model/Layout.php
 
@@ -13313,12 +13241,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: app/code/core/Mage/Dataflow/Model/Convert/Iterator.php
-
-		-
-			rawMessage: 'Method Mage_Dataflow_Model_Convert_Mapper_Column::getBatchImportModel() has invalid return type Mage_Dataflow_Model_Import_Export.'
-			identifier: class.notFound
-			count: 1
-			path: app/code/core/Mage/Dataflow/Model/Convert/Mapper/Column.php
 
 		-
 			rawMessage: 'Method Mage_Dataflow_Model_Convert_Mapper_Column::map() has no return type specified.'
@@ -15709,12 +15631,6 @@ parameters:
 			path: app/code/core/Mage/Payment/Model/Method/Abstract.php
 
 		-
-			rawMessage: 'Loose comparison using != between ''''|''OT'' and ''SS'' will always evaluate to true.'
-			identifier: notEqual.alwaysTrue
-			count: 1
-			path: app/code/core/Mage/Payment/Model/Method/Cc.php
-
-		-
 			rawMessage: Property Mage_Payment_Model_Method_Cc::$_canSaveCc has no type specified.
 			identifier: missingType.property
 			count: 1
@@ -16041,12 +15957,6 @@ parameters:
 		-
 			rawMessage: 'Method Mage_Paypal_Model_Api_Nvp::callUpdateBillingAgreement() has no return type specified.'
 			identifier: missingType.return
-			count: 1
-			path: app/code/core/Mage/Paypal/Model/Api/Nvp.php
-
-		-
-			rawMessage: 'Parameter #1 $array (non-empty-list) of array_values is already a list, call has no effect.'
-			identifier: arrayValues.list
 			count: 1
 			path: app/code/core/Mage/Paypal/Model/Api/Nvp.php
 
@@ -18649,12 +18559,6 @@ parameters:
 			path: app/code/core/Mage/Sales/Model/Quote/Config.php
 
 		-
-			rawMessage: Instanceof between Mage_Sales_Model_Quote_Item_Option and Mage_Sales_Model_Quote_Item_Option will always evaluate to true.
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: app/code/core/Mage/Sales/Model/Quote/Item.php
-
-		-
 			rawMessage: 'Method Mage_Sales_Model_Quote_Item::setMessage() invoked with 1 parameter, 0 required.'
 			identifier: arguments.count
 			count: 1
@@ -19954,18 +19858,6 @@ parameters:
 			path: app/code/core/Mage/Tax/Model/Config/Notification.php
 
 		-
-			rawMessage: 'Call to an undefined static method Mage_Core_Model_Config_Data::afterSave().'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/code/core/Mage/Tax/Model/Config/Price/Include.php
-
-		-
-			rawMessage: 'Method Mage_Tax_Model_Config_Price_Include::afterSave() has no return type specified.'
-			identifier: missingType.return
-			count: 1
-			path: app/code/core/Mage/Tax/Model/Config/Price/Include.php
-
-		-
 			rawMessage: 'Parameter #1 $tags of method Mage_Core_Model_App::cleanCache() expects array, string given.'
 			identifier: argument.type
 			count: 1
@@ -20968,12 +20860,6 @@ parameters:
 			path: app/design/adminhtml/default/default/template/rating/stars/detailed.phtml
 
 		-
-			rawMessage: 'Comparison operation ">" between int<1, max> and 0 is always true.'
-			identifier: greater.alwaysTrue
-			count: 1
-			path: app/design/adminhtml/default/default/template/report/grid.phtml
-
-		-
 			rawMessage: Variable $minAdminPasswordLength might not be defined.
 			identifier: variable.undefined
 			count: 2
@@ -21400,24 +21286,6 @@ parameters:
 			path: app/design/frontend/base/default/template/customer/balance.phtml
 
 		-
-			rawMessage: PHPDoc tag @var contains unresolvable type.
-			identifier: varTag.unresolvableType
-			count: 1
-			path: app/design/frontend/base/default/template/customer/form/remember.phtml
-
-		-
-			rawMessage: PHPDoc tag @var does not specify variable name.
-			identifier: varTag.noVariable
-			count: 1
-			path: app/design/frontend/base/default/template/customer/form/remember.phtml
-
-		-
-			rawMessage: Variable $this might not be defined.
-			identifier: variable.undefined
-			count: 4
-			path: app/design/frontend/base/default/template/customer/form/remember.phtml
-
-		-
 			rawMessage: Variable $currency might not be defined.
 			identifier: variable.undefined
 			count: 1
@@ -21520,12 +21388,6 @@ parameters:
 			path: app/design/frontend/base/default/template/page/html/breadcrumbs.phtml
 
 		-
-			rawMessage: 'Call to protected method _getRenderedMenuItemAttributes() of class Mage_Page_Block_Html_Topmenu.'
-			identifier: method.protected
-			count: 1
-			path: app/design/frontend/base/default/template/page/html/topmenu/renderer.phtml
-
-		-
 			rawMessage: Variable $this might not be defined.
 			identifier: variable.undefined
 			count: 7
@@ -21536,12 +21398,6 @@ parameters:
 			identifier: variable.undefined
 			count: 82
 			path: app/design/frontend/base/default/template/paypal/express/review/address.phtml
-
-		-
-			rawMessage: 'Class Mage_Paypal_Block_Express_Form referenced with incorrect case: Mage_PayPal_Block_Express_Form.'
-			identifier: class.nameCase
-			count: 1
-			path: app/design/frontend/base/default/template/paypal/payment/redirect.phtml
 
 		-
 			rawMessage: Variable $data might not be defined.

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -669,7 +669,7 @@ final class Mage
             }
             try {
                 self::dispatchEvent('mage_run_exception', ['exception' => $e]);
-                if (!headers_sent() && self::isInstalled()) {
+                if (!headers_sent()) {
                     header('Location:' . self::getUrl('install'));
                 } else {
                     self::printException($e);

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
@@ -421,7 +421,7 @@ class Mage_Adminhtml_Block_System_Config_Form extends Mage_Adminhtml_Block_Widge
                     $method = false;
                     if (preg_match('/^([^:]+?)::([^:]+?)$/', $factoryName, $matches)) {
                         array_shift($matches);
-                        [$factoryName, $method] = array_values($matches);
+                        [$factoryName, $method] = $matches;
                     }
 
                     $sourceModel = Mage::getSingleton($factoryName);

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Tabs.php
@@ -396,7 +396,6 @@ class Mage_Adminhtml_Block_Widget_Tabs extends Mage_Adminhtml_Block_Widget
      *
      * @param string $tabOneId
      * @param string $tabTwoId
-     * @param string $tabNId...
      */
     public function bindShadowTabs($tabOneId, $tabTwoId)
     {

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/SetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/SetController.php
@@ -56,7 +56,7 @@ class Mage_Adminhtml_Catalog_Product_SetController extends Mage_Adminhtml_Contro
             return;
         }
 
-        $this->_title($attributeSet->getId() ? $attributeSet->getAttributeSetName() : $this->__('New Set'));
+        $this->_title($attributeSet->getAttributeSetName());
 
         Mage::register('current_attribute_set', $attributeSet);
 

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
@@ -127,7 +127,7 @@ class Mage_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Con
                 $parentId = $orderItem->getParentItemId();
                 if (isset($backToStock[$orderItem->getId()])) {
                     $creditmemoItem->setBackToStock(true);
-                } elseif ($orderItem->getParentItem() && isset($backToStock[$parentId]) && $backToStock[$parentId]) {
+                } elseif ($orderItem->getParentItem() && isset($backToStock[$parentId])) {
                     $creditmemoItem->setBackToStock(true);
                 } elseif (empty($savedData)) {
                     $creditmemoItem->setBackToStock(Mage::helper('cataloginventory')->isAutoReturnEnabled());

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
@@ -250,9 +250,7 @@ class Mage_Adminhtml_Sales_Order_InvoiceController extends Mage_Adminhtml_Contro
                 }
                 $transactionSave->save();
 
-                if (isset($shippingResponse) && $shippingResponse->hasErrors()) {
-                    $this->_getSession()->addError($this->__('The invoice and the shipment  have been created. The shipping label cannot be created at the moment.'));
-                } elseif (!empty($data['do_shipment'])) {
+                if (!empty($data['do_shipment'])) {
                     $this->_getSession()->addSuccess($this->__('The invoice and shipment have been created.'));
                 } else {
                     $this->_getSession()->addSuccess($this->__('The invoice has been created.'));

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
@@ -447,9 +447,6 @@ class Mage_Adminhtml_Sales_Order_ShipmentController extends Mage_Adminhtml_Contr
      */
     protected function _createShippingLabel(Mage_Sales_Model_Order_Shipment $shipment)
     {
-        if (!$shipment) {
-            return false;
-        }
         $carrier = $shipment->getOrder()->getShippingCarrier();
         if (!$carrier->isShippingLabelsAvailable()) {
             return false;

--- a/app/code/core/Mage/Adminhtml/controllers/SalesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/SalesController.php
@@ -31,10 +31,6 @@ class Mage_Adminhtml_SalesController extends Mage_Adminhtml_Controller_Action
     {
         $this->loadLayout();
         $this->_setActiveMenu('sales');
-
-        $block = $this->getLayout()->createBlock('adminhtml/sales', 'sales');
-        $this->_addContent($block);
-
         $this->_addBreadcrumb($this->__('Sales'), $this->__('Sales'));
         $this->_addBreadcrumb($this->__('Orders'), $this->__('Orders'));
         $this->renderLayout();

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/RuleController.php
@@ -18,9 +18,7 @@ class Mage_Adminhtml_Tax_RuleController extends Mage_Adminhtml_Controller_Action
      */
     public const ADMIN_RESOURCE = 'sales/tax/rules';
 
-    /**
-     * @inheritDoc
-     */
+    #[\Override]
     protected function _construct()
     {
         $this->setUsedModuleName('Mage_Tax');

--- a/app/code/core/Mage/Bundle/Model/Product/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Type.php
@@ -579,7 +579,7 @@ class Mage_Bundle_Model_Product_Type extends Mage_Catalog_Model_Product_Type_Abs
                             $moreSelections = false;
                         }
                         if ($selectedOption->getRequired()
-                            && (!$selectedOption->isMultiSelection() || ($selectedOption->isMultiSelection() && !$moreSelections))
+                            && (!$selectedOption->isMultiSelection() || !$moreSelections)
                         ) {
                             return Mage::helper('bundle')->__('Selected required options are not available.');
                         }

--- a/app/code/core/Mage/Catalog/Helper/Product.php
+++ b/app/code/core/Mage/Catalog/Helper/Product.php
@@ -558,7 +558,7 @@ class Mage_Catalog_Helper_Product extends Mage_Core_Helper_Url
     {
         $fieldsetData = Mage::getConfig()->getFieldset($fieldset, $area);
         if ($fieldsetData) {
-            return $fieldsetData ? $fieldsetData->$field : $fieldsetData;
+            return $fieldsetData->$field;
         }
         return $fieldsetData;
     }

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Rest.php
@@ -395,19 +395,8 @@ abstract class Mage_Catalog_Model_Api2_Product_Rest extends Mage_Catalog_Model_A
                     $price = $this->_calculatePrice($price, $percent, true);
                 }
             }
-        } else {
-            if ($priceIncludesTax) {
-                if ($includingTax) {
-                    $price = $this->_calculatePrice($price, $includingPercent, false);
-                    $price = $this->_calculatePrice($price, $percent, true);
-                } else {
-                    $price = $this->_calculatePrice($price, $includingPercent, false);
-                }
-            } else {
-                if ($includingTax) {
-                    $price = $this->_calculatePrice($price, $percent, true);
-                }
-            }
+        } elseif ($priceIncludesTax) {
+            $price = $this->_calculatePrice($price, $includingPercent, false);
         }
 
         return $store->roundPrice($price);

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
@@ -190,7 +190,7 @@ class Mage_Catalog_Model_Api2_Product_Validator_Product extends Mage_Api2_Model_
                     }
                 }
                 // Validate positive number required attributes
-                if (in_array($attributeCode, $positiveNumberAttributes) && (!empty($value) && $value !== 0)
+                if (in_array($attributeCode, $positiveNumberAttributes) && !empty($value)
                     && (!is_numeric($value) || $value < 0)
                 ) {
                     $this->_addError(sprintf('Please enter a number 0 or greater in the "%s" field.', $attributeCode));

--- a/app/code/core/Mage/Catalog/Model/Category.php
+++ b/app/code/core/Mage/Catalog/Model/Category.php
@@ -901,7 +901,7 @@ class Mage_Catalog_Model_Category extends Mage_Catalog_Model_Abstract
         if (empty($available)) {
             return [];
         }
-        if ($available && !is_array($available)) {
+        if (!is_array($available)) {
             $available = explode(',', $available);
         }
         return $available;

--- a/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
@@ -510,15 +510,8 @@ class Mage_Catalog_Model_Convert_Adapter_Product extends Mage_Eav_Model_Convert_
                                 unset($default);
                             } // end
 
-                            #Mage::getResourceSingleton('catalog_entity/convert')->addProductToStore($model->getId(), 0);
                         }
                         if (!$new || $storeId !== 0) {
-                            if ($storeId !== 0) {
-                                Mage::getResourceSingleton('catalog_entity/convert')->addProductToStore(
-                                    $model->getId(),
-                                    $storeId,
-                                );
-                            }
                             $model->save();
                         }
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Abstract.php
@@ -70,7 +70,7 @@ abstract class Mage_Catalog_Model_Resource_Abstract extends Mage_Eav_Model_Entit
     protected function _isCallableAttributeInstance($instance, $method, $args)
     {
         if ($instance instanceof Mage_Eav_Model_Entity_Attribute_Backend_Abstract
-            && ($method == 'beforeSave' || $method = 'afterSave')
+            && ($method == 'beforeSave' || $method == 'afterSave')
         ) {
             $attributeCode = $instance->getAttribute()->getAttributeCode();
             if (isset($args[0]) && $args[0] instanceof \Maho\DataObject && $args[0]->getData($attributeCode) === false) {

--- a/app/code/core/Mage/Catalog/Model/Resource/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product.php
@@ -621,7 +621,7 @@ class Mage_Catalog_Model_Resource_Product extends Mage_Catalog_Model_Resource_Ab
         if (!empty($columns) && is_string($columns)) {
             $columns = [$columns];
         }
-        if (empty($columns) || !is_array($columns)) {
+        if (empty($columns)) {
             $columns = $this->_getDefaultAttributes();
         }
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Link/Product/Collection.php
@@ -103,7 +103,7 @@ class Mage_Catalog_Model_Resource_Product_Link_Product_Collection extends Mage_C
     public function setProduct(Mage_Catalog_Model_Product $product)
     {
         $this->_product = $product;
-        if ($product && $product->getId()) {
+        if ($product->getId()) {
             $this->_hasLinkFilter = true;
             $this->setStore($product->getStore());
         }

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -429,7 +429,7 @@ class Mage_Catalog_Model_Url
         $process = true;
         $lastEntityId = 0;
         $firstIteration = true;
-        while ($process == true) {
+        while ($process) {
             $products = $this->getResource()->getProductsByCategory($category, $lastEntityId);
             if (!$products) {
                 if ($firstIteration) {
@@ -575,7 +575,7 @@ class Mage_Catalog_Model_Url
         $lastEntityId = 0;
         $process = true;
 
-        while ($process == true) {
+        while ($process) {
             $products = $this->getResource()->getProductsByStore($storeId, $lastEntityId);
             if (!$products) {
                 $process = false;

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -553,9 +553,6 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
              */
             $result->setItemQty($qty);
 
-            if (!is_numeric($qty)) {
-                $qty = Mage::app()->getLocale()->getNumber($qty);
-            }
             $origQty = (int) $origQty;
             $result->setOrigQty($origQty);
         }

--- a/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Coupon/Api.php
@@ -74,7 +74,7 @@ class Mage_Checkout_Model_Cart_Coupon_Api extends Mage_Checkout_Model_Api_Resour
         }
 
         if ($couponCode) {
-            if (!$couponCode == $quote->getCouponCode()) {
+            if ($couponCode != $quote->getCouponCode()) {
                 $this->_fault('coupon_code_is_not_valid');
             }
         }

--- a/app/code/core/Mage/Core/Block/Messages.php
+++ b/app/code/core/Mage/Core/Block/Messages.php
@@ -190,7 +190,7 @@ class Mage_Core_Block_Messages extends Mage_Core_Block_Template
         $html = '<' . $this->_messagesFirstLevelTagName . ' id="admin_messages">';
         foreach ($this->getMessages($type) as $message) {
             $html .= '<' . $this->_messagesSecondLevelTagName . ' class="' . $message->getType() . '-msg">'
-                . ($this->_escapeMessageFlag) ? $this->escapeHtml($message->getText()) : $message->getText()
+                . ($this->_escapeMessageFlag ? $this->escapeHtml($message->getText()) : $message->getText())
                 . '</' . $this->_messagesSecondLevelTagName . '>';
         }
         $html .= '</' . $this->_messagesFirstLevelTagName . '>';

--- a/app/code/core/Mage/Core/Controller/Varien/Front.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Front.php
@@ -177,7 +177,7 @@ class Mage_Core_Controller_Varien_Front extends \Maho\DataObject
             }
         }
         \Maho\Profiler::stop('mage::dispatch::routers_match');
-        if ($i > 100) {
+        if (!$request->isDispatched()) {
             Mage::throwException('Front controller reached 100 router match iterations');
         }
         // This event gives possibility to launch something before sending output (allow cookie setting)

--- a/app/code/core/Mage/Core/Model/Layout.php
+++ b/app/code/core/Mage/Core/Model/Layout.php
@@ -477,8 +477,7 @@ class Mage_Core_Model_Layout extends Maho\Simplexml\Config
         }
         $block = new $className($attributes);
         if (!$block instanceof Mage_Core_Block_Abstract) {
-            $block = is_object($block) ? $block::class : $block;
-            Mage::throwException(Mage::helper('core')->__('Invalid block type: %s', $block));
+            Mage::throwException(Mage::helper('core')->__('Invalid block type: %s', $block::class));
         }
         return $block;
     }

--- a/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
@@ -223,7 +223,7 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends \Maho\Dat
 
                 if (($alias !== null && in_array($alias, $columnsToSelect)) ||
                     // If field already joined from another table
-                    ($alias === null && isset($alias, $columnsToSelect))
+                    ($alias === null && in_array($column, $columnsToSelect))
                 ) {
                     continue;
                 }

--- a/app/code/core/Mage/Core/Model/Resource/Setup/Query/Modifier.php
+++ b/app/code/core/Mage/Core/Model/Resource/Setup/Query/Modifier.php
@@ -308,7 +308,7 @@ class Mage_Core_Model_Resource_Setup_Query_Modifier
             }
 
             // We fix only int columns
-            if (!$refColumnDefinition || !in_array($refColumnDefinition['type'], $this->_processedTypes)) {
+            if (!in_array($refColumnDefinition['type'], $this->_processedTypes)) {
                 continue;
             }
 

--- a/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Io.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Adapter/Io.php
@@ -23,8 +23,6 @@ class Mage_Dataflow_Model_Convert_Adapter_Io extends Mage_Dataflow_Model_Convert
             $className = '\Maho\Io\\' . ucwords($type);
             $this->_resource = new $className();
 
-            $isError = false;
-
             $ioConfig = $this->getVars();
             switch (strtolower($this->getVar('type', 'file'))) {
                 case 'file':
@@ -47,19 +45,17 @@ class Mage_Dataflow_Model_Convert_Adapter_Io extends Mage_Dataflow_Model_Convert
 
                     $realPath = realpath($path);
 
-                    if (!$isError && $realPath === false) {
+                    if ($realPath === false) {
                         $message = Mage::helper('dataflow')->__('The destination folder "%s" does not exist or there is no access to create it.', $ioConfig['path']);
                         Mage::throwException($message);
-                    } elseif (!$isError && !is_dir($realPath)) {
+                    } elseif (!is_dir($realPath)) {
                         $message = Mage::helper('dataflow')->__('Destination folder "%s" is not a directory.', $realPath);
                         Mage::throwException($message);
-                    } elseif (!$isError) {
-                        if ($forWrite && !is_writable($realPath)) {
-                            $message = Mage::helper('dataflow')->__('Destination folder "%s" is not writable.', $realPath);
-                            Mage::throwException($message);
-                        } else {
-                            $ioConfig['path'] = rtrim($realPath, DS);
-                        }
+                    } elseif ($forWrite && !is_writable($realPath)) {
+                        $message = Mage::helper('dataflow')->__('Destination folder "%s" is not writable.', $realPath);
+                        Mage::throwException($message);
+                    } else {
+                        $ioConfig['path'] = rtrim($realPath, DS);
                     }
                     break;
                 default:
@@ -67,9 +63,6 @@ class Mage_Dataflow_Model_Convert_Adapter_Io extends Mage_Dataflow_Model_Convert
                     break;
             }
 
-            if ($isError) {
-                return false;
-            }
             try {
                 $this->_resource->open($ioConfig);
             } catch (Exception $e) {

--- a/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Column.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Mapper/Column.php
@@ -63,7 +63,7 @@ class Mage_Dataflow_Model_Convert_Mapper_Column extends Mage_Dataflow_Model_Conv
     /**
      * Retrieve Batch import model
      *
-     * @return Mage_Dataflow_Model_Import_Export
+     * @return Mage_Dataflow_Model_Batch_Import
      */
     public function getBatchImportModel()
     {

--- a/app/code/core/Mage/Dataflow/Model/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile.php
@@ -233,7 +233,7 @@ class Mage_Dataflow_Model_Profile extends Mage_Core_Model_Abstract
                     }
                 }
                 //BOM deleting for UTF files
-                if (isset($path, $newFilename) && $newFilename) {
+                if (isset($path, $newFilename)) {
                     $contents = file_get_contents($path . $newFilename);
                     if (ord($contents[0]) == 0xEF && ord($contents[1]) == 0xBB && ord($contents[2]) == 0xBF) {
                         $contents = substr($contents, 3);

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
@@ -1343,8 +1343,6 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
     protected function _saveProducts()
     {
         $priceIsGlobal  = Mage::helper('catalog')->isPriceGlobal();
-        $productLimit   = null;
-        $productsQty    = null;
 
         while ($bunch = $this->_dataSourceModel->getNextBunch()) {
             $entityRowsIn = [];
@@ -1380,21 +1378,14 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
                             'attribute_set_id' => $this->_oldSku[$rowSku]['attr_set_id'],
                         ];
                     } else { // new row
-                        if (!$productLimit || $productsQty < $productLimit) {
-                            $entityRowsIn[$rowSku] = [
-                                'entity_type_id'   => $this->_entityTypeId,
-                                'attribute_set_id' => $this->_newSku[$rowSku]['attr_set_id'],
-                                'type_id'          => $this->_newSku[$rowSku]['type_id'],
-                                'sku'              => $rowSku,
-                                'created_at'       => $now,
-                                'updated_at'       => $now,
-                            ];
-                            $productsQty++;
-                        } else {
-                            $rowSku = null; // sign for child rows to be skipped
-                            $this->_rowsToSkip[$rowNum] = true;
-                            continue;
-                        }
+                        $entityRowsIn[$rowSku] = [
+                            'entity_type_id'   => $this->_entityTypeId,
+                            'attribute_set_id' => $this->_newSku[$rowSku]['attr_set_id'],
+                            'type_id'          => $this->_newSku[$rowSku]['type_id'],
+                            'sku'              => $rowSku,
+                            'created_at'       => $now,
+                            'updated_at'       => $now,
+                        ];
                     }
                 } elseif ($rowSku === null) {
                     $this->_rowsToSkip[$rowNum] = true;

--- a/app/code/core/Mage/Page/Block/Html/Topmenu.php
+++ b/app/code/core/Mage/Page/Block/Html/Topmenu.php
@@ -135,7 +135,7 @@ class Mage_Page_Block_Html_Topmenu extends Mage_Core_Block_Template
      *
      * @return string
      */
-    protected function _getRenderedMenuItemAttributes(\Maho\Data\Tree\Node $item)
+    public function _getRenderedMenuItemAttributes(\Maho\Data\Tree\Node $item)
     {
         $html = '';
         $attributes = $this->_getMenuItemAttributes($item);

--- a/app/code/core/Mage/Payment/Model/Method/Cc.php
+++ b/app/code/core/Mage/Payment/Model/Method/Cc.php
@@ -85,14 +85,11 @@ class Mage_Payment_Model_Method_Cc extends Mage_Payment_Model_Method_Abstract
         $ccNumber = preg_replace('/[\-\s]+/', '', $ccNumber);
         $info->setCcNumber($ccNumber);
 
-        $ccType = '';
-
         if (in_array($info->getCcType(), $availableTypes)) {
             if ($this->validateCcNum($ccNumber)
                 // Other credit card type number validation
                 || ($this->otherCcType($info->getCcType()) && $this->validateCcNumOther($ccNumber))
             ) {
-                $ccType = 'OT';
                 $discoverNetworkRegexp = '/^(30[0-5]\d{13}|3095\d{12}|35(2[8-9]\d{12}|[3-8]\d{13})|36\d{12}'
                     . '|3[8-9]\d{14}|6011(0\d{11}|[2-4]\d{11}|74\d{10}|7[7-9]\d{10}|8[6-9]\d{10}|9\d{11})'
                     . '|62(2(12[6-9]\d{10}|1[3-9]\d{11}|[2-8]\d{12}|9[0-1]\d{11}|92[0-5]\d{10})|[4-6]\d{13}'
@@ -145,7 +142,7 @@ class Mage_Payment_Model_Method_Cc extends Mage_Payment_Model_Method_Abstract
             }
         }
 
-        if ($ccType != 'SS' && !$this->_validateExpDate($info->getCcExpYear(), $info->getCcExpMonth())) {
+        if ($info->getCcType() != 'SS' && !$this->_validateExpDate($info->getCcExpYear(), $info->getCcExpMonth())) {
             $errorMsg = Mage::helper('payment')->__('Incorrect credit card expiration date.');
         }
 

--- a/app/code/core/Mage/Paypal/Model/Api/Nvp.php
+++ b/app/code/core/Mage/Paypal/Model/Api/Nvp.php
@@ -1015,7 +1015,7 @@ class Mage_Paypal_Model_Api_Nvp extends Mage_Paypal_Model_Api_Abstract
             $this->_callErrors[] = $error['code'];
         }
 
-        $errorMessages = implode(' ', array_values($errorMessages));
+        $errorMessages = implode(' ', $errorMessages);
         $exceptionLogMessage = sprintf(
             'PayPal NVP gateway errors: %s Correlation ID: %s. Version: %s.',
             $errorMessages,

--- a/app/code/core/Mage/Paypal/Model/Cart.php
+++ b/app/code/core/Mage/Paypal/Model/Cart.php
@@ -405,7 +405,7 @@ class Mage_Paypal_Model_Cart
             $this->_areTotalsValid = $itemsSubtotal > 0.00001;
         }
 
-        $this->_areItemsValid = $this->_areItemsValid && $this->_areTotalsValid;
+        $this->_areItemsValid = $this->_areTotalsValid;
     }
 
     /**

--- a/app/code/core/Mage/Paypal/Model/Cart.php
+++ b/app/code/core/Mage/Paypal/Model/Cart.php
@@ -37,7 +37,7 @@ class Mage_Paypal_Model_Cart
      * Rendered cart items
      * Array of \Maho\DataObject
      *
-     * @var array
+     * @var array<int, \Maho\DataObject>
      */
     protected $_items = [];
 

--- a/app/code/core/Mage/Paypal/Model/Config.php
+++ b/app/code/core/Mage/Paypal/Model/Config.php
@@ -713,9 +713,7 @@ class Mage_Paypal_Model_Config
                 // check for direct payments dependence
                 if ($this->isMethodActive(self::METHOD_WPP_PE_DIRECT)) {
                     $result = true;
-                } elseif (!$this->isMethodActive(self::METHOD_WPP_PE_DIRECT)
-                    && !$this->isMethodActive(self::METHOD_PAYFLOWPRO)
-                ) {
+                } elseif (!$this->isMethodActive(self::METHOD_PAYFLOWPRO)) {
                     $result = false;
                 }
                 break;

--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -377,7 +377,7 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
     {
         $customer = $this->getQuote()->getCustomer();
         return !$customer->getDefaultShippingAddress()
-            || $customer->getDefaultBillingAddress() && $customer->getDefaultShippingAddress()
+            || $customer->getDefaultBillingAddress()
                 && $customer->getDefaultBillingAddress()->getId() == $customer->getDefaultShippingAddress()->getId();
     }
 

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Shipping.php
@@ -105,9 +105,7 @@ class Mage_Sales_Model_Quote_Address_Total_Shipping extends Mage_Sales_Model_Quo
                     $item->setRowWeight($rowWeight);
                 }
             } else {
-                if (!$item->getProduct()->isVirtual()) {
-                    $addressQty += $item->getQty();
-                }
+                $addressQty += $item->getQty();
                 $itemWeight = $item->getWeight();
                 $rowWeight  = $itemWeight * $item->getQty();
                 $addressWeight += $rowWeight;

--- a/app/code/core/Mage/Sales/Model/Quote/Item.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item.php
@@ -636,10 +636,8 @@ class Mage_Sales_Model_Quote_Item extends Mage_Sales_Model_Quote_Item_Abstract
             $option = Mage::getModel('sales/quote_item_option')->setData($option->getData())
                 ->setProduct($option->getProduct())
                 ->setItem($this);
-        } elseif ($option instanceof Mage_Sales_Model_Quote_Item_Option) {
-            $option->setItem($this);
         } else {
-            Mage::throwException(Mage::helper('sales')->__('Invalid item option format.'));
+            $option->setItem($this);
         }
 
         if ($exOption = $this->getOptionByCode($option->getCode())) {

--- a/app/code/core/Mage/Sales/Model/Service/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Service/Quote.php
@@ -268,7 +268,7 @@ class Mage_Sales_Model_Service_Quote
             }
             $method = $address->getShippingMethod();
             $rate  = $address->getShippingRateByCode($method);
-            if (!$this->getQuote()->isVirtual() && (!$method || !$rate)) {
+            if (!$method || !$rate) {
                 Mage::throwException(Mage::helper('sales')->__('Please specify a shipping method.'));
             }
         }

--- a/app/code/core/Mage/Sales/Model/Status/List.php
+++ b/app/code/core/Mage/Sales/Model/Status/List.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Maho
  *
@@ -8,7 +10,6 @@
  * @copyright  Copyright (c) 2019-2024 The OpenMage Contributors (https://openmage.org)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-
 /**
  * Service model for managing statuses information. Statuses are just records with code, message and any
  * additional data. The model helps to keep track and manipulate statuses, that different modules want to set

--- a/app/code/core/Mage/Sales/Model/Status/List.php
+++ b/app/code/core/Mage/Sales/Model/Status/List.php
@@ -99,7 +99,7 @@ class Mage_Sales_Model_Status_List
      */
     public function removeItems($indexes)
     {
-        if (![$indexes]) {
+        if (!is_array($indexes)) {
             $indexes = [$indexes];
         }
         if (!$indexes) {

--- a/app/code/core/Mage/SalesRule/Model/Resource/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Coupon.php
@@ -100,7 +100,7 @@ class Mage_SalesRule_Model_Resource_Coupon extends Mage_Core_Model_Resource_Db_A
      */
     public function updateSpecificCoupons(Mage_SalesRule_Model_Rule $rule)
     {
-        if (!$rule || !$rule->getId() || !$rule->hasDataChanges()) {
+        if (!$rule->getId() || !$rule->hasDataChanges()) {
             return $this;
         }
 

--- a/app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
+++ b/app/code/core/Mage/Shipping/Model/Carrier/Abstract.php
@@ -191,7 +191,7 @@ abstract class Mage_Shipping_Model_Carrier_Abstract extends \Maho\DataObject
         if (empty($containersFilter)) {
             return $containersAll;
         }
-        if (!$params || !$method || !$countryShipper || !$countryRecipient) {
+        if (!$method || !$countryShipper || !$countryRecipient) {
             return $containersAll;
         }
 
@@ -258,8 +258,7 @@ abstract class Mage_Shipping_Model_Carrier_Abstract extends \Maho\DataObject
             if ($availableCountries && in_array($request->getDestCountryId(), $availableCountries)) {
                 return $this;
             }
-            if ($showMethod && (!$availableCountries || ($availableCountries
-                 && !in_array($request->getDestCountryId(), $availableCountries)))) {
+            if ($showMethod) {
                 $error = Mage::getModel('shipping/rate_result_error');
                 $error->setCarrier($this->_code);
                 $error->setCarrierTitle($this->getConfigData('title'));

--- a/app/code/core/Mage/Tax/Helper/Data.php
+++ b/app/code/core/Mage/Tax/Helper/Data.php
@@ -793,23 +793,27 @@ class Mage_Tax_Helper_Data extends Mage_Core_Helper_Abstract
         $request = Mage::getSingleton('tax/calculation')->getRateRequest();
         $currentTaxes = Mage::getSingleton('tax/calculation')->getRatesForAllProductTaxClasses($request);
 
-        $defaultTaxString = $currentTaxString = '';
+        $defaultTaxString = '';
+        if (is_array($defaultTaxes)) {
+            foreach ($defaultTaxes as $classId => $rate) {
+                if ($rate) {
+                    $defaultTaxString .= sprintf('WHEN %d THEN %12.4f ', $classId, $rate / 100);
+                }
+            }
+            if ($defaultTaxString) {
+                $defaultTaxString = "CASE {$taxClassField} {$defaultTaxString} ELSE 0 END";
+            }
+        }
 
-        $rateToVariable = [
-            'defaultTaxString' => 'defaultTaxes',
-            'currentTaxString' => 'currentTaxes',
-        ];
-        foreach ($rateToVariable as $rateVariable => $rateArray) {
-            if (${$rateArray} && is_array(${$rateArray})) {
-                ${$rateVariable} = '';
-                foreach (${$rateArray} as $classId => $rate) {
-                    if ($rate) {
-                        ${$rateVariable} .= sprintf('WHEN %d THEN %12.4f ', $classId, $rate / 100);
-                    }
+        $currentTaxString = '';
+        if (is_array($currentTaxes)) {
+            foreach ($currentTaxes as $classId => $rate) {
+                if ($rate) {
+                    $currentTaxString .= sprintf('WHEN %d THEN %12.4f ', $classId, $rate / 100);
                 }
-                if (${$rateVariable}) {
-                    ${$rateVariable} = "CASE {$taxClassField} {${$rateVariable}} ELSE 0 END";
-                }
+            }
+            if ($currentTaxString) {
+                $currentTaxString = "CASE {$taxClassField} {$currentTaxString} ELSE 0 END";
             }
         }
 

--- a/app/code/core/Mage/Tax/Model/Config/Price/Include.php
+++ b/app/code/core/Mage/Tax/Model/Config/Price/Include.php
@@ -11,9 +11,11 @@
 
 class Mage_Tax_Model_Config_Price_Include extends Mage_Core_Model_Config_Data
 {
-    public function afterSave()
+    #[\Override]
+    protected function _afterSave()
     {
-        parent::afterSave();
+        parent::_afterSave();
         Mage::app()->cleanCache('checkout_quote');
+        return $this;
     }
 }

--- a/app/code/core/Mage/Weee/Model/Resource/Tax.php
+++ b/app/code/core/Mage/Weee/Model/Resource/Tax.php
@@ -103,7 +103,7 @@ class Mage_Weee_Model_Resource_Tax extends Mage_Core_Model_Resource_Db_Abstract
         $prevKey     = false;
         while ($row = $data->fetch()) {
             $key = "{$row['product_id']}-{$row['website_id']}-{$row['customer_group_id']}";
-            if (isset($stops[$key]) && $stops[$key]) {
+            if (isset($stops[$key])) {
                 continue;
             }
 

--- a/app/design/adminhtml/default/default/template/report/grid.phtml
+++ b/app/design/adminhtml/default/default/template/report/grid.phtml
@@ -107,7 +107,7 @@ $numColumns = count($this->getColumns());
                     <?php endforeach ?>
                     </tr>
                 <?php endforeach ?>
-                <?php if($this->getCountTotals() && $rows > 0 && $this->getSubtotalVisibility()): ?>
+                <?php if($this->getCountTotals() && $this->getSubtotalVisibility()): ?>
                 <tr>
                     <?php $j=0;
                     foreach ($this->getColumns() as $_column): ?>

--- a/app/design/adminhtml/default/default/template/system/store/tree.phtml
+++ b/app/design/adminhtml/default/default/template/system/store/tree.phtml
@@ -28,14 +28,9 @@
             <?php if (count($webSiteData['storeGroups']) == 0): ?>
 
                 <tr>
-                    <?php if (!$printedWebsite): ?>
-                        <td class="a-left" rowspan="<?= $webSiteData['count'] ?>"><?= $this->renderWebsite($webSiteData['object']) ?></td>
-                    <?php endif ?>
-
+                    <td class="a-left" rowspan="<?= $webSiteData['count'] ?>"><?= $this->renderWebsite($webSiteData['object']) ?></td>
                     <td colspan="2" class="a-left last"><span class="not-available"></span></td>
                 </tr>
-
-                <?php $printedWebsite = false; ?>
                 <?php continue ?>
             <?php endif ?>
 
@@ -47,13 +42,9 @@
                             <?php $printedWebsite = true; ?>
                         <?php endif ?>
 
-                        <?php if (!$printedStoreGroup): ?>
                         <td class="a-left" rowspan="<?= $storeGroupData['count'] ?>"><?= $this->renderStoreGroup($storeGroupData['object']) ?></td>
-                        <?php endif ?>
-
                         <td class="a-left last"><span class="not-available"></span></td>
                     </tr>
-                    <?php $printedStoreGroup = false; ?>
                     <?php continue ?>
                 <?php endif ?>
 

--- a/app/design/frontend/base/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price.phtml
@@ -155,7 +155,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                      <?= $_coreHelper->currency($_price + $weeeAmountToDisplay, true, true) ?>
                 </span>
 
-                <?php if ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, 1)): // show description ?>
+                <?php if ($_weeeHelper->typeOfDisplay($_product, 1)): // show description ?>
                     <span class="weee-info" data-tooltip="<?php foreach ($_weeeTaxAttributes as $_weeeTaxAttribute): ?><?= $_weeeSeparator ?><?= $this->escapeHtml($_weeeTaxAttribute->getName()) ?> <?= strip_tags($_coreHelper->currency($_weeeTaxAttribute->getAmount() + ($_taxHelper->displayPriceIncludingTax() ? $_weeeTaxAttribute->getTaxAmount() : 0), true, true)) ?><?php $_weeeSeparator = ' + '; ?><?php endforeach ?>"><?= $this->getIconSvg('info-circle') ?></span>
                 <?php endif ?>
             <?php elseif ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, 4)): // incl. + weee ?>
@@ -409,7 +409,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
     if ($showMinPrice && $_minimalPriceValue) {
         $_exclTax = $_taxHelper->getPrice($_product, $_minimalPriceValue);
         $_inclTax = $_taxHelper->getPrice($_product, $_minimalPriceValue, true);
-        $price = $showMinPrice ? $_minimalPriceValue : 0;
+        $price = $_minimalPriceValue;
     } else {
         $price = $_convertedFinalPrice;
         $_exclTax = $_taxHelper->getPrice($_product, $price);

--- a/app/design/frontend/base/default/template/checkout/onepage/progress/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/progress/shipping.phtml
@@ -12,9 +12,8 @@
 /** @var Mage_Checkout_Block_Onepage_Progress $this */
 ?>
 <?php if ($this->getCheckout()->getStepData('shipping', 'complete')): ?>
-<?php $completeClass = $this->getCheckout()->getStepData('shipping', 'complete') ? 'complete' : ''; ?>
-<dt class="<?= $completeClass ?>"><?= $this->__('Shipping Address') ?></dt>
-<dd class="<?= $completeClass ?>">
+<dt class="complete"><?= $this->__('Shipping Address') ?></dt>
+<dd class="complete">
     <address><?= $this->getShipping()->format('html') ?></address>
 </dd>
 <?php else: ?>

--- a/app/design/frontend/base/default/template/customer/form/remember.phtml
+++ b/app/design/frontend/base/default/template/customer/form/remember.phtml
@@ -13,7 +13,7 @@
 /**
  * Customer "Remember Me" template
  *
- * @var $this Mage_Customer_Block_Form_Remember
+ * @var Mage_Customer_Block_Form_Remember $this
  */
 ?>
 <li class="control remember-me-box">

--- a/app/design/frontend/base/default/template/paypal/payment/redirect.phtml
+++ b/app/design/frontend/base/default/template/paypal/payment/redirect.phtml
@@ -9,7 +9,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-/** @var Mage_PayPal_Block_Express_Form $this */
+/** @var Mage_Paypal_Block_Express_Form $this */
 ?>
 <ul class="form-list" id="payment_form_<?= $this->getMethodCode() ?>" style="display:none;">
     <li class="form-alt"><?= $this->getRedirectMessage() ?></li>

--- a/app/locale/en_US/Mage_Adminhtml.csv
+++ b/app/locale/en_US/Mage_Adminhtml.csv
@@ -986,7 +986,6 @@
 "The image cache was cleaned.","The image cache was cleaned."
 "The image cache was cleared.","The image cache was cleared."
 "The invoice and shipment have been created.","The invoice and shipment have been created."
-"The invoice and the shipment  have been created. The shipping label cannot be created at the moment.","The invoice and the shipment  have been created. The shipping label cannot be created at the moment."
 "The invoice has been canceled.","The invoice has been canceled."
 "The invoice has been captured.","The invoice has been captured."
 "The invoice has been created.","The invoice has been created."

--- a/lib/Maho/Convert/Mapper/Column.php
+++ b/lib/Maho/Convert/Mapper/Column.php
@@ -31,7 +31,7 @@ class Column extends AbstractMapper
         foreach ($data as $i => $row) {
             $newRow = [];
             foreach ($row as $field => $value) {
-                if (!$onlySpecified || $onlySpecified && isset($attributesToSelect[$field])) {
+                if (!$onlySpecified || isset($attributesToSelect[$field])) {
                     $newRow[$this->getVar($field, $field)] = $value;
                 }
             }

--- a/lib/Maho/Simplexml/Config.php
+++ b/lib/Maho/Simplexml/Config.php
@@ -301,7 +301,7 @@ class Config
             return true;
         }
         $cachedChecksum = $this->getCache()->load($this->getCacheChecksumId());
-        return $newChecksum === false && $cachedChecksum === false || $newChecksum === $cachedChecksum;
+        return $newChecksum === $cachedChecksum;
     }
 
     /**


### PR DESCRIPTION
## Summary

Cleared **67 entries** from `.phpstan.dist.baseline.neon` by fixing the underlying issues across two passes. Several of the fixes turned out to be real bugs hiding behind dead-code or always-true/always-false conditions:

### Bug fixes uncovered

- **`Mage_Tax_Model_Config_Price_Include`** — the override was named `afterSave()` but the parent has no public `afterSave()` (only protected `_afterSave()`), so the override never fired and the `checkout_quote` cache was never cleaned after save.
- **`Mage_Catalog_Model_Resource_Abstract::_isCallableAttributeInstance`** — `$method = 'afterSave'` was an assignment instead of a comparison; the condition was always true and the assignment silently mutated `$method`.
- **`Mage_Core_Block_Messages::getHtml`** — operator-precedence bug: ternary evaluated outside the concat, so message text + closing tag were never appended; output was just the opening tag + `"1"`.
- **`Mage_Sales_Model_Status_List::removeItems`** — `if (![$indexes])` instead of `!is_array($indexes)`; an `int|array` input was never normalized.
- **`Mage_Checkout_Model_Cart_Coupon_Api::add`** — `if (!$couponCode == $quote->getCouponCode())` precedence bug; the validation never tripped.
- **`Mage_Core_Model_Resource_Db_Collection_Abstract::_initSelectFields`** — `isset($alias, $columnsToSelect)` was always false (because `$alias` is null on that branch); the "field already joined from another table" skip never fired.
- **`Mage_Payment_Model_Method_Cc::validate`** — `'SS' != $ccType` checked a local variable that was always `''` or `'OT'`, so the SS-specific exp-date skip never triggered. Now reads from `$info->getCcType()`.
- **`Mage_ImportExport_Model_Import_Entity_Product::_saveProducts`** — dead `$productLimit` (always null) made the import-limit / skip path unreachable; removed.
- **`Mage_Adminhtml_SalesController::indexAction`** — `createBlock('adminhtml/sales', 'sales')` returned `false` (no such block class), then `_addContent(false)` would TypeError. Removed dead lines; layout still renders normally.
- **`Mage_Catalog_Model_Convert_Adapter_Product`** — `Mage::getResourceSingleton('catalog_entity/convert')->addProductToStore(...)` would have fataled at runtime (alias unregistered). Removed dead block.
- **`Mage_Adminhtml_Tax_RuleController::_construct`** — added missing `#[\Override]` (introduced in #878 without it).
- **`Mage_Page_Block_Html_Topmenu::_getRenderedMenuItemAttributes`** — bumped to public; it's called from the renderer template, where the `include` happens outside the class scope phpstan can see.

### Cleanups

The rest are dead-code / always-true / always-false condition cleanups:
- Redundant `is_array` / `is_numeric` / `is_object` / `instanceof` guards.
- Redundant `array_values()` calls on already-list arrays.
- `while ($x == true)` loops.
- PHPDoc typos (`@param $tabNId...`, `@var $this Class` reversed, wrong return type, wrong class case).
- Always-true left/right sides of `&&` (e.g. `!$availableCountries || ($availableCountries && !in_array(...))` — the second `$availableCountries` is always true on that path).
- Always-false `if` branches (e.g. checks against properties that were just initialized to `null` and never reassigned).
- Redundant ternaries with always-true conditions.

### What's left in baseline

5 entries kept — genuine phpstan false positives where state mutates through method calls (so phpstan can't tell the second read is different from the first):
- `Mage_Paypal_Model_Express::order` — fraud check after `importPaymentInfo` may have set `is_fraud_detected`.
- `Mage_Sales_Model_Order_Payment::_capture` — pending check after `capture()` may have set `is_transaction_pending`.
- The two `Maho\Filter\Template\Tokenizer\{Parameter,Variable}` loops where `isWhiteSpace()` reads `$this->char()` after `$this->next()` advanced it.

The Customer install/upgrade script entry was deliberately left alone per the CLAUDE.md rule against modifying historical migration scripts.

Diff: 55 files changed (combined across both commits), 88 insertions(+), 554 deletions(-). PHPStan passes clean.

## Test plan

- [ ] `vendor/bin/phpstan analyze` exits with no errors
- [ ] `composer test` passes
- [ ] Spot-check checkout flow with a CC-based payment method (covers `Mage_Payment_Model_Method_Cc::validate` change)
- [ ] Save a value under `tax/calculation/price_includes_tax` in admin and verify the `checkout_quote` cache gets flushed (covers `Mage_Tax_Model_Config_Price_Include` change)
- [ ] Sanity check admin messages display (covers `Mage_Core_Block_Messages::getHtml` precedence fix)
- [ ] Spot-check Bundle product validation with multi-select required options (covers `Mage_Bundle_Model_Product_Type` simplification)