### PR TITLE
Fix WYSIWYG editor crash for restricted admin roles

### DIFF
--- a/public/js/varien/js.js
+++ b/public/js/varien/js.js
@@ -176,6 +176,9 @@ function generateRandomString(length) {
  * @param {Object} params - key value pairs to add, update, or remove
  */
 function setRouteParams(url, params = {}) {
+    if (!url) {
+        return url;
+    }
     url = new URL(url);
 
     const noTrailingSlash = !url.pathname.endsWith('/');
@@ -205,6 +208,9 @@ function setRouteParams(url, params = {}) {
  * @param {Object} params - key value pairs to add, update, or remove
  */
 function setQueryParams(url, params = {}) {
+    if (!url) {
+        return url;
+    }
     url = new URL(url);
     for (const [ key, val ] of Object.entries(params)) {
         if (val === null || val === false) {


### PR DESCRIPTION
## The bug

Reported as an uncaught error that breaks the WYSIWYG (TipTap) editor for some admins, while it works fine for others:

```
Uncaught TypeError: URL constructor: undefined is not a valid URL.
    setRouteParams  /js/varien/js.js:179
    setup           /js/mage/adminhtml/wysiwyg/tiptap/setup.js:270
```

## Root cause

It's an ACL-dependent, client-side assumption mismatch, not specific to any page.

`setup.js` builds the editor and unconditionally passes three **optional** URLs into `setRouteParams()`:

- `files_browser_window_url`
- `widget_window_url`
- `variable_window_url`

But the server only adds each of those URLs to the WYSIWYG config when the logged-in admin has the corresponding permission:

| Config URL | Required ACL |
|---|---|
| `files_browser_window_url` | `cms/media_gallery` |
| `widget_window_url` | `cms/widget_instance` |
| `variable_window_url` | `system/variable` |

See `Mage_Cms_Model_Wysiwyg_Config::getConfig()` and `Mage_Core_Model_Variable_Observer::prepareWysiwygPluginConfig()` (the latter only injects `variable_window_url` when `add_variables` is true).

For a **restricted admin role** missing one of those permissions, the URL is absent from the config and is therefore `undefined`. `setRouteParams()` then runs `new URL(undefined)`, which throws *"undefined is not a valid URL"* and aborts the entire editor initialization.

This is why full admins never see it (they always receive all three URLs) and restricted roles always do. The reporter's role lacked **System → Variables** (`system/variable`), so it failed at the `variable_window_url` call on line 270.

The URLs themselves are only ever consumed when the user clicks the matching toolbar button (Insert Variable / Widget / Image), and those buttons are already gated by the same `add_variables` / `add_widgets` / `add_images` flags. So a missing optional URL never needs to be valid, it just must not crash setup.

## The fix

Guard both `setRouteParams()` and `setQueryParams()` in `public/js/varien/js.js` to return a falsy input unchanged instead of passing it to the `URL` constructor.

## How to reproduce / test

1. Create an admin role **without** the "System → Variables" permission.
2. Assign a user to that role.
3. Open any WYSIWYG editor (blog post, CMS page/block, product description).

Before this change the editor fails to initialize with the error above; after it, it loads normally (the Insert Variable button simply stays disabled, as intended).