### PR TITLE
Adminhtml Sales Order Create: Set attribute frontend labels instead of store labels

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Form/Abstract.php
@@ -132,7 +132,7 @@ abstract class Mage_Adminhtml_Block_Sales_Order_Create_Form_Abstract extends Mag
             if ($inputType) {
                 $element = $form->addField($attribute->getAttributeCode(), $inputType, [
                     'name'      => $attribute->getAttributeCode(),
-                    'label'     => $this->__($attribute->getStoreLabel()),
+                    'label'     => $this->__($attribute->getFrontendLabel() ?? $attribute->getStoreLabel()),
                     'class'     => $attribute->getFrontend()->getClass(),
                     'required'  => $attribute->getIsRequired(),
                     'note'      => $this->escapeHtml($this->__($attribute->getNote())),


### PR DESCRIPTION
## Description

When having different anguages in adminhtml and some store views, the customer address attributes are displayed in the language of the store view if an order is created via sales oder create in adminhtml, which is very confusing and difficult for the customer service (if the employee does not speak the store view language).

For months now, I have been applying this adjustment as a Composer patch across all the Maho instances I maintain (including in production environments). Rather than remaining confined to my local Composer patches, this change should ideally be integrated directly into the core. :)

Here is an example of a German adminhtml (imagine only German speaking people are creating orders for customers) with a Polish store view. An order should be created in the Polish store view via adminhtml.

### Before

<img width="684" height="395" alt="grafik" src="https://github.com/user-attachments/assets/6739794b-8b6d-4b2e-912a-876ea22321a7" />

### After

<img width="693" height="395" alt="grafik" src="https://github.com/user-attachments/assets/be556e5f-8bdb-44ed-8bcb-85e2c54b75c1" />