### PR TITLE
Updated formatTime() docblock to reflect DateTimeInterface support

### DIFF
--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -229,9 +229,9 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Format time using current locale options
      *
-     * @param   string|DateTime|null $time
-     * @param   string              $format
-     * @param   bool                $showDate
+     * @param   string|DateTimeInterface|null $time
+     * @param   string                        $format
+     * @param   bool                          $showDate
      * @return  string
      */
     public function formatTime($time = null, $format = Mage_Core_Model_Locale::FORMAT_TYPE_SHORT, $showDate = false)


### PR DESCRIPTION
## Summary

- Resolves #883.
- The runtime fix was already in `main`: `Mage_Core_Helper_Data::formatTime()` checks `$time instanceof DateTimeInterface` (line 246), so `DateTimeImmutable` returned by `Mage_Core_Model_Locale::utcToStore()` no longer falls through to `strtotime()` and crashes.
- This PR only updates the stale docblock (`string|DateTime|null` → `string|DateTimeInterface|null`) to match the runtime check and the convention already used by `formatDate` / `formatTimezoneDate`.

## Test plan

- [x] `vendor/bin/phpstan analyze` clean on the touched file.
- [x] No behavior change — docblock-only edit.