### PR TITLE
Fixed block reference reset on widget instance save for "Specified Page…

### DIFF
--- a/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
+++ b/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
@@ -295,6 +295,12 @@ const WidgetInstance = {
             if (layoutHandleField) {
                 layoutHandle = layoutHandleField.value;
             }
+            // For 'pages' group type: use the actual selected layout handle from the dropdown
+            const layoutSelect = element.querySelector('select#layout_handle');
+            if (layoutSelect && layoutSelect.value) {
+                layoutHandle = layoutSelect.value;
+            }
+            
             this.loadSelectBoxByType('block_reference', element, layoutHandle, additional);
         }
         this.loadSelectBoxByType('block_template', element, additional.selectedBlock, additional);

--- a/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
+++ b/app/design/adminhtml/default/default/template/widget/instance/edit/layout.phtml
@@ -290,17 +290,9 @@ const WidgetInstance = {
         this.showBlockContainer(element);
         const blockContainer = element.querySelector('div.block_reference');
         if (blockContainer && blockContainer.innerHTML === '') {
-            let layoutHandle = '';
-            const layoutHandleField = element.querySelector('input.layout_handle_pattern');
-            if (layoutHandleField) {
-                layoutHandle = layoutHandleField.value;
-            }
-            // For 'pages' group type: use the actual selected layout handle from the dropdown
-            const layoutSelect = element.querySelector('select#layout_handle');
-            if (layoutSelect && layoutSelect.value) {
-                layoutHandle = layoutSelect.value;
-            }
-            
+            const layoutHandle = element.querySelector('select#layout_handle')?.value
+                || element.querySelector('input.layout_handle_pattern')?.value
+                || '';
             this.loadSelectBoxByType('block_reference', element, layoutHandle, additional);
         }
         this.loadSelectBoxByType('block_template', element, additional.selectedBlock, additional);


### PR DESCRIPTION
## Block Reference resets to "-- Please Select --" after saving a widget instance

  When editing a widget instance configured to display on a **Specified Page**, the Block Reference dropdown is reset to `-- Please Select --` every time the form is reloaded after saving. Any previously
  saved block reference is silently overwritten with an empty value on the next save.

  ---

  ### Cause

  The `pages` group container holds a hidden input used as a layout handle hint for other group types:

  ```html
  <input type="hidden" class="layout_handle_pattern" value="default" />
  ```

  On load, `addPageGroup()` correctly pre-selects the saved layout handle in the visible `<select id="layout_handle">` dropdown. But `displayPageGroup()` then fires the block chooser AJAX request using the
  **hidden input's static value** (`"default"`) rather than the select's actual value:

  ```javascript
  // always reads "default" for the pages group
  const layoutHandleField = element.querySelector('input.layout_handle_pattern');
  if (layoutHandleField) {
      layoutHandle = layoutHandleField.value;
  }
  this.loadSelectBoxByType('block_reference', element, layoutHandle, additional);
  ```

  The block chooser only returns blocks declared with a `<label>` in the requested layout handle's XML. Blocks defined on specific page layouts (e.g. `cms_index_index`) are not present in `default`, so the
  AJAX response contains no matching option and the dropdown shows `-- Please Select --`. On the next save, the empty selection overwrites the stored value in the database.

  ---

  ### Fix

  After reading the hidden input, check whether the container also has a `select#layout_handle` element — which only exists in the `pages` group. If it does and carries a value, use that as the layout handle
  instead:

  ```javascript
  const layoutHandleField = element.querySelector('input.layout_handle_pattern');
  if (layoutHandleField) {
      layoutHandle = layoutHandleField.value;
  }
  // For the 'pages' group: use the actual selected layout handle from the dropdown
  const layoutSelect = element.querySelector('select#layout_handle');
  if (layoutSelect && layoutSelect.value) {
      layoutHandle = layoutSelect.value;
  }
  this.loadSelectBoxByType('block_reference', element, layoutHandle, additional);
  ```

  This passes the correct layout handle to the block chooser, which then returns the right options with the saved block reference pre-selected. All other group types are unaffected — they have no
  `select#layout_handle` element and continue to use the hidden input as before.

