### PR TITLE
Fixed dead store param in `{{protocol}}` email directive, removeed `getSafeStore()`

### DIFF
--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -874,25 +874,6 @@ class Mage_Core_Model_App
     }
 
     /**
-     * Retrieve application store object without Store_Exception
-     *
-     * @param string|int|Mage_Core_Model_Store $id
-     * @return Mage_Core_Model_Store|\Maho\DataObject
-     */
-    public function getSafeStore($id = null)
-    {
-        try {
-            return $this->getStore($id);
-        } catch (Exception $e) {
-            if ($this->_currentStore) {
-                $this->getRequest()->setActionName('noRoute');
-                return new \Maho\DataObject();
-            }
-            Mage::throwException(Mage::helper('core')->__('Requested invalid store "%s"', $id));
-        }
-    }
-
-    /**
      * Retrieve stores array
      *
      * @param bool $withDefault

--- a/app/code/core/Mage/Core/Model/Email/Template/Filter.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Filter.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_Core
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2019-2025 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2019-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -417,10 +417,6 @@ class Mage_Core_Model_Email_Template_Filter extends \Maho\Filter\Template
     public function protocolDirective($construction)
     {
         $params = $this->_getIncludeParameters($construction[2]);
-        $store = null;
-        if (isset($params['store'])) {
-            $store = Mage::app()->getSafeStore($params['store']);
-        }
         $isSecure = Mage::app()->isCurrentlySecure();
         $protocol = $isSecure ? 'https' : 'http';
         if (isset($params['url'])) {

--- a/app/locale/en_US/Mage_Core.csv
+++ b/app/locale/en_US/Mage_Core.csv
@@ -318,7 +318,6 @@
 "Rate limit","Rate limit"
 "Recovery Link Expiration Period (hours)","Recovery Link Expiration Period (hours)"
 "Referrer Policy","Referrer Policy"
-"Requested invalid store ""%s""","Requested invalid store ""%s"""
 "Request Path for Specified Store","Request Path for Specified Store"
 "Request path length exceeds allowed %s symbols.","Request path length exceeds allowed %s symbols."
 "Resource ""%s"" is not found.","Resource ""%s"" is not found."


### PR DESCRIPTION
## Summary

Fixes a long-standing bug in `Mage_Core_Model_Email_Template_Filter::protocolDirective()` and removes the unused `Mage_Core_Model_App::getSafeStore()`.

The directive looked like it honored a `store` parameter:

```php
$store = null;
if (isset($params['store'])) {
    $store = Mage::app()->getSafeStore($params['store']);
}
$isSecure = Mage::app()->isCurrentlySecure();
```

…but `$store` was assigned and never read. The `isCurrentlySecure()` call was on `Mage::app()` (which inspects `$_SERVER` / offloader header, not store config), so `{{protocol store=\"foo\"}}` always behaved identically to `{{protocol}}`.

`getSafeStore()` itself is a fail-silent footgun — on lookup failure it returns a stub `Maho\DataObject` that swallows arbitrary method calls and returns `null`. With the `store` param now dropped, it has zero callers in the codebase, so it goes too.

Originally reported (against OpenMage) by @Hanmac in OpenMage/magento-lts#5404 — thank you! The proposed snippet there (`getStore(...)->isCurrentlySecure()`) actually crashes at runtime in our codebase because `isCurrentlySecure()` lives on `Mage_Core_Model_App`, not on `Mage_Core_Model_Store`, and `Maho\DataObject::__call` only handles `get/set/uns/has` prefixes. So this PR drops the dead param handling entirely rather than rewiring it.

## Test plan

- [ ] `vendor/bin/phpstan analyze` clean for both changed files (verified locally)
- [ ] `vendor/bin/php-cs-fixer fix` clean (verified locally)
- [ ] Manually render an email template containing `{{protocol}}`, `{{protocol url=\"example.com/foo\"}}`, and `{{protocol http=\"http://x\" https=\"https://x\"}}` over both HTTP and HTTPS requests — output unchanged from before
- [ ] `composer test` green