### PR TITLE
Fixed Feed Manager admin UI regressions

### DIFF
--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/General.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/General.php
@@ -371,6 +371,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 XmlBuilder.loadPreset(platform, { force: true });
             } else if ((format === 'json' || format === 'jsonl') && typeof JsonBuilder !== 'undefined' && typeof JsonBuilder.loadPreset === 'function') {
                 JsonBuilder.loadPreset(platform, { force: true });
+            } else if (format === 'csv' && typeof CsvBuilder !== 'undefined' && typeof CsvBuilder.loadPreset === 'function') {
+                CsvBuilder.loadPreset(platform, { force: true });
             }
         }
     }

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/General.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/General.php
@@ -361,15 +361,11 @@ document.addEventListener('DOMContentLoaded', function() {
         if (platformField) platformField.value = platform;
         if (formatField) {
             formatField.value = format;
-            // Notify the mapping tab so the matching builder fieldset reveals itself
             formatField.dispatchEvent(new Event('change'));
         }
 
-        // When the user actively switches Feed Template to a real platform,
-        // also push that platform's preset into the matching builder so the
-        // structure tree reflects the choice immediately. Skip 'custom' (no
-        // preset to load) and skip on initial page load (loadBuilderPreset
-        // would clobber an existing feed's saved structure).
+        // Push the platform preset on a user-driven change only; skip on init
+        // so existing feeds keep their saved structure.
         if (loadBuilderPreset && platform !== 'custom') {
             if (format === 'xml' && typeof XmlBuilder !== 'undefined' && typeof XmlBuilder.loadPreset === 'function') {
                 XmlBuilder.loadPreset(platform, { force: true });
@@ -379,14 +375,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // On a fresh feed the template selector renders with its default value
-    // ("Custom XML" = custom:xml) but the hidden file_format field is still
-    // empty, so the format-change listener in feedmanager-mapping.js sees no
-    // matching builder and leaves every fieldset hidden. Sync once on load so
-    // the default selection wires up the format and reveals the right builder
-    // without requiring the user to first pick a different template and come
-    // back. Existing feeds keep their saved file_format because the template
-    // selector's current value already reflects it.
+    // Wire the default template selection to file_format on a fresh feed so
+    // the matching builder fieldset reveals itself without user interaction.
     if (formatField && !formatField.value) {
         syncFromTemplate(false);
     }

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/General.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/General.php
@@ -350,7 +350,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     if (!templateSelect) return;
 
-    function syncFromTemplate() {
+    function syncFromTemplate(loadBuilderPreset) {
         const value = templateSelect.value;
         if (!value || value.indexOf(':') === -1) return;
 
@@ -364,6 +364,19 @@ document.addEventListener('DOMContentLoaded', function() {
             // Notify the mapping tab so the matching builder fieldset reveals itself
             formatField.dispatchEvent(new Event('change'));
         }
+
+        // When the user actively switches Feed Template to a real platform,
+        // also push that platform's preset into the matching builder so the
+        // structure tree reflects the choice immediately. Skip 'custom' (no
+        // preset to load) and skip on initial page load (loadBuilderPreset
+        // would clobber an existing feed's saved structure).
+        if (loadBuilderPreset && platform !== 'custom') {
+            if (format === 'xml' && typeof XmlBuilder !== 'undefined' && typeof XmlBuilder.loadPreset === 'function') {
+                XmlBuilder.loadPreset(platform, { force: true });
+            } else if ((format === 'json' || format === 'jsonl') && typeof JsonBuilder !== 'undefined' && typeof JsonBuilder.loadPreset === 'function') {
+                JsonBuilder.loadPreset(platform, { force: true });
+            }
+        }
     }
 
     // On a fresh feed the template selector renders with its default value
@@ -375,10 +388,12 @@ document.addEventListener('DOMContentLoaded', function() {
     // back. Existing feeds keep their saved file_format because the template
     // selector's current value already reflects it.
     if (formatField && !formatField.value) {
-        syncFromTemplate();
+        syncFromTemplate(false);
     }
 
-    templateSelect.addEventListener('change', syncFromTemplate);
+    templateSelect.addEventListener('change', function() {
+        syncFromTemplate(true);
+    });
 });
 </script>
 JS;

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/General.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/General.php
@@ -348,23 +348,37 @@ document.addEventListener('DOMContentLoaded', function() {
     const platformField = document.getElementById('feed_platform');
     const formatField = document.getElementById('feed_file_format');
 
-    if (templateSelect) {
-        // Only sync hidden fields when user changes the selector
-        templateSelect.addEventListener('change', function() {
-            const value = this.value;
-            if (!value || value.indexOf(':') === -1) return;
+    if (!templateSelect) return;
 
-            const parts = value.split(':');
-            const platform = parts[0];
-            const format = parts[1];
+    function syncFromTemplate() {
+        const value = templateSelect.value;
+        if (!value || value.indexOf(':') === -1) return;
 
-            if (platformField) platformField.value = platform;
-            if (formatField) formatField.value = format;
+        const parts = value.split(':');
+        const platform = parts[0];
+        const format = parts[1];
 
-            // Trigger change event on format field to update builder visibility
+        if (platformField) platformField.value = platform;
+        if (formatField) {
+            formatField.value = format;
+            // Notify the mapping tab so the matching builder fieldset reveals itself
             formatField.dispatchEvent(new Event('change'));
-        });
+        }
     }
+
+    // On a fresh feed the template selector renders with its default value
+    // ("Custom XML" = custom:xml) but the hidden file_format field is still
+    // empty, so the format-change listener in feedmanager-mapping.js sees no
+    // matching builder and leaves every fieldset hidden. Sync once on load so
+    // the default selection wires up the format and reveals the right builder
+    // without requiring the user to first pick a different template and come
+    // back. Existing feeds keep their saved file_format because the template
+    // selector's current value already reflects it.
+    if (formatField && !formatField.value) {
+        syncFromTemplate();
+    }
+
+    templateSelect.addEventListener('change', syncFromTemplate);
 });
 </script>
 JS;

--- a/public/skin/adminhtml/default/default/feedmanager.css
+++ b/public/skin/adminhtml/default/default/feedmanager.css
@@ -286,10 +286,10 @@
   font-weight: 600;
 }
 .json-key {
-  color: #1976d2;
+  color: light-dark(#1976d2, #6fb1f7);
 }
 .xml-tag {
-  color: #2e7d32;
+  color: light-dark(#2e7d32, #74c87c);
 }
 .json-type {
   color: var(--maho-ink-muted);
@@ -469,7 +469,8 @@
   display: flex;
   align-items: center;
   padding: 10px 12px;
-  background: #f8f9fa;
+  background: light-dark(#f8f9fa, #2a2a2a);
+  color: var(--maho-ink);
   cursor: pointer;
 }
 .transformer-item-number {
@@ -496,17 +497,37 @@
 }
 .transformer-item-options {
   padding: 14px;
-  border-top: 1px solid #e9ecef;
+  border-top: 1px solid var(--maho-hairline, #e9ecef);
   display: none;
-  grid-template-columns: 35% 55%;
-  align-items: center;
-  gap: 8px 12px;
+  flex-direction: column;
+  gap: 14px;
 }
 .transformer-item.expanded .transformer-item-options {
-  display: grid;
+  display: flex;
 }
 .transformer-option {
-  display: contents;
+  display: grid;
+  grid-template-columns: 35% 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 12px;
+  align-items: start;
+}
+.transformer-option > label {
+  grid-column: 1;
+  grid-row: 1;
+}
+.transformer-option > input,
+.transformer-option > select,
+.transformer-option > textarea {
+  grid-column: 2;
+  grid-row: 1;
+}
+.transformer-option > .note {
+  grid-column: 2;
+  grid-row: 2;
+  font-size: var(--maho-text-xs, 11px);
+  color: var(--maho-ink-muted, #888);
+  margin-top: 2px;
 }
 .transformer-add-section {
   text-align: center;

--- a/public/skin/adminhtml/default/default/feedmanager.css
+++ b/public/skin/adminhtml/default/default/feedmanager.css
@@ -221,6 +221,16 @@
 .category-mapping-container {
   margin-top: var(--maho-space-5);
 }
+#category-mapping-grid {
+  table-layout: fixed;
+  width: 100%;
+}
+#category-mapping-grid thead th:nth-child(1),
+#category-mapping-grid tbody td:nth-child(1) { width: 35%; }
+#category-mapping-grid thead th:nth-child(2),
+#category-mapping-grid tbody td:nth-child(2) { width: 50%; }
+#category-mapping-grid thead th:nth-child(3),
+#category-mapping-grid tbody td:nth-child(3) { width: 15%; }
 /* Bulk Mode Bar */
 .bulk-mode-bar {
   display: none;

--- a/public/skin/adminhtml/default/default/feedmanager.css
+++ b/public/skin/adminhtml/default/default/feedmanager.css
@@ -11,6 +11,24 @@
   display: flex;
   gap: var(--maho-space-5);
 }
+/* The XML / JSON / CSV builders render inside the standard admin .form-list
+   wrapper, so their inputs inherit the global 330px / 280px fixed widths
+   from form.css and base.css. Those collide with the builders' own flex /
+   grid layouts and force horizontal scroll on narrow viewports. Scope an
+   override so width follows the container instead. Specificity (0,1,3,1)
+   beats the global rule (0,0,3,1) without touching any other admin form. */
+.form-list td.value #xml-builder-container input.input-text,
+.form-list td.value #xml-builder-container textarea,
+.form-list td.value #xml-builder-container select,
+.form-list td.value #json-builder-container input.input-text,
+.form-list td.value #json-builder-container textarea,
+.form-list td.value #json-builder-container select,
+.form-list td.value #csv-builder-container input.input-text,
+.form-list td.value #csv-builder-container textarea,
+.form-list td.value #csv-builder-container select {
+  width: auto;
+  max-width: 100%;
+}
 .feedmanager-mapping-source,
 .feedmanager-mapping-target {
   flex: 1;

--- a/public/skin/adminhtml/default/default/feedmanager.css
+++ b/public/skin/adminhtml/default/default/feedmanager.css
@@ -29,6 +29,19 @@
   width: auto;
   max-width: 100%;
 }
+/* The Properties panel selects (e.g. Source Value) auto-size to their widest
+   <option>, which for product-attribute pickers can be 40+ chars and overflow
+   the narrow side panel. Pin them to container width with min-width: 0 so
+   they shrink when the panel does. */
+#xml-properties-content select,
+#xml-properties-content input.input-text,
+#json-properties-content select,
+#json-properties-content input.input-text {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
+}
 .feedmanager-mapping-source,
 .feedmanager-mapping-target {
   flex: 1;


### PR DESCRIPTION
Bundles six small UI fixes that surfaced after recent theme work, plus a chore commit to trim verbose comments. Each is independent.

- **Transformer modal layout + dark-mode contrast.** Every `.transformer-option` emits three children (label, input, note) but used `display: contents` against a 2-column parent grid, so the note wrapped into column 1 of the next row and ended up next to the next option's label. Each option becomes its own 2-col subgrid. Also redirects hardcoded greens/blues and the transformer header light-grey bg to `light-dark()` so dark mode no longer renders white text on light grey.

- **Category Mapping table column widths.** `#category-mapping-grid` had no explicit widths; long Store Category paths starved Platform Category down to a width that truncated targets like `Sporting Goods > Athletics > Tennis` into `...Te`. Switched to `table-layout: fixed` with a 35/50/15 split.

- **Builder inputs inheriting global `.form-list` 330/280px widths.** Those fixed widths fought the builders' own flex/grid layouts and forced horizontal scroll. Scoped override only inside `#xml-builder-container`, `#json-builder-container`, `#csv-builder-container` so other admin forms are untouched.

- **Properties-panel selects overflowing.** Source Value auto-sized to its widest `<option>` (some product-attribute labels are 40+ chars) and pushed the panel wider than its container. Pinned to `width: 100%; min-width: 0`.

- **Builder fieldset hidden on fresh feeds.** Template selector renders with `Custom XML` as default but the hidden `file_format` field is still empty, so `updateContentMode()` matches none of xml/csv/json and every builder fieldset stays hidden. Sync once on `DOMContentLoaded` when format is empty.

- **Feed Template change not refreshing builder.** Structure tree is rendered server-side from the old platform value and never re-rendered when the dropdown changes. Wire `syncFromTemplate` to call `XmlBuilder.loadPreset(platform, {force:true})` on user-driven changes. Depends on the `force` option added in the preset PR — if merged in isolation the call falls back to the existing confirm flow.

PHPStan / cs-fixer / rector all clean.
