### PR TITLE
Enabled AJAX reload on admin grids that support it

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Grid.php
@@ -27,6 +27,13 @@ class Mage_Adminhtml_Block_Checkout_Agreement_Grid extends Mage_Adminhtml_Block_
         $this->setId('agreementGrid');
         $this->setDefaultDir('asc');
         $this->setSaveParametersInSession(true);
+        $this->setUseAjax(true);
+    }
+
+    #[\Override]
+    public function getGridUrl()
+    {
+        return $this->getUrl('*/*/grid', ['_current' => true]);
     }
 
     #[\Override]

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
@@ -16,6 +16,13 @@ class Mage_Adminhtml_Block_Cms_Block_Grid extends Mage_Adminhtml_Block_Widget_Gr
         $this->setId('cmsBlockGrid');
         $this->setDefaultSort('title');
         $this->setDefaultDir('ASC');
+        $this->setUseAjax(true);
+    }
+
+    #[\Override]
+    public function getGridUrl()
+    {
+        return $this->getUrl('*/*/grid', ['_current' => true]);
     }
 
     #[\Override]

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
@@ -16,6 +16,7 @@ class Mage_Adminhtml_Block_Cms_Block_Grid extends Mage_Adminhtml_Block_Widget_Gr
         $this->setId('cmsBlockGrid');
         $this->setDefaultSort('title');
         $this->setDefaultDir('ASC');
+        $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
@@ -16,6 +16,13 @@ class Mage_Adminhtml_Block_Cms_Page_Grid extends Mage_Adminhtml_Block_Widget_Gri
         $this->setId('cmsPageGrid');
         $this->setDefaultSort('title');
         $this->setDefaultDir('ASC');
+        $this->setUseAjax(true);
+    }
+
+    #[\Override]
+    public function getGridUrl()
+    {
+        return $this->getUrl('*/*/grid', ['_current' => true]);
     }
 
     #[\Override]

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
@@ -16,6 +16,7 @@ class Mage_Adminhtml_Block_Cms_Page_Grid extends Mage_Adminhtml_Block_Widget_Gri
         $this->setId('cmsPageGrid');
         $this->setDefaultSort('title');
         $this->setDefaultDir('ASC');
+        $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group/Grid.php
@@ -17,6 +17,13 @@ class Mage_Adminhtml_Block_Customer_Group_Grid extends Mage_Adminhtml_Block_Widg
         $this->setDefaultSort('type');
         $this->setDefaultDir('asc');
         $this->setSaveParametersInSession(true);
+        $this->setUseAjax(true);
+    }
+
+    #[\Override]
+    public function getGridUrl()
+    {
+        return $this->getUrl('*/*/grid', ['_current' => true]);
     }
 
     #[\Override]

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Online/Grid.php
@@ -19,6 +19,7 @@ class Mage_Adminhtml_Block_Customer_Online_Grid extends Mage_Adminhtml_Block_Wid
         $this->setId('onlineGrid');
         $this->setSaveParametersInSession(true);
         $this->setDefaultSort('last_activity');
+        $this->setUseAjax(true);
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
@@ -17,6 +17,7 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
         parent::__construct();
         $this->setId('reviwGrid');
         $this->setDefaultSort('created_at');
+        $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Grid.php
@@ -17,6 +17,7 @@ class Mage_Adminhtml_Block_Review_Grid extends Mage_Adminhtml_Block_Widget_Grid
         parent::__construct();
         $this->setId('reviwGrid');
         $this->setDefaultSort('created_at');
+        $this->setUseAjax(true);
     }
 
     #[\Override]

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Grid.php
@@ -15,6 +15,7 @@ class Mage_Adminhtml_Block_System_Convert_Gui_Grid extends Mage_Adminhtml_Block_
         parent::__construct();
         $this->setId('convertProfileGrid');
         $this->setDefaultSort('profile_id');
