### PR TITLE
Fixed `renewSession()` wiping cookie when `cookie_domain` has leading dot

### DIFF
--- a/app/code/core/Mage/Core/Model/Session/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract.php
@@ -792,10 +792,11 @@ class Mage_Core_Model_Session_Abstract extends \Maho\DataObject
         $this->regenerateSessionId();
 
         $sessionHosts = $this->getSessionHosts();
-        $currentCookieDomain = $this->getCookie()->getDomain();
+        $currentCookieDomain = ltrim((string) $this->getCookie()->getDomain(), '.');
         foreach (array_keys($sessionHosts) as $host) {
-            // Delete cookies with the same name for parent domains
-            if (strpos($currentCookieDomain, $host) > 0) {
+            if ($host !== '' && $host !== $currentCookieDomain
+                && str_ends_with($currentCookieDomain, '.' . $host)
+            ) {
                 $this->getCookie()->delete($this->getSessionName(), null, $host);
             }
         }


### PR DESCRIPTION
## Summary

Fixes #910.

`Mage_Core_Model_Session_Abstract::renewSession()` silently wiped the freshly-regenerated session cookie when `web/cookie/cookie_domain` was configured with a leading dot (e.g. `.example.com`) and traffic reached the apex host. Result: login worked server-side, the new session id was set, then immediately deleted in the same response, so the user landed back on the login page with no error.

The parent-domain cleanup loop used `strpos($currentCookieDomain, $host) > 0`. With `$currentCookieDomain = '.example.com'` and the apex host `'example.com'` registered as a session host, `strpos` returned `1` (matched the substring past the leading dot), so an extra `Set-Cookie: <name>=deleted; domain=example.com` was emitted. Per RFC 6265 §5.2.3 browsers strip the leading dot, so both Set-Cookie headers referred to the same cookie and the expired one won.

The fix strips the leading dot before comparing and only deletes on strict parent domains (`$host` must be a proper suffix preceded by `.`).

## Test plan
- [ ] With `web/cookie/cookie_domain = .example.test`, log in on the apex host `example.test` and confirm the session survives the redirect chain
- [ ] With `web/cookie/cookie_domain` empty or without a leading dot, confirm login still works (regression check)
- [ ] With a configured cookie_domain on a sub-host (e.g. browsing `www.example.test` against `cookie_domain=.example.test`), confirm parent-domain cookie cleanup still happens when intended