### PR TITLE
Fix: admin create-order reverts payment method to last in list

### DIFF
--- a/public/js/mage/adminhtml/sales.js
+++ b/public/js/mage/adminhtml/sales.js
@@ -1103,6 +1103,12 @@ class AdminOrder
         }
         const data = {};
         for (const field of container.querySelectorAll('input, select, textarea')) {
+            // Skip unchecked radios/checkboxes: otherwise the last radio in DOM order
+            // overwrites the selected one (e.g. payment[method] on any billing_method
+            // reload always became the last payment method, ignoring the user's choice).
+            if ((field.type === 'radio' || field.type === 'checkbox') && !field.checked) {
+                continue;
+            }
             data[field.name] = field.value;
         }
         return data;


### PR DESCRIPTION
In **Admin > Sales > Create New Order**, selecting a payment method that is *not last* in the list, then triggering any area reload that re-renders the billing method block (e.g. changing the shipping method), reverts the selected payment method to the **last** one in the list.

### Steps to reproduce
1. Have 2+ active payment methods on a store.
2. Admin > Sales > Orders > Create New Order, pick a customer/store.
3. Add a product, select a payment method that is **not** the last in the list.
4. Change the shipping method (or any action that reloads `billing_method`).
5. The payment method silently switches to the **last** method in the list.

### Root cause
`AdminOrder.serializeData()` iterates every input and assigns `data[field.name] = field.value` without honouring the `checked` state of radios/checkboxes. For the `payment[method]` radio group, each radio overwrites the previous one, so the **last radio in DOM order always wins** regardless of which is selected. `prepareParams()` merges this serialized data into every `loadArea()` request, so the wrong method is sent to the server and the block re-renders with it selected.

### Fix
Skip unchecked radios/checkboxes in `serializeData()` (matches the `checked`-guard already used elsewhere in the same file):

```js
if ((field.type === 'radio' || field.type === 'checkbox') && !field.checked) {
    continue;
}
```

One-line guard, no behaviour change for text/select/textarea inputs.