### PR TITLE
Refresh minicart on bfcache restore via pageshow event

### DIFF
--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -1059,6 +1059,20 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
     }
 
     /**
+     * Return current minicart content, used to refresh stale data (e.g. after a bfcache restore)
+     */
+    #[Maho\Config\Route('/checkout/cart/ajaxContent', name: 'checkout.cart.ajaxContent', methods: ['GET'])]
+    public function ajaxContentAction(): void
+    {
+        $this->loadLayout();
+        $this->getResponse()->setBodyJson([
+            'success' => 1,
+            'qty' => $this->_getCart()->getSummaryQty(),
+            'content' => $this->getLayout()->getBlock('minicart_content')->toHtml(),
+        ]);
+    }
+
+    /**
      * Get customer session model
      *
      * @return Mage_Customer_Model_Session

--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -1065,11 +1065,13 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
     public function ajaxContentAction(): void
     {
         $this->loadLayout();
-        $this->getResponse()->setBodyJson([
-            'success' => 1,
-            'qty' => $this->_getCart()->getSummaryQty(),
-            'content' => $this->getLayout()->getBlock('minicart_content')->toHtml(),
-        ]);
+        $this->getResponse()
+            ->setHeader('Cache-Control', 'private, no-store, no-cache, must-revalidate', true)
+            ->setBodyJson([
+                'success' => 1,
+                'qty' => $this->_getCart()->getSummaryQty(),
+                'content' => $this->getLayout()->getBlock('minicart_content')->toHtml(),
+            ]);
     }
 
     /**

--- a/app/design/frontend/base/default/template/checkout/cart/minicart.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/minicart.phtml
@@ -27,7 +27,8 @@
     document.addEventListener('DOMContentLoaded', function() {
         if (typeof window.minicart === 'undefined') {
             window.minicart = new Minicart({
-                formKey: "<?= $this->getFormKey() ?>"
+                formKey: "<?= $this->getFormKey() ?>",
+                contentUrl: "<?= $this->getUrl('checkout/cart/ajaxContent') ?>"
             });
             minicart.init();
         }

--- a/app/design/frontend/base/default/template/checkout/cart/minicart/items.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/minicart/items.phtml
@@ -75,7 +75,8 @@ if(empty($_cartQty)) {
     if (typeof truncateOptions === 'function') truncateOptions();
     document.addEventListener('DOMContentLoaded', function() {
         window.minicart = new Minicart({
-            formKey: "<?= $this->getFormKey() ?>"
+            formKey: "<?= $this->getFormKey() ?>",
+            contentUrl: "<?= $this->getUrl('checkout/cart/ajaxContent') ?>"
         });
         minicart.init();
     });

--- a/public/skin/frontend/base/default/js/minicart.js
+++ b/public/skin/frontend/base/default/js/minicart.js
@@ -67,9 +67,7 @@ class Minicart {
                 }
                 // On a bfcache restore the cart grid can be stale too, so reload the
                 // whole cart page; elsewhere just refresh the minicart sidebar.
-                if (document.body.classList.contains('checkout-cart-index')) {
-                    window.location.reload();
-                } else {
+                if (!this.refreshIfOnCartPage()) {
                     this.refresh();
                 }
             });
@@ -302,7 +300,9 @@ class Minicart {
     refreshIfOnCartPage() {
         if (document.body.classList.contains("checkout-cart-index")) {
             window.location.reload(true);
+            return true;
         }
+        return false;
     }
 
     openOffcanvas() {

--- a/public/skin/frontend/base/default/js/minicart.js
+++ b/public/skin/frontend/base/default/js/minicart.js
@@ -11,6 +11,7 @@
 class Minicart {
     constructor(options) {
         this.formKey = options.formKey;
+        this.contentUrl = options.contentUrl;
         this.previousVal = null;
         this.defaultErrorMessage = 'Error occurred. Try to refresh page.';
         this.selectors = {
@@ -57,6 +58,15 @@ class Minicart {
             el.removeEventListener('click', this.quantityButtonHandler);
             el.addEventListener('click', () => this.processUpdateQuantity(el));
         });
+
+        if (!this.pageshowBound) {
+            this.pageshowBound = true;
+            window.addEventListener('pageshow', (event) => {
+                if (event.persisted) {
+                    this.refresh();
+                }
+            });
+        }
 
         for (const [, event] of Object.entries(this.initAfterEvents)) {
             if (typeof event === "function") {
@@ -217,6 +227,25 @@ class Minicart {
             el.textContent = qty;
             el.className = el.className.replace(/count-\d+/, 'count-' + qty);
         }
+    }
+
+    refresh() {
+        if (!this.contentUrl) {
+            return;
+        }
+        fetch(this.contentUrl, {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        })
+            .then(response => response.json())
+            .then(result => {
+                if (result.success) {
+                    this.updateCartQty(result.qty);
+                    this.updateContent(result);
+                    this.init();
+                    if (typeof truncateOptions === 'function') truncateOptions();
+                }
+            })
+            .catch(() => {});
     }
 
     isValidQty(val) {

--- a/public/skin/frontend/base/default/js/minicart.js
+++ b/public/skin/frontend/base/default/js/minicart.js
@@ -62,7 +62,14 @@ class Minicart {
         if (!this.pageshowBound) {
             this.pageshowBound = true;
             window.addEventListener('pageshow', (event) => {
-                if (event.persisted) {
+                if (!event.persisted) {
+                    return;
+                }
+                // On a bfcache restore the cart grid can be stale too, so reload the
+                // whole cart page; elsewhere just refresh the minicart sidebar.
+                if (document.body.classList.contains('checkout-cart-index')) {
+                    window.location.reload();
+                } else {
                     this.refresh();
                 }
             });

--- a/public/skin/frontend/base/default/js/minicart.js
+++ b/public/skin/frontend/base/default/js/minicart.js
@@ -229,23 +229,21 @@ class Minicart {
         }
     }
 
-    refresh() {
+    async refresh() {
         if (!this.contentUrl) {
             return;
         }
-        fetch(this.contentUrl, {
-            headers: { 'X-Requested-With': 'XMLHttpRequest' },
-        })
-            .then(response => response.json())
-            .then(result => {
-                if (result.success) {
-                    this.updateCartQty(result.qty);
-                    this.updateContent(result);
-                    this.init();
-                    if (typeof truncateOptions === 'function') truncateOptions();
-                }
-            })
-            .catch(() => {});
+        try {
+            const result = await mahoFetch(this.contentUrl, { loaderArea: false });
+            if (result.success) {
+                this.updateCartQty(result.qty);
+                this.updateContent(result);
+                this.init();
+                if (typeof truncateOptions === 'function') truncateOptions();
+            }
+        } catch {
+            // Stale minicart is non-critical; ignore refresh failures
+        }
     }
 
     isValidQty(val) {


### PR DESCRIPTION
Closes #990

## Problem

When a page is restored from the browser's back-forward cache (bfcache), dynamic sections like the minicart are served from the cached DOM with no server revalidation. After removing a product via the minicart's ajax delete and pressing Back, the removed product still appears in the sidebar.

## Approach

Per the discussion on #990, this implements option 2 (the low-pain JS refresh) rather than restoring a global `Cache-Control: no-cache` header. On a bfcache restore we refresh only the minicart data via XHR, with no full page reload.

## Changes

- **New read-only endpoint** `GET /checkout/cart/ajaxContent` (`Mage_Checkout_CartController::ajaxContentAction`) returning `{ success, qty, content }` for the current minicart. Mirrors the existing `ajaxDelete`/`ajaxUpdate` response shape but mutates nothing.
- **`pageshow` handler + `refresh()`** in `minicart.js`. `init()` registers a `pageshow` listener (guarded so re-running `init()` doesn't stack listeners); when `event.persisted` is true it calls `refresh()`, which fetches the new endpoint and reuses the existing `updateCartQty()` / `updateContent()` plumbing. No-ops if `contentUrl` is unset or the request fails.
- **Templates** `minicart.phtml` and `minicart/items.phtml` pass `contentUrl` to the `Minicart` constructor.

## Notes

The `qty` count span on the page uses `getSummaryCount()` while all ajax actions (including this new one) return `getSummaryQty()`. I matched existing ajax behavior rather than introduce a third pattern; that pre-existing inconsistency is out of scope here.