### PR TITLE
Fixed CLI command discovery dropping project commands when vendor packages also register commands

### DIFF
--- a/maho
+++ b/maho
@@ -96,7 +96,10 @@ $application->addCommand(new \MahoCLI\Commands\FrontendLayoutDebug());
 $application->addCommand(new \MahoCLI\Commands\FrontendThemeCreate());
 
 $discoverer = new CommandDiscoverer();
-$commands = $discoverer->discover(__DIR__ . '/vendor/*/*') + $discoverer->discover(__DIR__);
+$commands = array_merge(
+    $discoverer->discover(__DIR__ . '/vendor/*/*'),
+    $discoverer->discover(__DIR__),
+);
 foreach ($commands as $command) {
     $application->addCommand($command);
 }


### PR DESCRIPTION
## Summary

The `maho` entrypoint discovers commands from two sources — vendor packages and the
project root — and combines them with the PHP array-union operator `+`. Since both
lists are zero-indexed integer-keyed arrays, the union silently drops the project's
first *N* commands whenever *N* commands come from vendor packages. This PR switches to
`array_merge()` so every discovered command is registered.

## Root cause

```php
$commands = $discoverer->discover(__DIR__ . '/vendor/*/*') + $discoverer->discover(__DIR__);
```

`discover()` returns a fresh, zero-indexed array each call (`$commands[] = new $className()`).
On a key collision `+` keeps the left-hand (vendor) value, so vendor keys `0..N-1`
shadow the project's first `N` commands. Which commands vanish depends on filesystem
iteration order (`RecursiveIteratorIterator` is unsorted), so it differs per machine.

```php
["a", "b"] + ["x", "y", "z"]            // → [a, b, z]   — x, y dropped
array_merge(["a", "b"], ["x", "y", "z"]) // → [a, b, x, y, z]
```

## Fix

```diff
-$commands = $discoverer->discover(__DIR__ . '/vendor/*/*') + $discoverer->discover(__DIR__);
+$commands = array_merge(
+    $discoverer->discover(__DIR__ . '/vendor/*/*'),
+    $discoverer->discover(__DIR__),
+);
```

`array_merge()` renumbers integer keys and appends, so nothing is overwritten. Project
commands merge *after* vendor commands, and `Application::addCommand()` already
de-duplicates by command **name** (last wins) — so a project command intentionally
overriding a vendor one keeps the expected precedence.

## Testing

- `./maho list` before/after on an install with vendor-supplied commands: previously
  missing project commands are now registered and listed.
- Operator semantics runnable online: https://onlinephp.io/c/9da47