### PR TITLE
Fix #922 + #923: admin frontname migration and install wizard redirect loop

### DIFF
--- a/app/code/core/Mage/Adminhtml/Helper/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Data.php
@@ -99,13 +99,17 @@ class Mage_Adminhtml_Helper_Data extends Mage_Adminhtml_Helper_Help_Mapping
             }
             $this->adminFrontNames = [$adminPath];
 
-            // Check for other modules that can use admin router (a lot of Magento extensions do that)
-            $adminFrontNameNodes = Mage::getConfig()->getNode('admin/routers')
-                ->xpath('*[not(self::adminhtml) and use = "admin"]/args/frontName');
-
-            if (is_array($adminFrontNameNodes)) {
-                foreach ($adminFrontNameNodes as $frontNameNode) {
-                    $this->adminFrontNames[] = (string) $frontNameNode;
+            // Check for other modules that can use admin router (a lot of Magento extensions do that).
+            // The <admin><routers> node may be absent on fresh installs that only declare <admin><base_path>.
+            $adminRoutersNode = Mage::getConfig()->getNode('admin/routers');
+            if ($adminRoutersNode) {
+                $adminFrontNameNodes = $adminRoutersNode->xpath(
+                    '*[not(self::adminhtml) and use = "admin"]/args/frontName',
+                );
+                if (is_array($adminFrontNameNodes)) {
+                    foreach ($adminFrontNameNodes as $frontNameNode) {
+                        $this->adminFrontNames[] = (string) $frontNameNode;
+                    }
                 }
             }
         }

--- a/app/code/core/Mage/Cms/Controller/Router.php
+++ b/app/code/core/Mage/Cms/Controller/Router.php
@@ -33,6 +33,13 @@ class Mage_Cms_Controller_Router extends Mage_Core_Controller_Varien_Router_Abst
     public function match(Mage_Core_Controller_Request_Http $request): bool
     {
         if (!Mage::isInstalled()) {
+            // The install URL would loop if we redirected here: let the default
+            // router's Symfony matcher dispatch /install/... natively, since the
+            // legacy Mage_Install_Controller_Router_Install no longer runs ahead
+            // of us in the chain.
+            if (preg_match('#^/install(/|$)#', $request->getPathInfo()) === 1) {
+                return false;
+            }
             Mage::app()->getFrontController()->getResponse()
                 ->setRedirect(Mage::getUrl('install'))
                 ->sendResponse();

--- a/app/code/core/Mage/Core/Model/Store.php
+++ b/app/code/core/Mage/Core/Model/Store.php
@@ -49,7 +49,6 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
     public const XML_PATH_STORE_STORE_PHONE         = 'general/store_information/phone';
     public const XML_PATH_STORE_STORE_HOURS         = 'general/store_information/hours';
     public const XML_PATH_STORE_IN_URL              = 'web/url/use_store';
-    public const XML_PATH_USE_REWRITES              = 'web/seo/use_rewrites';
     public const XML_PATH_UNSECURE_BASE_URL         = 'web/unsecure/base_url';
     public const XML_PATH_UNSECURE_BASE_JS_URL      = 'web/unsecure/base_js_url';
     public const XML_PATH_UNSECURE_BASE_LINK_URL    = 'web/unsecure/base_link_url';
@@ -252,7 +251,6 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
             self::XML_PATH_SECURE_IN_FRONTEND,
             self::XML_PATH_STORE_IN_URL,
             self::XML_PATH_UNSECURE_BASE_URL,
-            self::XML_PATH_USE_REWRITES,
             self::XML_PATH_UNSECURE_BASE_LINK_URL,
             self::XML_PATH_SECURE_BASE_LINK_URL,
             'general/locale/code',
@@ -514,24 +512,19 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
                 case self::URL_TYPE_LINK:
                     $secure = (bool) $secure;
                     $url = $this->getConfig('web/' . ($secure ? 'secure' : 'unsecure') . '/base_link_url');
-                    $url = $this->_updatePathUseRewrites($url);
                     $url = $this->_updatePathUseStoreView($url);
                     break;
 
                 case self::URL_TYPE_DIRECT_LINK:
                     $secure = (bool) $secure;
                     $url = $this->getConfig('web/' . ($secure ? 'secure' : 'unsecure') . '/base_link_url');
-                    $url = $this->_updatePathUseRewrites($url);
                     break;
 
                 case self::URL_TYPE_SKIN:
                 case self::URL_TYPE_JS:
+                case self::URL_TYPE_MEDIA:
                     $secure = is_null($secure) ? Mage::app()->isCurrentlySecure() : (bool) $secure;
                     $url = $this->getConfig('web/' . ($secure ? 'secure' : 'unsecure') . '/base_' . $type . '_url');
-                    break;
-
-                case self::URL_TYPE_MEDIA:
-                    $url = $this->_updateMediaPathUseRewrites($secure);
                     break;
 
                 default:
@@ -551,45 +544,6 @@ class Mage_Core_Model_Store extends Mage_Core_Model_Abstract
         }
 
         return $this->_baseUrlCache[$cacheKey];
-    }
-
-    /**
-     * Remove script file name from url in case when server rewrites are enabled
-     *
-     * @param   string $url
-     * @return  string
-     */
-    protected function _updatePathUseRewrites($url)
-    {
-        if (!Mage::isInstalled() || !$this->getConfig(self::XML_PATH_USE_REWRITES)) {
-            $indexFileName = $this->_isCustomEntryPoint() ? 'index.php' : basename($_SERVER['SCRIPT_FILENAME']);
-            $url .= $indexFileName . '/';
-        }
-        return $url;
-    }
-
-    /**
-     * Check if used entry point is custom
-     *
-     * @return bool
-     */
-    protected function _isCustomEntryPoint()
-    {
-        return (bool) Mage::registry('custom_entry_point');
-    }
-
-    /**
-     * Retrieve URL for media catalog
-     *
-     * @param null|bool $secure
-     * @param string $type
-     * @return string
-     */
-    protected function _updateMediaPathUseRewrites($secure = null, $type = self::URL_TYPE_MEDIA)
-    {
-        $secure = is_null($secure) ? Mage::app()->isCurrentlySecure() : (bool) $secure;
-        $secureStringFlag = $secure ? 'secure' : 'unsecure';
-        return $this->getConfig('web/' . $secureStringFlag . '/base_' . $type . '_url');
     }
 
     /**

--- a/app/code/core/Mage/Core/etc/config.xml
+++ b/app/code/core/Mage/Core/etc/config.xml
@@ -299,9 +299,6 @@
                 <redirect_to_base>1</redirect_to_base>
                 <trailing_slash_behavior>add</trailing_slash_behavior>
             </url>
-            <seo>
-                <use_rewrites>1</use_rewrites>
-            </seo>
             <unsecure>
                 <base_url>{{base_url}}</base_url>
                 <base_web_url>{{unsecure_base_url}}</base_web_url>

--- a/app/etc/local.xml.template
+++ b/app/etc/local.xml.template
@@ -37,12 +37,6 @@
         <session_save>{{session_save}}</session_save>
     </global>
     <admin>
-        <routers>
-            <adminhtml>
-                <args>
-                    <frontName>{{admin_frontname}}</frontName>
-                </args>
-            </adminhtml>
-        </routers>
+        <base_path>{{admin_frontname}}</base_path>
     </admin>
 </config>

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -256,6 +256,36 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
+     * Detect a legacy `<admin><routers><adminhtml><args><frontName>` declaration
+     * in `app/etc/local.xml`. The constant `Mage_Adminhtml_Helper_Data::XML_PATH_ADMINHTML_ROUTER_FRONTNAME`
+     * now resolves to `admin/base_path`; an entry at the old path is silently ignored,
+     * leaving the admin reachable only at `/admin/...` regardless of the value declared here.
+     *
+     * @return ?array{file: string, frontName: string}
+     */
+    public static function findLegacyLocalXmlAdminPath(): ?array
+    {
+        $file = MAHO_ROOT_DIR . '/app/etc/local.xml';
+        if (!is_file($file)) {
+            return null;
+        }
+
+        libxml_use_internal_errors(true);
+        $xml = simplexml_load_file($file);
+        libxml_clear_errors();
+        if ($xml === false) {
+            return null;
+        }
+
+        $frontName = (string) ($xml->admin->routers->adminhtml->args->frontName ?? '');
+        if ($frontName === '') {
+            return null;
+        }
+
+        return ['file' => 'app/etc/local.xml', 'frontName' => $frontName];
+    }
+
+    /**
      * @param list<array{module: string, file?: string, frontName?: string, area?: string, count?: int}> $findings
      */
     private static function formatLegacyXmlSummary(string $label, array $findings, string $attribute): string
@@ -344,6 +374,19 @@ class HealthCheck extends BaseMahoCommand
                 'cron job declarations',
                 $legacyXml['cron'],
                 '#[Maho\\Config\\CronJob]',
+            ),
+        ];
+
+        $legacyAdminPath = self::findLegacyLocalXmlAdminPath();
+        $checks[] = [
+            'check' => 'Legacy Admin Frontname in local.xml',
+            'severity' => $legacyAdminPath === null ? 'ok' : 'warning',
+            'details' => $legacyAdminPath === null ? '' : sprintf(
+                'Found <admin><routers><adminhtml><args><frontName>%s</frontName> in %s. This node is ignored; '
+                . 'replace it with <admin><base_path>%s</base_path> (or run `./maho legacy:migrate-routes`).',
+                $legacyAdminPath['frontName'],
+                $legacyAdminPath['file'],
+                $legacyAdminPath['frontName'],
             ),
         ];
 