+        $this->setUseAjax(true);
     }
 
     #[\Override]

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Gui/Grid.php
@@ -15,6 +15,7 @@ class Mage_Adminhtml_Block_System_Convert_Gui_Grid extends Mage_Adminhtml_Block_
         parent::__construct();
         $this->setId('convertProfileGrid');
         $this->setDefaultSort('profile_id');
+        $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Grid.php
@@ -15,6 +15,7 @@ class Mage_Adminhtml_Block_System_Convert_Profile_Grid extends Mage_Adminhtml_Bl
         parent::__construct();
         $this->setId('convertProfileGrid');
         $this->setDefaultSort('profile_id');
+        $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Grid.php
@@ -15,6 +15,7 @@ class Mage_Adminhtml_Block_System_Convert_Profile_Grid extends Mage_Adminhtml_Bl
         parent::__construct();
         $this->setId('convertProfileGrid');
         $this->setDefaultSort('profile_id');
+        $this->setUseAjax(true);
     }
 
     #[\Override]

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Grid.php
@@ -17,6 +17,7 @@ class Mage_Adminhtml_Block_Urlrewrite_Grid extends Mage_Adminhtml_Block_Widget_G
         parent::__construct();
         $this->setId('urlrewriteGrid');
         $this->setDefaultSort('url_rewrite_id');
+        $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Grid.php
@@ -17,6 +17,13 @@ class Mage_Adminhtml_Block_Urlrewrite_Grid extends Mage_Adminhtml_Block_Widget_G
         parent::__construct();
         $this->setId('urlrewriteGrid');
         $this->setDefaultSort('url_rewrite_id');
+        $this->setUseAjax(true);
+    }
+
+    #[\Override]
+    public function getGridUrl()
+    {
+        return $this->getUrl('*/*/grid', ['_current' => true]);
     }
 
     #[\Override]

--- a/app/code/core/Mage/Adminhtml/controllers/Checkout/AgreementController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Checkout/AgreementController.php
@@ -39,6 +39,14 @@ class Mage_Adminhtml_Checkout_AgreementController extends Mage_Adminhtml_Control
         return $this;
     }
 
+    #[Maho\Config\Route('/admin/checkout_agreement/grid')]
+    public function gridAction(): void
+    {
+        $this->getResponse()->setBody(
+            $this->getLayout()->createBlock('adminhtml/checkout_agreement_grid')->toHtml(),
+        );
+    }
+
     #[Maho\Config\Route('/admin/checkout_agreement/new')]
     public function newAction(): void
     {

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/BlockController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/BlockController.php
@@ -56,6 +56,13 @@ class Mage_Adminhtml_Cms_BlockController extends Mage_Adminhtml_Controller_Actio
         $this->renderLayout();
     }
 
+    #[Maho\Config\Route('/admin/cms_block/grid')]
+    public function gridAction(): void
+    {
+        $this->loadLayout();
+        $this->renderLayout();
+    }
+
     /**
      * Create new CMS block
      */

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/PageController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/PageController.php
@@ -40,6 +40,13 @@ class Mage_Adminhtml_Cms_PageController extends Mage_Adminhtml_Controller_Action
         $this->renderLayout();
     }
 
+    #[Maho\Config\Route('/admin/cms_page/grid')]
+    public function gridAction(): void
+    {
+        $this->loadLayout();
+        $this->renderLayout();
+    }
+
     /**
      * Create new CMS page
      */

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/GroupController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/GroupController.php
@@ -54,6 +54,13 @@ class Mage_Adminhtml_Customer_GroupController extends Mage_Adminhtml_Controller_
         $this->renderLayout();
     }
 
+    #[Maho\Config\Route('/admin/customer_group/grid')]
+    public function gridAction(): void
+    {
+        $this->loadLayout();
+        $this->renderLayout();
+    }
+
     /**
      * Edit or create customer group.
      */

