### PR TITLE
Added event before session start to allow opting out on cacheable GETs (#869)

### DIFF
--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -464,7 +464,7 @@ abstract class Mage_Core_Controller_Varien_Action
             return;
         }
 
-        Mage::dispatchEvent('controller_action_predispatch_start_session', ['controller_action' => $this]);
+        Mage::dispatchEvent('controller_action_predispatch_session_start', ['controller_action' => $this]);
 
         if (!$this->getFlag('', self::FLAG_NO_START_SESSION)) {
             Mage::getSingleton('core/session', ['name' => $this->_sessionNamespace])->start();

--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -464,6 +464,8 @@ abstract class Mage_Core_Controller_Varien_Action
             return;
         }
 
+        Mage::dispatchEvent('controller_action_predispatch_start_session', ['controller_action' => $this]);
+
         if (!$this->getFlag('', self::FLAG_NO_START_SESSION)) {
             Mage::getSingleton('core/session', ['name' => $this->_sessionNamespace])->start();
         }


### PR DESCRIPTION
## Summary

- Dispatches a new event `controller_action_predispatch_session_start` in `Mage_Core_Controller_Varien_Action::preDispatch()`, immediately before the `FLAG_NO_START_SESSION` guard.
- Lets observers (e.g. an FPC / edge-cache module) flip the flag at runtime for anonymous cookieless GETs to cacheable routes, avoiding both the `Set-Cookie` on the response and the empty session row in the configured backend.
- Backward compatible: no consumer required, `FLAG_NO_START_SESSION` semantics unchanged.

Closes #869.

## Why

`preDispatch()` always starts the session unless `FLAG_NO_START_SESSION` was set in the constructor. Today that flag is only set in 3 controllers (Api + 2 Oauth), so for anonymous traffic on CMS / category / product routes Maho:

1. emits `Set-Cookie: <session>` — making the HTML unsafe to cache in any shared/edge cache (Cloudflare, Bunny, Varnish), since `Set-Cookie` + `Cache-Control: public` is per RFC unsafe.
2. writes an empty session row on every anonymous hit, then GCs it — non-trivial write amplification under crawler/bot traffic.

A core event is the single integration point any current/future FPC implementation can hook into without forking `Action.php`.

## Usage example

```php
#[Maho\Config\Observer('controller_action_predispatch_session_start')]
public function maybeSkipSession(Maho\Event\Observer $observer): void
{
    $controller = $observer->getControllerAction();
    $request    = $controller->getRequest();
    $hasSid     = (bool) $request->getCookie(Mage_Core_Controller_Front_Action::SESSION_NAMESPACE);

    if ($request->isGet() && !$hasSid && $this->isCacheableRoute($controller)) {
        $controller->setFlag('', Mage_Core_Controller_Varien_Action::FLAG_NO_START_SESSION, true);
    }
}
```

## Caveat

If session start is skipped, `getFormKey()` returns empty for that response. The first state-changing POST from an anonymous visitor (e.g. add-to-cart) will fail `_validateFormKey()` and redirect — at that point the session establishes normally. This "first POST establishes session" pattern is acceptable in practice and is the responsibility of the observing module to handle.

## Test plan

- [ ] Unit/integration: hit a frontend route, assert `controller_action_predispatch_session_start` fires before the session-start guard
- [ ] Verify no behavior change when no observer is registered (existing flow unchanged)
- [ ] With a sample observer that sets `FLAG_NO_START_SESSION` on anonymous GETs: confirm no `Set-Cookie` on response and no row written to the session backend
- [ ] After login / cart action establishes a real cookie, confirm session lifecycle is unchanged