### PR TITLE
Update TipTap to 3.26.0 and adopt core ResizableNodeView for images

### DIFF
--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
@@ -6,13 +6,13 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-import { Editor, Node, Mark, Extension, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.23.4';
-import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.23.4';
-import Image from 'https://esm.sh/@tiptap/extension-image@3.23.4';
-import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.23.4';
-import { Table, TableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.23.4';
-import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.23.4';
-import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.23.4';
+import { Editor, Node, Mark, Extension, mergeAttributes, ResizableNodeView } from 'https://esm.sh/@tiptap/core@3.26.0';
+import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.26.0';
+import Image from 'https://esm.sh/@tiptap/extension-image@3.26.0';
+import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.26.0';
+import { Table, TableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.26.0';
+import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.26.0';
+import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.26.0';
 import { MahoColumns, MahoColumn, COLUMN_PRESETS } from './extensions/columns.js';
 import { MahoBentoGrid, MahoBentoCell, BENTO_PRESETS } from './extensions/bento.js';
 
@@ -382,17 +382,13 @@ export const MahoImage = Image.extend({
 
     addNodeView() {
         return ({ node, editor, HTMLAttributes, getPos }) => {
-            const container = document.createElement('div');
-            container.className = 'image-container';
-            container.title = editor.options.wysiwygSetup.translate('Double-click to edit');
-
             const img = document.createElement('img');
-            container.appendChild(img);
 
             for (const [key, value] of Object.entries(HTMLAttributes)) {
                 if (key === 'src') {
                     img.src = renderDirectiveImageUrl(value, node.attrs.directiveObj, this.options.directivesUrl);
-                } else if (value !== null) {
+                } else if (key !== 'width' && key !== 'height' && value !== null) {
+                    // width/height are applied as styles by ResizableNodeView from node attrs
                     img.setAttribute(key, value);
                 }
             }
@@ -406,63 +402,33 @@ export const MahoImage = Image.extend({
                 editor.commands.insertMahoImage(node);
             });
 
-            // Create resize handles
-            for (const position of ['nw', 'ne', 'sw', 'se']) {
-                const handle = document.createElement('div');
-                handle.className = `resize-handle resize-handle-${position}`;
-                container.appendChild(handle);
+            const view = new ResizableNodeView({
+                element: img,
+                editor,
+                node,
+                getPos,
+                onResize: (width, height) => {
+                    img.style.width = `${width}px`;
+                    img.style.height = `${height}px`;
+                },
+                onCommit: (width, height) => {
+                    const pos = getPos();
+                    if (pos !== undefined) {
+                        editor.chain().setNodeSelection(pos).updateAttributes(this.name, { width, height }).run();
+                    }
+                },
+                onUpdate: (updatedNode) => updatedNode.type === node.type,
+                options: {
+                    min: { width: 50, height: 50 },
+                    preserveAspectRatio: true,
+                    className: { container: 'image-container', handle: 'resize-handle' },
+                },
+            });
 
-                handle.addEventListener('mousedown', (event) => {
-                    // Select the image when resizing
-                    editor.commands.setNodeSelection(getPos());
-                    event.preventDefault();
+            // Tooltip lives on the container so the styled .image-container[title] hint applies
+            view.dom.title = editor.options.wysiwygSetup.translate('Double-click to edit');
 
-                    const startX = event.clientX;
-                    const startY = event.clientY;
-                    const startWidth = img.offsetWidth;
-                    const startHeight = img.offsetHeight;
-                    const aspectRatio = startWidth / startHeight;
-
-                    const handleMouseMove = (event) => {
-                        const deltaX = event.clientX - startX;
-                        const deltaY = event.clientY - startY;
-
-                        let newWidth = startWidth + deltaX;
-                        let newHeight = startHeight + deltaY;
-
-                        // Maintain aspect ratio
-                        if (Math.abs(deltaX) > Math.abs(deltaY)) {
-                            newHeight = newWidth / aspectRatio;
-                        } else {
-                            newWidth = newHeight * aspectRatio;
-                        }
-
-                        // Minimum size
-                        newWidth = Math.max(50, newWidth);
-                        newHeight = Math.max(50, newHeight);
-
-                        img.width = Math.round(newWidth);
-                        img.height = Math.round(newHeight);
-                    };
-
-                    const handleMouseUp = () => {
-                        document.removeEventListener('mousemove', handleMouseMove);
-                        document.removeEventListener('mouseup', handleMouseUp);
-
-                        editor.commands.updateAttributes(this.name, {
-                            width: img.width,
-                            height: img.height,
-                        });
-                    };
-
-                    document.addEventListener('mousemove', handleMouseMove);
-                    document.addEventListener('mouseup', handleMouseUp);
-                });
-            }
-
-            return {
-                dom: container,
-            };
+            return view;
         };
     },
 

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/bento.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/bento.js
@@ -6,7 +6,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.22.2';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.26.0';
 import { findParentNodeOfType, createGridNodeView } from './grid-utils.js';
 
 /**

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
@@ -6,7 +6,7 @@
  * @license     https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.22.2';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.26.0';
 import { findParentNodeOfType, createGridNodeView } from './grid-utils.js';
 
 /**

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/tiptap.css
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/tiptap.css
@@ -506,6 +506,7 @@
             position: absolute;
             width: 10px;
             height: 10px;
+            margin: -5px;
             background: var(--tt-color-primary);
             border: 1px solid white;
             display: none;
@@ -515,10 +516,10 @@
             display: block;
         }
 
-        .resize-handle-nw { cursor: nw-resize; top: -5px; left: -5px; }
-        .resize-handle-ne { cursor: ne-resize; top: -5px; right: -5px; }
-        .resize-handle-sw { cursor: sw-resize; bottom: -5px; left: -5px; }
-        .resize-handle-se { cursor: se-resize; bottom: -5px; right: -5px; }
+        [data-resize-handle="top-left"] { cursor: nw-resize; }
+        [data-resize-handle="top-right"] { cursor: ne-resize; }
+        [data-resize-handle="bottom-left"] { cursor: sw-resize; }
+        [data-resize-handle="bottom-right"] { cursor: se-resize; }
     }
 
     /* Slideshow */


### PR DESCRIPTION
## What

- Bumps all `@tiptap/*` CDN imports from `3.23.4` to `3.26.0` (current npm `latest`).
- Fixes a latent dual-copy bug: `extensions/columns.js` and `extensions/bento.js` were still pinned to `@tiptap/core@3.22.2` while `extensions.js` used `3.23.4`, so esm.sh resolved **two** separate `@tiptap/core` module instances. They now all share `3.26.0`.
- Replaces the hand-rolled image resize in `MahoImage` (manual corner-handle divs + `mousedown`/`mousemove`/`mouseup` aspect-ratio math) with the `ResizableNodeView` class now exported by `@tiptap/core`.

## Why

The image resize was fully custom Maho code. Recent TipTap moved resizing into core (`ResizableNodeView`), so we can delegate the resize mechanics upstream and maintain less code. Net: +41 / -74 lines.

The custom node view keeps everything Maho-specific:
- `{{media url=...}}` directive → real-URL `src` resolution
- double-click → media browser
- broken-image placeholder fallback
- styled "Double-click to edit" tooltip

Resize UX is mapped to match the previous behavior: 4 corner handles, min 50x50, aspect ratio locked, and `width`/`height` persisted via `updateAttributes` on commit. The class also implements `destroy()`, so its listeners are cleaned up on node removal (the old code never removed its `document` listeners).

## Release notes review (3.23.4 → 3.26.0)

All releases in range are patch/minor within v3, no API breaks. Reviewed 3.23.5/3.23.6 (markdown + perf fixes), 3.24.0 (mostly collaboration memory-leak fixes, unused here), 3.25.0 (image/table HTMLAttributes fixes, list backspace), 3.26.0 (ProseMirror dep bump). No required code changes beyond this PR.

## Testing

Manual smoke test in the admin WYSIWYG recommended:
- [ ] Insert image, hover shows 4 corner handles, drag resizes with aspect ratio locked (min ~50px)
- [ ] Size persists after release and after save/reload
- [ ] Double-click still opens the media browser
- [ ] Broken `src` still shows the placeholder; tooltip still shows
- [ ] Columns and bento grids still insert/edit correctly (shared core instance)