### PR TITLE
Added `OneStepCheckout::ajaxFailure()` for compatibility with base Checkout

### DIFF
--- a/public/js/varien/onestepcheckout.js
+++ b/public/js/varien/onestepcheckout.js
@@ -878,10 +878,7 @@ class OneStepCheckout {
     }
 
     /**
-     * Mirror Checkout.ajaxFailure() so error handlers in Billing/Shipping/Payment/Review
-     * (defined in opcheckout.js) that fall back to the global `checkout` reference can
-     * surface the failure and redirect to the cart, instead of throwing
-     * "checkout.ajaxFailure is not a function".
+     * Mirrors Checkout.ajaxFailure() for the shared `window.checkout` global.
      */
     ajaxFailure(error) {
         alert(error);

--- a/public/js/varien/onestepcheckout.js
+++ b/public/js/varien/onestepcheckout.js
@@ -878,6 +878,17 @@ class OneStepCheckout {
     }
 
     /**
+     * Mirror Checkout.ajaxFailure() so error handlers in Billing/Shipping/Payment/Review
+     * (defined in opcheckout.js) that fall back to the global `checkout` reference can
+     * surface the failure and redirect to the cart, instead of throwing
+     * "checkout.ajaxFailure is not a function".
+     */
+    ajaxFailure(error) {
+        alert(error);
+        location.href = encodeURI(this.urls.failure);
+    }
+
+    /**
      * Get URLs object (for compatibility)
      */
     get progressUrl() { return this.urls.progress; }


### PR DESCRIPTION
… API

OneStepCheckout overrides window.checkout (onestepcheckout.js sets `window.checkout = this` in the constructor) but does not implement the ajaxFailure(error) method defined on the base Checkout class (opcheckout.js).

The Billing, Shipping, ShippingMethod, Payment and Review classes in opcheckout.js all catch fetch errors and call `checkout.ajaxFailure(error)` to alert the user and redirect to the cart. In the classic onepage flow that bare-name `checkout` resolves to the `const checkout = new Checkout(...)` declared inline in onepage.phtml, where the method exists. In the onestep flow there is no such const (onestep.phtml only instantiates OneStepCheckout), so the lookup falls through to window.checkout and the call crashes with "checkout.ajaxFailure is not a function".

This swallows the original server-side failure (4xx/5xx, invalid JSON, network error) silently. The user sees nothing happen when clicking "Place Order" and the console only shows the TypeError, not the real cause.

Add an ajaxFailure(error) method to OneStepCheckout that mirrors the base Checkout behaviour (alert + redirect to the failure URL). Slots in next to the other compatibility methods (reloadProgressBlock, reloadStep, reloadReviewBlock) that already exist for this exact reason.