### PR TITLE
Fix PHP 8.5 null array offset deprecation in tax rate form

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tax/Rate/Form.php
@@ -134,7 +134,9 @@ class Mage_Adminhtml_Block_Tax_Rate_Form extends Mage_Adminhtml_Block_Widget_For
         $form->setMethod('post');
 
         if (!Mage::app()->isSingleStoreMode()) {
-            $form->addElement(Mage::getBlockSingleton('adminhtml/tax_rate_title_fieldset')->setLegend(Mage::helper('tax')->__('Tax Titles')));
+            $form->addElement(Mage::getBlockSingleton('adminhtml/tax_rate_title_fieldset')
+                ->setId('tax_titles_fieldset')
+                ->setLegend(Mage::helper('tax')->__('Tax Titles')));
         }
 
         $rateData = $rateObject->getData();

--- a/lib/Maho/Data/Form.php
+++ b/lib/Maho/Data/Form.php
@@ -150,10 +150,7 @@ class Form extends AbstractForm
 
     public function getElement(?string $elementId): ?Form\Element\AbstractElement
     {
-        if ($this->_elementIdExists($elementId)) {
-            return $this->_elementsIndex[(string) $elementId];
-        }
-        return null;
+        return $this->_elementsIndex[(string) $elementId] ?? null;
     }
 
     /**
@@ -233,9 +230,7 @@ class Form extends AbstractForm
     #[\Override]
     public function removeField(?string $elementId): self
     {
-        if ($this->_elementIdExists($elementId)) {
-            unset($this->_elementsIndex[(string) $elementId]);
-        }
+        unset($this->_elementsIndex[(string) $elementId]);
         return $this;
     }
 

--- a/lib/Maho/Data/Form.php
+++ b/lib/Maho/Data/Form.php
@@ -116,32 +116,23 @@ class Form extends AbstractForm
 
     /**
      * Check existing element
-     *
-     * @param   string $elementId
-     * @return  bool
      */
-    protected function _elementIdExists($elementId)
+    protected function _elementIdExists(?string $elementId): bool
     {
-        return isset($this->_elementsIndex[$elementId]);
+        return isset($this->_elementsIndex[(string) $elementId]);
     }
 
-    /**
-     * @param Form\Element\AbstractElement $element
-     * @return $this
-     */
-    public function addElementToCollection($element)
+    public function addElementToCollection(Form\Element\AbstractElement $element): self
     {
-        $this->_elementsIndex[$element->getId()] = $element;
+        $this->_elementsIndex[(string) $element->getId()] = $element;
         $this->_allElements->add($element);
         return $this;
     }
 
     /**
-     * @param string $elementId
-     * @return bool
      * @throws \Exception
      */
-    public function checkElementId($elementId)
+    public function checkElementId(?string $elementId): bool
     {
         if ($this->_elementIdExists($elementId)) {
             throw new \Exception('Element with id "' . $elementId . '" already exists');
@@ -157,14 +148,10 @@ class Form extends AbstractForm
         return $this;
     }
 
-    /**
-     * @param string $elementId
-     * @return Form\Element\AbstractElement|null
-     */
-    public function getElement($elementId)
+    public function getElement(?string $elementId): ?Form\Element\AbstractElement
     {
         if ($this->_elementIdExists($elementId)) {
-            return $this->_elementsIndex[$elementId];
+            return $this->_elementsIndex[(string) $elementId];
         }
         return null;
     }
@@ -241,14 +228,13 @@ class Form extends AbstractForm
     }
 
     /**
-     * @param string $elementId
-     * @return $this|AbstractForm
+     * @return $this
      */
     #[\Override]
-    public function removeField($elementId)
+    public function removeField(?string $elementId): self
     {
         if ($this->_elementIdExists($elementId)) {
-            unset($this->_elementsIndex[$elementId]);
+            unset($this->_elementsIndex[(string) $elementId]);
         }
         return $this;
     }

--- a/lib/Maho/Data/Form/AbstractForm.php
+++ b/lib/Maho/Data/Form/AbstractForm.php
@@ -144,10 +144,9 @@ abstract class AbstractForm extends \Maho\DataObject
     }
 
     /**
-     * @param string $elementId
      * @return $this
      */
-    public function removeField($elementId)
+    public function removeField(?string $elementId): self
     {
         $this->getElements()->remove($elementId);
         return $this;

--- a/lib/Maho/Data/Form/Element/AbstractElement.php
+++ b/lib/Maho/Data/Form/Element/AbstractElement.php
@@ -153,7 +153,7 @@ abstract class AbstractElement extends AbstractForm
     }
 
     #[\Override]
-    public function removeField($elementId)
+    public function removeField(?string $elementId): self
     {
         $this->getForm()->removeField($elementId);
         return parent::removeField($elementId);


### PR DESCRIPTION
Fixes #1005

## Problem

On PHP 8.5, opening **Sales > Tax > Manage Tax Zones & Rates** and clicking any rate in a multistore setup emits:

> Using null as an array offset is deprecated, use an empty string instead — in `lib/Maho/Data/Form.php` line 125

## Cause

In multistore mode `Mage_Adminhtml_Block_Tax_Rate_Form::_prepareForm()` adds a "Tax Titles" fieldset element to the form **without an ID**. `Maho\Data\Form::addElement()` then calls `checkElementId($element->getId())` with `null`, and `_elementIdExists()` does `isset($this->_elementsIndex[null])`, which PHP 8.5 deprecates.

## Fix

- Give the tax titles fieldset an explicit ID (`tax_titles_fieldset`) — the root cause.
- Harden `Maho\Data\Form` so any element added without an ID can't re-trigger this: cast ids to string at every `_elementsIndex` access point (`_elementIdExists`, `addElementToCollection`, `getElement`, `removeField`).
- While here, add real parameter/return types to the `$elementId`-handling methods. `removeField` is typed consistently across `AbstractForm`, `Form` and `AbstractElement` (the param type can only be added to an override if the base is typed too).

## Verification

- Classes load with no LSP/compatibility error.
- PHPStan level 6 clean on all changed files.
- php-cs-fixer reports no style changes.