### PR TITLE
fix(adminhtml): Add check for menuNode in getMenuItemLabel

### DIFF
--- a/app/code/core/Mage/Admin/Model/Config.php
+++ b/app/code/core/Mage/Admin/Model/Config.php
@@ -138,7 +138,7 @@ class Mage_Admin_Model_Config extends \Maho\Simplexml\Config
     {
         $moduleName = 'adminhtml';
         $menuNode = $this->getAdminhtmlConfig()->getNode('menu/' . str_replace('/', '/children/', trim($path, '/')));
-        if ($menuNode->getAttribute('module')) {
+        if ($menuNode !== false && $menuNode->getAttribute('module')) {
             $moduleName = (string) $menuNode->getAttribute('module');
         }
         return Mage::helper($moduleName)->__((string) $menuNode->title);

--- a/app/code/core/Mage/Admin/Model/Config.php
+++ b/app/code/core/Mage/Admin/Model/Config.php
@@ -138,7 +138,10 @@ class Mage_Admin_Model_Config extends \Maho\Simplexml\Config
     {
         $moduleName = 'adminhtml';
         $menuNode = $this->getAdminhtmlConfig()->getNode('menu/' . str_replace('/', '/children/', trim($path, '/')));
-        if ($menuNode !== false && $menuNode->getAttribute('module')) {
+        if ($menuNode === false) {
+            return '';
+        }
+        if ($menuNode->getAttribute('module')) {
             $moduleName = (string) $menuNode->getAttribute('module');
         }
         return Mage::helper($moduleName)->__((string) $menuNode->title);


### PR DESCRIPTION
## Description

Another try to get rid of some local composer patches. :)

I use `System > Configuration` in adminhtml very often, so I moved the `Configuration` entry from `System` into an own menu entry to avoid hovering `System` and scroll down to the last entry every time. So far, so good - no problem at all.

But there is a problem when a user without permissions for `Configuration` tries to load the default values of a transactional email template.

This PR fixes this functionality by adding a check of `$menuNode !== false` in `getMenuItemLabel`.

### Steps to reproduce

* Move adminhtml `System > Configuration` to own `Configuration` menu entry:
```
<menu>
    <configuration>
        <title>Configuration</title>
        <sort_order>1100</sort_order>
        <action>adminhtml/system_config/edit/section/dev</action>
    </configuration>
    <system>
        <children>
            <config>
                <disabled>1</disabled>
            </config>
        </children>
    </system>
</menu>
```

* Add a new adminhtml user with permissions for `Transactional Emails`
* Login with that new adminhtml user
* Open `System > Transactional Emails`
* Click on `Add New Template`
* Select a template to load, e.g. `Changed Password or Email`
* Click on the `Load Template` button
* The template isn't loaded because of the following error:
```
ERROR: Warning: Attempt to read property "title" on false  in /var/www/html/app/code/core/Mage/Admin/Model/Config.php on line 144
```
