### PR TITLE
Delegate response header emission to Symfony so its Cache-Control default applies

### DIFF
--- a/app/code/core/Mage/Catalog/controllers/CategoryController.php
+++ b/app/code/core/Mage/Catalog/controllers/CategoryController.php
@@ -108,10 +108,6 @@ class Mage_Catalog_CategoryController extends Mage_Core_Controller_Front_Action
             $this->_initLayoutMessages('catalog/session');
             $this->_initLayoutMessages('checkout/session');
             $this->renderLayout();
-
-            $this->getResponse()
-                ->setHeader('Pragma', 'public', true)
-                ->setHeader('Cache-Control', 'private, max-age=60', true);
         } elseif (!$this->getResponse()->isRedirect()) {
             $this->_forward('noRoute');
         }

--- a/app/code/core/Mage/Catalog/controllers/CategoryController.php
+++ b/app/code/core/Mage/Catalog/controllers/CategoryController.php
@@ -111,7 +111,7 @@ class Mage_Catalog_CategoryController extends Mage_Core_Controller_Front_Action
 
             $this->getResponse()
                 ->setHeader('Pragma', 'public', true)
-                ->setHeader('Cache-Control', 'private max-age=60', true);
+                ->setHeader('Cache-Control', 'private, max-age=60', true);
         } elseif (!$this->getResponse()->isRedirect()) {
             $this->_forward('noRoute');
         }

--- a/app/code/core/Mage/Catalog/controllers/ProductController.php
+++ b/app/code/core/Mage/Catalog/controllers/ProductController.php
@@ -48,7 +48,7 @@ class Mage_Catalog_ProductController extends Mage_Core_Controller_Front_Action
             $viewHelper->prepareAndRender($productId, $this, $params);
             $this->getResponse()
                 ->setHeader('Pragma', 'public', true)
