### PR TITLE
Remove duplicate /cms route from Mage_Cms_IndexController

### DIFF
--- a/app/code/core/Mage/Cms/controllers/IndexController.php
+++ b/app/code/core/Mage/Cms/controllers/IndexController.php
@@ -49,6 +49,8 @@ class Mage_Cms_IndexController extends Mage_Core_Controller_Front_Action
      * @param string $coreRoute
      */
     #[\Override]
+    #[Maho\Config\Route('/cms', name: 'cms.legacy_root')]
+    #[Maho\Config\Route('/cms/index', name: 'cms.legacy_index')]
     public function norouteAction($coreRoute = null): void
     {
         $this->getResponse()->setHeader('HTTP/1.1', '404 Not Found');

--- a/app/code/core/Mage/Cms/controllers/IndexController.php
+++ b/app/code/core/Mage/Cms/controllers/IndexController.php
@@ -49,8 +49,8 @@ class Mage_Cms_IndexController extends Mage_Core_Controller_Front_Action
      * @param string $coreRoute
      */
     #[\Override]
-    #[Maho\Config\Route('/cms', name: 'cms.legacy_root')]
-    #[Maho\Config\Route('/cms/index', name: 'cms.legacy_index')]
+    #[Maho\Config\Route('/cms', name: 'cms.index')]
+    #[Maho\Config\Route('/cms/index', name: 'cms.index_index')]
     public function norouteAction($coreRoute = null): void
     {
         $this->getResponse()->setHeader('HTTP/1.1', '404 Not Found');

--- a/app/code/core/Mage/Cms/controllers/IndexController.php
+++ b/app/code/core/Mage/Cms/controllers/IndexController.php
@@ -18,7 +18,6 @@ class Mage_Cms_IndexController extends Mage_Core_Controller_Front_Action
      * @param string $coreRoute
      */
     #[Maho\Config\Route('/', name: 'cms.home', methods: ['GET'])]
-    #[Maho\Config\Route('/cms', name: 'cms.index', methods: ['GET'])]
     public function indexAction($coreRoute = null)
     {
         $pageId = Mage::getStoreConfig(Mage_Cms_Helper_Page::XML_PATH_HOME_PAGE);

--- a/tests/Backend/Unit/Maho/Routing/RouteResolutionTest.php
+++ b/tests/Backend/Unit/Maho/Routing/RouteResolutionTest.php
@@ -33,7 +33,6 @@ function matchPath(string $path): array
 
 dataset('frontend_routes', [
     'home'                  => ['/',                              Mage_Cms_IndexController::class,              'indexAction'],
-    'cms (cms frontname)'   => ['/cms',                           Mage_Cms_IndexController::class,              'indexAction'],
     'cms page view'         => ['/cms/page/view/2',               Mage_Cms_PageController::class,               'viewAction'],
     'catalog product view'  => ['/catalog/product/view/1',        Mage_Catalog_ProductController::class,        'viewAction'],
     'catalog category view' => ['/catalog/category/view/2',       Mage_Catalog_CategoryController::class,       'viewAction'],

--- a/tests/Backend/Unit/Maho/Routing/RouteResolutionTest.php
+++ b/tests/Backend/Unit/Maho/Routing/RouteResolutionTest.php
@@ -33,6 +33,8 @@ function matchPath(string $path): array
 
 dataset('frontend_routes', [
     'home'                  => ['/',                              Mage_Cms_IndexController::class,              'indexAction'],
+    'cms legacy /cms'       => ['/cms',                           Mage_Cms_IndexController::class,              'norouteAction'],
+    'cms legacy /cms/index' => ['/cms/index',                     Mage_Cms_IndexController::class,              'norouteAction'],
     'cms page view'         => ['/cms/page/view/2',               Mage_Cms_PageController::class,               'viewAction'],
     'catalog product view'  => ['/catalog/product/view/1',        Mage_Catalog_ProductController::class,        'viewAction'],
     'catalog category view' => ['/catalog/category/view/2',       Mage_Catalog_CategoryController::class,       'viewAction'],


### PR DESCRIPTION
## Summary

Route `/cms` and `/cms/index` to `Mage_Cms_IndexController::norouteAction` so they return a proper 404 instead of duplicating the home page content.

## The problem

`Mage_Cms_IndexController::indexAction` previously declared two routes:

```php
#[Maho\Config\Route('/', name: 'cms.home', methods: ['GET'])]
#[Maho\Config\Route('/cms', name: 'cms.index', methods: ['GET'])]
public function indexAction(...) { ... }
```

The `/cms` route was M1 frontName back-compat. It caused the home page to render at two URLs (`/` and `/cms`), an SEO duplicate-content negative, plus it made the `cms/index/index` reverse-lookup order-dependent.

## Why simply removing the attribute wasn't enough

My first attempt removed the `#[Route('/cms')]` attribute and called it done. It didn't work: `/cms` still rendered the home page in the browser.

The cause is the legacy convention-based dispatch fallback. When the Symfony matcher throws `ResourceNotFoundException`, `Mage_Core/Controller/Varien/Router/Default.php:80` catches it and falls through to `ControllerDispatcher::dispatchLegacyPath()`, which parses the path as `frontName/controller/action` (defaulting both controller and action to `index`), resolves `Mage_Cms_IndexController` via the compiled `controllerLookup`, and dispatches `indexAction`. So removing the route attribute is a no-op for this URL as long as the controller exists.

This dispatch path exists by design (it catches URL rewrites stored in legacy format like `catalog/category/view/id/14` and dispatches third-party M1 modules without `#[Route]` attributes), so it can't simply be disabled.

## The fix

Add `#[Route]` attributes on `norouteAction` for the two legacy URLs:

```php
#[\Override]
#[Maho\Config\Route('/cms', name: 'cms.legacy_root')]
#[Maho\Config\Route('/cms/index', name: 'cms.legacy_index')]
public function norouteAction($coreRoute = null): void
{
    $this->getResponse()->setHeader('HTTP/1.1', '404 Not Found');
    ...
}
```

This claims the URLs via the Symfony matcher before the legacy fallback runs, dispatching them to the configured "Page Not Found" CMS page with a 404 status.

`/cms/index/index` doesn't need an explicit route: the admin route pattern `/{_adminFrontName}/index/index` (from `Mage_Adminhtml_IndexController`) shadows it via Symfony's regex matcher. The dispatcher rejects the match because `cms != configured admin frontName`, and the front controller's no-route handler dispatches to `norouteAction` anyway. End behavior is consistent across all three URLs.

## What we considered and rejected

- **Renaming the home page controller** (e.g. to `Maho_Home_IndexController`) would break the `cms_index_index` layout handle that third-party themes commonly use to customize the home page.
- **Removing `#[Route('/')]` entirely** and routing through `Mage_Cms_Controller_Router` for `/` would break the same layout handle plus `Mage::getUrl('cms/index/index')`.
- **301 redirect `/cms` → `/`** is fine functionally but adds a controller action just to issue a redirect.

The 404 approach is the most honest: `/cms` is not a valid URL, so the server says so.

## Notes

- One harmless reverseLookup collision warning is emitted during `composer dump-autoload` (`cms/index/noroute` registered twice). Nothing in core calls `Mage::getUrl('cms/index/noroute')` (the no-route flow uses internal `_forward`, not URL generation), so this is informational only.
- The `cms/index/index` dispatch identity remains intact via the `cms.home` route, so `Mage::getUrl('cms/index/index')` still resolves deterministically to `/` (an improvement over the previous order-dependent state).

Closes #935.

## Test plan

- [x] `composer dump-autoload` regenerates compiled route maps with the new entries
- [x] `composer test -- --testsuite=Backend --filter='Compiled matcher'` passes (32 tests, 101 assertions)
- [x] Verify `/` still renders the home page
- [x] Verify `/cms` returns 404 and renders the configured Page Not Found CMS page
- [x] Verify `/cms/index` returns 404
- [x] Verify `/cms/index/index` returns 404
- [ ] Verify `Mage::getUrl('cms/index/index')` returns `/`