--- a/app/code/core/Mage/Adminhtml/controllers/Customer/OnlineController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Customer/OnlineController.php
@@ -37,4 +37,12 @@ class Mage_Adminhtml_Customer_OnlineController extends Mage_Adminhtml_Controller
 
         $this->renderLayout();
     }
+
+    #[Maho\Config\Route('/admin/customer_online/grid')]
+    public function gridAction(): void
+    {
+        $this->getResponse()->setBody(
+            $this->getLayout()->createBlock('adminhtml/customer_online_grid', 'customer.grid')->toHtml(),
+        );
+    }
 }

--- a/app/code/core/Mage/Adminhtml/controllers/UrlrewriteController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/UrlrewriteController.php
@@ -66,6 +66,14 @@ class Mage_Adminhtml_UrlrewriteController extends Mage_Adminhtml_Controller_Acti
         $this->renderLayout();
     }
 
+    #[Maho\Config\Route('/admin/urlrewrite/grid')]
+    public function gridAction(): void
+    {
+        $this->getResponse()->setBody(
+            $this->getLayout()->createBlock('adminhtml/urlrewrite_grid')->toHtml(),
+        );
+    }
+
     /**
      * Show urlrewrite edit/create page
      */

--- a/app/code/core/Mage/Payment/Block/Adminhtml/Payment/Restriction/Grid.php
+++ b/app/code/core/Mage/Payment/Block/Adminhtml/Payment/Restriction/Grid.php
@@ -15,6 +15,13 @@ class Mage_Payment_Block_Adminhtml_Payment_Restriction_Grid extends Mage_Adminht
         $this->setDefaultSort('restriction_id');
         $this->setDefaultDir('ASC');
         $this->setSaveParametersInSession(true);
+        $this->setUseAjax(true);
+    }
+
+    #[\Override]
+    public function getGridUrl(): string
+    {
+        return $this->getUrl('*/*/grid', ['_current' => true]);
     }
 
     #[\Override]

--- a/app/code/core/Mage/Payment/controllers/Adminhtml/Payment/RestrictionController.php
+++ b/app/code/core/Mage/Payment/controllers/Adminhtml/Payment/RestrictionController.php
@@ -37,6 +37,13 @@ class Mage_Payment_Adminhtml_Payment_RestrictionController extends Mage_Adminhtm
             ->renderLayout();
     }
 
+    #[Maho\Config\Route('/admin/payment_restriction/grid')]
+    public function gridAction(): void
+    {
+        $this->loadLayout();
+        $this->renderLayout();
+    }
+
     #[Maho\Config\Route('/admin/payment_restriction/new')]
     public function newAction(): void
     {

--- a/app/code/core/Maho/CatalogLinkRule/Block/Adminhtml/Rule/Grid.php
+++ b/app/code/core/Maho/CatalogLinkRule/Block/Adminhtml/Rule/Grid.php
@@ -17,6 +17,13 @@ class Maho_CatalogLinkRule_Block_Adminhtml_Rule_Grid extends Mage_Adminhtml_Bloc
         $this->setDefaultSort('priority');
         $this->setDefaultDir('ASC');
         $this->setSaveParametersInSession(true);
+        $this->setUseAjax(true);
+    }
+
+    #[\Override]
+    public function getGridUrl(): string
+    {
+        return $this->getUrl('*/*/grid', ['_current' => true]);
     }
 
     #[\Override]

--- a/app/code/core/Maho/CatalogLinkRule/controllers/Adminhtml/Cataloglinkrule/RuleController.php
+++ b/app/code/core/Maho/CatalogLinkRule/controllers/Adminhtml/Cataloglinkrule/RuleController.php
@@ -22,6 +22,13 @@ class Maho_CatalogLinkRule_Adminhtml_Cataloglinkrule_RuleController extends Mage
             ->renderLayout();
     }
 
