### PR TITLE
Added `Mage_CatalogRule` enabled check before using `catalogrule/rule` model

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Price.php
@@ -382,8 +382,10 @@ class Mage_Catalog_Model_Product_Type_Price
 
         if ($rulePrice === false) {
             $storeDateTime = Mage::app()->getLocale()->utcToStore($sId, 'now');
-            $rulePrice = Mage::getResourceModel('catalogrule/rule')
-                ->getRulePrice($storeDateTime, $wId, $gId, $productId);
+            if (Mage::helper('core')->isModuleEnabled('Mage_CatalogRule')) {
+                $rulePrice = Mage::getResourceModel('catalogrule/rule')
+                    ->getRulePrice($storeDateTime, $wId, $gId, $productId);
+            }
         }
 
         if ($rulePrice !== null && $rulePrice !== false) {


### PR DESCRIPTION
## Description

When the `Mage_CatalogRule` module is disabled in `app/etc/modules`, the location specified in the PR indicates an error.
This PR adds a check if the module is enabled to fix this problem.

For months now, I have been applying this adjustment as a Composer patch across all the Maho instances I maintain where catalog rules are not required (including in production environments). Rather than remaining confined to my local Composer patches, this change should ideally be integrated directly into the core. :)