### PR TITLE
Converted indexer `_tmp` tables from `MEMORY` to `InnoDB` engine

### DIFF
--- a/.github/workflows/install-with-prefix.yml
+++ b/.github/workflows/install-with-prefix.yml
@@ -24,6 +24,9 @@ jobs:
     services:
       mysql:
         image: mysql:latest
+        # Enable binlog + GTID so enforce_gtid_consistency actually fires in CI
+        # (mixed-engine transactions get caught, not silently warned).
+        command: --log-bin --gtid-mode=ON --enforce-gtid-consistency=ON
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: maho

--- a/.github/workflows/install-with-prefix.yml
+++ b/.github/workflows/install-with-prefix.yml
@@ -24,8 +24,6 @@ jobs:
     services:
       mysql:
         image: mysql:latest
-        # Enable binlog + GTID so enforce_gtid_consistency actually fires in CI
-        # (mixed-engine transactions get caught, not silently warned).
         command: --log-bin --gtid-mode=ON --enforce-gtid-consistency=ON
         env:
           MYSQL_ROOT_PASSWORD: root

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -23,40 +23,49 @@ jobs:
             db_user: root
             db_pass: root
             health_cmd: mysqladmin ping
+            db_command: --log-bin --gtid-mode=ON --enforce-gtid-consistency=ON
           - name: mysql-latest
             db_engine: mysql
             db_image: mysql:latest
             db_user: root
             db_pass: root
             health_cmd: mysqladmin ping
+            db_command: --log-bin --gtid-mode=ON --enforce-gtid-consistency=ON
           - name: mariadb-10.11
             db_engine: mysql
             db_image: mariadb:10.11
             db_user: root
             db_pass: root
             health_cmd: healthcheck.sh --connect --innodb_initialized
+            db_command: --skip-name-resolve
           - name: mariadb-latest
             db_engine: mysql
             db_image: mariadb:latest
             db_user: root
             db_pass: root
             health_cmd: healthcheck.sh --connect --innodb_initialized
+            db_command: --skip-name-resolve
           - name: pgsql-14
             db_engine: pgsql
             db_image: postgres:14
             db_user: postgres
             db_pass: postgres
             health_cmd: pg_isready
+            db_command: postgres
           - name: pgsql-latest
             db_engine: pgsql
             db_image: postgres:latest
             db_user: postgres
             db_pass: postgres
             health_cmd: pg_isready
+            db_command: postgres
 
     services:
       db:
         image: ${{ matrix.db_image }}
+        # MySQL: enable binlog + GTID so enforce_gtid_consistency actually fires
+        # in CI (mixed-engine transactions get caught, not silently warned).
+        command: ${{ matrix.db_command }}
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: maho

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -63,8 +63,6 @@ jobs:
     services:
       db:
         image: ${{ matrix.db_image }}
-        # MySQL: enable binlog + GTID so enforce_gtid_consistency actually fires
-        # in CI (mixed-engine transactions get caught, not silently warned).
         command: ${{ matrix.db_command }}
         env:
           MYSQL_ROOT_PASSWORD: root

--- a/app/code/core/Mage/Catalog/etc/config.xml
+++ b/app/code/core/Mage/Catalog/etc/config.xml
@@ -13,7 +13,7 @@
 <config>
     <modules>
         <Mage_Catalog>
-            <version>1.6.0.0.19.1.7</version>
+            <version>1.6.0.0.19.1.8</version>
         </Mage_Catalog>
     </modules>
     <admin>

--- a/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.7-1.6.0.0.19.1.8.php
+++ b/app/code/core/Mage/Catalog/sql/catalog_setup/upgrade-1.6.0.0.19.1.7-1.6.0.0.19.1.8.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @package    Mage_Catalog
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+/** @var Mage_Catalog_Model_Resource_Setup $this */
+$installer = $this;
+$installer->startSetup();
+
+// Revert the 2012-era MEMORY-engine optimization on indexer `_tmp` tables.
+// On MySQL 8.4+ `enforce_gtid_consistency=ON` is the default, which forbids
+// mixing writes to non-transactional (MEMORY) and transactional (InnoDB)
+// tables in the same transaction. The price indexer runs inside the order
+// transaction during checkout, so the MEMORY tables break checkout out of
+// the box on stock MySQL 8.4+. See issue #942.
+$connection = $installer->getConnection();
+if ($connection instanceof Maho\Db\Adapter\Pdo\Mysql) {
+    $tables = [
+        'catalog/category_anchor_indexer_tmp',
+        'catalog/category_anchor_products_indexer_tmp',
+        'catalog/category_product_enabled_indexer_tmp',
+        'catalog/category_product_indexer_tmp',
+        'catalog/product_eav_decimal_indexer_tmp',
+        'catalog/product_eav_indexer_tmp',
+        'catalog/product_price_indexer_cfg_option_aggregate_tmp',
+        'catalog/product_price_indexer_cfg_option_tmp',
+        'catalog/product_price_indexer_final_tmp',
+        'catalog/product_price_indexer_option_aggregate_tmp',
+        'catalog/product_price_indexer_option_tmp',
+        'catalog/product_price_indexer_tmp',
+    ];
+
+    foreach ($tables as $table) {
+        $connection->changeTableEngine($installer->getTable($table), 'InnoDB');
+    }
+}
+
+$installer->endSetup();

--- a/app/code/core/Mage/CatalogInventory/etc/config.xml
+++ b/app/code/core/Mage/CatalogInventory/etc/config.xml
@@ -12,7 +12,7 @@
 <config>
     <modules>
         <Mage_CatalogInventory>
