### PR TITLE
Captcha + login fixes (W3C validity, route GET, login fatal)

### DIFF
--- a/app/code/core/Mage/Customer/Block/Form/Login.php
+++ b/app/code/core/Mage/Customer/Block/Form/Login.php
@@ -115,8 +115,6 @@ class Mage_Customer_Block_Form_Login extends Mage_Core_Block_Template
 
     /**
      * Retrieve username for form field
-     *
-     * @return string
      */
     public function getUsername(): string
     {

--- a/app/code/core/Mage/Customer/Block/Form/Login.php
+++ b/app/code/core/Mage/Customer/Block/Form/Login.php
@@ -19,7 +19,7 @@
  */
 class Mage_Customer_Block_Form_Login extends Mage_Core_Block_Template
 {
-    private string|int $_username = -1;
+    private ?string $_username = null;
 
     /**
      * Set redirect URL before rendering login form
@@ -118,10 +118,10 @@ class Mage_Customer_Block_Form_Login extends Mage_Core_Block_Template
      *
      * @return string
      */
-    public function getUsername()
+    public function getUsername(): string
     {
-        if ($this->_username === -1) {
-            $this->_username = Mage::getSingleton('customer/session')->getUsername(true);
+        if ($this->_username === null) {
+            $this->_username = (string) Mage::getSingleton('customer/session')->getUsername(true);
         }
         return $this->_username;
     }

--- a/app/code/core/Maho/Captcha/Helper/Data.php
+++ b/app/code/core/Maho/Captcha/Helper/Data.php
@@ -66,7 +66,6 @@ class Maho_Captcha_Helper_Data extends Mage_Core_Helper_Abstract
     {
         return new \Maho\DataObject([
             'challenge' => $this->getChallengeUrl(),
-            'name' => 'maho_captcha',
             'id' => 'maho_captcha',
             'auto' => 'onload',
             'hideLogo' => '',

--- a/app/code/core/Maho/Captcha/controllers/IndexController.php
+++ b/app/code/core/Maho/Captcha/controllers/IndexController.php
@@ -10,7 +10,7 @@
 
 class Maho_Captcha_IndexController extends Mage_Core_Controller_Front_Action
 {
-    #[Maho\Config\Route('/captcha/index/challenge', methods: ['POST'])]
+    #[Maho\Config\Route('/captcha/index/challenge')]
     public function challengeAction(): void
     {
         $helper = Mage::helper('captcha');


### PR DESCRIPTION
Three small frontend fixes uncovered while addressing #902.

## 1. Remove invalid `name` attribute from `<altcha-widget>` (fixes #902)
W3C Nu HTML Checker: `The name attribute is never allowed on the altcha-widget element`. Per the [Altcha docs](https://altcha.org/docs/website-integration) and `Widget.svelte`, the prop only names the hidden input rendered inside the widget's own DOM — no deduplication, registry, or other side effect. Maho positions the widget as `position: fixed` outside every form (`public/js/maho-captcha.js`) and injects its own `<input name="maho_captcha">` via `setHiddenInputValue()`, so removing the attribute is safe — Altcha falls back to the default `'altcha'` for its unused internal input.

## 2. Restore GET on `/captcha/index/challenge` (regression from #834)
The Symfony routing migration in #834 restricted the route to `POST` only. The Altcha widget fetches with `GET` by default (`Widget.svelte:525`) and exposes no public attribute to switch — every Maho frontend captcha was failing with `405 Method Not Allowed`. Drop the `methods` restriction to restore pre-#834 behavior.

## 3. Drop int sentinel from `Mage_Customer_Block_Form_Login::$_username` (regression from #901)
#901 narrowed the property to `string|int`, but `customer/session::getUsername(true)` returns `null` on a fresh login page visit (no prior failed-login flash), causing a fatal TypeError on `/customer/account/login`. The `int` in the union only existed to host the `-1` "not yet fetched" sentinel — the value is conceptually always a string. Switch to empty string as both default and sentinel; "not fetched" and "fetched empty" produce the same observable result, and the lazy cache still avoids re-reading the session.

## Test plan
- [ ] Re-run W3C validation on a Maho frontend page → `name` info notice on `<altcha-widget>` is gone.
- [ ] Load any captcha-protected frontend page → `GET /captcha/index/challenge/` returns `200 OK` (no 405).
- [ ] Visit `/customer/account/login` on a fresh session → no fatal, form renders.
- [ ] Submit a captcha-protected form (e.g. contact form) → verification passes server-side.