### PR TITLE
Validated PayPal quote before capturing payment

### DIFF
--- a/app/code/core/Mage/Sales/Model/Service/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Service/Quote.php
@@ -250,6 +250,16 @@ class Mage_Sales_Model_Service_Quote
     }
 
     /**
+     * Public entry point to validate the quote without submitting it.
+     * Lets callers (e.g. PayPal) verify the quote is placeable before
+     * taking an irreversible action such as capturing payment.
+     */
+    public function validate(): self
+    {
+        return $this->_validate();
+    }
+
+    /**
      * Validate quote data before converting to order
      *
      * @return $this

--- a/app/code/core/Maho/Paypal/Helper/Data.php
+++ b/app/code/core/Maho/Paypal/Helper/Data.php
@@ -203,6 +203,36 @@ class Maho_Paypal_Helper_Data extends Mage_Core_Helper_Abstract
         }
     }
 
+    /**
+     * Prepare and validate the quote before any payment is captured.
+     *
+     * Imports the PayPal address (assigning a shipping method) when needed,
+     * recollects totals, then runs the same validation order placement will
+     * run. Throws here, before the irreversible capture, when the quote is not
+     * placeable (e.g. missing shipping method), so no money moves for an order
+     * that cannot be created.
+     */
+    public function prepareQuoteForPaypalOrder(
+        Mage_Sales_Model_Quote $quote,
+        array $paypalResult,
+        string $methodCode,
+    ): void {
+        $quote->getPayment()->setMethod($methodCode);
+
+        if (!$quote->getBillingAddress()->getFirstname()) {
+            $this->importPaypalAddress($paypalResult, $quote);
+        }
+
+        // Ensure correct checkout method for sessionless contexts (webhooks)
+        if ($quote->getCustomerId() && !$quote->getData('checkout_method')) {
+            $quote->setData('checkout_method', Mage_Checkout_Model_Type_Onepage::METHOD_CUSTOMER);
+        }
+
+        $quote->collectTotals();
+
+        Mage::getModel('sales/service_quote', $quote)->validate();
+    }
+
     public function saveVaultToken(array $paypalResult, Mage_Sales_Model_Quote $quote): void
     {
         $customerId = $quote->getCustomerId();

--- a/app/code/core/Maho/Paypal/Model/Webhook/Handler/OrderApproved.php
+++ b/app/code/core/Maho/Paypal/Model/Webhook/Handler/OrderApproved.php
@@ -57,6 +57,14 @@ class Maho_Paypal_Model_Webhook_Handler_OrderApproved extends Maho_Paypal_Model_
             /** @var Maho_Paypal_Model_Api_Client $client */
             $client = Mage::getModel('paypal/api_client', ['store_id' => (int) $quote->getStoreId()]);
 
+            /** @var Maho_Paypal_Helper_Data $helper */
+            $helper = Mage::helper('paypal');
+
+            // Prepare and validate the quote BEFORE capturing, so an unplaceable
+            // quote (e.g. missing shipping method) fails before money moves.
+            $paypalOrder = $client->getOrder($paypalOrderId);
+            $helper->prepareQuoteForPaypalOrder($quote, $paypalOrder, $methodCode);
+
             if ($intent === Maho_Paypal_Model_Config::PAYMENT_ACTION_CAPTURE) {
                 $paypalResult = $client->captureOrder($paypalOrderId);
             } else {

--- a/app/code/core/Maho/Paypal/controllers/CheckoutController.php
+++ b/app/code/core/Maho/Paypal/controllers/CheckoutController.php
@@ -127,6 +127,15 @@ class Maho_Paypal_CheckoutController extends Mage_Core_Controller_Front_Action
                 shippingCallbackUrl: $shippingCallbackUrl,
             );
 
+            // Vault payments capture synchronously inside createOrder (there is no
+            // popup/approve round-trip), so validate the quote here, before the money
+            // moves, just as the standard flow validates before its capture.
+            if ($vaultPaypalTokenId) {
+                $quote->getPayment()->setMethod($methodCode);
+                $quote->collectTotals();
+                Mage::getModel('sales/service_quote', $quote)->validate();
+            }
+
             /** @var Maho_Paypal_Model_Api_Client $client */
             $client = Mage::getModel('paypal/api_client', ['store_id' => (int) $quote->getStoreId()]);
             $paypalOrder = $client->createOrder(['body' => $orderRequest]);
@@ -291,6 +300,10 @@ class Maho_Paypal_CheckoutController extends Mage_Core_Controller_Front_Action
                     // different cart and place an order paid by someone else's capture.
                     $this->_assertPaypalOrderMatchesQuote($paypalResult, $quote);
                     $this->_assertPaypalOrderNotAlreadyUsed($paypalOrderId);
+
+                    // Prepare and validate the quote BEFORE capturing. A missing or
+                    // invalid shipping method must fail here, not after the money moves.
+                    $paypalHelper->prepareQuoteForPaypalOrder($quote, $paypalResult, $methodCode);
 
                     $status = $paypalResult['status'] ?? '';
 

--- a/tests/Frontend/Integration/Paypal/CapturePlacementSafetyTest.php
+++ b/tests/Frontend/Integration/Paypal/CapturePlacementSafetyTest.php
@@ -66,3 +66,39 @@ it('prepareQuoteForPaypalOrder blocks an unplaceable express quote before captur
     expect(fn() => $helper->prepareQuoteForPaypalOrder($quote, $paypalResult, 'paypal_standard_checkout'))
         ->toThrow(Mage_Core_Exception::class);
 });
