### PR TITLE
Fixed: quote from_date/to_date columns in SalesRule rule collection for newer MariaDB

### DIFF
--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
@@ -132,6 +132,10 @@ class Mage_SalesRule_Model_Resource_Rule_Collection extends Mage_Rule_Model_Reso
 
             $entityInfo = $this->_getAssociatedEntityInfo('customer_group');
             $connection = $this->getConnection();
+            // Quote from_date/to_date: newer MariaDB reserves them as date functions, so
+            // unquoted column references fail to parse.
+            $fromDate = $connection->quoteIdentifier('from_date');
+            $toDate = $connection->quoteIdentifier('to_date');
             $this->getSelect()
                 ->joinInner(
                     ['customer_group_ids' => $this->getTable($entityInfo['associations_table'])],
@@ -143,8 +147,8 @@ class Mage_SalesRule_Model_Resource_Rule_Collection extends Mage_Rule_Model_Reso
                     ),
                     [],
                 )
-                ->where('from_date is null or from_date <= ?', $now)
-                ->where('to_date is null or to_date >= ?', $now);
+                ->where("$fromDate is null or $fromDate <= ?", $now)
+                ->where("$toDate is null or $toDate >= ?", $now);
 
             $this->addIsActiveFilter();
 

--- a/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Mage/SalesRule/Model/Resource/Rule/Collection.php
@@ -147,8 +147,8 @@ class Mage_SalesRule_Model_Resource_Rule_Collection extends Mage_Rule_Model_Reso
                     ),
                     [],
                 )
-                ->where("$fromDate is null or $fromDate <= ?", $now)
-                ->where("$toDate is null or $toDate >= ?", $now);
+                ->where("$fromDate IS NULL OR $fromDate <= ?", $now)
+                ->where("$toDate IS NULL OR $toDate >= ?", $now);
 
             $this->addIsActiveFilter();
 

--- a/app/code/core/Maho/CatalogLinkRule/Model/Resource/Rule/Collection.php
+++ b/app/code/core/Maho/CatalogLinkRule/Model/Resource/Rule/Collection.php
@@ -29,9 +29,14 @@ class Maho_CatalogLinkRule_Model_Resource_Rule_Collection extends Mage_Core_Mode
         // from_date/to_date are admin-entered as store-local — compare in store TZ
         $now = Mage::app()->getLocale()->utcToStore()->format(Mage_Core_Model_Locale::DATETIME_FORMAT);
 
+        // Quote from_date/to_date: newer MariaDB reserves them as date functions, so
+        // unquoted column references fail to parse.
+        $connection = $this->getConnection();
+        $fromDate = $connection->quoteIdentifier('from_date');
+        $toDate = $connection->quoteIdentifier('to_date');
         $this->getSelect()
-            ->where('from_date IS NULL OR from_date <= ?', $now)
-            ->where('to_date IS NULL OR to_date >= ?', $now);
+            ->where("$fromDate IS NULL OR $fromDate <= ?", $now)
+            ->where("$toDate IS NULL OR $toDate >= ?", $now);
 
         return $this;
     }

--- a/tests/Backend/Integration/CatalogLinkRule/Model/Resource/Rule/DateColumnQuotingTest.php
+++ b/tests/Backend/Integration/CatalogLinkRule/Model/Resource/Rule/DateColumnQuotingTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('CatalogLinkRule rule collection date filter quoting', function () {
+    // from_date/to_date are reserved as date functions on newer MariaDB, so the
+    // collection must emit them as quoted identifiers, not bare column references.
+    test('quotes from_date/to_date and executes', function () {
+        $collection = Mage::getResourceModel('cataloglinkrule/rule_collection');
+        $collection->addDateFilter();
+
+        $read = Mage::getSingleton('core/resource')->getConnection('core_read');
+        $sql = $collection->getSelect()->__toString();
+
+        expect($sql)->toContain($read->quoteIdentifier('from_date'));
+        expect($sql)->toContain($read->quoteIdentifier('to_date'));
+        // No bare (unquoted) column reference must survive.
+        expect($sql)->not->toContain('from_date IS NULL');
+        expect($sql)->not->toContain('to_date IS NULL');
+
+        // Assemble + run against the live database to prove the syntax parses.
+        expect(fn() => $collection->getSize())->not->toThrow(Throwable::class);
+    });
+});

--- a/tests/Backend/Integration/SalesRule/Model/Resource/Rule/DateColumnQuotingTest.php
+++ b/tests/Backend/Integration/SalesRule/Model/Resource/Rule/DateColumnQuotingTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Maho
+ *
+ * @copyright  Copyright (c) 2026 Maho (https://mahocommerce.com)
+ * @license    https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('SalesRule rule collection date filter quoting', function () {
+    // from_date/to_date are reserved as date functions on newer MariaDB, so the
+    // collection must emit them as quoted identifiers, not bare column references.
+    test('quotes from_date/to_date and executes', function () {
+        $collection = Mage::getResourceModel('salesrule/rule_collection');
+        $collection->addWebsiteGroupDateFilter(1, 0);
+
+        $read = Mage::getSingleton('core/resource')->getConnection('core_read');
+        $sql = $collection->getSelect()->__toString();
+
+        expect($sql)->toContain($read->quoteIdentifier('from_date'));
+        expect($sql)->toContain($read->quoteIdentifier('to_date'));
+        // No bare (unquoted) column reference must survive.
+        expect($sql)->not->toContain('from_date IS NULL');
+        expect($sql)->not->toContain('to_date IS NULL');
+
+        // Assemble + run against the live database to prove the syntax parses.
+        expect(fn() => $collection->getSize())->not->toThrow(Throwable::class);
+    });
+});


### PR DESCRIPTION
## Problem
On the newest MariaDB (the rolling `mariadb-latest` CI image), `Mage_SalesRule_Model_Resource_Rule_Collection::addWebsiteGroupDateFilter()` fails with:

```
SQLSTATE[42000]: Syntax error ... near 'is null or to_date >= ...'
```

Newer MariaDB reserves `from_date`/`to_date` as Oracle-compatibility date functions, so the **unquoted** column references in the `where()` clauses no longer parse. This breaks all Giftcard/SalesRule total-collection tests on `mariadb-latest` (MySQL and MariaDB 10.11 still pass).

## Fix
Quote the identifiers via `quoteIdentifier()`, which emits adapter-correct quoting (backticks on MySQL/MariaDB, double-quotes on SQLite/PostgreSQL).

## Testing
- `composer test --filter="Gift Card|SalesRule|Giftcard"`: 199 passed on MySQL.
- Adapter-agnostic, so valid across all supported databases.

Pre-existing on `main` (surfaced by the rolling MariaDB tag), independent of any feature work.