### PR TITLE
Intelligence MCP: surface PHP-attribute observers, cron jobs, and routes

### DIFF
--- a/app/code/core/Maho/Intelligence/Model/Mcp/Server.php
+++ b/app/code/core/Maho/Intelligence/Model/Mcp/Server.php
@@ -164,7 +164,7 @@ class Maho_Intelligence_Model_Mcp_Server
 
         $this->addTool(
             'list_routes',
-            'List routing definitions in two sections: "xml_routers" — router-level frontName→module mappings with controller-override chains (legacy XML / custom projects); and "attribute_routes" — per-URL Symfony routes defined via #[Maho\\Config\\Route] attributes.',
+            'List routing definitions in two sections: "xml_routers" (router-level frontName→module mappings with controller-override chains, used by legacy XML / custom projects), and "attribute_routes" (per-URL Symfony routes defined via #[Maho\\Config\\Route] attributes).',
             ['type' => 'object', 'properties' => new \stdClass()],
             fn(array $args) => $registry->get('router', 'getAllRoutes'),
         );

--- a/app/code/core/Maho/Intelligence/Model/Mcp/Server.php
+++ b/app/code/core/Maho/Intelligence/Model/Mcp/Server.php
@@ -80,7 +80,7 @@ class Maho_Intelligence_Model_Mcp_Server
 
         $this->addTool(
             'list_events',
-            'List all events and their observers. Optionally filter by event name pattern (substring match).',
+            'List all events and their observers (both XML-declared and #[Maho\\Config\\Observer] attribute-based). Each observer carries a "source" field ("xml" or "attribute"). Optionally filter by event name pattern (substring match).',
             [
                 'type' => 'object',
                 'properties' => [
@@ -136,7 +136,7 @@ class Maho_Intelligence_Model_Mcp_Server
 
         $this->addTool(
             'list_cron_jobs',
-            'List all cron job definitions with their model::method callbacks and schedules.',
+            'List all cron job definitions (both XML-declared and #[Maho\\Config\\CronJob] attribute-based) with their model::method callbacks and schedules. Each job carries a "source" field ("xml" or "attribute").',
             ['type' => 'object', 'properties' => new \stdClass()],
             fn(array $args) => $registry->get('cron', 'getAllJobs'),
         );
@@ -164,7 +164,7 @@ class Maho_Intelligence_Model_Mcp_Server
 
         $this->addTool(
             'list_routes',
-            'List all frontend and admin route definitions with frontNames, modules, and controller overrides.',
+            'List routing definitions in two sections: "xml_routers" — router-level frontName→module mappings with controller-override chains (legacy XML / custom projects); and "attribute_routes" — per-URL Symfony routes defined via #[Maho\\Config\\Route] attributes.',
             ['type' => 'object', 'properties' => new \stdClass()],
             fn(array $args) => $registry->get('router', 'getAllRoutes'),
         );

--- a/app/code/core/Maho/Intelligence/Model/Provider/Cron.php
+++ b/app/code/core/Maho/Intelligence/Model/Provider/Cron.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 class Maho_Intelligence_Model_Provider_Cron
 {
     /**
-     * Get all cron job definitions
+     * Get all cron job definitions. Merges XML-defined jobs (legacy / custom
+     * projects) with PHP-attribute cron jobs compiled into
+     * vendor/composer/maho_attributes.php.
      */
     public function getAllJobs(): array
     {
@@ -43,6 +45,30 @@ class Maho_Intelligence_Model_Provider_Cron
                 'model' => $jobConfig['run']['model'] ?? '',
                 'schedule' => $cronExpr ?? '',
                 'config_path' => $jobConfig['schedule']['config_path'] ?? null,
+                'source' => 'xml',
+            ];
+        }
+
+        $compiledCron = Maho::getCompiledAttributes()['crontab'] ?? [];
+        foreach ($compiledCron as $jobName => $jobConfig) {
+            $cronExpr = $jobConfig['schedule'] ?? null;
+            $configPath = $jobConfig['config_path'] ?? null;
+
+            if (!$cronExpr && $configPath) {
+                $cronExpr = Mage::getStoreConfig($configPath);
+            }
+
+            $alias = $jobConfig['alias'] ?? '';
+            $method = $jobConfig['method'] ?? '';
+            $model = $alias !== '' && $method !== '' ? "{$alias}::{$method}" : '';
+
+            $result[$jobName] = [
+                'name' => $jobName,
+                'model' => $model,
+                'schedule' => $cronExpr ?? '',
+                'config_path' => $configPath,
+                'module' => $jobConfig['module'] ?? null,
+                'source' => 'attribute',
             ];
         }
 

--- a/app/code/core/Maho/Intelligence/Model/Provider/Cron.php
+++ b/app/code/core/Maho/Intelligence/Model/Provider/Cron.php
@@ -16,6 +16,10 @@ class Maho_Intelligence_Model_Provider_Cron
      * Get all cron job definitions. Merges XML-defined jobs (legacy / custom
      * projects) with PHP-attribute cron jobs compiled into
      * vendor/composer/maho_attributes.php.
+     *
+     * Collisions: if the same job name exists in both XML and as an attribute,
+     * the attribute version wins (the XML entry is replaced). This matches the
+     * runtime cron registration order.
      */
     public function getAllJobs(): array
     {
@@ -35,16 +39,18 @@ class Maho_Intelligence_Model_Provider_Cron
         $result = [];
         foreach ($jobs as $jobName => $jobConfig) {
             $cronExpr = $jobConfig['schedule']['cron_expr'] ?? null;
+            $configPath = $jobConfig['schedule']['config_path'] ?? null;
 
-            if (!$cronExpr && !empty($jobConfig['schedule']['config_path'])) {
-                $cronExpr = Mage::getStoreConfig($jobConfig['schedule']['config_path']);
+            if (!$cronExpr && !empty($configPath)) {
+                $cronExpr = Mage::getStoreConfig($configPath);
             }
 
             $result[$jobName] = [
                 'name' => $jobName,
                 'model' => $jobConfig['run']['model'] ?? '',
                 'schedule' => $cronExpr ?? '',
-                'config_path' => $jobConfig['schedule']['config_path'] ?? null,
+                'config_path' => $configPath,
+                'module' => null,
                 'source' => 'xml',
             ];
         }
@@ -54,7 +60,7 @@ class Maho_Intelligence_Model_Provider_Cron
             $cronExpr = $jobConfig['schedule'] ?? null;
             $configPath = $jobConfig['config_path'] ?? null;
 
-            if (!$cronExpr && $configPath) {
+            if (!$cronExpr && !empty($configPath)) {
                 $cronExpr = Mage::getStoreConfig($configPath);
             }
 

--- a/app/code/core/Maho/Intelligence/Model/Provider/Event.php
+++ b/app/code/core/Maho/Intelligence/Model/Provider/Event.php
@@ -12,12 +12,14 @@ declare(strict_types=1);
 
 class Maho_Intelligence_Model_Provider_Event
 {
-    private const AREAS = ['global', 'frontend', 'adminhtml', 'crontab'];
+    private const AREAS = ['global', 'frontend', 'adminhtml', 'crontab', 'install'];
 
     private ?array $cachedEvents = null;
 
     /**
-     * Get all events keyed by area, then event name, with observer details
+     * Get all events keyed by area, then event name, with observer details.
+     * Merges XML-defined observers (legacy / custom projects) with PHP-attribute
+     * observers compiled into vendor/composer/maho_attributes.php.
      */
     public function getAllEvents(): array
     {
@@ -41,21 +43,39 @@ class Maho_Intelligence_Model_Provider_Event
                     continue;
                 }
 
-                $observers = [];
                 foreach ($event->observers->children() as $observer) {
-                    $observers[] = [
+                    $result[$area][$eventName]['event'] = $eventName;
+                    $result[$area][$eventName]['area'] = $area;
+                    $result[$area][$eventName]['observers'][] = [
                         'name' => $observer->getName(),
                         'class' => (string) ($observer->class ?? ''),
                         'method' => (string) ($observer->method ?? ''),
                         'type' => (string) ($observer->type ?? 'singleton'),
+                        'module' => null,
+                        'alias' => null,
+                        'source' => 'xml',
                     ];
                 }
+            }
+        }
 
-                $result[$area][$eventName] = [
-                    'event' => $eventName,
-                    'area' => $area,
-                    'observers' => $observers,
-                ];
+        $compiledObservers = Maho::getCompiledAttributes()['observers'] ?? [];
+        foreach ($compiledObservers as $area => $events) {
+            foreach ($events as $eventName => $observers) {
+                $eventName = strtolower($eventName);
+                foreach ($observers as $observer) {
+                    $result[$area][$eventName]['event'] = $eventName;
+                    $result[$area][$eventName]['area'] = $area;
+                    $result[$area][$eventName]['observers'][] = [
+                        'name' => $observer['name'] ?? '',
+                        'class' => $observer['class'] ?? '',
+                        'method' => $observer['method'] ?? '',
+                        'type' => $observer['type'] ?? 'model',
+                        'module' => $observer['module'] ?? null,
+                        'alias' => $observer['alias'] ?? null,
+                        'source' => 'attribute',
+                    ];
+                }
             }
         }
 

--- a/app/code/core/Maho/Intelligence/Model/Provider/Event.php
+++ b/app/code/core/Maho/Intelligence/Model/Provider/Event.php
@@ -20,6 +20,13 @@ class Maho_Intelligence_Model_Provider_Event
      * Get all events keyed by area, then event name, with observer details.
      * Merges XML-defined observers (legacy / custom projects) with PHP-attribute
      * observers compiled into vendor/composer/maho_attributes.php.
+     *
+     * Observers within an event are returned in source-grouping order (XML first,
+     * then attribute). This is not the runtime dispatch order, which is determined
+     * by per-observer id/before/after semantics.
+     *
+     * Default observer `type` differs by source ('singleton' for XML, 'model' for
+     * attribute) to match each system's own default.
      */
     public function getAllEvents(): array
     {
@@ -80,7 +87,7 @@ class Maho_Intelligence_Model_Provider_Event
         }
 
         foreach ($result as &$areaEvents) {
-            ksort($areaEvents);
+            ksort($areaEvents, SORT_NATURAL | SORT_FLAG_CASE);
         }
 
         $this->cachedEvents = $result;

--- a/app/code/core/Maho/Intelligence/Model/Provider/Router.php
+++ b/app/code/core/Maho/Intelligence/Model/Provider/Router.php
@@ -15,7 +15,7 @@ class Maho_Intelligence_Model_Provider_Router
     /**
      * Get all routing definitions.
      *
-     * Returns two sections — XML routers are router-level frontName→module
+     * Returns two sections: XML routers are router-level frontName→module
      * mappings (with optional controller-override chains); attribute routes
      * are per-URL Symfony routes compiled from #[Maho\Config\Route]
      * attributes into vendor/composer/maho_attributes.php.

--- a/app/code/core/Maho/Intelligence/Model/Provider/Router.php
+++ b/app/code/core/Maho/Intelligence/Model/Provider/Router.php
@@ -13,9 +13,24 @@ declare(strict_types=1);
 class Maho_Intelligence_Model_Provider_Router
 {
     /**
-     * Get all route definitions across frontend and admin areas
+     * Get all routing definitions.
+     *
+     * Returns two sections — XML routers are router-level frontName→module
+     * mappings (with optional controller-override chains); attribute routes
+     * are per-URL Symfony routes compiled from #[Maho\Config\Route]
+     * attributes into vendor/composer/maho_attributes.php.
+     *
+     * @return array{xml_routers: array, attribute_routes: array}
      */
     public function getAllRoutes(): array
+    {
+        return [
+            'xml_routers' => $this->getXmlRouters(),
+            'attribute_routes' => $this->getAttributeRoutes(),
+        ];
+    }
+
+    private function getXmlRouters(): array
     {
         $config = Mage::getConfig();
         $result = [];
@@ -56,6 +71,30 @@ class Maho_Intelligence_Model_Provider_Router
 
                 $result["{$area}/{$routerName}"] = $route;
             }
+        }
+
+        ksort($result);
+        return $result;
+    }
+
+    private function getAttributeRoutes(): array
+    {
+        $routes = Maho::getCompiledAttributes()['routes'] ?? [];
+        $result = [];
+
+        foreach ($routes as $routeName => $route) {
+            $result[$routeName] = [
+                'name' => $routeName,
+                'area' => $route['area'] ?? null,
+                'path' => $route['path'] ?? '',
+                'methods' => $route['methods'] ?? [],
+                'class' => $route['class'] ?? '',
+                'action' => $route['action'] ?? '',
+                'module' => $route['module'] ?? null,
+                'controller_name' => $route['controllerName'] ?? null,
+                'defaults' => $route['defaults'] ?? [],
+                'requirements' => $route['requirements'] ?? [],
+            ];
         }
 
         ksort($result);

--- a/app/code/core/Maho/Intelligence/Model/Provider/Router.php
+++ b/app/code/core/Maho/Intelligence/Model/Provider/Router.php
@@ -73,7 +73,7 @@ class Maho_Intelligence_Model_Provider_Router
             }
         }
 
-        ksort($result);
+        ksort($result, SORT_NATURAL | SORT_FLAG_CASE);
         return $result;
     }
 
@@ -92,12 +92,13 @@ class Maho_Intelligence_Model_Provider_Router
                 'action' => $route['action'] ?? '',
                 'module' => $route['module'] ?? null,
                 'controller_name' => $route['controllerName'] ?? null,
+                'path_variables' => $route['pathVariables'] ?? [],
                 'defaults' => $route['defaults'] ?? [],
                 'requirements' => $route['requirements'] ?? [],
             ];
         }
 