+    #[Maho\Config\Route('/admin/cataloglinkrule_rule/grid')]
+    public function gridAction(): void
+    {
+        $this->loadLayout();
+        $this->renderLayout();
+    }
+
     #[Maho\Config\Route('/admin/cataloglinkrule_rule/new')]
     public function newAction(): void
     {

--- a/app/code/core/Maho/CustomerSegmentation/Block/Adminhtml/Segment/Grid.php
+++ b/app/code/core/Maho/CustomerSegmentation/Block/Adminhtml/Segment/Grid.php
@@ -17,6 +17,13 @@ class Maho_CustomerSegmentation_Block_Adminhtml_Segment_Grid extends Mage_Adminh
         $this->setDefaultSort('segment_id');
         $this->setDefaultDir('ASC');
         $this->setSaveParametersInSession(true);
+        $this->setUseAjax(true);
+    }
+
+    #[\Override]
+    public function getGridUrl(): string
+    {
+        return $this->getUrl('*/*/grid', ['_current' => true]);
     }
 
     #[\Override]

--- a/app/code/core/Maho/CustomerSegmentation/controllers/Adminhtml/CustomerSegmentation_IndexController.php
+++ b/app/code/core/Maho/CustomerSegmentation/controllers/Adminhtml/CustomerSegmentation_IndexController.php
@@ -35,6 +35,13 @@ class Maho_CustomerSegmentation_Adminhtml_CustomerSegmentation_IndexController e
             ->renderLayout();
     }
 
+    #[Maho\Config\Route('/admin/customersegmentation_index/grid')]
+    public function gridAction(): void
+    {
+        $this->loadLayout();
+        $this->renderLayout();
+    }
+
     #[Maho\Config\Route('/admin/customersegmentation_index/new')]
     public function newAction(): void
     {

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Destination/Grid.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Destination/Grid.php
@@ -16,6 +16,13 @@ class Maho_FeedManager_Block_Adminhtml_Destination_Grid extends Mage_Adminhtml_B
         $this->setId('feedmanagerDestinationGrid');
         $this->setDefaultSort('destination_id');
         $this->setSaveParametersInSession(true);
+        $this->setUseAjax(true);
+    }
+
+    #[\Override]
+    public function getGridUrl(): string
+    {
+        return $this->getUrl('*/*/grid', ['_current' => true]);
     }
 
     #[\Override]

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Dynamicrule/Grid.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Dynamicrule/Grid.php
@@ -17,6 +17,13 @@ class Maho_FeedManager_Block_Adminhtml_Dynamicrule_Grid extends Mage_Adminhtml_B
         $this->setDefaultSort('rule_id');
         $this->setDefaultDir('ASC');
         $this->setSaveParametersInSession(true);
+        $this->setUseAjax(true);
+    }
+
+    #[\Override]
+    public function getGridUrl(): string
+    {
+        return $this->getUrl('*/*/grid', ['_current' => true]);
     }
 
     #[\Override]

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Grid.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Grid.php
@@ -16,6 +16,13 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Grid extends Mage_Adminhtml_Block_Wi
         $this->setId('feedmanagerFeedGrid');
         $this->setDefaultSort('feed_id');
         $this->setSaveParametersInSession(true);
+        $this->setUseAjax(true);
+    }
+
+    #[\Override]
+    public function getGridUrl(): string
+    {
+        return $this->getUrl('*/*/grid', ['_current' => true]);
     }
 
     #[\Override]

--- a/app/code/core/Maho/FeedManager/controllers/Adminhtml/Feedmanager/DestinationController.php
+++ b/app/code/core/Maho/FeedManager/controllers/Adminhtml/Feedmanager/DestinationController.php
@@ -39,6 +39,13 @@ class Maho_FeedManager_Adminhtml_Feedmanager_DestinationController extends Mage_
         $this->renderLayout();
     }
 
