### PR TITLE
Added drag-to-reorder for Feed Manager XML structure tree siblings

### DIFF
--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Xml.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Xml.php
@@ -108,6 +108,66 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Xml extends Maho_Fe
                 if (!tree) return;
                 tree.innerHTML = this.renderNodes(this.structure, "", 0);
                 this.updateHiddenField();
+                this.setupSortable();
+            },
+
+            // Wire SortableJS (shipped globally as sortable.min.js) onto the tree root
+            // and every nested .xml-children container. Each container has its own
+            // group key, so dragging is constrained to same-parent siblings; cross-
+            // parent moves are not yet supported (would risk silently orphaning a
+            // node into an unrelated wrapper).
+            setupSortable: function() {
+                if (typeof Sortable === "undefined") return;
+                var self = this;
+                var containers = [];
+                var root = document.getElementById("xml-tree");
+                if (root) containers.push(root);
+                var nested = document.querySelectorAll("#xml-tree .xml-children");
+                for (var n = 0; n < nested.length; n++) containers.push(nested[n]);
+
+                for (var c = 0; c < containers.length; c++) {
+                    var cont = containers[c];
+                    var prior = Sortable.get(cont);
+                    if (prior) prior.destroy();
+                    var containerId = cont.id || "xml-tree";
+                    (function(cid, el) {
+                        Sortable.create(el, {
+                            group: "xml-tree-" + cid,
+                            draggable: ".xml-node",
+                            animation: 150,
+                            ghostClass: "xml-node-ghost",
+                            chosenClass: "xml-node-chosen",
+                            dragClass: "xml-node-dragging",
+                            filter: ".xml-node-actions, .xml-toggle, .xml-node-actions button",
+                            preventOnFilter: false,
+                            onEnd: function(evt) {
+                                if (evt.oldIndex === evt.newIndex) return;
+                                self.reorderSibling(cid, evt.oldIndex, evt.newIndex);
+                            }
+                        });
+                    })(containerId, cont);
+                }
+            },
+
+            // Move a node within its parent siblings list and re-render.
+            // containerId is "xml-tree" for top-level, or "xml-children-X-children-Y..."
+            // for nested — that latter form decodes to the path of the PARENT node.
+            reorderSibling: function(containerId, oldIndex, newIndex) {
+                var arr;
+                if (containerId === "xml-tree") {
+                    arr = this.structure;
+                } else {
+                    var nodePath = containerId.replace(/^xml-children-/, "").replace(/-/g, ".");
+                    var parentNode = this.getNodeByPath(nodePath);
+                    if (!parentNode || !Array.isArray(parentNode.children)) return;
+                    arr = parentNode.children;
+                }
+                if (oldIndex < 0 || oldIndex >= arr.length || newIndex < 0 || newIndex >= arr.length) return;
+                var moved = arr.splice(oldIndex, 1)[0];
+                arr.splice(newIndex, 0, moved);
+                // Path-indexed selection is invalidated by reordering.
+                this.selectedPath = null;
+                this.render();
             },
 
             renderNodes: function(nodes, pathPrefix, depth) {

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Xml.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Xml.php
@@ -158,7 +158,8 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Xml extends Maho_Fe
                 if (oldIndex < 0 || oldIndex >= arr.length || newIndex < 0 || newIndex >= arr.length) return;
                 var moved = arr.splice(oldIndex, 1)[0];
                 arr.splice(newIndex, 0, moved);
-                this.selectedPath = null;
+                // Inputs in the properties panel are bound to now-stale paths after a reorder.
+                this.clearSelection();
                 this.render();
             },
 
@@ -204,6 +205,15 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Xml extends Maho_Fe
                 this.selectedPath = path;
                 this.render();
                 this.showProperties(path);
+            },
+
+            // Clear the active selection and reset the properties panel; callers re-render.
+            clearSelection: function() {
+                this.selectedPath = null;
+                var panel = document.getElementById("xml-properties-content");
+                if (panel) panel.innerHTML = "<p class=\"fm-status-muted a-center\">' . addslashes($this->__('Select an element to edit its properties')) . '</p>";
+                var childBtn = document.getElementById("xml-add-child-btn");
+                if (childBtn) childBtn.style.display = "none";
             },
 
             showProperties: function(path) {
@@ -377,11 +387,8 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Xml extends Maho_Fe
                 var info = this.getParentAndIndex(path);
                 if (info.parent && Array.isArray(info.parent)) {
                     info.parent.splice(info.index, 1);
-                    this.selectedPath = null;
+                    this.clearSelection();
                     this.render();
-                    document.getElementById("xml-properties-content").innerHTML = "<p style=\"color: #666; text-align: center;\">' . addslashes($this->__('Select an element to edit its properties')) . '</p>";
-                    var childBtn = document.getElementById("xml-add-child-btn");
-                    if (childBtn) childBtn.style.display = "none";
                 }
             },
 
