### PR TITLE
Adminhtml: Fix invoice view without payment data

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View.php
@@ -55,7 +55,10 @@ class Mage_Adminhtml_Block_Sales_Order_Invoice_View extends Mage_Adminhtml_Block
 
         $orderPayment = $this->getInvoice()->getOrder()->getPayment();
 
-        if ($this->_isAllowedAction('creditmemo') && $this->getInvoice()->getOrder()->canCreditmemo()) {
+        if ($orderPayment !== false
+            && $this->_isAllowedAction('creditmemo')
+            && $this->getInvoice()->getOrder()->canCreditmemo()
+        ) {
             if (($orderPayment->canRefundPartialPerInvoice()
                 && $this->getInvoice()->canRefund()
                 && $orderPayment->getAmountPaid() > $orderPayment->getAmountRefunded())

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -339,7 +339,8 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
              * If we not retrieve negative answer from payment yet
              */
             if (is_null($canVoid)) {
-                $canVoid = $this->getOrder()->getPayment()->canVoid($this);
+                $payment = $this->getOrder()->getPayment();
+                $canVoid = $payment !== false ? $payment->canVoid($this) : false;
                 if ($canVoid === false) {
                     $this->setCanVoidFlag(false);
                     $this->_saveBeforeDestruct = true;

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -320,9 +320,11 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
      */
     public function canCapture()
     {
+        $payment = $this->getOrder()->getPayment();
         return $this->getState() != self::STATE_CANCELED
             && $this->getState() != self::STATE_PAID
-            && $this->getOrder()->getPayment()->canCapture();
+            && $payment !== false
+            && $payment->canCapture();
     }
 
     /**


### PR DESCRIPTION
## Description

This PR is kind of a followup to #15. On local environments I always work with anonymized database dumps (generated by https://github.com/Smile-SA/gdpr-dump).

I tested the current main branch and saw that invoices can't be viewed when the related payment data is removed.
These are the related errors:
```
Fatal error: Uncaught Error: Call to a member function canRefundPartialPerInvoice() on false in /var/www/html/vendor/mahocommerce/maho/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View.php on line 59
```
When this is solved, the next error occurs:
```
Fatal error: Uncaught Error: Call to a member function canVoid() on false in /var/www/html/vendor/mahocommerce/maho/app/code/core/Mage/Sales/Model/Order/Invoice.php on line 342
```

This PR solves the rendering of the invoice view page in adminhtml without the related payment data.
As always, this PR is just a proposal. I'm grateful for any working version. :)