### PR TITLE
Fix UTF-8 mangling in MaliciousCode::linkFilter() via XML PI hint

### DIFF
--- a/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
+++ b/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
@@ -100,6 +100,10 @@ class Mage_Core_Model_Input_Filter_MaliciousCode
         // is present, which mangles UTF-8 multi-byte sequences during the
         // saveHTML() round-trip (e.g. "ö" becomes "&Atilde;&para;"). Prepend a
         // <?xml encoding> processing instruction so libxml parses as UTF-8.
+        // TODO: when the minimum PHP version reaches 8.4, replace this whole
+        // DOMDocument + XML-PI workaround with \DOM\HTMLDocument::createFromString(),
+        // which parses UTF-8 natively (and drop the <?xml ...> strip from the
+        // wrapper regex below).
         if (!$dom->loadHTML('<?xml encoding="UTF-8">' . $html)) {
             Mage::throwException(Mage::helper('core')->__('HTML filtration has failed.'));
         }

--- a/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
+++ b/app/code/core/Mage/Core/Model/Input/Filter/MaliciousCode.php
@@ -96,7 +96,11 @@ class Mage_Core_Model_Input_Filter_MaliciousCode
 
         $libXmlErrorsState = libxml_use_internal_errors(true);
         $dom = $this->_initDOMDocument();
-        if (!$dom->loadHTML($html)) {
+        // DOMDocument::loadHTML() defaults to ISO-8859-1 when no encoding hint
+        // is present, which mangles UTF-8 multi-byte sequences during the
+        // saveHTML() round-trip (e.g. "ö" becomes "&Atilde;&para;"). Prepend a
+        // <?xml encoding> processing instruction so libxml parses as UTF-8.
+        if (!$dom->loadHTML('<?xml encoding="UTF-8">' . $html)) {
             Mage::throwException(Mage::helper('core')->__('HTML filtration has failed.'));
         }
 
@@ -118,7 +122,10 @@ class Mage_Core_Model_Input_Filter_MaliciousCode
         }
 
         if ($removeWrapper) {
-            $html = preg_replace('/<(?:!DOCTYPE|\/?(?:html|body))[^>]*>\s*/i', '', $html);
+            // Strip the wrapper tags libxml adds, plus the XML PI we injected
+            // above (libxml may emit it with or without a trailing question
+            // mark depending on version; [^>]* matches both forms).
+            $html = preg_replace('/<(?:!DOCTYPE|\?xml\b|\/?(?:html|body))[^>]*>\s*/i', '', $html);
         }
 
         libxml_use_internal_errors($libXmlErrorsState);

--- a/tests/Backend/Unit/Core/Model/Input/Filter/MaliciousCodeTest.php
+++ b/tests/Backend/Unit/Core/Model/Input/Filter/MaliciousCodeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('Mage_Core_Model_Input_Filter_MaliciousCode::linkFilter', function () {
+    beforeEach(function () {
+        $this->filter = new Mage_Core_Model_Input_Filter_MaliciousCode();
+    });
+
+    it('preserves UTF-8 multi-byte characters when content contains a link', function () {
+        // Regression: loadHTML() without an encoding hint defaulted to ISO-8859-1
+        // and mangled UTF-8 (e.g. "ö" -> "&Atilde;&para;"), corrupting stored
+        // content via _beforeSave(). The bug only triggered when an <a> tag was
+        // present, since the no-link early return skips the DOMDocument round-trip.
+        $result = $this->filter->linkFilter('<div>Grüße ö</div><a href="x">l</a>');
+
+        expect($result)->toContain('&uuml;')
+            ->and($result)->toContain('&szlig;')
+            ->and($result)->toContain('&ouml;')
+            ->and($result)->not->toContain('&Atilde;');
+    });
+
+    it('does not leave the injected XML processing instruction in the output', function () {
+        $result = $this->filter->linkFilter('<div>ö</div><a href="x">l</a>');
+
+        expect($result)->not->toContain('<?xml');
+    });
+
+    it('adds safe rel and target attributes to links', function () {
+        $result = $this->filter->linkFilter('<a href="https://example.com">link</a>');
+
+        expect($result)->toContain('rel="noopener noreferrer"')
+            ->and($result)->toContain('target="_blank"');
+    });
+
+    it('returns input untouched when no link is present (fast path)', function () {
+        $input = '<div>Grüße ö</div>';
+
+        expect($this->filter->linkFilter($input))->toBe($input);
+    });
+});


### PR DESCRIPTION
Maybe there is a better way to fix this.

`Mage_Core_Model_Input_Filter_MaliciousCode::linkFilter()` parses the HTML through `DOMDocument::loadHTML()` without an explicit charset. libxml defaults to ISO-8859-1, so every UTF-8 multi-byte sequence in the input is treated as a run of single Latin-1 characters and then re-emitted by `saveHTML()` as their named-entity equivalents:

    "ö" (0xC3 0xB6) -> "&Atilde;&para;"
    "ü" (0xC3 0xBC) -> "&Atilde;&frac14;"
    "ß" (0xC3 0x9F) -> "&Atilde;&#159;"

This affects every caller that runs user-supplied HTML through the filter and the content contains both an `<a>` tag (which triggers the DOMDocument path past the early return) and any non-ASCII text. In practice the most visible victim is `Maho_Blog_Model_Resource_Post::_beforeSave()`, where saving a blog post that contains umlauts and at least one link produces permanently corrupted content in `blog_post_entity.content`. Content without an `<a>` tag is unaffected because of the `stristr($html, '<a ') === false` early return, which is why the bug is easy to miss in casual testing.

Fix: prepend `<?xml encoding="UTF-8">` before the input passed to `loadHTML()` so libxml parses the document as UTF-8 (a well-known PHP libxml workaround). The PI then surfaces in `saveHTML()`'s output, so extend the existing wrapper-strip regex to also drop `<?xml ...>` (matching both `?>`-terminated and `>`-terminated forms libxml emits across versions). The early-return path for inputs without `<a>` is unchanged, so the fast path stays byte-identical to before.

Verified with a standalone reproducer:

    $f = new Mage_Core_Model_Input_Filter_MaliciousCode();
    echo $f->linkFilter('<div>Grüße ö</div><a href="x">l</a>');
    // before: <div>Gr&Atilde;&frac14;&Atilde;&#159;e &Atilde;&para;</div><a href="x" rel="noopener noreferrer" target="_blank">l</a>
    // after:  <div>Gr&uuml;&szlig;e &ouml;</div><a href="x" rel="noopener noreferrer" target="_blank">l</a>

<img width="2157" height="1440" alt="Bildschirmfoto vom 2026-05-29 00-04-45" src="https://github.com/user-attachments/assets/e77376ab-500b-4409-94f9-33a0a8c685a1" />
<img width="2157" height="1440" alt="Bildschirmfoto vom 2026-05-29 00-04-22" src="https://github.com/user-attachments/assets/8d635b71-9c4e-40a2-b699-23c2ed4b0dbc" />
<img width="1862" height="1313" alt="Bildschirmfoto vom 2026-05-29 00-04-12" src="https://github.com/user-attachments/assets/9bf9dd33-a374-4cab-9b33-efb94e1b48bc" />