@@ -823,6 +866,28 @@ class HealthCheck extends BaseMahoCommand
             }
 
             $output->writeln('See: https://mahocommerce.com/routing/');
+            $output->writeln('');
+        }
+
+        // Check for a legacy admin frontName declaration in app/etc/local.xml
+        $output->write('Checking app/etc/local.xml admin frontName... ');
+        $legacyAdminPath = self::findLegacyLocalXmlAdminPath();
+        if ($legacyAdminPath === null) {
+            $output->writeln('<info>OK</info>');
+        } else {
+            $output->writeln('');
+            $output->writeln(sprintf(
+                '<comment>Warning: Legacy admin frontName found in %s.</comment>',
+                $legacyAdminPath['file'],
+            ));
+            $output->writeln(sprintf(
+                '  <admin><routers><adminhtml><args><frontName>%s</frontName>... is no longer honored.',
+                $legacyAdminPath['frontName'],
+            ));
+            $output->writeln(sprintf(
+                '  Replace it with <admin><base_path>%s</base_path>, or run: ./maho legacy:migrate-routes',
+                $legacyAdminPath['frontName'],
+            ));
             $output->writeln('');
         }
 

--- a/lib/MahoCLI/Commands/LegacyMigrateRoutes.php
+++ b/lib/MahoCLI/Commands/LegacyMigrateRoutes.php
@@ -177,7 +177,97 @@ class LegacyMigrateRoutes extends BaseMahoCommand
             $output->writeln('<comment>Tip: review the generated routes carefully; controller-method scanning is best-effort.</comment>');
         }
 
