### PR TITLE
Adminhtml Sales Order View: Add payment method existence check

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View.php
@@ -159,7 +159,11 @@ class Mage_Adminhtml_Block_Sales_Order_View extends Mage_Adminhtml_Block_Widget_
 
         if ($this->_isAllowedAction('creditmemo') && $order->canCreditmemo()) {
             $onClick = Mage::helper('core/js')->getSetLocationJs($this->getCreditmemoUrl());
-            if ($order->getPayment() && $order->getPayment()->getMethodInstance()->isGateway()) {
+            if (
+                $order->getPayment()
+                && Mage::helper('payment')->paymentMethodExists($order->getPayment())
+                && $order->getPayment()->getMethodInstance()->isGateway()
+            ) {
                 $onClick = Mage::helper('core/js')->getConfirmSetLocationJs(
                     $this->getCreditmemoUrl(),
                     Mage::helper('sales')->__('This will create an offline refund. To create an online refund, open an invoice and create credit memo for it. Do you wish to proceed?'),

--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -267,6 +267,12 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
         return $methods;
     }
 
+    public function paymentMethodExists(Mage_Sales_Model_Order_Payment $payment): bool
+    {
+        return ($method = $payment->getMethod()) !== null
+            && Mage::getStoreConfig(self::XML_PATH_PAYMENT_METHODS . '/' . $method . '/title') !== null;
+    }
+
     /**
      * Retrieve all billing agreement methods (code and label)
      *


### PR DESCRIPTION
## Description

Another local composer patch which should be added to the core. :)

Currently, no longer existing methods cause an exception in adminhtml sales order view.
A 2nd condition is added to check if a payment method exist before using it to try to create a method instance.

As always, this PR is merely a suggestion. I am also happy with any other approach that resolves the exception.