### PR TITLE
Fixed ACL role saving when sub-resources are partially allowed

### DIFF
--- a/app/code/core/Mage/Admin/Model/Resource/Rules.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Rules.php
@@ -51,8 +51,18 @@ class Mage_Admin_Model_Resource_Rules extends Mage_Core_Model_Resource_Db_Abstra
 
                     $adapter->insert($this->getMainTable(), $insertData);
                 } else {
-                    foreach (Mage::getModel('admin/roles')->getResourcesList2D() as $index => $resName) {
-                        $row['permission']  = (in_array($resName, $postedResources) ? 'allow' : 'deny');
+                    // Auto-allow ancestors of any posted resource: a partially-selected parent
+                    // would otherwise be saved as deny, hiding its (allowed) children from the menu.
+                    $allowedResources = [];
+                    foreach ($postedResources as $resource) {
+                        $parts = explode('/', $resource);
+                        for ($i = 1, $n = count($parts); $i <= $n; $i++) {
+                            $allowedResources[implode('/', array_slice($parts, 0, $i))] = true;
+                        }
+                    }
+
+                    foreach (Mage::getModel('admin/roles')->getResourcesList2D() as $resName) {
+                        $row['permission']  = (isset($allowedResources[$resName]) ? 'allow' : 'deny');
                         $row['resource_id'] = trim($resName, '/');
 
                         $insertData = $this->_prepareDataForTable(new \Maho\DataObject($row), $this->getMainTable());

--- a/app/code/core/Mage/Rule/Model/Condition/Combine.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Combine.php
@@ -135,7 +135,7 @@ class Mage_Rule_Model_Condition_Combine extends Mage_Rule_Model_Condition_Abstra
     public function getAggregatorElement()
     {
         if (is_null($this->getAggregator())) {
-            foreach ((array) $this->getAggregatorOption() as $k => $v) {
+            foreach (array_keys((array) $this->getAggregatorOption()) as $k) {
                 $this->setAggregator($k);
                 break;
             }

--- a/app/design/adminhtml/default/default/template/page/header.phtml
+++ b/app/design/adminhtml/default/default/template/page/header.phtml
@@ -66,9 +66,11 @@
         </fieldset>
         <?php endif ?>
         <div class="user-menu-icons">
+            <?php if (Mage::getSingleton('admin/session')->isAllowed('admin/system/myaccount')): ?>
             <a href="<?= Mage::helper("adminhtml")->getUrl("adminhtml/system_account") ?>" class="user-icon" title="<?= $this->__("My Account") ?>">
                 <?= $this->getIconSvg('user') ?>
             </a>
+            <?php endif ?>
             <a href="<?= $this->getLogoutLink() ?>" class="logout-icon" title="<?= $this->__('Log Out') ?>">
                 <?= $this->getIconSvg('logout') ?>
             </a>


### PR DESCRIPTION
## Summary

- When saving a role's resources with only some descendants of a parent selected, the tree leaves the parent `indeterminate` (so it isn't posted) and `Mage_Admin_Model_Resource_Rules::saveRel()` wrote it as `deny`. The admin menu walker exits at a denied parent and never recurses into its allowed children — users only saw the Dashboard. Fix: at save time, auto-`allow` every ancestor of any posted resource. This also incidentally fixes the always-`deny` `admin` root row in custom mode.
- Gate the My Account pictogram in the admin header on `admin/system/myaccount`, matching the pattern already used for the global search icon. Without this, users without account access still see the icon and get redirected to the access-denied page.

Closes #891

## Test plan

- [ ] Create a new role, set Resource Access to "Custom", and select **all** resources manually. Save → DB rules table shows every resource (including `admin`) as `allow`.
- [ ] Edit the same role: deselect everything except *Sales > Order* (and a couple of its sub-items). Save → `admin`, `admin/sales`, `admin/sales/order` and the selected sub-items are `allow`; siblings of Sales and unselected Sales sub-items are `deny`.
- [ ] Assign a user to that role and log in: Dashboard **and** Sales menu render; only the allowed sub-items appear under Sales.
- [ ] As a user whose role does **not** include `admin/system/myaccount`, confirm the user-icon link is no longer shown in the header. The Logout icon still renders.
- [ ] Switching Resource Access back to "All" still saves a single `resource_id=all, permission=allow` row (unchanged path).