+
+it('prepareQuoteForPaypalOrder accepts a placeable express quote and assigns a shipping method', function () {
+    $quote = paypalNonVirtualQuote();
+    if (!$quote) {
+        $this->markTestSkipped('No simple product available for testing');
+    }
+    $quote->save();
+
+    // Express-style PayPal result carrying a full shipping address. prepare must
+    // import it, collect rates and assign the (active, default) flatrate method,
+    // then pass validation without throwing — money is allowed to move.
+    // GB has no required region, keeping this focused on the shipping-method gate.
+    $paypalResult = [
+        'id' => 'TESTORDER2',
+        'payer' => ['email_address' => 'buyer@example.com', 'name' => ['given_name' => 'Jane', 'surname' => 'Doe']],
+        'purchase_units' => [[
+            'shipping' => [
+                'name' => ['full_name' => 'Jane Doe'],
+                'address' => [
+                    'address_line_1' => '10 Downing St',
+                    'admin_area_2' => 'London',
+                    'postal_code' => 'SW1A 2AA',
+                    'country_code' => 'GB',
+                ],
+            ],
+        ]],
+    ];
+
+    /** @var Maho_Paypal_Helper_Data $helper */
+    $helper = Mage::helper('paypal');
+    $helper->prepareQuoteForPaypalOrder($quote, $paypalResult, 'paypal_standard_checkout');
+
+    // Reaching here means validation passed before any capture; the shipping
+    // method resolved from the imported address proves the gate is not over-strict.
+    expect($quote->getShippingAddress()->getShippingMethod())->not->toBeEmpty();
+});