-                ->setHeader('Cache-Control', 'private max-age=60', true);
+                ->setHeader('Cache-Control', 'private, max-age=60', true);
         } catch (Exception $e) {
             if ($e->getCode() == $viewHelper->ERR_NO_PRODUCT_LOADED) {
                 if (isset($_GET['store'])  && !$this->getResponse()->isRedirect()) {

--- a/app/code/core/Mage/Catalog/controllers/ProductController.php
+++ b/app/code/core/Mage/Catalog/controllers/ProductController.php
@@ -46,9 +46,6 @@ class Mage_Catalog_ProductController extends Mage_Core_Controller_Front_Action
         // Render page
         try {
             $viewHelper->prepareAndRender($productId, $this, $params);
-            $this->getResponse()
-                ->setHeader('Pragma', 'public', true)
-                ->setHeader('Cache-Control', 'private, max-age=60', true);
         } catch (Exception $e) {
             if ($e->getCode() == $viewHelper->ERR_NO_PRODUCT_LOADED) {
                 if (isset($_GET['store'])  && !$this->getResponse()->isRedirect()) {

--- a/app/code/core/Mage/Cms/controllers/IndexController.php
+++ b/app/code/core/Mage/Cms/controllers/IndexController.php
@@ -24,10 +24,6 @@ class Mage_Cms_IndexController extends Mage_Core_Controller_Front_Action
         if (!Mage::helper('cms/page')->renderPage($this, $pageId)) {
             return $this->_forward('defaultIndex');
         }
-
-        $this->getResponse()
-            ->setHeader('Pragma', 'public', true)
-            ->setHeader('Cache-Control', 'private, max-age=60', true);
     }
 
     /**

--- a/app/code/core/Mage/Cms/controllers/IndexController.php
+++ b/app/code/core/Mage/Cms/controllers/IndexController.php
@@ -27,7 +27,7 @@ class Mage_Cms_IndexController extends Mage_Core_Controller_Front_Action
 
         $this->getResponse()
             ->setHeader('Pragma', 'public', true)
-            ->setHeader('Cache-Control', 'private max-age=60', true);
+            ->setHeader('Cache-Control', 'private, max-age=60', true);
     }
 
     /**

--- a/app/code/core/Mage/Cms/controllers/PageController.php
+++ b/app/code/core/Mage/Cms/controllers/PageController.php
@@ -20,9 +20,5 @@ class Mage_Cms_PageController extends Mage_Core_Controller_Front_Action
         if (!Mage::helper('cms/page')->renderPage($this, $pageId)) {
             return $this->_forward('noRoute');
         }
-
-        $this->getResponse()
-            ->setHeader('Pragma', 'public', true)
-            ->setHeader('Cache-Control', 'private, max-age=60', true);
     }
 }

--- a/app/code/core/Mage/Cms/controllers/PageController.php
+++ b/app/code/core/Mage/Cms/controllers/PageController.php
@@ -23,6 +23,6 @@ class Mage_Cms_PageController extends Mage_Core_Controller_Front_Action
 
         $this->getResponse()
             ->setHeader('Pragma', 'public', true)
-            ->setHeader('Cache-Control', 'private max-age=60', true);
+            ->setHeader('Cache-Control', 'private, max-age=60', true);
     }
 }

--- a/app/code/core/Mage/Core/Controller/Response/Http.php
+++ b/app/code/core/Mage/Core/Controller/Response/Http.php
@@ -74,6 +74,12 @@ class Mage_Core_Controller_Response_Http implements \Stringable
      */
     public bool $headersSentThrowsException = false;
 
+    /**
+     * Whether headers have been emitted; Symfony sends with replace=false,
+     * so a second emission would duplicate headers instead of replacing them
+     */
+    protected bool $_headersSent = false;
+
     public function __construct(array|SymfonyResponse|null $args = null)
     {
         // Handle both array (Mage factory) and SymfonyResponse (direct instantiation) arguments
@@ -302,6 +308,9 @@ class Mage_Core_Controller_Response_Http implements \Stringable
      */
     public function sendHeaders(): self
     {
+        if ($this->_headersSent) {
+            return $this;
+        }
         if (!$this->canSendHeaders()) {
             Mage::log('HEADERS ALREADY SENT: ' . mageDebugBacktrace(true, true, true));
             return $this;
@@ -310,11 +319,12 @@ class Mage_Core_Controller_Response_Http implements \Stringable
         foreach ($this->_headersRaw as $rawHeader) {
             header($rawHeader);
             if (($pos = strpos($rawHeader, ':')) !== false) {
-                $this->symfonyResponse->headers->remove(substr($rawHeader, 0, $pos));
+                $this->symfonyResponse->headers->remove(trim(substr($rawHeader, 0, $pos)));
             }
         }
 
         $this->symfonyResponse->sendHeaders();
+        $this->_headersSent = true;
 
         return $this;
     }

--- a/app/code/core/Mage/Core/Controller/Response/Http.php
+++ b/app/code/core/Mage/Core/Controller/Response/Http.php
@@ -296,8 +296,9 @@ class Mage_Core_Controller_Response_Http implements \Stringable
     /**
      * Send all headers
      *
-     * Sends any headers specified. If an {@link setHttpResponseCode() HTTP response code}
-     * has been specified, it is sent with the first header.
+     * Emission is delegated to the wrapped Symfony response, so ResponseHeaderBag
+     * defaults (conservative Cache-Control, Date) apply. Raw headers are sent
+     * first and suppress any same-named header from the bag.
      */
     public function sendHeaders(): self
     {
@@ -306,51 +307,14 @@ class Mage_Core_Controller_Response_Http implements \Stringable
             return $this;
         }
 
-        if (str_starts_with(php_sapi_name(), 'cgi')) {
-            $statusSent = false;
-            foreach ($this->_headersRaw as $i => $header) {
-                if (stripos($header, 'status:') === 0) {
-                    if ($statusSent) {
-                        unset($this->_headersRaw[$i]);
-                    } else {
-                        $statusSent = true;
-                    }
-                }
-            }
-            foreach ($this->_headers as $i => $header) {
-                if (strcasecmp($header['name'], 'status') === 0) {
-                    if ($statusSent) {
-                        unset($this->_headers[$i]);
-                    } else {
-                        $statusSent = true;
-                    }
-                }
+        foreach ($this->_headersRaw as $rawHeader) {
+            header($rawHeader);
+            if (($pos = strpos($rawHeader, ':')) !== false) {
+                $this->symfonyResponse->headers->remove(substr($rawHeader, 0, $pos));
             }
         }
 
-        $httpCodeSent = false;
-
-        foreach ($this->_headersRaw as $header) {
-            if (!$httpCodeSent && $this->_httpResponseCode) {
-                header($header, true, $this->_httpResponseCode);
-                $httpCodeSent = true;
-            } else {
-                header($header);
-            }
-        }
-
-        foreach ($this->_headers as $header) {
-            if (!$httpCodeSent && $this->_httpResponseCode) {
-                header($header['name'] . ': ' . $header['value'], $header['replace'], $this->_httpResponseCode);
-                $httpCodeSent = true;
-            } else {
-                header($header['name'] . ': ' . $header['value'], $header['replace']);
-            }
-        }
-
-        if (!$httpCodeSent) {
-            header('HTTP/1.1 ' . $this->_httpResponseCode);
-        }
+        $this->symfonyResponse->sendHeaders();
 
         return $this;
     }

--- a/app/code/core/Mage/Core/Controller/Response/Http.php
+++ b/app/code/core/Mage/Core/Controller/Response/Http.php
@@ -30,19 +30,9 @@ class Mage_Core_Controller_Response_Http implements \Stringable
     protected static ?\Maho\DataObject $_transportObject = null;
 
     /**
-     * Array of headers
-     */
-    protected array $_headers = [];
-
-    /**
      * Array of raw headers
      */
     protected array $_headersRaw = [];
-
-    /**
-     * HTTP response code
-     */
-    protected int $_httpResponseCode = 200;
 
     /**
      * Flag; is this response a redirect?
@@ -85,17 +75,12 @@ class Mage_Core_Controller_Response_Http implements \Stringable
         // Handle both array (Mage factory) and SymfonyResponse (direct instantiation) arguments
         if ($args instanceof SymfonyResponse) {
             $this->symfonyResponse = $args;
-            // Sync content and code
             $this->setBody($args->getContent() ?: '');
-            $this->_httpResponseCode = $args->getStatusCode();
         } elseif (is_array($args) && isset($args[0]) && $args[0] instanceof SymfonyResponse) {
             $this->symfonyResponse = $args[0];
             $this->setBody($args[0]->getContent() ?: '');
-            $this->_httpResponseCode = $args[0]->getStatusCode();
         } else {
             $this->symfonyResponse = new SymfonyResponse();
-            // Set default protocol version to 1.1
-            $this->symfonyResponse->setProtocolVersion('1.1');
         }
     }
 
@@ -113,24 +98,7 @@ class Mage_Core_Controller_Response_Http implements \Stringable
     public function setHeader(string $name, string $value, bool $replace = true): self
     {
         $this->canSendHeaders(true);
-        $name = $this->_normalizeHeader($name);
-
-        if ($replace) {
-            foreach ($this->_headers as $key => $header) {
-                if ($name == $header['name']) {
-                    unset($this->_headers[$key]);
-                }
-            }
-        }
-
-        $this->_headers[] = [
-            'name' => $name,
-            'value' => $value,
-            'replace' => $replace,
-        ];
-
-        $this->symfonyResponse->headers->set($name, $value, $replace);
-
+        $this->symfonyResponse->headers->set($this->_normalizeHeader($name), $value, $replace);
         return $this;
     }
 
@@ -156,10 +124,16 @@ class Mage_Core_Controller_Response_Http implements \Stringable
         );
 
         $this->canSendHeaders(true);
+        $code = self::$_transportObject->getCode();
         $this->setHeader('Location', self::$_transportObject->getUrl(), true)
-             ->setHttpResponseCode(self::$_transportObject->getCode());
+             ->setHttpResponseCode($code);
 
-        $this->symfonyResponse->setStatusCode(self::$_transportObject->getCode());
+        // Keep permanent redirects browser-cacheable; the header bag default
+        // (no-cache, private) would force a re-request of the old URL every visit
+        if ($code === 301 || $code === 308) {
+            $this->setHeader('Cache-Control', 'max-age=86400', true);
+        }
+
         $this->_isRedirect = true;
 
         return $this;
@@ -184,11 +158,30 @@ class Mage_Core_Controller_Response_Http implements \Stringable
     }
 
     /**
-     * Return array of headers; see {@link $_headers} for format
+     * Return headers as [['name' => ..., 'value' => ..., 'replace' => ...], ...]
+     * (legacy M1 format, derived from the Symfony header bag)
      */
     public function getHeaders(): array
     {
-        return $this->_headers;
+        $headers = [];
+        foreach ($this->symfonyResponse->headers->allPreserveCase() as $name => $values) {
+            foreach ($values as $value) {
+                $headers[] = [
+                    'name' => $name,
+                    'value' => $value,
+                    'replace' => true,
+                ];
+            }
+        }
+        return $headers;
+    }
+
+    /**
+     * Whether a header is present
+     */
+    public function hasHeader(string $name): bool
+    {
+        return $this->symfonyResponse->headers->has($name);
     }
 
     /**
@@ -196,7 +189,6 @@ class Mage_Core_Controller_Response_Http implements \Stringable
      */
     public function clearHeaders(): self
     {
-        $this->_headers = [];
         $this->symfonyResponse->headers = new \Symfony\Component\HttpFoundation\ResponseHeaderBag();
         return $this;
     }
@@ -206,12 +198,6 @@ class Mage_Core_Controller_Response_Http implements \Stringable
      */
     public function clearHeader(string $name): self
     {
-        $name = $this->_normalizeHeader($name);
-        foreach ($this->_headers as $key => $header) {
-            if ($name == $header['name']) {
-                unset($this->_headers[$key]);
-            }
-        }
         $this->symfonyResponse->headers->remove($name);
         return $this;
     }
@@ -269,11 +255,6 @@ class Mage_Core_Controller_Response_Http implements \Stringable
      */
     public function setHttpResponseCode(int $code): self
     {
-        if ((100 > $code) || (599 < $code)) {
-            throw new Exception('Invalid HTTP response code');
-        }
-
-        $this->_httpResponseCode = $code;
         $this->symfonyResponse->setStatusCode($code);
         return $this;
     }
@@ -283,7 +264,7 @@ class Mage_Core_Controller_Response_Http implements \Stringable
      */
     public function getHttpResponseCode(): int
     {
-        return $this->_httpResponseCode;
+        return $this->symfonyResponse->getStatusCode();
     }
 
     /**
@@ -303,8 +284,10 @@ class Mage_Core_Controller_Response_Http implements \Stringable
      * Send all headers
      *
      * Emission is delegated to the wrapped Symfony response, so ResponseHeaderBag
-     * defaults (conservative Cache-Control, Date) apply. Raw headers are sent
-     * first and suppress any same-named header from the bag.
+     * defaults (conservative Cache-Control, Date) apply. The response is prepared
+     * against the current request first (RFC compliance: Content-Type charset,
+     * HEAD/304 body stripping, protocol version, secure cookies). Raw headers are
+     * sent after preparation and suppress any same-named header from the bag.
      */
     public function sendHeaders(): self
     {
@@ -316,10 +299,16 @@ class Mage_Core_Controller_Response_Http implements \Stringable
             return $this;
         }
 
+        $this->symfonyResponse->prepare(Mage::app()->getRequest()->getSymfonyRequest());
+
         foreach ($this->_headersRaw as $rawHeader) {
             header($rawHeader);
             if (($pos = strpos($rawHeader, ':')) !== false) {
-                $this->symfonyResponse->headers->remove(trim(substr($rawHeader, 0, $pos)));
+                $name = trim(substr($rawHeader, 0, $pos));
+                // Set-Cookie is multi-valued; removing it would wipe every bag cookie
+                if (strcasecmp($name, 'Set-Cookie') !== 0) {
+                    $this->symfonyResponse->headers->remove($name);
+                }
             }
         }
 
@@ -486,6 +475,7 @@ class Mage_Core_Controller_Response_Http implements \Stringable
     public function setOutputOrder(array $order): self
     {
         $this->_bodyOrder = $order;
+        $this->symfonyResponse->setContent($this->outputBody());
         return $this;
     }
 
@@ -673,8 +663,7 @@ class Mage_Core_Controller_Response_Http implements \Stringable
         }
 
         $this->sendHeaders();
-
-        echo $this->outputBody();
+        $this->symfonyResponse->sendContent();
     }
 
     /**
@@ -711,32 +700,17 @@ class Mage_Core_Controller_Response_Http implements \Stringable
         bool $secure = false,
         bool $httponly = false,
     ): self {
-        // Set expiry time
-        if ($lifetime > 0) {
-            $expire = time() + $lifetime;
-        } else {
-            $expire = 0;
-        }
-
-        // Build cookie header
-        $cookieHeader = $name . '=' . urlencode($value);
-        if ($expire > 0) {
-            $cookieHeader .= '; expires=' . gmdate('D, d-M-Y H:i:s', $expire) . ' GMT';
-        }
-        if (!empty($path)) {
-            $cookieHeader .= '; path=' . $path;
-        }
-        if (!empty($domain)) {
-            $cookieHeader .= '; domain=' . $domain;
-        }
-        if ($secure) {
-            $cookieHeader .= '; Secure';
-        }
-        if ($httponly) {
-            $cookieHeader .= '; HttpOnly';
-        }
-
-        $this->setHeader('Set-Cookie', $cookieHeader, false);
+        $this->symfonyResponse->headers->setCookie(new \Symfony\Component\HttpFoundation\Cookie(
+            $name,
+            $value,
+            $lifetime > 0 ? time() + $lifetime : 0,
+            $path ?: '/',
+            $domain ?: null,
+            $secure,
+            $httponly,
+            false,
+            null,
+        ));
 
         return $this;
     }
@@ -746,18 +720,7 @@ class Mage_Core_Controller_Response_Http implements \Stringable
      */
     public function clearCookie(string $name, string $path = '/', string|null $domain = null): self
     {
-        // Set cookie with past expiry time
-        $cookieHeader = $name . '=deleted';
-        $cookieHeader .= '; expires=' . gmdate('D, d-M-Y H:i:s', time() - 3600) . ' GMT';
-        if (!empty($path)) {
-            $cookieHeader .= '; path=' . $path;
-        }
-        if (!empty($domain)) {
-            $cookieHeader .= '; domain=' . $domain;
-        }
-
-        $this->setHeader('Set-Cookie', $cookieHeader, false);
-
+        $this->symfonyResponse->headers->clearCookie($name, $path ?: '/', $domain ?: null, false, false);
         return $this;
     }
 
@@ -825,13 +788,7 @@ class Mage_Core_Controller_Response_Http implements \Stringable
         }
 
         // Skip for non-HTML responses
-        $contentType = '';
-        foreach ($this->_headers as $header) {
-            if (strcasecmp($header['name'], 'Content-Type') === 0) {
-                $contentType = $header['value'];
-                break;
-            }
-        }
+        $contentType = (string) $this->symfonyResponse->headers->get('Content-Type');
 
         // If no content type is set, check if body contains HTML
         if (empty($contentType)) {

--- a/app/code/core/Mage/Oauth/Model/Observer.php
+++ b/app/code/core/Mage/Oauth/Model/Observer.php
@@ -32,7 +32,6 @@ class Mage_Oauth_Model_Observer
             $url = Mage::helper('oauth')->getAuthorizeUrl();
             Mage::app()->getResponse()
                 ->setRedirect($url)
-                ->sendHeaders()
                 ->sendResponse();
             exit();
         }
@@ -52,7 +51,6 @@ class Mage_Oauth_Model_Observer
             $url = Mage::helper('oauth')->getAuthorizeUrl();
             Mage::app()->getResponse()
                 ->setRedirect($url)
-                ->sendHeaders()
                 ->sendResponse();
             exit();
         }

--- a/tests/Backend/Unit/Core/Controller/Response/HttpTest.php
+++ b/tests/Backend/Unit/Core/Controller/Response/HttpTest.php
@@ -410,6 +410,15 @@ describe('Mage_Core_Controller_Response_Http', function () {
             $this->response->sendHeaders();
             expect($this->response->getSymfonyResponse()->headers->has('Cache-Control'))->toBeFalse();
         });
+
+        it('is a no-op on a second sendHeaders call', function () {
+            $this->response->sendHeaders();
+            $this->response->setRawHeader('X-Test: raw');
+            $this->response->setHeader('X-Test', 'bag');
+            $this->response->sendHeaders();
+            // raw-header shadowing did not run, proving the second call was skipped
+            expect($this->response->getSymfonyResponse()->headers->has('X-Test'))->toBeTrue();
+        });
     });
 
     describe('Content Type Management', function () {

--- a/tests/Backend/Unit/Core/Controller/Response/HttpTest.php
+++ b/tests/Backend/Unit/Core/Controller/Response/HttpTest.php
@@ -115,7 +115,8 @@ describe('Mage_Core_Controller_Response_Http', function () {
         it('clears headers', function () {
             $this->response->setHeader('X-Header', 'value');
             $this->response->clearHeaders();
-            expect($this->response->getHeaders())->toBe([]);
+            // the header bag keeps its Cache-Control and Date defaults
+            expect($this->response->hasHeader('X-Header'))->toBeFalse();
         });
 
         it('handles raw headers', function () {
@@ -136,7 +137,7 @@ describe('Mage_Core_Controller_Response_Http', function () {
             $this->response->setRawHeader('HTTP/1.1 200 OK');
             $this->response->clearAllHeaders();
 
-            expect($this->response->getHeaders())->toBe([]);
+            expect($this->response->hasHeader('X-Header'))->toBeFalse();
             expect($this->response->getRawHeaders())->toBe([]);
         });
     });
@@ -208,6 +209,25 @@ describe('Mage_Core_Controller_Response_Http', function () {
             $this->response->setRedirect('https://example.com');
             expect($this->response->isRedirect())->toBeTrue();
         });
+
+        it('makes permanent redirects browser-cacheable', function () {
+            $this->response->setRedirect('https://example.com', 301);
+            expect($this->response->getSymfonyResponse()->headers->get('Cache-Control'))
+                ->toBe('max-age=86400, private');
+        });
+
+        it('keeps temporary redirects uncacheable', function () {
+            $this->response->setRedirect('https://example.com', 302);
+            expect($this->response->getSymfonyResponse()->headers->get('Cache-Control'))
+                ->toBe('no-cache, private');
+        });
+
+        it('lets an explicit Cache-Control set after a permanent redirect win', function () {
+            $this->response->setRedirect('https://example.com', 301);
+            $this->response->setHeader('Cache-Control', 'no-store');
+            expect($this->response->getSymfonyResponse()->headers->get('Cache-Control'))
+                ->toBe('no-store, private');
+        });
     });
 
     describe('Cookie Management', function () {
@@ -250,8 +270,9 @@ describe('Mage_Core_Controller_Response_Http', function () {
             }
 
             expect($cookieHeader)->toContain('custom_cookie');
-            expect($cookieHeader)->toContain('Secure');
-            expect($cookieHeader)->toContain('HttpOnly');
+            // Symfony emits the attributes lowercase
+            expect($cookieHeader)->toContain('secure');
+            expect($cookieHeader)->toContain('httponly');
         });
 
         it('clears cookies', function () {
@@ -370,13 +391,15 @@ describe('Mage_Core_Controller_Response_Http', function () {
     });
 
     describe('HTTP Protocol Version', function () {
-        it('defaults to HTTP/1.1', function () {
-            // Check via raw headers or default behavior
-            $this->response->setHttpResponseCode(200);
+        it('upgrades to HTTP/1.1 on send via prepare()', function () {
+            $this->response->sendHeaders();
+            expect($this->response->getSymfonyResponse()->getProtocolVersion())->toBe('1.1');
+        });
 
-            // The response should use HTTP/1.1 by default
-            $symfonyResponse = $this->response->getSymfonyResponse();
-            expect($symfonyResponse->getProtocolVersion())->toBe('1.1');
+        it('upgrades an injected Symfony response on send', function () {
+            $response = new Mage_Core_Controller_Response_Http(new SymfonyResponse('content'));
+            $response->sendHeaders();
+            expect($response->getSymfonyResponse()->getProtocolVersion())->toBe('1.1');
         });
     });
 
@@ -405,10 +428,39 @@ describe('Mage_Core_Controller_Response_Http', function () {
                 ->toBe('max-age=3600, public');
         });
 
+        it('does not wipe bag cookies when a raw Set-Cookie header is sent', function () {
+            $this->response->setCookie('keep_me', 'value');
+            $this->response->setRawHeader('Set-Cookie: raw_cookie=1');
+            $this->response->sendHeaders();
+            expect($this->response->getSymfonyResponse()->headers->getCookies())->toHaveCount(1);
+        });
+
         it('removes a bag header shadowed by a raw header on send', function () {
             $this->response->setRawHeader('Cache-Control: no-store');
             $this->response->sendHeaders();
             expect($this->response->getSymfonyResponse()->headers->has('Cache-Control'))->toBeFalse();
+        });
+
+        it('prepares the response against the request on send', function () {
+            $this->response->sendHeaders();
+            // prepare() supplies a default Content-Type with charset
+            expect($this->response->getSymfonyResponse()->headers->get('Content-Type'))
+                ->toBe('text/html; charset=utf-8');
+        });
+
+        it('appends the charset to a text Content-Type on send', function () {
+            $this->response->setHeader('Content-Type', 'text/xml');
+            $this->response->sendHeaders();
+            expect($this->response->getSymfonyResponse()->headers->get('Content-Type'))
+                ->toBe('text/xml; charset=utf-8');
+        });
+
+        it('strips body and entity headers from a 304 response on send', function () {
+            $this->response->setBody('stale content');
+            $this->response->setHttpResponseCode(304);
+            $this->response->sendHeaders();
+            expect($this->response->getSymfonyResponse()->getContent())->toBe('')
+                ->and($this->response->getSymfonyResponse()->headers->has('Content-Type'))->toBeFalse();
         });
 
         it('is a no-op on a second sendHeaders call', function () {

--- a/tests/Backend/Unit/Core/Controller/Response/HttpTest.php
+++ b/tests/Backend/Unit/Core/Controller/Response/HttpTest.php
@@ -380,6 +380,38 @@ describe('Mage_Core_Controller_Response_Http', function () {
         });
     });
 
+    describe('Default Cache-Control', function () {
+        it('defaults to no-cache, private when no caching headers are set', function () {
+            expect($this->response->getSymfonyResponse()->headers->get('Cache-Control'))
+                ->toBe('no-cache, private');
+        });
+
+        it('switches to private, must-revalidate when Last-Modified is set', function () {
+            $this->response->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT');
+            expect($this->response->getSymfonyResponse()->headers->get('Cache-Control'))
+                ->toBe('private, must-revalidate');
+        });
+
+        it('switches to private, must-revalidate when Expires is set', function () {
+            $this->response->setHeader('Expires', 'Thu, 01 Jan 1970 00:00:00 GMT');
+            expect($this->response->getSymfonyResponse()->headers->get('Cache-Control'))
+                ->toBe('private, must-revalidate');
+        });
+
+        it('keeps an explicitly set Cache-Control header', function () {
+            $this->response->setHeader('Cache-Control', 'public, max-age=3600');
+            // Symfony normalizes directive order
+            expect($this->response->getSymfonyResponse()->headers->get('Cache-Control'))
+                ->toBe('max-age=3600, public');
+        });
+
+        it('removes a bag header shadowed by a raw header on send', function () {
+            $this->response->setRawHeader('Cache-Control: no-store');
+            $this->response->sendHeaders();
+            expect($this->response->getSymfonyResponse()->headers->has('Cache-Control'))->toBeFalse();
+        });
+    });
+
     describe('Content Type Management', function () {
         it('sets content type header', function () {
             $this->response->setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
Closes #992.

## What

`Mage_Core_Controller_Response_Http` now fully delegates response emission and state to the wrapped `SymfonyResponse` instead of maintaining parallel custom logic:

- `sendHeaders()` delegates emission to `SymfonyResponse::sendHeaders()`, after calling `Response::prepare()` against the wrapped Symfony request (the step Symfony's HttpKernel normally performs before sending).
- `sendResponse()` emits the body via `SymfonyResponse::sendContent()`, mirroring Symfony's own `send()`.
- The `$_headers` and `$_httpResponseCode` mirror properties are removed; `getHeaders()`, `hasHeader()`, `clearHeader(s)()`, `setHttpResponseCode()`, and `getHttpResponseCode()` read/write the `ResponseHeaderBag` and status code directly. `getHeaders()` still returns the legacy M1 `name`/`value`/`replace` array shape, derived from the bag.
- `setCookie()` / `clearCookie()` build Symfony `Cookie` objects instead of hand-assembled header strings (same defaults as before: not secure, not httponly, no SameSite).
- Status code validation is Symfony's (`InvalidArgumentException` outside 100-599, same range as before).

Only M1 semantics Symfony doesn't model remain custom: named body segments, raw headers, and the `canSendHeaders()` guard.

## Behavior changes

- Responses that set no caching headers now ship `Cache-Control: no-cache, private` (Symfony's conservative default, close to the old OpenMage global no-cache). `no-cache` does not affect bfcache eligibility (only `no-store` does), so back/forward navigation is unchanged.
- Responses with `Last-Modified` or `Expires` get `private, must-revalidate`.
- Explicit `Cache-Control` headers are kept, with Symfony normalization: directives are sorted, and `, private` is appended when none of `public`/`private`/`s-maxage` is present (correct for per-user content such as downloads).
- A `Date` header is always sent (RFC 9110, handled by Symfony).
- **301/308 redirects get `Cache-Control: max-age=86400, private`** so browsers keep caching permanent redirects (canonical URLs, URL rewrites). Without this, the new bag default would force a re-request of the old URL on every visit. A later explicit `setHeader('Cache-Control', ...)` still wins.
- **`Response::prepare()` now runs on every send**, which means:
  - Responses without a `Content-Type` get `text/html; charset=utf-8`; `text/*` types without a charset get `; charset=utf-8` appended.
  - HEAD requests and 204/304 responses get their body and entity headers stripped per RFC.
  - Cookies set via the response are Secure-by-default on HTTPS requests.
  - The protocol version comes from `prepare()` (HTTP/1.1 unless the client spoke 1.0), replacing the hard-coded constructor value.
- Headers present on a `SymfonyResponse` passed into the constructor are now actually emitted; previously they were silently dropped because emission only read the mirrored array.
- Raw headers (`setRawHeader()`, no core users) are emitted first and suppress any same-named header from the bag, so they still win. `Set-Cookie` is exempt from this shadowing since removing it from the bag would wipe every cookie. The ancient CGI `Status:` dedup branch is removed; PHP's `header()` handles status lines per SAPI.
- `getHeaders()` now always includes the bag's `Cache-Control` and `Date` defaults, and cookie header strings are Symfony-formatted (lowercase `secure`/`httponly`, explicit `Max-Age`).

## Side fix

The catalog product/category and CMS index/page controllers sent `Cache-Control: private max-age=60` (missing comma, inherited from Magento 1). That is a single invalid directive browsers ignore, so these pages were never actually cached. Fixing the comma made the 60s cache real for the first time and served stale session state: after a currency switch, the redirect landed on the browser-cached page still showing the old currency (caught by `CurrencySwitcherTest`). These pages embed per-session state (currency, minicart, customer greeting), so time-based browser caching is the wrong policy for them. The headers are removed entirely; Symfony's `no-cache, private` default requires revalidation, matching the de-facto behavior stores have always had. (`Pragma` is a request header in HTTP/1.1, so `Pragma: public` did nothing.)

## Testing

- New tests in `tests/Backend/Unit/Core/Controller/Response/HttpTest.php`: default Cache-Control, redirect caching, raw-header shadowing, `prepare()` effects (charset, 304 stripping, protocol version), cookie preservation (51 passing)
- `composer lint` clean