+    #[Maho\Config\Route('/admin/feedmanager_destination/grid')]
+    public function gridAction(): void
+    {
+        $this->loadLayout();
+        $this->renderLayout();
+    }
+
     #[Maho\Config\Route('/admin/feedmanager_destination/new')]
     public function newAction(): void
     {

--- a/app/code/core/Maho/FeedManager/controllers/Adminhtml/Feedmanager/DynamicruleController.php
+++ b/app/code/core/Maho/FeedManager/controllers/Adminhtml/Feedmanager/DynamicruleController.php
@@ -39,6 +39,13 @@ class Maho_FeedManager_Adminhtml_Feedmanager_DynamicruleController extends Mage_
         $this->renderLayout();
     }
 
+    #[Maho\Config\Route('/admin/feedmanager_dynamicrule/grid')]
+    public function gridAction(): void
+    {
+        $this->loadLayout();
+        $this->renderLayout();
+    }
+
     #[Maho\Config\Route('/admin/feedmanager_dynamicrule/new')]
     public function newAction(): void
     {

--- a/app/code/core/Maho/FeedManager/controllers/Adminhtml/Feedmanager/FeedController.php
+++ b/app/code/core/Maho/FeedManager/controllers/Adminhtml/Feedmanager/FeedController.php
@@ -54,6 +54,13 @@ class Maho_FeedManager_Adminhtml_Feedmanager_FeedController extends Mage_Adminht
         $this->renderLayout();
     }
 
