### PR TITLE
Fixed TypeError decoding empty PayPal API responses

### DIFF
--- a/app/code/core/Maho/Paypal/Model/Api/Client.php
+++ b/app/code/core/Maho/Paypal/Model/Api/Client.php
@@ -335,16 +335,10 @@ class Maho_Paypal_Model_Api_Client
         }
 
         if (is_object($response) && method_exists($response, 'getBody')) {
-            // No-content responses (e.g. HTTP 204 from voidPayment) have an empty
-            // body. jsonDecode('') yields the string "", which violates the array
-            // return type. Treat empty or non-array bodies as an empty result.
+            // Empty body (HTTP 204) decodes to "", not an array.
             $body = (string) $response->getBody();
-            if ($body !== '') {
-                $decoded = Mage::helper('core')->jsonDecode($body);
-                if (is_array($decoded)) {
-                    return $decoded;
-                }
-            }
+            $decoded = $body === '' ? [] : Mage::helper('core')->jsonDecode($body);
+            return is_array($decoded) ? $decoded : [];
         }
 
         return [];

--- a/app/code/core/Maho/Paypal/Model/Api/Client.php
+++ b/app/code/core/Maho/Paypal/Model/Api/Client.php
@@ -335,7 +335,16 @@ class Maho_Paypal_Model_Api_Client
         }
 
         if (is_object($response) && method_exists($response, 'getBody')) {
-            return Mage::helper('core')->jsonDecode((string) $response->getBody());
+            // No-content responses (e.g. HTTP 204 from voidPayment) have an empty
+            // body. jsonDecode('') yields the string "", which violates the array
+            // return type. Treat empty or non-array bodies as an empty result.
+            $body = (string) $response->getBody();
+            if ($body !== '') {
+                $decoded = Mage::helper('core')->jsonDecode($body);
+                if (is_array($decoded)) {
+                    return $decoded;
+                }
+            }
         }
 
         return [];


### PR DESCRIPTION
# Fix TypeError decoding empty PayPal API responses (HTTP 204)

## Problem

Cancelling an order whose PayPal payment was **authorized but not yet captured**
crashes with a fatal `TypeError`:

```
Maho_Paypal_Model_Api_Client::_decodeResponse(): Return value must be of type
array, string returned in app/code/core/Maho/Paypal/Model/Api/Client.php:340
```

Call path: `Mage_Sales_Model_Order::cancel()` → `payment->cancel()` → `_void()`
→ `Maho_Paypal_Model_Method_Abstract::void()` → `Api_Client::voidAuthorization()`.

`voidPayment` (and other no-content PayPal endpoints) return **HTTP 204 No
Content** with an empty body. In `_decodeResponse()`:

- `getResult()` is `null` for a 204, so neither the `is_object` nor the
  `is_array` result branch is taken.
- Control falls to the `getBody()` branch, where the raw body is `''`.
- `Mage::helper('core')->jsonDecode('')` maps `'' → '""'` and returns the
  **empty string** `""`.
- The method is typed `: array`, so returning a string throws the `TypeError`.

The void itself already succeeded at PayPal, so the order is left in a
half-cancelled state and the admin sees a 500.

## Fix

Guard the body branch in `_decodeResponse()`: only decode a non-empty body, and
only return it when it decodes to an array; otherwise fall through to `[]`. This
makes empty 204 responses (void, and any future no-content endpoint routed
through `_decodeResponse`) decode to an empty array instead of crashing, with no
change to the existing object/array/JSON-body paths.

## Testing

- `php-cs-fixer` and `phpstan` (level 6) clean on the changed file.
- Verified by reflection against a stub response:
  - `getResult()=null`, `getBody()=''` → `[]` (previously a `TypeError`).
  - `getResult()=null`, `getBody()='{"id":"ABC","status":"COMPLETED"}'` →
    decoded array unchanged (no regression on the body-decode path).