-            <version>1.6.0.0.3</version>
+            <version>1.6.0.0.4</version>
         </Mage_CatalogInventory>
     </modules>
     <global>

--- a/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/upgrade-1.6.0.0.3-1.6.0.0.4.php
+++ b/app/code/core/Mage/CatalogInventory/sql/cataloginventory_setup/upgrade-1.6.0.0.3-1.6.0.0.4.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @package    Mage_CatalogInventory
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+/** @var Mage_Core_Model_Resource_Setup $this */
+$installer = $this;
+$installer->startSetup();
+
+// Revert the 2012-era MEMORY-engine optimization on the stock indexer `_tmp`
+// table. On MySQL 8.4+ `enforce_gtid_consistency=ON` is the default, which
+// forbids mixing writes to non-transactional (MEMORY) and transactional
+// (InnoDB) tables in the same transaction. The stock indexer runs inside the
+// order transaction during checkout, so the MEMORY table breaks checkout out
+// of the box on stock MySQL 8.4+. See issue #942.
+$connection = $installer->getConnection();
+if ($connection instanceof Maho\Db\Adapter\Pdo\Mysql) {
+    $connection->changeTableEngine(
+        $installer->getTable('cataloginventory/stock_status_indexer_tmp'),
+        'InnoDB',
+    );
+}
+
+$installer->endSetup();


### PR DESCRIPTION
## Summary

Fixes #942.

MySQL 8.4 GA flipped `enforce_gtid_consistency` to `ON` by default. That setting forbids mixing writes to non-transactional (MEMORY) and transactional (InnoDB) tables in the same transaction. The price and stock indexers populate MEMORY `_tmp` tables while writing to InnoDB index/sales tables, so checkout fails with SQLSTATE 1785 out of the box on any MySQL 8.4+ install with binary logging enabled (the default for any replication-ready production config):

```
SQLSTATE[HY000]: General error: 1785 Statement violates GTID consistency:
Updates to non-transactional tables can only be done in either autocommitted statements
or single-statement transactions, and never in the same statement as updates to
transactional tables.
```

The MEMORY-engine optimization dates to Magento 1.7.0.0-alpha1 (2012), when InnoDB buffer pools were tiny and SSDs weren't the norm. On contemporary hardware the perf delta is negligible compared to the structural cost. This PR converts the 13 affected `_tmp` tables back to InnoDB via two new upgrade scripts.

The fix is at the schema level rather than the checkout-observer level, which means it also closes the same bug for every other caller that wraps the indexer in a transaction: admin product save, mass actions, catalog import, CatalogRule application, API product updates.

## Why this slipped past CI until now

The official `mysql:latest` Docker image starts **without** binary logging by default. Per the MySQL docs, `enforce_gtid_consistency` only fires SQL errors when binlog produces an event, so without `--log-bin` it's a no-op. CI was hitting the mixed-engine writes on every run but only logging `[Warning] [MY-015142] Combining the storage engines MEMORY and InnoDB is deprecated...` to the server stderr (visible in current CI logs but never failing a job).

The PR also reconfigures CI to enable `--log-bin --gtid-mode=ON --enforce-gtid-consistency=ON` on MySQL test containers, matching what real production deployments run. This makes CI a regression gate for this class of bug going forward, and would have caught #942 the first time it was introduced. The change is strictly safer: every constraint enforced in production is now enforced in CI, with no test coverage removed.

## Changes

**Schema (the actual fix):**
- `Mage_Catalog` version bumped `1.6.0.0.19.1.7` -> `1.6.0.0.19.1.8`, new upgrade script converts 12 catalog indexer `_tmp` tables to InnoDB
- `Mage_CatalogInventory` version bumped `1.6.0.0.3` -> `1.6.0.0.4`, new upgrade script converts 1 stock indexer `_tmp` table to InnoDB
- Both upgrade scripts are gated on `instanceof Maho\Db\Adapter\Pdo\Mysql` (Postgres and SQLite no-op)

**CI hardening:**
- `.github/workflows/pest.yml` — MySQL service container now starts with `--log-bin --gtid-mode=ON --enforce-gtid-consistency=ON`. MariaDB and Postgres entries get benign no-op commands to satisfy the now-required `command` field.
- `.github/workflows/install-with-prefix.yml` — same MySQL flag set applied.

## Affected engines

| Engine | Affected | Reason |
|---|---|---|
| MySQL 8.4+ with binlog enabled | Yes | `enforce_gtid_consistency=ON` by default + binlog produces events |
| MySQL <= 8.0 (default config) | No | `enforce_gtid_consistency=OFF` by default |
| MariaDB | No | Different GTID semantics, no equivalent restriction |
| PostgreSQL | No | No MEMORY engine, existing `instanceof Mysql` guard already skipped |
| SQLite | No | No storage engines, no GTID concept |

## Test plan

- [ ] Full Pest matrix (mysql-8.4, mysql-latest, mariadb-10.11, mariadb-latest, pgsql-14, pgsql-latest, sqlite) passes under the new stricter MySQL config
- [ ] `install-with-prefix.yml` job passes against MySQL with binlog + GTID enforced
- [ ] After merge, confirm the `[Warning] [MY-015142] Combining the storage engines MEMORY and InnoDB is deprecated...` lines stop appearing in CI server logs (proves the underlying engine mix is gone, not just suppressed)
- [ ] Manual one-page checkout completes with a configurable product in the cart against `mysql:8.4 --log-bin --gtid-mode=ON --enforce-gtid-consistency=ON` (the original #942 reproduction)