@@ -454,11 +461,8 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Xml extends Maho_Fe
                         alert("Error: " + data.message);
                     } else if (data.structure) {
                         self.structure = data.structure;
-                        self.selectedPath = null;
+                        self.clearSelection();
                         self.render();
-                        document.getElementById("xml-properties-content").innerHTML = "<p style=\"color: #666; text-align: center;\">' . addslashes($this->__('Select an element to edit its properties')) . '</p>";
-                        var childBtn = document.getElementById("xml-add-child-btn");
-                        if (childBtn) childBtn.style.display = "none";
                         // Update platform field in General tab
                         self.updatePlatform(data.platform);
                     }

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Xml.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Xml.php
@@ -111,11 +111,7 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Xml extends Maho_Fe
                 this.setupSortable();
             },
 
-            // Wire SortableJS (shipped globally as sortable.min.js) onto the tree root
-            // and every nested .xml-children container. Each container has its own
-            // group key, so dragging is constrained to same-parent siblings; cross-
-            // parent moves are not yet supported (would risk silently orphaning a
-            // node into an unrelated wrapper).
+            // Constrain drag to same-parent siblings via per-container group keys.
             setupSortable: function() {
                 if (typeof Sortable === "undefined") return;
                 var self = this;
@@ -149,9 +145,6 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Xml extends Maho_Fe
                 }
             },
 
-            // Move a node within its parent siblings list and re-render.
-            // containerId is "xml-tree" for top-level, or "xml-children-X-children-Y..."
-            // for nested — that latter form decodes to the path of the PARENT node.
             reorderSibling: function(containerId, oldIndex, newIndex) {
                 var arr;
                 if (containerId === "xml-tree") {
@@ -165,7 +158,6 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Xml extends Maho_Fe
                 if (oldIndex < 0 || oldIndex >= arr.length || newIndex < 0 || newIndex >= arr.length) return;
                 var moved = arr.splice(oldIndex, 1)[0];
                 arr.splice(newIndex, 0, moved);
-                // Path-indexed selection is invalidated by reordering.
                 this.selectedPath = null;
                 this.render();
             },

--- a/public/skin/adminhtml/default/default/feedmanager.css
+++ b/public/skin/adminhtml/default/default/feedmanager.css
@@ -281,6 +281,17 @@
 .xml-node.selected {
   background: var(--maho-success-bg);
 }
+/* SortableJS drag states for the XML structure tree */
+.xml-node-ghost {
+  opacity: 0.4;
+  background: var(--maho-surface-sunken, #f5f5f5);
+}
+.xml-node-chosen {
+  background: var(--maho-info-bg);
+}
+.xml-node-dragging {
+  opacity: 0.8;
+}
 .json-key,
 .xml-tag {
   font-weight: 600;


### PR DESCRIPTION
SortableJS already ships globally on adminhtml (`main.xml:123`) but the XML structure tree didn't wire it up. Adds drag-to-reorder so siblings inside the same parent can be dragged into a new order; the underlying structure array mutates and the tree re-renders.

- Each container (`#xml-tree` and every nested `.xml-children`) gets its own Sortable instance keyed by `"xml-tree-" + containerId`, so dragging is constrained to same-parent siblings. Cross-parent moves are intentionally out of scope — they risk silently orphaning a child into a wrapper that doesn't accept it.

- `setupSortable()` runs after every `render()` so newly created or duplicated nodes pick up the drag affordance immediately. Prior instances are torn down before recreate to avoid stacked listeners.

- `filter` excludes `.xml-node-actions` buttons and `.xml-toggle` so clicking them doesn't start a drag.

- Path-indexed selection is cleared on reorder since the paths it points to are no longer stable.

- Adds three small CSS classes for ghost / chosen / dragging visuals.

JSON tree is out of scope (properties are keyed, no stable order).

PHPStan / cs-fixer / rector all clean.
