### PR TITLE
Fixed unserialize warning when deleting cart item with custom options

### DIFF
--- a/app/code/core/Mage/Core/Helper/String.php
+++ b/app/code/core/Mage/Core/Helper/String.php
@@ -543,7 +543,14 @@ class Mage_Core_Helper_String extends Mage_Core_Helper_Abstract
             return Mage::helper('core')->jsonDecode($str);
         }
 
-        return unserialize($str, ['allowed_classes' => false]);
+        // Tolerate never-serialized input (e.g. plain custom-option values): pass it through
+        // unchanged instead of warning. serialize(false) is the one input that legitimately
+        // unserializes to false, so it must not be treated as a decode failure.
+        $result = @unserialize($str, ['allowed_classes' => false]);
+        if ($result === false && $str !== 'b:0;') {
+            return $str;
+        }
+        return $result;
     }
 
     /**

--- a/tests/Backend/Unit/Core/Helper/StringSerializationTest.php
+++ b/tests/Backend/Unit/Core/Helper/StringSerializationTest.php
@@ -288,6 +288,52 @@ describe('Legacy serialized data conversion via core/string helper', function ()
     });
 });
 
+describe('unserialize tolerates non-serialized input (issue #980)', function () {
+    beforeEach(function () {
+        $this->helper = Mage::helper('core/string');
+    });
+
+    it('returns null for null', function () {
+        expect($this->helper->unserialize(null))->toBeNull();
+    });
+
+    it('passes a plain non-serialized string through unchanged', function () {
+        expect($this->helper->unserialize('just a string'))->toBe('just a string');
+    });
+
+    it('does not emit a reportable warning for a plain non-serialized string', function () {
+        // Mirror Maho's error handler (Mage/Core/functions.php): a warning is only
+        // logged/displayed when it survives the active error_reporting() mask. The @ in
+        // the helper zeroes that mask, so a suppressed warning must not count here.
+        $warned = false;
+        set_error_handler(function (int $errno) use (&$warned) {
+            if ($errno & error_reporting()) {
+                $warned = true;
+            }
+            return false;
+        });
+        try {
+            $this->helper->unserialize('option text value');
+        } finally {
+            restore_error_handler();
+        }
+        expect($warned)->toBeFalse();
+    });
+
+    it('passes an empty string through unchanged', function () {
+        expect($this->helper->unserialize(''))->toBe('');
+    });
+
+    it('decodes a legacy serialized scalar', function () {
+        expect($this->helper->unserialize('i:5;'))->toBe(5);
+        expect($this->helper->unserialize(serialize('hello')))->toBe('hello');
+    });
+
+    it('returns false for legacy serialized false', function () {
+        expect($this->helper->unserialize(serialize(false)))->toBeFalse();
+    });
+});
+
 describe('isSerializedArrayOrObject detects both JSON and legacy formats', function () {
     beforeEach(function () {
         $this->helper = Mage::helper('core/string');

--- a/tests/Backend/Unit/Core/Model/FlagSerializationTest.php
+++ b/tests/Backend/Unit/Core/Model/FlagSerializationTest.php
@@ -28,11 +28,12 @@ describe('Flag model handles null and empty flag_data', function () {
         expect($flag->getFlagData())->toBeNull();
     });
 
-    it('returns false when flag_data is empty string', function () {
-        // Empty string passes hasFlagData() but unserialize('') returns false
+    it('returns the empty string when flag_data is empty string', function () {
+        // Empty string passes hasFlagData() and is not serialized data, so the
+        // core/string helper passes it through unchanged (still falsy for callers).
         $flag = Mage::getModel('core/flag');
         $flag->setData('flag_data', '');
-        expect($flag->getFlagData())->toBeFalse();
+        expect($flag->getFlagData())->toBe('');
     });
 });
 


### PR DESCRIPTION
## Problem

Closes #980. Deleting a cart item that has non-file custom options (text fields, dropdowns, etc.) logs a PHP warning:

```
unserialize(): Error at offset 0 of N bytes
```

`Mage_Sales_Model_Quote_Item::_beforeDelete()` loops over every option whose code starts with the option prefix to clean up uploaded files, but that prefix covers **all** custom option types, not just file uploads. Only file options store a structured (JSON/serialized) value with `quote_path`; text/select options hold a plain string. `Mage_Core_Helper_String::unserialize()` then calls PHP `unserialize()` on that plain string and warns.

This was masked before PR #552: the original code used `@unserialize(...)`. The migration to route the call through the helper dropped the `@`, surfacing the warning.

## Fix

Make `Mage_Core_Helper_String::unserialize()` tolerant of never-serialized input: it now passes a plain string through unchanged instead of warning, mirroring the behavior already present in `Mage_Core_Helper_UnserializeArray::unserialize()`. `serialize(false)` is still decoded correctly (it is the one input that legitimately unserializes to `false`).

Fixing the shared helper resolves the issue at every call site rather than adding a guard at each one.

## Tests

- Added contract tests on the helper: plain-string passthrough, no reportable warning (asserted against the active `error_reporting()` mask, matching Maho's error handler), empty-string passthrough, serialized-scalar decode, and `serialize(false)` decode.
- Updated the Flag empty-string test from the old `false` artifact to the new passthrough result `''` (still falsy for callers).
- Full Backend and Frontend suites pass (the unrelated CustomerSegmentation integration failures are a pre-existing sample-data install issue, reproduced on a clean checkout). `composer lint` clean.