### PR TITLE
Added return type to `Mage::app()`

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -580,9 +580,8 @@ final class Mage
      * @param string $code
      * @param string $type
      * @param string|array $options
-     * @return Mage_Core_Model_App
      */
-    public static function app($code = '', $type = 'store', $options = [])
+    public static function app($code = '', $type = 'store', $options = []): Mage_Core_Model_App
     {
         if (self::$_app === null) {
             self::$_app = new Mage_Core_Model_App();


### PR DESCRIPTION
## Description

This PR adds the return type `Mage_Core_Model_App` to `Mage::app()`.

For months now, I have been applying this adjustment as a Composer patch across all the Maho instances I maintain (including in production environments). At least in older versions of PHPStorm, the absence of this patch triggered a false-positive "possible null" warning. Rather than remaining confined to my local Composer patches, this change should ideally be integrated directly into the core. :)