+    #[Maho\Config\Route('/admin/feedmanager_feed/grid')]
+    public function gridAction(): void
+    {
+        $this->loadLayout();
+        $this->renderLayout();
+    }
+
     #[Maho\Config\Route('/admin/feedmanager_feed/new')]
     public function newAction(): void
     {

--- a/app/design/adminhtml/default/default/layout/cataloglinkrule.xml
+++ b/app/design/adminhtml/default/default/layout/cataloglinkrule.xml
@@ -33,4 +33,8 @@ SPDX-License-Identifier: AFL-3.0
             </block>
         </reference>
     </adminhtml_cataloglinkrule_rule_edit>
+
+    <adminhtml_cataloglinkrule_rule_grid>
+        <block type="cataloglinkrule/adminhtml_rule_grid" name="root" output="toHtml" />
+    </adminhtml_cataloglinkrule_rule_grid>
 </layout>

--- a/app/design/adminhtml/default/default/layout/cms.xml
+++ b/app/design/adminhtml/default/default/layout/cms.xml
@@ -13,6 +13,10 @@ SPDX-License-Identifier: AFL-3.0
         </reference>
     </adminhtml_cms_page_index>
 
+    <adminhtml_cms_page_grid>
+        <block type="adminhtml/cms_page_grid" name="root" output="toHtml" />
+    </adminhtml_cms_page_grid>
+
     <adminhtml_cms_page_new>
         <update handle="adminhtml_cms_page_edit" />
     </adminhtml_cms_page_new>
@@ -41,6 +45,10 @@ SPDX-License-Identifier: AFL-3.0
             <block type="adminhtml/cms_block" name="cms_block"></block>
         </reference>
     </adminhtml_cms_block_index>
+
+    <adminhtml_cms_block_grid>
+        <block type="adminhtml/cms_block_grid" name="root" output="toHtml" />
+    </adminhtml_cms_block_grid>
 
     <adminhtml_cms_block_new>
         <update handle="adminhtml_cms_block_edit" />

--- a/app/design/adminhtml/default/default/layout/customer.xml
+++ b/app/design/adminhtml/default/default/layout/customer.xml
@@ -35,6 +35,9 @@ SPDX-License-Identifier: AFL-3.0
             <block type="adminhtml/customer_group" name="customer_group"></block>
         </reference>
     </adminhtml_customer_group_index>
+    <adminhtml_customer_group_grid>
+        <block type="adminhtml/customer_group_grid" name="root" output="toHtml" />
+    </adminhtml_customer_group_grid>
     <adminhtml_customer_wishlist>
         <block type="adminhtml/customer_edit_tab_wishlist" name="customer.wishlist.edit.tab" output="toHtml" />
     </adminhtml_customer_wishlist>

--- a/app/design/adminhtml/default/default/layout/customersegmentation.xml
+++ b/app/design/adminhtml/default/default/layout/customersegmentation.xml
@@ -39,4 +39,8 @@ SPDX-License-Identifier: AFL-3.0
             </block>
         </reference>
     </adminhtml_customersegmentation_index_editsequence>
+
+    <adminhtml_customersegmentation_index_grid>
+        <block type="customersegmentation/adminhtml_segment_grid" name="root" output="toHtml" />
+    </adminhtml_customersegmentation_index_grid>
 </layout>

--- a/app/design/adminhtml/default/default/layout/feedmanager.xml
+++ b/app/design/adminhtml/default/default/layout/feedmanager.xml
@@ -120,4 +120,17 @@ SPDX-License-Identifier: OSL-3.0
             </block>
         </reference>
     </adminhtml_feedmanager_dynamicrule_edit>
+
+    <!-- AJAX grid reload handles -->
+    <adminhtml_feedmanager_feed_grid>
+        <block type="feedmanager/adminhtml_feed_grid" name="root" output="toHtml" />
+    </adminhtml_feedmanager_feed_grid>
+
+    <adminhtml_feedmanager_destination_grid>
+        <block type="feedmanager/adminhtml_destination_grid" name="root" output="toHtml" />
+    </adminhtml_feedmanager_destination_grid>
+
+    <adminhtml_feedmanager_dynamicrule_grid>
+        <block type="feedmanager/adminhtml_dynamicrule_grid" name="root" output="toHtml" />
+    </adminhtml_feedmanager_dynamicrule_grid>
 </layout>

--- a/app/design/adminhtml/default/default/layout/payment.xml
+++ b/app/design/adminhtml/default/default/layout/payment.xml
@@ -29,4 +29,8 @@ SPDX-License-Identifier: AFL-3.0
             <block type="payment/adminhtml_payment_restriction_edit" name="payment_restriction_edit"></block>
         </reference>
     </adminhtml_payment_restriction_edit>
+
+    <adminhtml_payment_restriction_grid>
+        <block type="payment/adminhtml_payment_restriction_grid" name="root" output="toHtml" />
+    </adminhtml_payment_restriction_grid>
 </layout>


### PR DESCRIPTION
## Summary

Enables AJAX reload (in-place pagination, sorting and filtering) on admin grids whose listing can be served as grid-only HTML, instead of triggering a full page refresh.

## Approach

Wiring follows the existing convention already used by the Gift Card and Customer grids:

- The grid block calls `setUseAjax(true)` and (where needed) overrides `getGridUrl()` to point at a dedicated `*/*/grid` action.
- The controller serves the AJAX request as grid-only HTML, either via `loadLayout()`/`renderLayout()` with a dedicated `*_grid` layout handle, or via a direct `setBody()` of the grid block for containers that are built programmatically (no index layout handle).

Each grid was checked individually: only grids backed by a real DB collection whose reload endpoint returns just the grid are included. Reports, dashboard tiles, export-only grids and static lists were intentionally left untouched.

## Grids enabled

**Core**
- Review
- System Convert (Gui, Profile)
- CMS Block, CMS Page
- Customer Group, Customer Online
- Checkout Agreement
- Url Rewrite
- Payment Restriction

**Maho modules**
- CatalogLinkRule Rule
- CustomerSegmentation Segment
- FeedManager (Feed, Destination, Dynamicrule)

## Notable fix

`Customer/Online` previously forwarded AJAX requests to a `grid` action that did not exist (dead code, never reached because the grid did not use AJAX). The missing `gridAction` is now added so the forward resolves correctly.

## Verification

- `php -l` on all changed files
- php-cs-fixer (clean)
- PHPStan level 6 (no errors)
- Layout XML parses
- All new grid routes compile into the route tables

Not yet click-tested in the browser; the AJAX reloads are verified structurally.