-        ksort($result);
+        ksort($result, SORT_NATURAL | SORT_FLAG_CASE);
         return $result;
     }
 }

--- a/tests/Backend/Unit/Maho/Intelligence/Provider/CronTest.php
+++ b/tests/Backend/Unit/Maho/Intelligence/Provider/CronTest.php
@@ -25,6 +25,21 @@ function injectCronConfig(string $innerXml): void
     $config->extend($extra);
 }
 
+function withInjectedCompiledCron(array $extraJobs, callable $fn): void
+{
+    $prop = new ReflectionProperty(Maho::class, 'compiledAttributes');
+    $original = Maho::getCompiledAttributes();
+    $patched = $original;
+    $patched['crontab'] = array_merge($patched['crontab'] ?? [], $extraJobs);
+
+    $prop->setValue(null, $patched);
+    try {
+        $fn();
+    } finally {
+        $prop->setValue(null, $original);
+    }
+}
+
 describe('Provider_Cron attribute-based jobs', function () {
     it('returns compiled attribute cron jobs', function () {
         $jobs = Mage::getModel('intelligence/provider_cron')->getAllJobs();
@@ -128,6 +143,47 @@ describe('Provider_Cron XML-defined jobs', function () {
         expect($jobs)->toHaveKey('configurable_cron');
         expect($jobs['configurable_cron']['config_path'])->toBe('cron_test/my_schedule');
         expect($jobs['configurable_cron']['model'])->toBe('x/y::z');
+    });
+
+    it('lets attribute jobs win when the same name exists in XML', function () {
+        // api_session_cleanup is a real attribute cron job (Mage_Api).
+        injectCronConfig('
+            <crontab>
+                <jobs>
+                    <api_session_cleanup>
+                        <schedule><cron_expr>0 0 * * *</cron_expr></schedule>
+                        <run><model>fake/xml::override</model></run>
+                    </api_session_cleanup>
+                </jobs>
+            </crontab>
+        ');
+
+        $jobs = Mage::getModel('intelligence/provider_cron')->getAllJobs();
+
+        expect($jobs)->toHaveKey('api_session_cleanup');
+        expect($jobs['api_session_cleanup']['source'])->toBe('attribute');
+        expect($jobs['api_session_cleanup']['model'])->not->toBe('fake/xml::override');
+    });
+
+    it('captures config_path on attribute jobs that schedule via store config', function () {
+        withInjectedCompiledCron([
+            'attr_configurable_cron' => [
+                'module' => 'Test_Module',
+                'alias' => 'test/cron',
+                'method' => 'run',
+                'schedule' => null,
+                'config_path' => 'cron_test/attr_schedule',
+            ],
+        ], function () {
+            $jobs = Mage::getModel('intelligence/provider_cron')->getAllJobs();
+
+            expect($jobs)->toHaveKey('attr_configurable_cron');
+            $job = $jobs['attr_configurable_cron'];
+            expect($job['source'])->toBe('attribute');
+            expect($job['config_path'])->toBe('cron_test/attr_schedule');
+            expect($job['model'])->toBe('test/cron::run');
+            expect($job['module'])->toBe('Test_Module');
+        });
     });
 
     it('returns jobs sorted naturally and case-insensitively', function () {

--- a/tests/Backend/Unit/Maho/Intelligence/Provider/CronTest.php
+++ b/tests/Backend/Unit/Maho/Intelligence/Provider/CronTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+uses(Tests\MahoBackendTestCase::class);
+
+function injectCronConfig(string $innerXml): void
+{
+    // The merged config caches the 'crontab' section separately
+    // (Mage_Core_Model_Config::$_cacheSections), so getNode('crontab/jobs')
+    // reads from the cached section file and ignores runtime extend() calls.
+    // Disable the section cache so the live in-memory tree is used.
+    $config = Mage::getConfig();
+    (new ReflectionProperty($config, '_useCache'))->setValue($config, false);
+
+    $extra = new Maho\Simplexml\Config();
+    $extra->loadString('<?xml version="1.0"?><config>' . $innerXml . '</config>');
+    $config->extend($extra);
+}
+
+describe('Provider_Cron attribute-based jobs', function () {
+    it('returns compiled attribute cron jobs', function () {
+        $jobs = Mage::getModel('intelligence/provider_cron')->getAllJobs();
+
+        expect($jobs)->not->toBeEmpty();
+
+        $attributeJobs = array_filter($jobs, fn($j) => ($j['source'] ?? null) === 'attribute');
+        expect($attributeJobs)->not->toBeEmpty();
+    });
+
+    it('builds model as "{alias}::{method}" for attribute jobs', function () {
+        $jobs = Mage::getModel('intelligence/provider_cron')->getAllJobs();
+        $attributeJob = null;
+        foreach ($jobs as $job) {
+            if (($job['source'] ?? null) === 'attribute') {
+                $attributeJob = $job;
+                break;
+            }
+        }
+
+        expect($attributeJob)->not->toBeNull();
+        expect($attributeJob['model'])->toMatch('/^[a-z0-9_]+\/[a-z0-9_]+::[a-zA-Z0-9_]+$/');
+    });
+
+    it('exposes required shape for attribute jobs', function () {
+        $jobs = Mage::getModel('intelligence/provider_cron')->getAllJobs();
+        $attributeJob = null;
+        foreach ($jobs as $job) {
+            if (($job['source'] ?? null) === 'attribute') {
+                $attributeJob = $job;
+                break;
+            }
+        }
+
+        expect($attributeJob)->toHaveKeys(['name', 'model', 'schedule', 'config_path', 'module', 'source']);
+        expect($attributeJob['name'])->toBeString()->not->toBeEmpty();
+    });
+});
+
+describe('Provider_Cron XML-defined jobs', function () {
+    it('returns an injected XML cron job with source=xml', function () {
+        injectCronConfig('
+            <crontab>
+                <jobs>
+                    <test_xml_cron>
+                        <schedule><cron_expr>*/15 * * * *</cron_expr></schedule>
+                        <run><model>core/observer::cleanCache</model></run>
+                    </test_xml_cron>
+                </jobs>
+            </crontab>
+        ');
+
+        $jobs = Mage::getModel('intelligence/provider_cron')->getAllJobs();
+
+        expect($jobs)->toHaveKey('test_xml_cron');
+        $job = $jobs['test_xml_cron'];
+        expect($job['source'])->toBe('xml');
+        expect($job['name'])->toBe('test_xml_cron');
+        expect($job['model'])->toBe('core/observer::cleanCache');
+        expect($job['schedule'])->toBe('*/15 * * * *');
+        expect($job['config_path'])->toBeNull();
+    });
+
+    it('reads cron jobs from default/crontab/jobs', function () {
+        injectCronConfig('
+            <default>
+                <crontab>
+                    <jobs>
+                        <test_default_cron>
+                            <schedule><cron_expr>0 3 * * *</cron_expr></schedule>
+                            <run><model>foo/bar::baz</model></run>
+                        </test_default_cron>
+                    </jobs>
+                </crontab>
+            </default>
+        ');
+
+        $jobs = Mage::getModel('intelligence/provider_cron')->getAllJobs();
+
+        expect($jobs)->toHaveKey('test_default_cron');
+        expect($jobs['test_default_cron']['schedule'])->toBe('0 3 * * *');
+        expect($jobs['test_default_cron']['source'])->toBe('xml');
+    });
+
+    it('captures config_path when schedule uses a configurable path', function () {
+        injectCronConfig('
+            <default>
+                <crontab>
+                    <jobs>
+                        <configurable_cron>
+                            <schedule><config_path>cron_test/my_schedule</config_path></schedule>
+                            <run><model>x/y::z</model></run>
+                        </configurable_cron>
+                    </jobs>
+                </crontab>
+            </default>
+        ');
+
+        $jobs = Mage::getModel('intelligence/provider_cron')->getAllJobs();
+
+        expect($jobs)->toHaveKey('configurable_cron');
+        expect($jobs['configurable_cron']['config_path'])->toBe('cron_test/my_schedule');
+        expect($jobs['configurable_cron']['model'])->toBe('x/y::z');
+    });
+
+    it('returns jobs sorted naturally and case-insensitively', function () {
+        injectCronConfig('
+            <crontab>
+                <jobs>
+                    <zeta_cron>
+                        <schedule><cron_expr>0 1 * * *</cron_expr></schedule>
+                        <run><model>x/y::z</model></run>
+                    </zeta_cron>
+                    <alpha_cron>
+                        <schedule><cron_expr>0 1 * * *</cron_expr></schedule>
+                        <run><model>x/y::z</model></run>
+                    </alpha_cron>
+                </jobs>
+            </crontab>
+        ');
+
+        $jobs = Mage::getModel('intelligence/provider_cron')->getAllJobs();
+        $keys = array_keys($jobs);
+        $alphaPos = array_search('alpha_cron', $keys, true);
+        $zetaPos = array_search('zeta_cron', $keys, true);
+
+        expect($alphaPos)->toBeLessThan($zetaPos);
+    });
+});

--- a/tests/Backend/Unit/Maho/Intelligence/Provider/EventTest.php
+++ b/tests/Backend/Unit/Maho/Intelligence/Provider/EventTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+uses(Tests\MahoBackendTestCase::class);
+
+function injectEventsConfig(string $innerXml): void
+{
+    $extra = new Maho\Simplexml\Config();
+    $extra->loadString('<?xml version="1.0"?><config>' . $innerXml . '</config>');
+    Mage::getConfig()->extend($extra);
+}
+
+describe('Provider_Event attribute-based observers', function () {
+    it('surfaces compiled attribute observers across all known areas', function () {
+        $events = Mage::getModel('intelligence/provider_event')->getAllEvents();
+
+        expect($events)->toHaveKey('global');
+        expect($events)->toHaveKey('adminhtml');
+        expect($events)->toHaveKey('frontend');
+
+        $anyAttribute = false;
+        foreach ($events as $areaEvents) {
+            foreach ($areaEvents as $event) {
+                foreach ($event['observers'] as $observer) {
+                    if (($observer['source'] ?? null) === 'attribute') {
+                        $anyAttribute = true;
+                        break 3;
+                    }
+                }
+            }
+        }
+        expect($anyAttribute)->toBeTrue();
+    });
+
+    it('tags attribute observers with module and alias metadata', function () {
+        $events = Mage::getModel('intelligence/provider_event')->getAllEvents();
+
+        $sample = null;
+        foreach ($events as $areaEvents) {
+            foreach ($areaEvents as $event) {
+                foreach ($event['observers'] as $observer) {
+                    if (($observer['source'] ?? null) === 'attribute') {
+                        $sample = $observer;
+                        break 3;
+                    }
+                }
+            }
+        }
+
+        expect($sample)->not->toBeNull();
+        expect($sample)->toHaveKeys(['name', 'class', 'method', 'type', 'module', 'alias', 'source']);
+        expect($sample['class'])->toBeString()->not->toBeEmpty();
+        expect($sample['method'])->toBeString()->not->toBeEmpty();
+    });
+});
+
+describe('Provider_Event XML-defined observers', function () {
+    it('surfaces an injected XML observer with source=xml', function () {
+        injectEventsConfig('
+            <global>
+                <events>
+                    <test_xml_event>
+                        <observers>
+                            <my_listener>
+                                <class>Mage_Core_Model_Observer</class>
+                                <method>handleTest</method>
+                                <type>singleton</type>
+                            </my_listener>
+                        </observers>
+                    </test_xml_event>
+                </events>
+            </global>
+        ');
+
+        $events = Mage::getModel('intelligence/provider_event')->getAllEvents();
+
+        expect($events['global'])->toHaveKey('test_xml_event');
+        $observers = $events['global']['test_xml_event']['observers'];
+        expect($observers)->toHaveCount(1);
+
+        $observer = $observers[0];
+        expect($observer['source'])->toBe('xml');
+        expect($observer['name'])->toBe('my_listener');
+        expect($observer['class'])->toBe('Mage_Core_Model_Observer');
+        expect($observer['method'])->toBe('handleTest');
+        expect($observer['type'])->toBe('singleton');
+        expect($observer['module'])->toBeNull();
+        expect($observer['alias'])->toBeNull();
+    });
+
+    it('defaults observer type to singleton when XML omits it', function () {
+        injectEventsConfig('
+            <frontend>
+                <events>
+                    <test_default_type>
+                        <observers>
+                            <listener><class>Foo_Bar</class><method>baz</method></listener>
+                        </observers>
+                    </test_default_type>
+                </events>
+            </frontend>
+        ');
+
+        $events = Mage::getModel('intelligence/provider_event')->getAllEvents();
+        expect($events['frontend']['test_default_type']['observers'][0]['type'])->toBe('singleton');
+    });
+
+    it('merges XML and attribute observers on the same event', function () {
+        injectEventsConfig('
+            <global>
+                <events>
+                    <controller_action_predispatch>
+                        <observers>
+                            <custom_xml_listener>
+                                <class>Custom_Class</class>
+                                <method>customMethod</method>
+                            </custom_xml_listener>
+                        </observers>
+                    </controller_action_predispatch>
+                </events>
+            </global>
+        ');
+
+        $events = Mage::getModel('intelligence/provider_event')->getAllEvents();
+        $observers = $events['global']['controller_action_predispatch']['observers'] ?? [];
+
+        $sources = array_column($observers, 'source');
+        expect($sources)->toContain('xml');
+    });
+});
+
+describe('Provider_Event::getObserversForEvent', function () {
+    it('returns observers grouped by area when both XML and attributes contribute', function () {
+        injectEventsConfig('
+            <adminhtml>
+                <events>
+                    <my_shared_event>
+                        <observers>
+                            <xml_observer><class>Foo</class><method>bar</method></xml_observer>
+                        </observers>
+                    </my_shared_event>
+                </events>
+            </adminhtml>
+        ');
+
+        $provider = Mage::getModel('intelligence/provider_event');
+        $result = $provider->getObserversForEvent('my_shared_event');
+
+        expect($result)->toHaveKey('adminhtml');
+        expect($result['adminhtml'])->toHaveCount(1);
+        expect($result['adminhtml'][0]['name'])->toBe('xml_observer');
+    });
+
+    it('is case-insensitive on event names', function () {
+        injectEventsConfig('
+            <global>
+                <events>
+                    <CaseSensitiveEvent>
+                        <observers>
+                            <o><class>X</class><method>y</method></o>
+                        </observers>
+                    </CaseSensitiveEvent>
+                </events>
+            </global>
+        ');
+
+        $provider = Mage::getModel('intelligence/provider_event');
+        expect($provider->getObserversForEvent('casesensitiveevent'))->toHaveKey('global');
+    });
+});
+
+describe('Provider_Event caching', function () {
+    it('returns the same cached result on repeated calls', function () {
+        $provider = Mage::getModel('intelligence/provider_event');
+        $first = $provider->getAllEvents();
+        $second = $provider->getAllEvents();
+
+        expect($second)->toBe($first);
+    });
+});

--- a/tests/Backend/Unit/Maho/Intelligence/Provider/EventTest.php
+++ b/tests/Backend/Unit/Maho/Intelligence/Provider/EventTest.php
@@ -134,11 +134,12 @@ describe('Provider_Event XML-defined observers', function () {
 
         $sources = array_column($observers, 'source');
         expect($sources)->toContain('xml');
+        expect($sources)->toContain('attribute');
     });
 });
 
 describe('Provider_Event::getObserversForEvent', function () {
-    it('returns observers grouped by area when both XML and attributes contribute', function () {
+    it('returns observers grouped by area for an XML-defined event', function () {
         injectEventsConfig('
             <adminhtml>
                 <events>

--- a/tests/Backend/Unit/Maho/Intelligence/Provider/EventTest.php
+++ b/tests/Backend/Unit/Maho/Intelligence/Provider/EventTest.php
@@ -160,6 +160,11 @@ describe('Provider_Event::getObserversForEvent', function () {
         expect($result['adminhtml'][0]['name'])->toBe('xml_observer');
     });
 
+    it('returns an empty array for an unknown event name', function () {
+        $provider = Mage::getModel('intelligence/provider_event');
+        expect($provider->getObserversForEvent('this_event_definitely_does_not_exist_xyz'))->toBe([]);
+    });
+
     it('is case-insensitive on event names', function () {
         injectEventsConfig('
             <global>

--- a/tests/Backend/Unit/Maho/Intelligence/Provider/RouterTest.php
+++ b/tests/Backend/Unit/Maho/Intelligence/Provider/RouterTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Maho
+ *
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+uses(Tests\MahoBackendTestCase::class);
+
+function injectRouterConfig(string $innerXml): void
+{
+    $extra = new Maho\Simplexml\Config();
+    $extra->loadString('<?xml version="1.0"?><config>' . $innerXml . '</config>');
+    Mage::getConfig()->extend($extra);
+}
+
+describe('Provider_Router top-level shape', function () {
+    it('returns xml_routers and attribute_routes sections', function () {
+        $result = Mage::getModel('intelligence/provider_router')->getAllRoutes();
+
+        expect($result)->toHaveKeys(['xml_routers', 'attribute_routes']);
+        expect($result['xml_routers'])->toBeArray();
+        expect($result['attribute_routes'])->toBeArray();
+    });
+});
+
+describe('Provider_Router attribute routes', function () {
+    it('surfaces compiled attribute routes', function () {
+        $result = Mage::getModel('intelligence/provider_router')->getAllRoutes();
+        expect($result['attribute_routes'])->not->toBeEmpty();
+    });
+
+    it('exposes per-route metadata in the expected shape', function () {
+        $result = Mage::getModel('intelligence/provider_router')->getAllRoutes();
+        $sample = reset($result['attribute_routes']);
+
+        expect($sample)->toHaveKeys([
+            'name', 'area', 'path', 'methods', 'class', 'action',
+            'module', 'controller_name', 'defaults', 'requirements',
+        ]);
+        expect($sample['path'])->toBeString()->not->toBeEmpty();
+        expect($sample['class'])->toBeString()->not->toBeEmpty();
+        expect($sample['action'])->toBeString()->not->toBeEmpty();
+        expect($sample['methods'])->toBeArray();
+    });
+
+    it('surfaces both adminhtml and frontend routes', function () {
+        $result = Mage::getModel('intelligence/provider_router')->getAllRoutes();
+
+        $areas = array_unique(array_column($result['attribute_routes'], 'area'));
+        expect($areas)->toContain('adminhtml');
+        expect($areas)->toContain('frontend');
+    });
+
+    it('sorts attribute routes by name', function () {
+        $result = Mage::getModel('intelligence/provider_router')->getAllRoutes();
+        $names = array_keys($result['attribute_routes']);
+        $sorted = $names;
+        sort($sorted);
+
+        expect($names)->toBe($sorted);
+    });
+});
+
+describe('Provider_Router XML routers', function () {
+    it('returns an injected XML frontend router with frontName and module', function () {
+        injectRouterConfig('
+            <frontend>
+                <routers>
+                    <testrouter>
+                        <use>standard</use>
+                        <args>
+                            <module>My_Test</module>
+                            <frontName>testpath</frontName>
+                        </args>
+                    </testrouter>
+                </routers>
+            </frontend>
+        ');
+
+        $result = Mage::getModel('intelligence/provider_router')->getAllRoutes();
+
+        expect($result['xml_routers'])->toHaveKey('frontend/testrouter');
+        $router = $result['xml_routers']['frontend/testrouter'];
+        expect($router['name'])->toBe('testrouter');
+        expect($router['area'])->toBe('frontend');
+        expect($router['type'])->toBe('standard');
+        expect($router['module'])->toBe('My_Test');
+        expect($router['front_name'])->toBe('testpath');
+    });
+
+    it('captures controller-override chains with before/after attributes', function () {
+        injectRouterConfig('
+            <admin>
+                <routers>
+                    <adminhtml>
+                        <args>
+                            <modules>
+                                <Custom_Override before="Mage_Adminhtml">Custom_Override</Custom_Override>
+                            </modules>
+                        </args>
+                    </adminhtml>
+                </routers>
+            </admin>
+        ');
+
+        $result = Mage::getModel('intelligence/provider_router')->getAllRoutes();
+        $router = $result['xml_routers']['admin/adminhtml'] ?? null;
+
+        expect($router)->not->toBeNull();
+        expect($router)->toHaveKey('module_overrides');
+        expect($router['module_overrides'])->toHaveKey('Custom_Override');
+        expect($router['module_overrides']['Custom_Override']['before'])->toBe('Mage_Adminhtml');
+        expect($router['module_overrides']['Custom_Override']['module'])->toBe('Custom_Override');
+    });
+
+    it('captures after attribute on override chain entries', function () {
+        injectRouterConfig('
+            <frontend>
+                <routers>
+                    <catalog>
+                        <args>
+                            <modules>
+                                <Custom_After after="Mage_Catalog">Custom_After</Custom_After>
+                            </modules>
+                        </args>
+                    </catalog>
+                </routers>
+            </frontend>
+        ');
+
+        $result = Mage::getModel('intelligence/provider_router')->getAllRoutes();
+        $entry = $result['xml_routers']['frontend/catalog']['module_overrides']['Custom_After'] ?? null;
+
+        expect($entry)->not->toBeNull();
+        expect($entry['after'])->toBe('Mage_Catalog');
+    });
+
+    it('omits module_overrides when none are defined', function () {
+        injectRouterConfig('
+            <frontend>
+                <routers>
+                    <minimalrouter>
+                        <use>standard</use>
+                        <args>
+                            <module>Min_Mod</module>
+                            <frontName>min</frontName>
+                        </args>
+                    </minimalrouter>
+                </routers>
+            </frontend>
+        ');
+
+        $result = Mage::getModel('intelligence/provider_router')->getAllRoutes();
+        expect($result['xml_routers']['frontend/minimalrouter'])->not->toHaveKey('module_overrides');
+    });
+
+    it('sorts xml_routers by composite area/name key', function () {
+        injectRouterConfig('
+            <frontend>
+                <routers>
+                    <zrouter><use>s</use><args><module>Z</module><frontName>z</frontName></args></zrouter>
+                    <arouter><use>s</use><args><module>A</module><frontName>a</frontName></args></arouter>
+                </routers>
+            </frontend>
+        ');
+
+        $result = Mage::getModel('intelligence/provider_router')->getAllRoutes();
+        $keys = array_keys($result['xml_routers']);
+
+        $aPos = array_search('frontend/arouter', $keys, true);
+        $zPos = array_search('frontend/zrouter', $keys, true);
+        expect($aPos)->toBeLessThan($zPos);
+    });
+});

--- a/tests/Backend/Unit/Maho/Intelligence/Provider/RouterTest.php
+++ b/tests/Backend/Unit/Maho/Intelligence/Provider/RouterTest.php
@@ -60,7 +60,7 @@ describe('Provider_Router attribute routes', function () {
         $result = Mage::getModel('intelligence/provider_router')->getAllRoutes();
         $names = array_keys($result['attribute_routes']);
         $sorted = $names;
-        sort($sorted);
+        sort($sorted, SORT_NATURAL | SORT_FLAG_CASE);
 
         expect($names)->toBe($sorted);
     });


### PR DESCRIPTION
## Summary

The `Maho_Intelligence` MCP providers for events, cron jobs, and routes only read XML config. Since current Maho defines observers, cron jobs, and routes via PHP attributes (compiled into `vendor/composer/maho_attributes.php`), the `list_events`, `list_cron_jobs`, and `list_routes` MCP tools returned empty results, so AI agents using the MCP server got an incorrect picture of the running application.

- Each provider now merges its XML data with the compiled attribute data and tags every entry with a `source` field (`"xml"` or `"attribute"`).
- XML reading is preserved unchanged so custom projects still declaring observers/cron/routers in `config.xml` keep working alongside attribute-based ones.
- The router result is split into `{xml_routers, attribute_routes}` because the two are different concepts: XML routers are frontName→module mappings (with optional override chains); attribute routes are per-URL Symfony route definitions.
- MCP tool descriptions in `Mcp/Server.php` updated to document the dual sources.
- 25 backend unit tests added covering both code paths.

Live numbers against current Maho (previously all empty):
- 196 events across 5 areas (`global`, `frontend`, `adminhtml`, `crontab`, `install`)
- 40 cron jobs
- 1058 attribute routes

## Test plan

- [x] `composer test -- --testsuite=Backend --filter='Intelligence'` — 25 passed, 97 assertions
- [x] `vendor/bin/phpstan analyze app/code/core/Maho/Intelligence/Model/Provider/` — no errors
- [x] `vendor/bin/php-cs-fixer fix` on changed files — no fixes needed