--- a/tests/Frontend/Integration/Paypal/CapturePlacementSafetyTest.php
+++ b/tests/Frontend/Integration/Paypal/CapturePlacementSafetyTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoFrontendTestCase::class)->group('frontend', 'paypal');
+
+function paypalNonVirtualQuote(): ?Mage_Sales_Model_Quote
+{
+    $product = Mage::getResourceModel('catalog/product_collection')
+        ->addAttributeToFilter('type_id', 'simple')
+        ->addAttributeToFilter('status', 1)
+        ->addAttributeToSelect(['price', 'name'])
+        ->setPageSize(1)
+        ->getFirstItem();
+    if (!$product->getId()) {
+        return null;
+    }
+
+    $quote = Mage::getModel('sales/quote');
+    $quote->setStoreId(1);
+    $quote->addProduct($product, 1);
+    return $quote;
+}
+
+it('validate() rejects a non-virtual quote with no shipping method', function () {
+    $quote = paypalNonVirtualQuote();
+    if (!$quote) {
+        $this->markTestSkipped('No simple product available for testing');
+    }
+
+    $address = ['firstname' => 'Jane', 'lastname' => 'Doe', 'street' => '1 St', 'city' => 'LA', 'region_id' => 12, 'postcode' => '90210', 'country_id' => 'US', 'telephone' => '0000000000'];
+    $quote->getBillingAddress()->addData($address);
+    $quote->getShippingAddress()->addData($address)->setSameAsBilling(1);
+    $quote->getPayment()->setMethod('paypal_standard_checkout');
+    $quote->collectTotals();
+
+    // No shipping method assigned -> validation must throw before any capture
+    $service = Mage::getModel('sales/service_quote', $quote);
+    expect(fn() => $service->validate())
+        ->toThrow(Mage_Core_Exception::class, 'Please specify a shipping method.');
+});
+
+it('prepareQuoteForPaypalOrder blocks an unplaceable express quote before capture', function () {
+    $quote = paypalNonVirtualQuote();
+    if (!$quote) {
+        $this->markTestSkipped('No simple product available for testing');
+    }
+    $quote->save();
+
+    // Express-style PayPal result: payer email but no usable shipping address,
+    // so no valid shipping address/method can be resolved. prepare must throw
+    // here (before capture) rather than let the flow reach captureOrder.
+    $paypalResult = [
+        'id' => 'TESTORDER1',
+        'payer' => ['email_address' => 'buyer@example.com', 'name' => ['given_name' => 'Jane', 'surname' => 'Doe']],
+        'purchase_units' => [[]],
+    ];
+
+    /** @var Maho_Paypal_Helper_Data $helper */
+    $helper = Mage::helper('paypal');
+    expect(fn() => $helper->prepareQuoteForPaypalOrder($quote, $paypalResult, 'paypal_standard_checkout'))
+        ->toThrow(Mage_Core_Exception::class);
+});


### PR DESCRIPTION
## Problem

The PayPal flow captured payment **before** validating the quote. When a quote was not placeable, most commonly because it had no valid shipping method, the customer's money was taken but no order was created:

1. `captureOrder()` moved the money.
2. `placeOrderFromPaypalResult()` then called `saveOrder()`, which runs `Mage_Sales_Model_Service_Quote::_validate()`.
3. `_validate()` threw *"Please specify a shipping method."* after the capture was already irreversible.
4. The catch block only logged a `CRITICAL` line and rethrew. No order, money gone.

Realistic triggers: express/smart-button checkout where the popup-selected shipping rate code goes stale by approval time (free-shipping threshold flips, qty changed in another tab, address differs), the shipping callback returning no rates, or vault payments with no shipping method on the quote.

## Fix

Move validation ahead of **every** point that takes money, so the capture never happens for an order that cannot be placed.

- `Mage_Sales_Model_Service_Quote::validate()` — public entry point to run the existing `_validate()` without submitting the quote.
- `Maho_Paypal_Helper_Data::prepareQuoteForPaypalOrder()` — imports the PayPal address, recollects totals and validates, throwing **before** capture when the quote is not placeable.
- Called before `captureOrder`/`authorizeOrder` in `approveOrderAction` and in the `OrderApproved` webhook handler (standard checkout path).
- Validated before `createOrder` in `createOrderAction` for **vault** payments, which capture synchronously at order creation with no approve round-trip.

On failure the request now throws before any charge, exactly as a normal "please pick a shipping method" error, with nothing to refund.

## Tests

`tests/Frontend/Integration/Paypal/CapturePlacementSafetyTest.php` covers the validation gate (`validate()` rejecting a non-virtual quote with no shipping method, and `prepareQuoteForPaypalOrder()` blocking an unplaceable express quote before capture).

Full frontend PayPal group passes; phpstan level 6 and php-cs-fixer clean.