### PR TITLE
Deprecated `Maho\DataObject\Mapper`

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -130,7 +130,7 @@ if (($_ENV['MAHO_ENABLE_VARIEN_ALIASES'] ?? $_SERVER['MAHO_ENABLE_VARIEN_ALIASES
     class_alias(\Maho\Io\Sftp::class, 'Varien_Io_Sftp');
     class_alias(\Maho\DataObject::class, 'Varien_Object');
     class_alias(\Maho\DataObject\Cache::class, 'Varien_Object_Cache');
-    class_alias(\Maho\DataObject\Mapper::class, 'Varien_Object_Mapper');
+    class_alias(\Maho\DataObject\Mapper::class, 'Varien_Object_Mapper'); // @phpstan-ignore classConstant.deprecatedClass
     class_alias(\Maho\Simplexml\Config::class, 'Varien_Simplexml_Config');
     class_alias(\Maho\Simplexml\Element::class, 'Varien_Simplexml_Element');
     class_alias(\Maho\Exception::class, 'Varien_Exception');

--- a/lib/Maho/DataObject/Mapper.php
+++ b/lib/Maho/DataObject/Mapper.php
@@ -17,8 +17,7 @@ use Maho\DataObject;
 /**
  * Utility class for mapping data between objects or arrays
  *
- * @deprecated since 26.5 No remaining callers in Maho core (Mage_Paypal/Mage_Paygate were extracted/removed).
- *             For DataObject-to-DataObject copies use $target->addData($source->toArray($map)).
+ * @deprecated since 26.5 For DataObject-to-DataObject copies use $target->addData($source->toArray($map)).
  *             For arrays use array_intersect_key() / direct assignment.
  */
 class Mapper

--- a/lib/Maho/DataObject/Mapper.php
+++ b/lib/Maho/DataObject/Mapper.php
@@ -16,6 +16,10 @@ use Maho\DataObject;
 
 /**
  * Utility class for mapping data between objects or arrays
+ *
+ * @deprecated since 26.5 No remaining callers in Maho core (Mage_Paypal/Mage_Paygate were extracted/removed).
+ *             For DataObject-to-DataObject copies use $target->addData($source->toArray($map)).
+ *             For arrays use array_intersect_key() / direct assignment.
  */
 class Mapper
 {
@@ -43,6 +47,10 @@ class Mapper
      * @param array|DataObject|callable $from
      * @param array|DataObject|callable $to
      * @return array|DataObject
+     *
+     * @deprecated since 26.5 For DataObject-to-DataObject copies use $target->addData($source->toArray($map)).
+     *             For arrays use array_intersect_key() / direct assignment. The callable-array source/target
+     *             form has no remaining callers in Maho core.
      */
     public static function &accumulateByMap($from, $to, array $map, array $defaults = [])
     {

--- a/lib/Maho/Rector/VarienToMahoClassMap.php
+++ b/lib/Maho/Rector/VarienToMahoClassMap.php
@@ -138,7 +138,7 @@ final class VarienToMahoClassMap
             // Object/DataObject namespace
             'Varien_Object' => \Maho\DataObject::class,
             'Varien_Object_Cache' => \Maho\DataObject\Cache::class,
-            'Varien_Object_Mapper' => \Maho\DataObject\Mapper::class,
+            'Varien_Object_Mapper' => \Maho\DataObject\Mapper::class, // @phpstan-ignore classConstant.deprecatedClass
 
             // Simplexml namespace
             'Varien_Simplexml_Config' => \Maho\Simplexml\Config::class,

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -93,7 +93,7 @@ class HealthCheck extends BaseMahoCommand
         'Varien_Io_Sftp' => \Maho\Io\Sftp::class,
         'Varien_Object' => \Maho\DataObject::class,
         'Varien_Object_Cache' => \Maho\DataObject\Cache::class,
-        'Varien_Object_Mapper' => \Maho\DataObject\Mapper::class,
+        'Varien_Object_Mapper' => \Maho\DataObject\Mapper::class, // @phpstan-ignore classConstant.deprecatedClass
         'Varien_Simplexml_Config' => \Maho\Simplexml\Config::class,
         'Varien_Simplexml_Element' => \Maho\Simplexml\Element::class,
         'Varien_Exception' => \Maho\Exception::class,


### PR DESCRIPTION
## Summary
- Marks `Maho\DataObject\Mapper` and its sole method `accumulateByMap()` as `@deprecated since 26.5`. The class has no remaining callers in Maho core — its only historical consumers were `Mage_Paypal` and `Mage_Paygate`, both of which have been extracted/removed.
- Adds replacement guidance in the docblocks: `$target->addData($source->toArray($map))` for `DataObject`-to-`DataObject` copies; `array_intersect_key()` / direct assignment for plain arrays.
- The class file, `class_alias` in `app/bootstrap.php`, the Rector migration entry, and the HealthCheck mapping are intentionally left in place so existing third-party callers keep working until removal.

## Credit
Thanks to @Hanmac for flagging the same design issue upstream in [OpenMage/magento-lts#5568 (comment)](https://github.com/OpenMage/magento-lts/pull/5568#issuecomment-4369211254) — the awkward callable-array source/target detection in `accumulateByMap()` is hard to type and adds no value for any current caller, which is what prompted this deprecation.

## Test plan
- [ ] `composer test` passes
- [ ] `vendor/bin/phpstan analyze` still clean
- [ ] Confirm no Maho core code calls `Maho\DataObject\Mapper::accumulateByMap()` or the legacy `Varien_Object_Mapper` alias (verified via grep at PR time)