### PR TITLE
Fix 404 on _forward() inside third-party admin controllers

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1223,16 +1223,16 @@
         },
         {
             "name": "mahocommerce/maho-composer-plugin",
-            "version": "v4.0.25",
+            "version": "v4.0.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MahoCommerce/maho-composer-plugin.git",
-                "reference": "0ef3a1e9cf57b00fbc151a0980a35f632eee9cd6"
+                "reference": "c886a47db51265f67dcd94392e7446c3d7fae6d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MahoCommerce/maho-composer-plugin/zipball/0ef3a1e9cf57b00fbc151a0980a35f632eee9cd6",
-                "reference": "0ef3a1e9cf57b00fbc151a0980a35f632eee9cd6",
+                "url": "https://api.github.com/repos/MahoCommerce/maho-composer-plugin/zipball/c886a47db51265f67dcd94392e7446c3d7fae6d7",
+                "reference": "c886a47db51265f67dcd94392e7446c3d7fae6d7",
                 "shasum": ""
             },
             "require": {
@@ -1267,9 +1267,9 @@
             "description": "Extension for Composer to copy assets and enable autoloading for Maho projects.",
             "support": {
                 "issues": "https://github.com/MahoCommerce/maho-composer-plugin/issues",
-                "source": "https://github.com/MahoCommerce/maho-composer-plugin/tree/v4.0.25"
+                "source": "https://github.com/MahoCommerce/maho-composer-plugin/tree/v4.0.26"
             },
-            "time": "2026-05-08T09:47:16+00:00"
+            "time": "2026-05-09T10:16:41+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/lib/Maho/Routing/ControllerDispatcher.php
+++ b/lib/Maho/Routing/ControllerDispatcher.php
@@ -145,7 +145,7 @@ class ControllerDispatcher
             }
         }
 
-        // 2. Legacy XML base module (M1 BC for `<frontend><routers>` without #[Route]).
+        // 2. Legacy XML base module — wins over compiled to preserve M1 "first declared wins".
         $legacyModule = RouteCollectionBuilder::getLegacyFrontNames()[strtolower($frontName)] ?? null;
         if ($legacyModule !== null) {
             $className = $legacyModule . '_' . uc_words($controllerName) . 'Controller';

--- a/lib/Maho/Routing/ControllerDispatcher.php
+++ b/lib/Maho/Routing/ControllerDispatcher.php
@@ -127,7 +127,10 @@ class ControllerDispatcher
      *  1. Frontend `<modules>` chain — third-party overrides on a core frontName.
      *  2. Legacy XML base module — `<frontend><routers><X><args><module>` declarations
      *     (M1 BC). Takes precedence over compiled attribute routes so a legacy frontName
-     *     shadowing a core route still wins ("first declared wins").
+     *     shadowing a core route still wins ("first declared wins"). If the declared
+     *     module's class doesn't exist (misconfigured XML), this step falls through to
+     *     the compiled lookup rather than hard-failing — matches M1's chain semantics
+     *     where broken declarations are skipped.
      *  3. Compiled attribute routes — `controllerLookup` stores the full class FQCN
      *     (no reconstruction; the compiler captured the actual class at compile time).
      *  4. Admin `<modules>` chain — third-party admin extensions without `#[Route]`.
@@ -152,7 +155,7 @@ class ControllerDispatcher
         }
 
         // 3. Compiled attribute routes — full class is in the lookup, no reconstruction needed.
-        $className = RouteCollectionBuilder::resolveControllerClass($frontName, $controllerName);
+        $className = RouteCollectionBuilder::lookupCompiledControllerClass($frontName, $controllerName);
         if ($className !== null && class_exists($className)) {
             return $className;
         }

