### PR TITLE
Fixed frontend `Add to Compare`

### DIFF
--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -212,7 +212,7 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('controller_action_predispatch', area: 'frontend')]
+    #[Maho\Config\Observer('controller_action_predispatch', area: 'frontend', type: 'singleton')]
     public function initByRequest($observer)
     {
         if ($this->_skipRequestLogging || $this->isModuleIgnored($observer)) {
@@ -257,7 +257,7 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('controller_action_postdispatch', area: 'frontend')]
+    #[Maho\Config\Observer('controller_action_postdispatch', area: 'frontend', type: 'singleton')]
     public function saveByRequest($observer)
     {
         if ($this->_skipRequestLogging || $this->isModuleIgnored($observer)) {
@@ -283,7 +283,7 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('customer_login', area: 'frontend')]
+    #[Maho\Config\Observer('customer_login', area: 'frontend', type: 'singleton')]
     public function bindCustomerLogin($observer)
     {
         /** @var Mage_Customer_Model_Customer $customer */
@@ -311,7 +311,7 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
      * @param \Maho\Event\Observer $observer
      * @return  $this
      */
-    #[Maho\Config\Observer('customer_logout', area: 'frontend')]
+    #[Maho\Config\Observer('customer_logout', area: 'frontend', type: 'singleton')]
     public function bindCustomerLogout($observer)
     {
         if ($this->getCustomerId() && $customer = $observer->getEvent()->getCustomer()) {
@@ -324,7 +324,7 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
      * @param \Maho\Event\Observer $observer
      * @return $this
      */
-    #[Maho\Config\Observer('sales_quote_save_after', area: 'frontend')]
+    #[Maho\Config\Observer('sales_quote_save_after', area: 'frontend', type: 'singleton')]
     public function bindQuoteCreate($observer)
     {
         /** @var Mage_Sales_Model_Quote $quote */
@@ -342,7 +342,7 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
      * @param \Maho\Event\Observer $observer
      * @return $this
      */
-    #[Maho\Config\Observer('checkout_quote_destroy', area: 'frontend')]
+    #[Maho\Config\Observer('checkout_quote_destroy', area: 'frontend', type: 'singleton')]
     public function bindQuoteDestroy($observer)
     {
         /** @var Mage_Sales_Model_Quote $quote */

--- a/app/design/frontend/base/default/template/catalog/product/list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list.phtml
@@ -89,7 +89,7 @@
                                 <li>
                                     <a href="#" data-url="<?= $_wishlistUrl ?>" data-params="<?= $_params ?>"
                                        class="link-wishlist" title="<?= $this->__('Add to Wishlist') ?>"
-                                       onclick="customFormSubmit('<?= $_wishlistUrl ?>', '<?= $_params ?>', 'post')">
+                                       onclick="customFormSubmit('<?= $_wishlistUrl ?>', '<?= $_params ?>', 'post'); return false;">
                                         <?= $this->getIconSvg('heart') ?>
                                         <?= $this->__('Add to Wishlist') ?>
                                     </a>
@@ -98,7 +98,7 @@
                             <?php if ($_compareUrl = $this->getAddToCompareUrlCustom($_product, false)) : ?>
                                 <li>
                                     <a href="#" title="<?= $this->__('Add to Compare') ?>"
-                                       onclick="customFormSubmit('<?= $_compareUrl ?>', '<?= $_params ?>', 'post')">
+                                       onclick="customFormSubmit('<?= $_compareUrl ?>', '<?= $_params ?>', 'post'); return false;">
                                         <?= $this->getIconSvg('scale') ?>
                                         <?= $this->__('Add to Compare') ?>
                                     </a>
@@ -139,7 +139,7 @@
                             <li>
                                 <a href="#" data-url="<?= $_wishlistUrl ?>" data-params="<?= $_params ?>"
                                    class="link-wishlist" title="<?= $this->__('Add to Wishlist') ?>"
-                                   onclick="customFormSubmit('<?= $_wishlistUrl ?>', '<?= $_params ?>', 'post')">
+                                   onclick="customFormSubmit('<?= $_wishlistUrl ?>', '<?= $_params ?>', 'post'); return false;">
                                     <?= $this->getIconSvg('heart') ?>
                                     <?= $this->__('Add to Wishlist') ?>
                                 </a>
@@ -148,7 +148,7 @@
                         <?php if ($_compareUrl = $this->getAddToCompareUrlCustom($_product, false)) : ?>
                             <li>
                                 <a href="#" title="<?= $this->__('Add to Compare') ?>"
-                                   onclick="customFormSubmit('<?= $_compareUrl ?>', '<?= $_params ?>', 'post')">
+                                   onclick="customFormSubmit('<?= $_compareUrl ?>', '<?= $_params ?>', 'post'); return false;">
                                     <?= $this->getIconSvg('scale') ?>
                                     <?= $this->__('Add to Compare') ?>
                                 </a>

--- a/app/design/frontend/base/default/template/catalog/product/view/addto.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/view/addto.phtml
@@ -25,7 +25,7 @@
         <?php if ($_compareUrl) : ?>
             <?php $_params = $this->escapeHtml(json_encode(['form_key' => $this->getFormKey()])) ?>
             <a href="#" class="link-compare" title="<?= $this->__('Add to Compare') ?>"
-               onclick="customFormSubmit('<?= $_compareUrl ?>', '<?= $_params ?>', 'post')">
+               onclick="customFormSubmit('<?= $_compareUrl ?>', '<?= $_params ?>', 'post'); return false;">
                 <?= $this->getIconSvg('scale') ?>
             </a>
         <?php endif ?>

--- a/tests/Frontend/Integration/Catalog/CompareAddTest.php
+++ b/tests/Frontend/Integration/Catalog/CompareAddTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+uses(Tests\MahoFrontendTestCase::class);
+
+/**
+ * Regression coverage for issue #1022 ("Add to Compare does not work").
+ *
+ * The frontend visitor is initialised by Mage_Log_Model_Visitor::initByRequest on
+ * controller_action_predispatch. The compare controller then reads the *same*
+ * Mage::getSingleton('log/visitor') to decide whether a guest may own a compare item.
+ *
+ * The #[Observer] attribute defaults to type 'model' (a fresh instance per dispatch),
+ * whereas the original M1 XML observer had no <type> and therefore defaulted to
+ * 'singleton'. Under 'model' the observer initialises a throwaway visitor, leaving the
+ * shared singleton empty, so a guest's getId() is null and the add is silently dropped.
+ */
+function startGuestSession(): void
+{
+    $session = new Session(new MockArraySessionStorage());
+    $session->start();
+    Mage::register('symfony_session', $session);
+
+    Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
+    Mage::app()->getStore()->setConfig('catalog/recently_products/enabled_product_compare', '1');
+    Mage::app()->getStore()->setConfig('system/log/enable_log', '2'); // log visitors
+    Mage::app()->addEventArea('frontend');
+}
+
+function firstEnabledProduct(): Mage_Catalog_Model_Product
+{
+    return Mage::getModel('catalog/product')->getCollection()
+        ->addAttributeToFilter('status', Mage_Catalog_Model_Product_Status::STATUS_ENABLED)
+        ->setPageSize(1)
+        ->getFirstItem();
+}
+
+it('populates the shared log/visitor singleton on controller_action_predispatch', function () {
+    startGuestSession();
+
+    $request = Mage::app()->getRequest();
+    $request->setRouteName('catalog');
+    $controllerAction = new class($request, new Mage_Core_Controller_Response_Http()) extends Mage_Core_Controller_Front_Action {};
+
+    // Same event the front controller fires before dispatching any frontend action.
+    Mage::dispatchEvent('controller_action_predispatch', ['controller_action' => $controllerAction]);
+
+    // The visitor the rest of the request reads is the singleton. It must carry an id.
+    expect(Mage::getSingleton('log/visitor')->getId())->not->toBeNull();
+});
+
+it('adds a product to a guest comparison list end to end', function () {
+    startGuestSession();
+
+    $product = firstEnabledProduct();
+    $productId = (int) $product->getId();
+    expect($productId)->toBeGreaterThan(0);
+
+    $formKey = Mage::getSingleton('core/session')->getFormKey();
+
+    $symfonyRequest = SymfonyRequest::create(
+        '/catalog/product_compare/add/?product=' . $productId . '&uenc=' . Mage::helper('core')->urlEncode('http://localhost/'),
+        'POST',
+        ['form_key' => $formKey],
+    );
+    $request = new Mage_Core_Controller_Request_Http($symfonyRequest);
+    $request->setPathInfo('/catalog/product_compare/add');
+    $request->setRouteName('catalog');
+    $request->setControllerName('product_compare');
+    $request->setActionName('add');
+    $request->setControllerModule('Mage_Catalog');
+    $request->setDispatched(true);
+
+    $controller = new Mage_Catalog_Product_CompareController($request, new Mage_Core_Controller_Response_Http());
+
+    // Visitor is initialised by the predispatch observer, exactly as in a real request.
+    Mage::dispatchEvent('controller_action_predispatch', ['controller_action' => $controller]);
+
+    $visitorId = Mage::getSingleton('log/visitor')->getId();
+    expect($visitorId)->not->toBeNull();
+
+    $before = (int) Mage::getResourceModel('catalog/product_compare_item_collection')
+        ->setVisitorId($visitorId)->getSize();
+
+    $controller->addAction();
+
+    $after = (int) Mage::getResourceModel('catalog/product_compare_item_collection')
+        ->setVisitorId($visitorId)->getSize();
+
+    expect($after)->toBe($before + 1);
+});

--- a/tests/Frontend/Integration/Catalog/CompareAddTest.php
+++ b/tests/Frontend/Integration/Catalog/CompareAddTest.php
@@ -50,7 +50,7 @@ it('populates the shared log/visitor singleton on controller_action_predispatch'
 
     $request = Mage::app()->getRequest();
     $request->setRouteName('catalog');
-    $controllerAction = new class($request, new Mage_Core_Controller_Response_Http()) extends Mage_Core_Controller_Front_Action {};
+    $controllerAction = new class ($request, new Mage_Core_Controller_Response_Http()) extends Mage_Core_Controller_Front_Action {};
 
     // Same event the front controller fires before dispatching any frontend action.
     Mage::dispatchEvent('controller_action_predispatch', ['controller_action' => $controllerAction]);


### PR DESCRIPTION
Fixes #1022.

## Problem

Clicking **Add to Compare** on a frontend product page reloaded the page and added nothing.

## Root causes (two, both required for the failure)

1. **Visitor singleton never populated (primary).** The `log/visitor` observers (`initByRequest`, `saveByRequest`, `bindCustomer*`, `bindQuote*`) used the `#[Observer]` default `type: 'model'`, so they ran on throwaway `Mage::getModel('log/visitor')` instances rather than the shared `Mage::getSingleton('log/visitor')`. The compare controller authorises a guest's compare item with `Mage::getSingleton('log/visitor')->getId()`, which was always `null`, so the add was dropped via `_redirectReferer()`. The same inversion created a new `log_visitor` row on nearly every request.

   Fix: mark those observers `type: 'singleton'`, restoring the M1 shared-instance behaviour for this stateful model. (The dispatcher's `getModel` default is intentional and unchanged; only the observers that depend on a shared instance opt in.)

2. **Form POST aborted by the anchor (secondary).** The compare/wishlist `<a href="#">` `onclick="customFormSubmit(...)"` had no `return false;`, so the default `#` navigation raced and aborted the JS-built form POST before it reached the controller. Added `return false;` to the compare and wishlist handlers in `view/addto.phtml` and `list.phtml` (the cart `<button type="button">` elements need no change).

This also repairs the guest -> customer comparison merge on login, which reads the same visitor singleton.

## Tests

New `tests/Frontend/Integration/Catalog/CompareAddTest.php`:
- the predispatch observer populates the shared `log/visitor` singleton;
- a guest add-to-compare creates a `catalog_compare_item` row end to end.

Both fail before the fix, pass after.

## Verification

- Backend suite: 2117 passed. Frontend suite: 113 passed (incl. new tests).
- `php-cs-fixer` clean, `phpstan` (level 6) OK.
- Manual browser check: clicking Add to Compare adds the product and shows "The product ... has been added to comparison list."; one `log_visitor` row per session instead of one per request.