+        $this->migrateLocalXmlAdminPath($output, $dryRun);
+
         return Command::SUCCESS;
+    }
+
+    /**
+     * Rewrite the legacy admin frontName declaration in `app/etc/local.xml`.
+     *
+     * Old (no longer honored after PR #834):
+     *   <admin><routers><adminhtml><args><frontName>X</frontName>
+     * New:
+     *   <admin><base_path>X</base_path>
+     */
+    private function migrateLocalXmlAdminPath(OutputInterface $output, bool $dryRun): void
+    {
+        $path = MAHO_ROOT_DIR . '/app/etc/local.xml';
+        if (!is_file($path)) {
+            return;
+        }
+
+        $dom = $this->loadConfigXmlAsDom($path);
+        if ($dom === null) {
+            return;
+        }
+
+        $config = $dom->documentElement;
+        if ($config === null) {
+            return;
+        }
+
+        $adminNode = $this->firstChildElement($config, 'admin');
+        if ($adminNode === null) {
+            return;
+        }
+        $routersNode = $this->firstChildElement($adminNode, 'routers');
+        if ($routersNode === null) {
+            return;
+        }
+        $adminhtmlNode = $this->firstChildElement($routersNode, 'adminhtml');
+        if ($adminhtmlNode === null) {
+            return;
+        }
+        $argsNode = $this->firstChildElement($adminhtmlNode, 'args');
+        if ($argsNode === null) {
+            return;
+        }
+        $frontNameNode = $this->firstChildElement($argsNode, 'frontName');
+        if ($frontNameNode === null) {
+            return;
+        }
+        $frontName = trim($frontNameNode->textContent);
+        if ($frontName === '') {
+            return;
+        }
+
+        $existingBasePath = $this->firstChildElement($adminNode, 'base_path');
+        $existingBasePathValue = $existingBasePath === null ? null : trim($existingBasePath->textContent);
+
+        $output->writeln('');
+        $output->writeln('<info>app/etc/local.xml</info> (admin frontName)');
+
+        if ($existingBasePathValue !== null && $existingBasePathValue !== '' && $existingBasePathValue !== $frontName) {
+            $output->writeln(sprintf(
+                '  <comment>skip</comment> <admin><base_path>%s</base_path> already differs from legacy <frontName>%s</frontName>; resolve manually.',
+                $existingBasePathValue,
+                $frontName,
+            ));
+            return;
+        }
+
+        if ($dryRun) {
+            $output->writeln(sprintf(
+                '  would replace <admin><routers><adminhtml><args><frontName>%s</frontName>... with <admin><base_path>%s</base_path>',
+                $frontName,
+                $frontName,
+            ));
+            return;
+        }
+
+        if ($existingBasePath === null) {
+            $newNode = $dom->createElement('base_path', $frontName);
+            $adminNode->insertBefore($newNode, $routersNode);
+        }
+
+        $this->detachAndPrune($adminhtmlNode);
+        $this->saveConfigXml($dom, $path);
+
+        $output->writeln(sprintf(
+            '  <info>migrated</info> <admin><base_path>%s</base_path>',
+            $frontName,
+        ));
     }
 
     /**

--- a/public/api.php
+++ b/public/api.php
@@ -30,8 +30,6 @@ $apiAlias = Mage::app()->getRequest()->getParam('type');
 
 // check request could be processed by API2
 if (in_array($apiAlias, Mage_Api2_Model_Server::getApiTypes())) {
-    // emulate index.php entry point for correct URLs generation in API
-    Mage::register('custom_entry_point', true);
     /** @var Mage_Api2_Model_Server $server */
     $server = Mage::getSingleton('api2/server');
     $server->run();
