### PR TITLE
Increased `ATTRIBUTE_CODE_MAX_LENGTH` from 30 to 64

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute.php
@@ -34,7 +34,7 @@ class Mage_Eav_Model_Entity_Attribute extends Mage_Eav_Model_Entity_Attribute_Ab
      */
     protected $_eventPrefix                         = 'eav_entity_attribute';
 
-    public const ATTRIBUTE_CODE_MAX_LENGTH                 = 30;
+    public const ATTRIBUTE_CODE_MAX_LENGTH                 = 64;
 
     /**
      * Parameter name in event


### PR DESCRIPTION
## Description

Another try to get rid of some local composer patches. :)

Unfortunately, for large shops with a vast number of attributes, 30 characters are insufficient.
Therefore, it would be great if we could increase the maximum length for attribute codes from 30 to at least 64 directly in the core.