### PR TITLE
Forced DB session time zone to UTC on connect

### DIFF
--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -132,6 +132,7 @@ class Mysql extends AbstractPdoAdapter
     {
         /** @link http://bugs.mysql.com/bug.php?id=18551 */
         $this->_connection->executeStatement("SET SQL_MODE=''");
+        $this->_connection->executeStatement("SET time_zone = '+00:00'");
     }
 
     /**

--- a/lib/Maho/Db/Adapter/Pdo/Pgsql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Pgsql.php
@@ -103,6 +103,7 @@ class Pgsql extends AbstractPdoAdapter
         $this->_connection->executeStatement("SET client_encoding = 'UTF8'");
         // Set standard conforming strings
         $this->_connection->executeStatement('SET standard_conforming_strings = on');
+        $this->_connection->executeStatement("SET TIME ZONE 'UTC'");
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #861.

Pin the DB session time zone to UTC in each adapter's `_initConnection()` hook so the rest of the codebase (which already treats DB columns as UTC and forces PHP's `date_default_timezone` to UTC at bootstrap) is no longer silently dependent on the DB server's `system_time_zone` / `timezone` GUC.

- `lib/Maho/Db/Adapter/Pdo/Mysql.php` — `SET time_zone = '+00:00'` alongside the existing `SET SQL_MODE=''`
- `lib/Maho/Db/Adapter/Pdo/Pgsql.php` — `SET TIME ZONE 'UTC'` alongside the existing client-encoding/standard-conforming-strings init
- `lib/Maho/Db/Adapter/Pdo/Sqlite.php` — no change needed; SQLite has no session TZ

## Test plan

- [ ] `composer test` — all suites green (1937 passed locally)
- [ ] On a MySQL server with `system_time_zone != 'UTC'`, confirm `SELECT @@session.time_zone` returns `+00:00` after connect, and a UTC string round-trips through INSERT/SELECT without offset shift
- [ ] On PostgreSQL, confirm `SHOW TIME ZONE` returns `UTC` after connect