### PR TITLE
Fixed slow cart query when sales rules use many product attributes

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule.php
@@ -5,7 +5,7 @@
  *
  * @package    Mage_SalesRule
  * @copyright  Copyright (c) 2006-2020 Magento, Inc. (https://magento.com)
- * @copyright  Copyright (c) 2017-2023 The OpenMage Contributors (https://openmage.org)
+ * @copyright  Copyright (c) 2017-2026 The OpenMage Contributors (https://openmage.org)
  * @copyright  Copyright (c) 2024-2026 Maho (https://mahocommerce.com)
  * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -237,12 +237,12 @@ class Mage_SalesRule_Model_Resource_Rule extends Mage_Rule_Model_Resource_Abstra
     public function getActiveAttributes($websiteId, $customerGroupId)
     {
         $read = $this->_getReadAdapter();
+        $distinctAttributeIds = $read->select()
+            ->distinct(true)
+            ->from($this->getTable('salesrule/product_attribute'), 'attribute_id');
         $select = $read->select()
-            ->from(
-                ['a' => $this->getTable('salesrule/product_attribute')],
-                new Maho\Db\Expr('DISTINCT ea.attribute_code'),
-            )
-            ->joinInner(['ea' => $this->getTable('eav/attribute')], 'ea.attribute_id = a.attribute_id', []);
+            ->from(['ea' => $this->getTable('eav/attribute')], ['attribute_code'])
+            ->joinInner(['a' => $distinctAttributeIds], 'ea.attribute_id = a.attribute_id', []);
         return $read->fetchAll($select);
     }
 


### PR DESCRIPTION
## Summary

Optimizes `Mage_SalesRule_Model_Resource_Rule::getActiveAttributes()` which previously joined `salesrule_product_attribute` to `eav_attribute` and applied `DISTINCT` against the joined result — forcing MySQL to materialize the join and sort to deduplicate.

This change deduplicates `attribute_id` first against `salesrule_product_attribute` (where the column is part of the primary key, so the dedup is index-only), then joins the unique set to `eav_attribute`.

## Credits

- Thanks to @EliasKotlyar for [reporting and measuring the slow query](https://github.com/OpenMage/magento-lts/issues/4979).
- Thanks to @colinmollenhour for the original fix in [OpenMage/magento-lts#5552](https://github.com/OpenMage/magento-lts/pull/5552), which this ports.

## Test plan
- [ ] Confirm the rendered SQL no longer DISTINCTs over the joined result (run with profiling on)
- [ ] Sanity-check that `addProductAttributes` observer still populates the `quote_item_collection_select_after` attribute set correctly on a quote with at least one active sales rule
- [ ] Spot-check store-front cart totals collection isn't affected