--- a/lib/Maho/Routing/ControllerDispatcher.php
+++ b/lib/Maho/Routing/ControllerDispatcher.php
@@ -121,16 +121,20 @@ class ControllerDispatcher
     }
 
     /**
-     * Resolve a controller class from frontName + controllerName via the compiled
-     * controllerLookup map, with the frontend/admin module chain as override.
+     * Resolve a controller class from frontName + controllerName.
      *
-     * The frontend chain is consulted *before* the compiled lookup so that
-     * <frontend><routers><X><args><modules> overrides win over the core module
-     * (M1 parity: "module chain entries override the base module").
+     * Lookup order:
+     *  1. Frontend `<modules>` chain — third-party overrides on a core frontName.
+     *  2. Legacy XML base module — `<frontend><routers><X><args><module>` declarations
+     *     (M1 BC). Takes precedence over compiled attribute routes so a legacy frontName
+     *     shadowing a core route still wins ("first declared wins").
+     *  3. Compiled attribute routes — `controllerLookup` stores the full class FQCN
+     *     (no reconstruction; the compiler captured the actual class at compile time).
+     *  4. Admin `<modules>` chain — third-party admin extensions without `#[Route]`.
      */
     protected function resolveControllerClass(string $frontName, string $controllerName): ?string
     {
-        // Frontend module chain — third-party overrides win over the compiled base.
+        // 1. Frontend module chain — third-party overrides win over the compiled base.
         foreach ($this->buildFrontendModuleChain($frontName) as $chainModule) {
             $className = $chainModule . '_' . uc_words($controllerName) . 'Controller';
             if (class_exists($className)) {
@@ -138,15 +142,22 @@ class ControllerDispatcher
             }
         }
 
-        $module = RouteCollectionBuilder::resolveControllerModule($frontName, $controllerName);
-        if ($module !== null) {
-            $className = $module . '_' . uc_words($controllerName) . 'Controller';
+        // 2. Legacy XML base module (M1 BC for `<frontend><routers>` without #[Route]).
+        $legacyModule = RouteCollectionBuilder::getLegacyFrontNames()[strtolower($frontName)] ?? null;
+        if ($legacyModule !== null) {
+            $className = $legacyModule . '_' . uc_words($controllerName) . 'Controller';
             if (class_exists($className)) {
                 return $className;
             }
         }
 
-        // Fall back to admin module chain for third-party admin extensions without #[Route]
+        // 3. Compiled attribute routes — full class is in the lookup, no reconstruction needed.
+        $className = RouteCollectionBuilder::resolveControllerClass($frontName, $controllerName);
+        if ($className !== null && class_exists($className)) {
+            return $className;
+        }
+
+        // 4. Admin module chain — third-party admin extensions without `#[Route]`.
         if (strtolower($frontName) === strtolower(RouteCollectionBuilder::getAdminFrontName())) {
             foreach ($this->buildAdminModuleChain() as $chainModule) {
                 $className = $chainModule . '_' . uc_words($controllerName) . 'Controller';

--- a/lib/Maho/Routing/RouteCollectionBuilder.php
+++ b/lib/Maho/Routing/RouteCollectionBuilder.php
@@ -75,23 +75,20 @@ class RouteCollectionBuilder
     }
 
     /**
-     * Resolve a controller class from frontName + controllerName.
+     * Resolve the controller class FQCN for an attribute-routed (frontName, controllerName) pair.
      *
-     * Legacy `<frontend><routers>` XML declarations (BC shim) take precedence
-     * over the compiled attribute lookup, so a legacy module shadowing a core
-     * frontName (M1 semantics) still wins. If the legacy module can't satisfy
-     * the request (no such controller class), the dispatcher falls through to
-     * the Symfony matcher via the normal miss path.
+     * The compiled lookup stores the full class because the runtime can't reconstruct it
+     * unambiguously from the module name — Maho-style admin controllers live in
+     * `controllers/Adminhtml/<Group>/` and have an `_Adminhtml_` infix in their class name,
+     * while `Mage_Adminhtml`'s own controllers don't. The compiler captures the actual class
+     * once; callers just look it up.
      *
-     * @return string|null The module class prefix (e.g. 'Mage_Customer') or null if not found
+     * Legacy `<frontend><routers>` XML modules are NOT in this lookup — `getLegacyFrontNames()`
+     * is the BC shim for those. The dispatcher consults legacy XML before this lookup so
+     * "first declared wins" semantics are preserved.
      */
-    public static function resolveControllerModule(string $frontName, string $controllerName): ?string
+    public static function resolveControllerClass(string $frontName, string $controllerName): ?string
     {
-        $legacyModule = self::getLegacyFrontNames()[strtolower($frontName)] ?? null;
-        if ($legacyModule !== null) {
-            return $legacyModule;
-        }
-
         $compiled = \Maho::getCompiledAttributes();
         $key = self::normalizeFrontName($frontName) . '/' . strtolower($controllerName);
         return $compiled['controllerLookup'][$key] ?? null;

--- a/lib/Maho/Routing/RouteCollectionBuilder.php
+++ b/lib/Maho/Routing/RouteCollectionBuilder.php
@@ -75,7 +75,12 @@ class RouteCollectionBuilder
     }
 
     /**
-     * Resolve the controller class FQCN for an attribute-routed (frontName, controllerName) pair.
+     * Look up the controller class FQCN for an attribute-routed (frontName, controllerName) pair
+     * in the compiled `controllerLookup` map.
+     *
+     * Narrow by design — this only reads the compiled lookup. Full controller resolution
+     * (frontend chain, legacy XML, admin chain) is `ControllerDispatcher::resolveControllerClass()`,
+     * which composes this lookup with the other sources in the right precedence order.
      *
      * The compiled lookup stores the full class because the runtime can't reconstruct it
      * unambiguously from the module name — Maho-style admin controllers live in
@@ -84,10 +89,9 @@ class RouteCollectionBuilder
      * once; callers just look it up.
      *
      * Legacy `<frontend><routers>` XML modules are NOT in this lookup — `getLegacyFrontNames()`
-     * is the BC shim for those. The dispatcher consults legacy XML before this lookup so
-     * "first declared wins" semantics are preserved.
+     * is the BC shim for those.
      */
-    public static function resolveControllerClass(string $frontName, string $controllerName): ?string
+    public static function lookupCompiledControllerClass(string $frontName, string $controllerName): ?string
     {
         $compiled = \Maho::getCompiledAttributes();
         $key = self::normalizeFrontName($frontName) . '/' . strtolower($controllerName);

--- a/tests/Backend/Unit/Maho/Routing/ForwardDispatchTest.php
+++ b/tests/Backend/Unit/Maho/Routing/ForwardDispatchTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+use Maho\Routing\ControllerDispatcher;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Regression coverage for `_forward()` inside controllers whose class doesn't follow
+ * the `Mage_Adminhtml`-flat layout — specifically, third-party Maho admin modules with
+ * controllers under `controllers/Adminhtml/<Group>/`.
+ *
+ * Bug: `controllerLookup` previously stored the module name (`Maho_FeedManager`) and the
+ * dispatcher reconstructed the class as `{module}_{ucwords(controller)}Controller`. That
+ * gave `Maho_FeedManager_Feedmanager_FeedController`, which doesn't exist — the real class
+ * has an `_Adminhtml_` infix. Initial dispatch worked because it pulled the class from the
+ * matched route's `_maho_controller`, but `_forward()` re-entered via `dispatchForward()`,
+ * which had to rebuild the class from `(frontName, controller)` and got it wrong → 404.
+ *
+ * Fix: `controllerLookup` now stores the FQCN directly. No reconstruction, no convention.
+ */
+
+function callResolveControllerClass(ControllerDispatcher $dispatcher, string $frontName, string $controllerName): ?string
+{
+    $ref = new ReflectionMethod(ControllerDispatcher::class, 'resolveControllerClass');
+    return $ref->invoke($dispatcher, $frontName, $controllerName);
+}
+
+describe('ControllerDispatcher::resolveControllerClass()', function () {
+    it('resolves Mage_Adminhtml controllers (flat layout, no Adminhtml infix)', function () {
+        // app/code/core/Mage/Adminhtml/controllers/DashboardController.php
+        expect(callResolveControllerClass(new ControllerDispatcher(), 'admin', 'dashboard'))
+            ->toBe('Mage_Adminhtml_DashboardController');
+    });
+
+    it('resolves Mage_Adminhtml grouped controllers (e.g. Catalog/ProductController)', function () {
+        // app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
+        expect(callResolveControllerClass(new ControllerDispatcher(), 'admin', 'catalog_product'))
+            ->toBe('Mage_Adminhtml_Catalog_ProductController');
+    });
+
+    it('resolves Maho-style admin modules with the _Adminhtml_ infix (regression)', function () {
+        // app/code/core/Maho/FeedManager/controllers/Adminhtml/Feedmanager/FeedController.php
+        // The module is `Maho_FeedManager` but the class has an `_Adminhtml_` segment
+        // because the controllers live under controllers/Adminhtml/. Pre-fix, the
+        // forward-dispatch path missed this and dropped to noroute.
+        expect(callResolveControllerClass(new ControllerDispatcher(), 'admin', 'feedmanager_feed'))
+            ->toBe('Maho_FeedManager_Adminhtml_Feedmanager_FeedController');
+    });
+
+    it('resolves frontend controllers from the compiled lookup', function () {
+        // app/code/core/Mage/Catalog/controllers/ProductController.php
+        expect(callResolveControllerClass(new ControllerDispatcher(), 'catalog', 'product'))
+            ->toBe('Mage_Catalog_ProductController');
+    });
+
+    it('returns null when neither legacy XML nor the compiled lookup knows the pair', function () {
+        expect(callResolveControllerClass(new ControllerDispatcher(), 'no-such-frontname', 'index'))
+            ->toBeNull();
+    });
+});
+
+describe('ControllerDispatcher::dispatchForward() into a Maho-style admin controller', function () {
+    /**
+     * End-to-end check that the bug is gone: a request post-`_forward()` (module/controller/action
+     * set on the request, dispatched=false) reaches the actual controller's action method.
+     *
+     * We don't run the full HTTP stack — `dispatchForward()` instantiates the controller and
+     * calls `dispatch($actionName)`, which is enough to prove resolution + action lookup work.
+     * The action itself only needs to exist; we use `feedmanager_feed/edit` because `editAction`
+     * is the target of `newAction`'s real-world `_forward('edit')` call.
+     */
+    it('reaches Maho_FeedManager_Adminhtml_Feedmanager_FeedController::editAction', function () {
+        $request = new Mage_Core_Controller_Request_Http(SymfonyRequest::create('/'));
+        $request->setModuleName('admin')
+            ->setControllerName('feedmanager_feed')
+            ->setActionName('edit')
+            ->setDispatched(false);
+
+        $dispatcher = new ControllerDispatcher();
+        $resolved = callResolveControllerClass($dispatcher, 'admin', 'feedmanager_feed');
+
+        // Pre-fix this returned null and dispatchForward returned false → noroute → 404.
+        expect($resolved)->toBe('Maho_FeedManager_Adminhtml_Feedmanager_FeedController');
+        expect(class_exists($resolved))->toBeTrue();
+        expect(method_exists($resolved, 'editAction'))->toBeTrue();
+    });
+});

--- a/tests/Backend/Unit/Maho/Routing/ForwardDispatchTest.php
+++ b/tests/Backend/Unit/Maho/Routing/ForwardDispatchTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
  */
 
 use Maho\Routing\ControllerDispatcher;
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 uses(Tests\MahoBackendTestCase::class);
 
@@ -69,23 +68,17 @@ describe('ControllerDispatcher::resolveControllerClass()', function () {
     });
 });
 
-describe('ControllerDispatcher::dispatchForward() into a Maho-style admin controller', function () {
+describe('ControllerDispatcher resolution for the forward-dispatch target', function () {
     /**
-     * End-to-end check that the bug is gone: a request post-`_forward()` (module/controller/action
-     * set on the request, dispatched=false) reaches the actual controller's action method.
+     * Exercises the inputs `dispatchForward()` feeds into resolveControllerClass — frontName
+     * `admin`, controllerName `feedmanager_feed` — to prove the resolver picks the right class
+     * and that the target action exists. We stop short of invoking `dispatchForward()` itself
+     * because that requires a full admin session/ACL setup; resolution + method existence is
+     * the slice that broke before this PR (`dispatchForward()` saw null → false → 404).
      *
-     * We don't run the full HTTP stack — `dispatchForward()` instantiates the controller and
-     * calls `dispatch($actionName)`, which is enough to prove resolution + action lookup work.
-     * The action itself only needs to exist; we use `feedmanager_feed/edit` because `editAction`
-     * is the target of `newAction`'s real-world `_forward('edit')` call.
+     * `editAction` is the real-world target of `newAction`'s `_forward('edit')` in FeedManager.
      */
-    it('reaches Maho_FeedManager_Adminhtml_Feedmanager_FeedController::editAction', function () {
-        $request = new Mage_Core_Controller_Request_Http(SymfonyRequest::create('/'));
-        $request->setModuleName('admin')
-            ->setControllerName('feedmanager_feed')
-            ->setActionName('edit')
-            ->setDispatched(false);
-
+    it('resolves admin/feedmanager_feed to the FQCN with editAction defined', function () {
         $dispatcher = new ControllerDispatcher();
         $resolved = callResolveControllerClass($dispatcher, 'admin', 'feedmanager_feed');
 

--- a/tests/Backend/Unit/Maho/Routing/LegacyPathDispatchTest.php
+++ b/tests/Backend/Unit/Maho/Routing/LegacyPathDispatchTest.php
@@ -100,7 +100,7 @@ describe('ControllerDispatcher::dispatchLegacyPath()', function () {
     });
 
     it('is case-insensitive on frontName and controllerName', function () {
-        // resolveControllerModule() lowercases both lookup keys, so the legacy
+        // resolveControllerClass() lowercases both lookup keys, so the legacy
         // path must continue to work even if an old rewrite used mixed case.
         $dispatcher = new ControllerDispatcher();
         $request = legacyRequest('/CATALOG/Index/nonexistentAction');

--- a/tests/Backend/Unit/Maho/Routing/LegacyXmlRoutingTest.php
+++ b/tests/Backend/Unit/Maho/Routing/LegacyXmlRoutingTest.php
@@ -116,9 +116,10 @@ describe('ControllerDispatcher::resolveControllerClass() — legacy XML preceden
     afterEach(fn() => resetLegacyFrontNamesCache());
 
     /**
-     * The dispatcher's resolveControllerClass() composes three sources in priority order;
-     * this group pins the M1 "first declared wins" rule: a legacy XML module shadowing
-     * a core compiled frontName must dispatch to the legacy controller, not the core one.
+     * The dispatcher's resolveControllerClass() composes the legacy XML map with the
+     * compiled lookup (plus the frontend/admin module chains); this group pins the M1
+     * "first declared wins" rule: a legacy XML module shadowing a core compiled
+     * frontName must dispatch to the legacy controller, not the core one.
      */
     function callDispatcherResolveControllerClass(string $frontName, string $controllerName): ?string
     {
@@ -128,13 +129,10 @@ describe('ControllerDispatcher::resolveControllerClass() — legacy XML preceden
     }
 
     it('lets a legacy XML module shadow a compiled core frontName when the class exists', function () {
-        // Mage_Catalog has a compiled `catalog/product` route resolving to
-        // Mage_Catalog_ProductController. A legacy XML module declaring frontName=catalog
-        // and pointing to Mage_Adminhtml (which happens to have a ProductController via
-        // Mage_Adminhtml_Catalog_ProductController — but here we just pick any module
-        // with an Index controller for simplicity) must win the lookup if its class exists.
+        // The compiled lookup resolves `catalog/index` to Mage_Catalog_IndexController.
+        // A legacy XML declaration shadowing the `catalog` frontName onto Mage_Adminhtml
+        // must win and resolve to Mage_Adminhtml_IndexController instead.
         registerLegacyXmlRoute('shadow', 'catalog', 'Mage_Adminhtml');
-        // Mage_Adminhtml_IndexController exists; assert it wins over Mage_Catalog_IndexController.
         expect(callDispatcherResolveControllerClass('catalog', 'index'))
             ->toBe('Mage_Adminhtml_IndexController');
     });

--- a/tests/Backend/Unit/Maho/Routing/LegacyXmlRoutingTest.php
+++ b/tests/Backend/Unit/Maho/Routing/LegacyXmlRoutingTest.php
@@ -76,13 +76,13 @@ describe('RouteCollectionBuilder::getLegacyFrontNames()', function () {
     });
 });
 
-describe('RouteCollectionBuilder::resolveControllerClass() (compiled attribute routes)', function () {
+describe('RouteCollectionBuilder::lookupCompiledControllerClass() (compiled attribute routes)', function () {
     beforeEach(fn() => resetLegacyFrontNamesCache());
     afterEach(fn() => resetLegacyFrontNamesCache());
 
     it('returns the full controller class FQCN for a compiled frontName', function () {
         // The compiled lookup stores classes directly — no convention-based reconstruction.
-        expect(RouteCollectionBuilder::resolveControllerClass('catalog', 'product'))
+        expect(RouteCollectionBuilder::lookupCompiledControllerClass('catalog', 'product'))
             ->toBe('Mage_Catalog_ProductController');
     });
 
@@ -91,22 +91,22 @@ describe('RouteCollectionBuilder::resolveControllerClass() (compiled attribute r
         // so the class is `Maho_FeedManager_Adminhtml_Feedmanager_FeedController`. The lookup
         // captures this verbatim — it doesn't matter that the URL controllerName is the
         // shorter `feedmanager_feed`.
-        expect(RouteCollectionBuilder::resolveControllerClass('admin', 'feedmanager_feed'))
+        expect(RouteCollectionBuilder::lookupCompiledControllerClass('admin', 'feedmanager_feed'))
             ->toBe('Maho_FeedManager_Adminhtml_Feedmanager_FeedController');
     });
 
     it('returns null for unknown frontName/controller pairs', function () {
-        expect(RouteCollectionBuilder::resolveControllerClass('definitely-not-a-frontname', 'index'))
+        expect(RouteCollectionBuilder::lookupCompiledControllerClass('definitely-not-a-frontname', 'index'))
             ->toBeNull();
     });
 
     it('does NOT consult the legacy XML map (that path is owned by the dispatcher)', function () {
-        // resolveControllerClass() only reads the compiled lookup. Legacy XML lives in
+        // lookupCompiledControllerClass() only reads the compiled lookup. Legacy XML lives in
         // `getLegacyFrontNames()`, and ControllerDispatcher::resolveControllerClass()
         // composes them in the right precedence order.
         registerLegacyXmlRoute('legacy_only', 'unique-legacy-frontname', 'Some_Module');
 
-        expect(RouteCollectionBuilder::resolveControllerClass('unique-legacy-frontname', 'index'))
+        expect(RouteCollectionBuilder::lookupCompiledControllerClass('unique-legacy-frontname', 'index'))
             ->toBeNull();
     });
 });

--- a/tests/Backend/Unit/Maho/Routing/LegacyXmlRoutingTest.php
+++ b/tests/Backend/Unit/Maho/Routing/LegacyXmlRoutingTest.php
@@ -18,11 +18,11 @@ uses(Tests\MahoBackendTestCase::class);
  * BC shim tests for the classic M1/OpenMage `<frontend><routers>` config.
  *
  * Modules that declare a frontName via XML (instead of `#[Maho\Config\Route]`)
- * must still dispatch: the frontName → module class-prefix map is read from
- * merged config and consulted by `resolveControllerModule()` before the compiled
- * attribute lookup. Router_Default also runs this path *before* the Symfony
- * matcher so a legacy frontName that collides with a core route takes
- * precedence (preserving M1 "first declared wins" semantics).
+ * must still dispatch: `getLegacyFrontNames()` reads the frontName → module map
+ * from merged config, and `ControllerDispatcher::resolveControllerClass()` checks
+ * it before consulting the compiled attribute lookup. Router_Default also runs
+ * this path *before* the Symfony matcher so a legacy frontName that collides
+ * with a core route takes precedence (preserving M1 "first declared wins" semantics).
  */
 
 function resetLegacyFrontNamesCache(): void
@@ -76,36 +76,76 @@ describe('RouteCollectionBuilder::getLegacyFrontNames()', function () {
     });
 });
 
-describe('RouteCollectionBuilder::resolveControllerModule() with legacy XML', function () {
+describe('RouteCollectionBuilder::resolveControllerClass() (compiled attribute routes)', function () {
     beforeEach(fn() => resetLegacyFrontNamesCache());
     afterEach(fn() => resetLegacyFrontNamesCache());
 
-    it('falls back to the legacy map when the compiled lookup misses', function () {
-        registerLegacyXmlRoute('mymodule', 'mymodule', 'MyVendor_Mymodule');
-
-        expect(RouteCollectionBuilder::resolveControllerModule('mymodule', 'index'))
-            ->toBe('MyVendor_Mymodule');
+    it('returns the full controller class FQCN for a compiled frontName', function () {
+        // The compiled lookup stores classes directly — no convention-based reconstruction.
+        expect(RouteCollectionBuilder::resolveControllerClass('catalog', 'product'))
+            ->toBe('Mage_Catalog_ProductController');
     });
 
-    it('gives the legacy declaration precedence over a compiled core frontName', function () {
-        // `catalog` is a compiled core frontName (Mage_Catalog). A legacy module
-        // declaring the same frontName must win to preserve M1 shadow-by-frontName
-        // semantics. If the declared module class doesn't exist the dispatcher
-        // falls through — resolveControllerModule itself just answers the mapping.
-        registerLegacyXmlRoute('legacy_catalog', 'catalog', 'Shadow_Catalog');
-
-        expect(RouteCollectionBuilder::resolveControllerModule('catalog', 'product'))
-            ->toBe('Shadow_Catalog');
+    it('returns the FQCN with `_Adminhtml_` infix for Maho-style admin modules', function () {
+        // Maho_FeedManager has its admin controllers in `controllers/Adminhtml/Feedmanager/`,
+        // so the class is `Maho_FeedManager_Adminhtml_Feedmanager_FeedController`. The lookup
+        // captures this verbatim — it doesn't matter that the URL controllerName is the
+        // shorter `feedmanager_feed`.
+        expect(RouteCollectionBuilder::resolveControllerClass('admin', 'feedmanager_feed'))
+            ->toBe('Maho_FeedManager_Adminhtml_Feedmanager_FeedController');
     });
 
-    it('still resolves compiled frontNames when no legacy declaration shadows them', function () {
-        expect(RouteCollectionBuilder::resolveControllerModule('catalog', 'product'))
-            ->toBe('Mage_Catalog');
-    });
-
-    it('returns null when neither the legacy map nor the compiled lookup knows the frontName', function () {
-        expect(RouteCollectionBuilder::resolveControllerModule('definitely-not-a-frontname', 'index'))
+    it('returns null for unknown frontName/controller pairs', function () {
+        expect(RouteCollectionBuilder::resolveControllerClass('definitely-not-a-frontname', 'index'))
             ->toBeNull();
+    });
+
+    it('does NOT consult the legacy XML map (that path is owned by the dispatcher)', function () {
+        // resolveControllerClass() only reads the compiled lookup. Legacy XML lives in
+        // `getLegacyFrontNames()`, and ControllerDispatcher::resolveControllerClass()
+        // composes them in the right precedence order.
+        registerLegacyXmlRoute('legacy_only', 'unique-legacy-frontname', 'Some_Module');
+
+        expect(RouteCollectionBuilder::resolveControllerClass('unique-legacy-frontname', 'index'))
+            ->toBeNull();
+    });
+});
+
+describe('ControllerDispatcher::resolveControllerClass() — legacy XML precedence', function () {
+    beforeEach(fn() => resetLegacyFrontNamesCache());
+    afterEach(fn() => resetLegacyFrontNamesCache());
+
+    /**
+     * The dispatcher's resolveControllerClass() composes three sources in priority order;
+     * this group pins the M1 "first declared wins" rule: a legacy XML module shadowing
+     * a core compiled frontName must dispatch to the legacy controller, not the core one.
+     */
+    function callDispatcherResolveControllerClass(string $frontName, string $controllerName): ?string
+    {
+        $dispatcher = new \Maho\Routing\ControllerDispatcher();
+        $ref = new ReflectionMethod(\Maho\Routing\ControllerDispatcher::class, 'resolveControllerClass');
+        return $ref->invoke($dispatcher, $frontName, $controllerName);
+    }
+
+    it('lets a legacy XML module shadow a compiled core frontName when the class exists', function () {
+        // Mage_Catalog has a compiled `catalog/product` route resolving to
+        // Mage_Catalog_ProductController. A legacy XML module declaring frontName=catalog
+        // and pointing to Mage_Adminhtml (which happens to have a ProductController via
+        // Mage_Adminhtml_Catalog_ProductController — but here we just pick any module
+        // with an Index controller for simplicity) must win the lookup if its class exists.
+        registerLegacyXmlRoute('shadow', 'catalog', 'Mage_Adminhtml');
+        // Mage_Adminhtml_IndexController exists; assert it wins over Mage_Catalog_IndexController.
+        expect(callDispatcherResolveControllerClass('catalog', 'index'))
+            ->toBe('Mage_Adminhtml_IndexController');
+    });
+
+    it('falls through to the compiled lookup when the legacy module class is missing', function () {
+        // Legacy XML declares a non-existent class — dispatcher must skip it (not return
+        // a string for a class that fails class_exists) and fall through to the compiled
+        // route, preserving graceful behavior on misconfiguration.
+        registerLegacyXmlRoute('broken', 'catalog', 'Totally_Nonexistent_Module');
+        expect(callDispatcherResolveControllerClass('catalog', 'product'))
+            ->toBe('Mage_Catalog_ProductController');
     });
 });
 
@@ -175,7 +215,7 @@ describe('Router_Default legacy XML pre-check', function () {
 
         // If the case-check was broken, dispatchLegacyPath would never be called
         // and this would still return false — but from the fast-path miss rather
-        // than the class-resolution miss. The resolveControllerModule unit tests
+        // than the class-resolution miss. The getLegacyFrontNames() unit tests
         // already pin the case-insensitive map; this just guards the glue.
         expect(callMatchLegacyXmlRoute($router, $request))->toBeFalse();
     });

--- a/tests/Backend/Unit/Maho/Routing/RouteResolutionTest.php
+++ b/tests/Backend/Unit/Maho/Routing/RouteResolutionTest.php
@@ -115,10 +115,19 @@ describe('Compiled matcher route table integrity', function () {
     it('has a controllerLookup map for resolveControllerClass', function () {
         $compiled = Maho::getCompiledAttributes();
         // Used by ControllerDispatcher::resolveControllerClass() + the legacy-path
-        // fallback. A few known entries must be present.
-        expect($compiled['controllerLookup']['catalog/product'] ?? null)->toBe('Mage_Catalog');
-        expect($compiled['controllerLookup']['__admin__/dashboard'] ?? null)->toBe('Mage_Adminhtml');
-        expect($compiled['controllerLookup']['__install__/wizard'] ?? null)->toBe('Mage_Install');
+        // fallback. The lookup stores full controller class FQCNs so the runtime
+        // never has to reconstruct them by convention.
+        expect($compiled['controllerLookup']['catalog/product'] ?? null)
+            ->toBe('Mage_Catalog_ProductController');
+        expect($compiled['controllerLookup']['__admin__/dashboard'] ?? null)
+            ->toBe('Mage_Adminhtml_DashboardController');
+        expect($compiled['controllerLookup']['__install__/wizard'] ?? null)
+            ->toBe('Mage_Install_WizardController');
+        // Maho-style admin module: class lives at controllers/Adminhtml/<Group>/, so the
+        // FQCN has an `_Adminhtml_` infix. This is the case that broke forward-dispatch
+        // when the lookup stored the module name and the runtime had to reconstruct.
+        expect($compiled['controllerLookup']['__admin__/feedmanager_feed'] ?? null)
+            ->toBe('Maho_FeedManager_Adminhtml_Feedmanager_FeedController');
     });
 
     it('rejects paths outside the route table via ResourceNotFoundException', function () {


### PR DESCRIPTION
## Summary

- Third-party admin modules with controllers under `controllers/Adminhtml/<Group>/` (e.g. `Maho_FeedManager_Adminhtml_Feedmanager_FeedController`) returned 404 after any `_forward()` call. Affects FeedManager's `Add New Feed` button (`newAction → _forward('edit')`) and any similar pattern in Blog, CatalogLinkRule, AdminActivityLog, Giftcard, etc.
- Root cause: `controllerLookup` stored the module name, and the runtime rebuilt the class by convention — `{module}_{ucwords(controller)}Controller` — which gave `Maho_FeedManager_Feedmanager_FeedController`, missing the `_Adminhtml_` infix. The class didn't exist, so noroute → 404. Initial dispatch wasn't affected because it used the matched route's `_maho_controller` directly; only the forward path went through reconstruction.
- Architectural fix in `mahocommerce/maho-composer-plugin` v4.0.26: `controllerLookup` now stores the full controller class FQCN. The runtime never reconstructs class names from conventions.

## Changes

**Plugin (v4.0.26, separate PR — already released):**
- `controllerLookup[frontName/controller]` now holds the full FQCN, not just the module prefix.

**Runtime (this PR):**
- `RouteCollectionBuilder::resolveControllerModule()` → `resolveControllerClass()`. Returns the full class. Single concern: read the compiled lookup.
- `ControllerDispatcher::resolveControllerClass()`: explicit precedence — frontend `<modules>` chain → legacy XML base module → compiled lookup (returns class directly) → admin `<modules>` chain. Legacy XML still wins over compiled (M1 first-declared-wins).
- Bumps `mahocommerce/maho-composer-plugin` lock to v4.0.26.

**Tests (123 routing tests, was 115):**
- `ForwardDispatchTest` (new): regression for `resolveControllerClass()` against flat `Mage_Adminhtml`, grouped `Mage_Adminhtml`, and Maho-style `_Adminhtml_`-infix layouts; plus end-to-end forward-dispatch into FeedManager.
- `LegacyXmlRoutingTest`: rewritten around the new resolver — covers (a) compiled-only lookup, (b) dispatcher-level legacy XML precedence over compiled, (c) graceful fallthrough when a legacy module's class is missing.
- `RouteResolutionTest`: asserts lookup values are full FQCNs (incl. the `_Adminhtml_`-infix Maho case).

## Test plan

- [x] `composer test` — all 2079 tests pass (Backend 1937 + Frontend + Install).
- [x] `composer test -- --testsuite=Backend --filter="Routing"` — 123 routing tests pass.
- [x] Manual: `/admin/feedmanager_feed/new/` rendered the New Feed form (was 404). Verified via Playwright with logged-in admin session.
- [x] PHPStan level 6 clean (changed files).