### PR TITLE
Added consistency guard for static EAV attributes vs declarative columns

### DIFF
--- a/tests/Backend/Unit/Maho/Db/Schema/StaticAttributeColumnTest.php
+++ b/tests/Backend/Unit/Maho/Db/Schema/StaticAttributeColumnTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Maho\Db\Schema\Collector;
+use Tests\MahoBackendTestCase;
+
+/**
+ * Consistency guard for the two halves of a `static` EAV attribute:
+ * the column declared in a module's sql/schema.php (declarative schema) and
+ * the attribute registered via Mage_Eav_Model_Entity_Setup::addAttribute(...,
+ * ['type' => 'static']) in a data script.
+ *
+ * EAV attributes are data (append-only data scripts), table shape is schema
+ * (declarative schema). The one failure mode of that split is silent drift: a
+ * static attribute registered with no backing column. addAttribute() only
+ * inserts the eav_attribute row, it does not create the column, and entity
+ * loads are SELECT * — so the missing column surfaces not as an install error
+ * but quietly (the attribute reads empty) or as an "unknown column" error only
+ * when something saves that attribute with a value. A new, thinly-covered
+ * static attribute (e.g. the customer 2FA attributes) can therefore slip
+ * through the functional suite. This test catches it structurally: every
+ * registered static attribute must have a matching column on its entity table
+ * in the collected declarative Schema.
+ *
+ * The reverse direction (a column with no registered attribute) is intentionally
+ * not flagged: entity tables legitimately carry many non-attribute columns
+ * (entity_id, attribute_set_id, type_id, flat denormalized fields, ...), so it
+ * is a convention tripwire rather than a bug detector and is out of scope.
+ */
+
+uses(MahoBackendTestCase::class);
+
+/**
+ * Static attributes that intentionally have no backing column, keyed by
+ * "{entity_type_code}/{attribute_code}" with the reason. These are virtual
+ * attributes: registered as `static` so the EAV layer treats them as part of
+ * the entity row rather than an EAV value, but their values are computed or
+ * persisted elsewhere through a backend model, so DBAL has no column to manage.
+ *
+ * Keep this list short and justified — every entry is a hole in the guard.
+ */
+const COLUMNLESS_STATIC_ATTRIBUTES = [
+    // Stored via the catalog_category_product link table (see
+    // Mage_Catalog_Model_Product::getCategoryIds), not a product row column.
+    'catalog_product/category_ids' => 'virtual attribute backed by the category-product link table',
+];
+
+it('backs every static EAV attribute with a declarative schema column', function () {
+    [$schema] = Collector::collect();
+
+    $resource = Mage::getSingleton('core/resource');
+    $read = $resource->getConnection('core_read');
+
+    // Every static attribute, paired with the entity type that owns it. Only
+    // backend_type = 'static' has a backing column; non-static attributes store
+    // their values in the EAV value tables and must be excluded.
+    $select = $read->select()
+        ->from(['a' => $resource->getTableName('eav/attribute')], ['attribute_code', 'backend_type'])
+        ->join(
+            ['e' => $resource->getTableName('eav/entity_type')],
+            'a.entity_type_id = e.entity_type_id',
+            ['entity_type_code', 'entity_table'],
+        )
+        ->where('a.backend_type = ?', 'static')
+        ->order(['e.entity_type_code', 'a.attribute_code']);
+
+    $rows = $read->fetchAll($select);
+
+    // Sanity: the core install registers plenty of static attributes (catalog
+    // product sku/created_at, customer email, ...). An empty set means the
+    // query or the install is broken, which would make the guard a silent no-op.
+    expect($rows)->not->toBeEmpty();
+
+    $missing = [];
+    foreach ($rows as $row) {
+        $key = $row['entity_type_code'] . '/' . $row['attribute_code'];
+        if (isset(COLUMNLESS_STATIC_ATTRIBUTES[$key])) {
+            continue;
+        }
+
+        $table = $resource->getTableName($row['entity_table']);
+
+        if (!$schema->hasTable($table)) {
+            $missing[] = sprintf(
+                '%s.%s (entity "%s") — entity table is not in the declarative schema',
+                $table,
+                $row['attribute_code'],
+                $row['entity_type_code'],
+            );
+            continue;
+        }
+
+        if (!$schema->getTable($table)->hasColumn($row['attribute_code'])) {
+            $missing[] = sprintf(
+                '%s.%s (entity "%s")',
+                $table,
+                $row['attribute_code'],
+                $row['entity_type_code'],
+            );
+        }
+    }
+
+    expect($missing)->toBe([], sprintf(
+        "Static EAV attributes without a backing column in the declarative schema:\n  %s\n"
+        . 'Declare the column in the entity table\'s sql/schema.php, or remove/rename the attribute registration.',
+        implode("\n  ", $missing),
+    ));
+});


### PR DESCRIPTION
Closes #1038.

## What

Adds a backend test that keeps the two halves of a `static` EAV attribute in sync: the column declared in a module's `sql/schema.php` (declarative schema) and the attribute registered via `addAttribute(..., ['type' => 'static'])` in a data script.

The test checks the forward direction against the collected declarative `Schema` (`Maho\Db\Schema\Collector::collect()`): every `backend_type = 'static'` attribute must have a matching column on its entity table. If the entity table isn't in the declarative schema at all, that's reported too.

## Why this catches something the functional suite doesn't

`addAttribute()` only inserts the `eav_attribute` row, it does **not** create the column. And entity loads are `SELECT *` (`_getLoadRowSelect`). So a column-less static attribute:

- does **not** fail install (just a row insert),
- loads quietly with the attribute simply absent (no SQL error),
- only errors loudly ("unknown column") when some flow saves that attribute *with a value*.

A new, thinly-covered static attribute, exactly the customer 2FA case the issue cites, can therefore stay green through the whole functional suite and only break in production. This guard is a structural invariant that doesn't depend on any behavioral test exercising the attribute.

## Allowlist

`COLUMNLESS_STATIC_ATTRIBUTES` documents virtual static attributes with no backing column (`catalog_product/category_ids`, stored via the category-product link table). Kept short and justified.

## Scope

Only the forward direction. The reverse (a column with no registered attribute) is intentionally out of scope: entity tables legitimately carry many non-attribute columns (`entity_id`, `type_id`, flat denormalized fields, ...), so it would be a convention tripwire requiring an ongoing allowlist rather than a bug detector. The quiet/conditionally-loud failure mode is specific to the forward direction.

## Verification

Confirmed the guard actually fails on induced drift, not just passes: renaming `twofa_secret` in `Customer/sql/schema.php` makes it fail with `customer_entity.twofa_secret (entity "customer")`. All `tests/Backend/Unit/Maho/Db/Schema/` tests pass; `php-cs-fixer` clean.