### PR TITLE
Gate paypal_vault_token lookup behind parent::isAvailable()

### DIFF
--- a/app/code/core/Maho/Paypal/Model/Method/Vault.php
+++ b/app/code/core/Maho/Paypal/Model/Method/Vault.php
@@ -21,6 +21,10 @@ class Maho_Paypal_Model_Method_Vault extends Maho_Paypal_Model_Method_Abstract
     #[\Override]
     public function isAvailable($quote = null): bool
     {
+        if (!parent::isAvailable($quote)) {
+            return false;
+        }
+
         $customerId = $quote?->getCustomerId()
             ?: Mage::getSingleton('customer/session')->getCustomerId();
 
@@ -30,13 +34,10 @@ class Maho_Paypal_Model_Method_Vault extends Maho_Paypal_Model_Method_Abstract
 
         /** @var Maho_Paypal_Model_Resource_Vault_Token_Collection $tokens */
         $tokens = Mage::getResourceModel('paypal/vault_token_collection');
-        $tokens->addCustomerFilter((int) $customerId)->addActiveFilter();
-
-        if ($tokens->getSize() === 0) {
-            return false;
-        }
-
-        return parent::isAvailable($quote);
+        return $tokens
+            ->addCustomerFilter((int) $customerId)
+            ->addActiveFilter()
+            ->getSize() > 0;
     }
 
     #[\Override]


### PR DESCRIPTION
Maho_Paypal_Model_Method_Vault::isAvailable() runs a SELECT COUNT(*) on paypal_vault_token before delegating to parent::isAvailable(). Because Mage_Payment_Helper_Data::getStoreMethods() calls isAvailable() on every declared payment method without pre-filtering by the active flag, the DB query fires on every payment-step render — even when the vault method is disabled in config (payment/paypal_vault/active = 0, the shipped default).

If paypal_vault_token is absent for any reason (e.g. a DB restored from a dump whose core_resource.paypal_setup was bumped to 6.0.0 without install-6.0.0.php ever running on that database), the resulting SQLSTATE[42S02] exception escapes isAvailable(), propagates through getStoreMethods(), and produces an HTTP 500 on /checkout/onepage/ for every logged-in customer — regardless of which payment method they would actually pick. Guests in the same store can check out normally, so the bug looks intermittent.

Inverting the check order so parent::isAvailable($quote) runs first fixes both issues. The parent chain
(Maho_Paypal_Model_Method_Abstract::isAvailable →
Mage_Payment_Model_Method_Abstract::isAvailable) covers credentials, the active flag, and payment restrictions, none of which touch paypal_vault_token. Only if the method survives those checks do we look up vault tokens for the current customer. The token-count check is also collapsed into a single return ... > 0, since at that point we have already confirmed the method is active.

With this change:

- Vault disabled (the shipped default): no paypal_vault_token query.
- Vault enabled, no PayPal credentials: no query.
- Vault enabled, credentials configured, guest checkout: no query.
- Vault enabled, credentials configured, logged-in customer: query runs exactly as before, with the same outcome.

No public API change. Method signature, return type, and #[\Override] attribute are preserved.