### PR TITLE
Read `sales_flat_shipment.packages` as JSON

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
@@ -183,12 +183,14 @@ class Mage_Adminhtml_Block_Sales_Order_Shipment_Packaging extends Mage_Adminhtml
     public function getPackages()
     {
         $packages = $this->getShipment()->getPackages();
-        if ($packages) {
-            $packages = unserialize($packages, ['allowed_classes' => false]);
-        } else {
-            $packages = [];
+        if (!$packages) {
+            return [];
         }
-        return $packages;
+        if (is_array($packages)) {
+            return $packages;
+        }
+        $decoded = Mage::helper('core')->jsonDecode($packages);
+        return is_array($decoded) ? $decoded : [];
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
@@ -182,15 +182,7 @@ class Mage_Adminhtml_Block_Sales_Order_Shipment_Packaging extends Mage_Adminhtml
      */
     public function getPackages()
     {
-        $packages = $this->getShipment()->getPackages();
-        if (!$packages) {
-            return [];
-        }
-        if (is_array($packages)) {
-            return $packages;
-        }
-        $decoded = Mage::helper('core')->jsonDecode($packages);
-        return is_array($decoded) ? $decoded : [];
+        return $this->getShipment()->getPackages() ?: [];
     }
 
     /**

--- a/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Order/Shipment.php
@@ -13,6 +13,15 @@
 class Mage_Sales_Model_Resource_Order_Shipment extends Mage_Sales_Model_Resource_Order_Abstract
 {
     /**
+     * Serializeable field: packages
+     *
+     * @var array
+     */
+    protected $_serializableFields = [
+        'packages' => [null, []],
+    ];
+
+    /**
      * @var string
      */
     protected $_eventPrefix                  = 'sales_order_shipment_resource';


### PR DESCRIPTION
Mage_Sales_Model_Order_Shipment::_beforeSave() has stored the packages column as JSON since the serialize/unserialize sweep in #552, but the admin block still read it back with unserialize(). unserialize() on a JSON string returns false (with a notice), so every shipment with packed packages displayed an empty packages popup in the admin and produced an empty packing-slip PDF (the PDF block delegates to the admin block's getPackages()).

Switch the read path to json_decode() so the column is read in the format it was written. The maho-26.2.1 setup script already converts any pre-migration PHP-serialized packages rows to JSON, so dropping the unserialize() branch is safe for both fresh and upgraded installs.

Defensive guards retained: empty values still yield [], non-array inputs that already happen to be arrays pass through unchanged, and invalid JSON yields [] rather than null/false reaching the caller.