### PR TITLE
Fix fatal error in Visitor logging when session start is skipped

### DIFF
--- a/app/code/core/Mage/Core/Model/Session/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract.php
@@ -340,12 +340,12 @@ class Mage_Core_Model_Session_Abstract extends \Maho\DataObject
      */
     public function getSessionId()
     {
-        return $this->getSymfonySession()->getId();
+        return $this->getSymfonySession()?->getId() ?? false;
     }
 
     public function getSessionName(): string
     {
-        return $this->getSymfonySession()->getName();
+        return $this->getSymfonySession()?->getName() ?? '';
     }
 
     public function setSessionName(string $name): self

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -215,7 +215,9 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
     #[Maho\Config\Observer('controller_action_predispatch', area: 'frontend', type: 'singleton')]
     public function initByRequest($observer)
     {
-        if ($this->_skipRequestLogging || $this->isModuleIgnored($observer)) {
+        if ($this->_skipRequestLogging || $this->isModuleIgnored($observer)
+            || $this->_session->getSessionId() === false
+        ) {
             return $this;
         }
 
@@ -260,7 +262,9 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
     #[Maho\Config\Observer('controller_action_postdispatch', area: 'frontend', type: 'singleton')]
     public function saveByRequest($observer)
     {
-        if ($this->_skipRequestLogging || $this->isModuleIgnored($observer)) {
+        if ($this->_skipRequestLogging || $this->isModuleIgnored($observer)
+            || $this->_session->getSessionId() === false
+        ) {
             return $this;
         }
 


### PR DESCRIPTION
## Summary

Fixes #1027.

On the frontend, when an action opts out of session startup via the supported `FLAG_NO_START_SESSION` mechanism, the core Log/Visitor observer crashed with a fatal `Call to a member function getId() on null`. The session was intentionally never started, but `Mage_Log_Model_Visitor::initByRequest()` (wired to `controller_action_predispatch`) unconditionally called `getSessionId()`, which dereferenced a `null` Symfony session.

## Changes

**`Mage_Core_Model_Session_Abstract` (root cause)** — make the session-id/name accessors null-safe, honoring their already-declared return types:
- `getSessionId()` returns `false` when there is no Symfony session (already documented `@return false|string`)
- `getSessionName()` returns `''` when there is no session

These match sibling methods like `init()` and `start()`, which already guard `getSymfonySession() === null`.

**`Mage_Log_Model_Visitor` (defense in depth)** — both the predispatch (`initByRequest`) and postdispatch (`saveByRequest`) observers early-return when there is no session, so a `FLAG_NO_START_SESSION` request is cleanly skipped instead of attempting to read/write visitor and session data. `saveByRequest` is guarded too since it also calls `initServerData()` and `$this->_session->setVisitorData()` and would hit the same null session on postdispatch.

## Result

A frontend action that opts out of sessions via `FLAG_NO_START_SESSION` now renders normally, and visitor logging quietly no-ops.