### PR TITLE
Fix onepage checkout 405 error on progress reload

### DIFF
--- a/app/code/core/Mage/Checkout/controllers/OnepageController.php
+++ b/app/code/core/Mage/Checkout/controllers/OnepageController.php
@@ -220,7 +220,7 @@ class Mage_Checkout_OnepageController extends Mage_Checkout_Controller_Action
      *
      * @return string|null
      */
-    #[Maho\Config\Route('/checkout/onepage/progress', name: 'checkout.onepage.progress', methods: ['POST'])]
+    #[Maho\Config\Route('/checkout/onepage/progress', name: 'checkout.onepage.progress', methods: ['GET'])]
     public function progressAction()
     {
         // previous step should never be null. We always start with billing and go forward


### PR DESCRIPTION
## Summary

Fixes #955: the onepage checkout (with One-Step Checkout disabled) failed with `Error: Server returned status 405` after clicking **Continue** on the billing step.

## Root cause

After saving billing, the JS reloads the progress block via `reloadStep()` in `public/js/varien/opcheckout.js`, which issues a plain `fetch(this.progressUrl)` (a **GET** request). The `progressAction` route, however, was declared `methods: ['POST']`, so the server rejected the GET with **405 Method Not Allowed**.

## Fix

Changed the `/checkout/onepage/progress` route to `methods: ['GET']`, matching the request the JS actually makes. `progressAction` is a read-only operation that only reads the `prevStep` param and renders a progress HTML fragment, so GET is the correct method.

## Steps to reproduce (before fix)

1. Set **Enable One-Step Checkout** to **No**.
2. Add a product to the cart and visit checkout as guest.
3. Fill in billing information and click **Continue**.
4. An alert `Error: Server returned status 405` appears.