@@ -53,8 +51,6 @@ if ($adapterCode === null) {
 
 try {
     $server->initialize($adapterCode);
-    // emulate index.php entry point for correct URLs generation in API
-    Mage::register('custom_entry_point', true);
     $server->run();
     Mage::app()->getResponse()->sendResponse();
 } catch (Exception $e) {


### PR DESCRIPTION
Closes #922 and #923.

Both bugs are fallout from PR #834 (Symfony routing migration), which removed legacy router pieces but left the rest of the codebase unaware.

## #922 — Admin frontname stored at the legacy XML path is silently ignored

Pre-26.5 Maho (and the install template still in main) stored the admin frontname at `<admin><routers><adminhtml><args><frontName>`. PR #834 switched the runtime to read `<admin><base_path>` only, so existing installs with a custom admin frontname were silently downgraded to `/admin/...`.

Going forward there are two supported, documented ways to configure the admin frontname (the second is new visibility for an already-existing system-config path, which makes this an improvement, not just a regression fix):

1. `<admin><base_path>X</base_path>` in `app/etc/local.xml` (file-tracked).
2. *System → Configuration → Advanced → Admin → Admin Base URL → Use Custom Admin Path* (DB-backed, configurable from the backend with no file edits).

Documentation: https://mahocommerce.com/routing/?h=routi#configuring-the-admin-frontname

### Changes

- `app/etc/local.xml.template`: writes `<admin><base_path>{{admin_frontname}}</base_path>` so fresh installs land on the new path.
- `lib/MahoCLI/Commands/HealthCheck.php`: new `findLegacyLocalXmlAdminPath()` check, surfaced in `./maho health-check` and (via `getCheckResults()`) in *System → Tools → Healthcheck*.
- `lib/MahoCLI/Commands/LegacyMigrateRoutes.php`: rewrites `<admin><routers><adminhtml><args><frontName>X</frontName>` to `<admin><base_path>X</base_path>` in `app/etc/local.xml`. Supports `--dry-run`, is idempotent, and skips with a warning when an existing `<base_path>` already disagrees.

## #923 — Install wizard redirect loop

When the app isn't installed, `Mage_Cms_Controller_Router::match()` redirected every request to `Mage::getUrl('install')`. With the dedicated install Router gone (it used to match `/install/...` first), the CMS short-circuit started firing for `/install/` itself: infinite loop.

### Changes

- `Mage_Cms_Controller_Router::match()` now returns `false` for `/install/*` paths when not installed, letting the default router's Symfony matcher dispatch the install wizard natively. Non-install paths still get the "not installed → install" redirect.
- Dropped the whole `web/seo/use_rewrites` code path. No `system.xml` entry exposes it anymore; in 2026 rewrites are universally available. Removed: `XML_PATH_USE_REWRITES`, `_updatePathUseRewrites()`, `_updateMediaPathUseRewrites()`, `_isCustomEntryPoint()`, the `<seo><use_rewrites>` default in `config.xml`, and the orphan `custom_entry_point` registry hack in `public/api.php`. Install URLs (and all other URLs) no longer contain `index.php`.

## Test plan

- [x] `./maho health-check` warns when `app/etc/local.xml` still carries the legacy admin frontName node
- [x] Backend *System → Tools → Healthcheck* shows the same warning row
- [x] `./maho legacy:migrate-routes --dry-run` reports the would-be rewrite without modifying files
- [x] `./maho legacy:migrate-routes` rewrites `local.xml` and re-running is a no-op
- [x] Conflict case (existing `<base_path>` with a different value) is reported as skip, no destructive edit
- [x] Fresh install via the updated template produces a working admin URL at the chosen frontname
- [x] Fresh (uninstalled) Maho: `/`, `/install`, `/install/`, `/index.php/install/` all reach the wizard (no loop), Location headers contain no `index.php`
- [x] Existing route resolution tests still pass (`composer test -- --testsuite=Backend --filter='CustomAdminPath|RouteResolution|SentinelConsistency'`)