### PR TITLE
Honor address attribute visibility in admin order create

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Abstract.php
@@ -123,6 +123,9 @@ abstract class Mage_Adminhtml_Block_Sales_Order_Create_Form_Abstract extends Mag
 
         foreach ($attributes as $attribute) {
             /** @var Mage_Customer_Model_Attribute $attribute */
+            if (!$attribute->getIsVisible()) {
+                continue;
+            }
             $attribute->setStoreId(Mage::getSingleton('adminhtml/session_quote')->getStoreId());
             $inputType = $attribute->getFrontend()->getInputType();
 

--- a/app/code/core/Mage/Customer/sql/customer_setup/data-upgrade-1.4.0.0.7-1.4.0.0.8.php
+++ b/app/code/core/Mage/Customer/sql/customer_setup/data-upgrade-1.4.0.0.7-1.4.0.0.8.php
@@ -144,9 +144,9 @@ $attributes = [
     'taxvat'            => [
         'is_user_defined'   => 0,
         'is_system'         => 0,
-        'is_visible'        => $addressHelper->getConfig('dob_show', $store) == '' ? 0 : 1,
+        'is_visible'        => $addressHelper->getConfig('taxvat_show', $store) == '' ? 0 : 1,
         'sort_order'        => 100,
-        'is_required'       => $addressHelper->getConfig('dob_show', $store) == 'req' ? 1 : 0,
+        'is_required'       => $addressHelper->getConfig('taxvat_show', $store) == 'req' ? 1 : 0,
         'validate_rules'    => [
             'max_text_length'   => 255,
         ],


### PR DESCRIPTION
## Summary
- The admin "Create New Order" address form (`Mage_Adminhtml_Block_Sales_Order_Create_Form_Abstract::_addAttributesToForm()`) added every attribute from the customer-address EAV form unconditionally, ignoring `is_visible`.
- As a result, the `customer/address/{prefix,middlename,suffix}_show` admin settings had no effect on order creation, even though the frontend already respected them.
- Skip invisible attributes so admin order create matches frontend behavior.

Closes #899.

## Notes
- `vat_id` (Billing Address VAT number) is unaffected — its `is_visible` is hardcoded `1` at install time and isn't driven by any config, so this gate doesn't reach it. Bringing `vat_id` under the same model would be a separate change (a data upgrade that flips `is_visible`/`is_required` based on a config).
- Side effect: `gender_show=Optional` now also hides `gender` in the Account form via the same gate (previously gender only appeared in admin order create when set to Required, due to a separate required-only filter). This brings consistency with the frontend.

## Test plan
- [ ] Set `customer/address/prefix_show` to "No" in admin → "Prefix" hidden in order create Billing/Shipping address.
- [ ] Set it to "Optional" → field shown.
- [ ] Set it to "Required" → field shown and required.
- [ ] Repeat for `middlename_show`, `suffix_show`.
- [ ] Verify frontend behavior unchanged.