### PR TITLE
Fixed double attribute_id remap corrupting sample data EAV values

### DIFF
--- a/lib/MahoCLI/Helper/SampleDataImporter.php
+++ b/lib/MahoCLI/Helper/SampleDataImporter.php
@@ -39,16 +39,20 @@ class SampleDataImporter
 
     /**
      * Tables that contain attribute_id column that needs remapping
+     *
+     * catalog_product_entity_int and catalog_category_entity_int are intentionally
+     * excluded: their attribute_id is remapped by remapOptionValuesInProductEntityInt()
+     * and remapOptionValuesInCategoryEntityInt(), which also remap the option value.
+     * Listing them here too would remap attribute_id twice and misroute values when an
+     * attribute's new ID collides with another attribute's old ID.
      */
     private const TABLES_WITH_ATTRIBUTE_ID = [
         'catalog_category_entity_datetime',
         'catalog_category_entity_decimal',
-        'catalog_category_entity_int',
         'catalog_category_entity_text',
         'catalog_category_entity_varchar',
         'catalog_product_entity_datetime',
         'catalog_product_entity_decimal',
-        'catalog_product_entity_int',
         'catalog_product_entity_text',
         'catalog_product_entity_varchar',
         'catalog_eav_attribute',


### PR DESCRIPTION
## Problem

Some configurable products imported from the sample data render as broken (no configurable attributes / missing child option values), and the affected product varies by environment. The reporter saw `shw003` (a shoe, configurable on `shoe_type`); a current clean install instead shows the `Pearl Strand Necklace` (546, `frame_style`) plus misrouted `size` and `length` values.

## Root cause

`SampleDataImporter::remapSql()` remapped `attribute_id` **twice** for `catalog_product_entity_int` and `catalog_category_entity_int`:

1. `remapAttributeIdInTable()`, because both tables were listed in `TABLES_WITH_ATTRIBUTE_ID`, and
2. `remapOptionValuesInProductEntityInt()` / `remapOptionValuesInCategoryEntityInt()`, which already remap `attribute_id` for every row before remapping the option value.

The dump and a fresh install assign EAV attribute IDs differently (a roughly constant shift), so an attribute's **new** ID frequently equals some other attribute's **old** ID. When that happens, the second pass re-maps the already-correct ID down the wrong attribute's chain, e.g. `necklace_length` 210 → 183 (first pass) → 156 `frame_style` (second pass). The select value is then stored on the wrong attribute, so the configurable's children lose the value for its super attribute and the product renders broken.

On a clean MySQL import this corrupted 31 `catalog_product_entity_int` rows across `size` ← `gendered` (18), `length` ← `books_music_type` (10), and `frame_style` ← `necklace_length` (3).

## Fix

Remove `catalog_product_entity_int` and `catalog_category_entity_int` from `TABLES_WITH_ATTRIBUTE_ID`. The dedicated option-value methods already remap `attribute_id` for every row (select or not), so the ID is now remapped exactly once.

## Verification

After a clean re-import with the patch, this should return 0 (was 31):

\`\`\`sql
SELECT COUNT(*) FROM catalog_product_entity_int v
JOIN eav_attribute a1 ON a1.attribute_id = v.attribute_id
JOIN eav_attribute_option o ON o.option_id = v.value
WHERE v.store_id = 0
  AND a1.frontend_input IN ('select','multiselect')
  AND (a1.source_model IS NULL OR a1.source_model = 'eav/entity_attribute_source_table')
  AND o.attribute_id <> v.attribute_id;
\`\`\`

Fixes #1030