### PR TITLE
Fixed running single attribute-registered jobs via cron:run

### DIFF
--- a/lib/MahoCLI/Commands/CronRun.php
+++ b/lib/MahoCLI/Commands/CronRun.php
@@ -142,6 +142,9 @@ class CronRun extends BaseMahoCommand
         $compiledJobs = Maho::getCompiledAttributes()['crontab'] ?? [];
         if (isset($compiledJobs[$jobCode])) {
             $jobDef = $compiledJobs[$jobCode];
+            if (!empty($jobDef['module']) && !Mage::helper('core')->isModuleEnabled($jobDef['module'])) {
+                return null;
+            }
             return $jobDef['alias'] . '::' . $jobDef['method'];
         }
 

--- a/lib/MahoCLI/Commands/CronRun.php
+++ b/lib/MahoCLI/Commands/CronRun.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace MahoCLI\Commands;
 
+use Maho;
 use Mage;
 use Mage_Cron_Model_Observer;
 use Mage_Cron_Model_Schedule;
@@ -66,17 +67,12 @@ class CronRun extends BaseMahoCommand
             $output->writeln("<comment>{$jobCode} is disabled in admin. Running anyway via CLI.</comment>");
         }
 
-        $jobConfig = $this->getJobConfig($jobCode);
-        if (!$jobConfig) {
+        $runModel = $this->getJobRunModel($jobCode);
+        if ($runModel === null) {
             $output->writeln("<error>Unknown mode/job: {$modeOrJobCode}</error>");
             return Command::FAILURE;
         }
-        $runConfig = $jobConfig['run'];
-        if (!$runConfig['model']) {
-            $output->writeln("<error>Invalid model definition for {$jobCode}</error>");
-            return Command::FAILURE;
-        }
-        if (!preg_match(Mage_Cron_Model_Observer::REGEX_RUN_MODEL, (string) $runConfig['model'], $run)) {
+        if (!preg_match(Mage_Cron_Model_Observer::REGEX_RUN_MODEL, $runModel, $run)) {
             $output->writeln('<error>Invalid model/method definition, expecting "model/class::method"</error>');
             return Command::FAILURE;
         }
@@ -135,19 +131,28 @@ class CronRun extends BaseMahoCommand
         return Command::SUCCESS;
     }
 
-    protected function getJobConfig(string $jobCode): array|false
+    /**
+     * Resolve the "model/class::method" run definition for a job_code.
+     *
+     * Looks up attribute-registered (compiled) cron jobs first, then falls back to
+     * legacy XML-declared jobs under crontab/jobs and default/crontab/jobs.
+     */
+    protected function getJobRunModel(string $jobCode): ?string
     {
-        $jobConfig = Mage::getConfig()->getNode("crontab/jobs/{$jobCode}")->asArray();
-        if ($jobConfig) {
-            return $jobConfig;
+        $compiledJobs = Maho::getCompiledAttributes()['crontab'] ?? [];
+        if (isset($compiledJobs[$jobCode])) {
+            $jobDef = $compiledJobs[$jobCode];
+            return $jobDef['alias'] . '::' . $jobDef['method'];
         }
 
-        $jobConfig = Mage::getConfig()->getNode("default/crontab/jobs/{$jobCode}")->asArray();
-        if ($jobConfig) {
-            return $jobConfig;
+        foreach (['crontab/jobs', 'default/crontab/jobs'] as $path) {
+            $node = Mage::getConfig()->getNode("{$path}/{$jobCode}");
+            if ($node && $node->run && (string) $node->run->model !== '') {
+                return (string) $node->run->model;
+            }
         }
 
-        return false;
+        return null;
     }
 
 }


### PR DESCRIPTION
## Problem

Fixes #1049.

After the routing/attribute migration in Maho 26.5, cron jobs are registered via the `#[Maho\Config\CronJob]` attribute and compiled into `Maho::getCompiledAttributes()['crontab']` — they no longer exist as XML nodes under `crontab/jobs`. But `CronRun::getJobConfig()` only looked at the XML config tree and called `->asArray()` directly on the result of `Mage::getConfig()->getNode(...)`, which returns `false` for a missing node:

```
PHP Fatal error:  Uncaught Error: Call to a member function asArray() on false in lib/MahoCLI/Commands/CronRun.php:140
```

So running a single job by `job_code` (e.g. `./maho cron:run api_session_cleanup`) fatally errored.

## Fix

Replace `getJobConfig()` with `getJobRunModel()`, which resolves a job's `model/class::method` run definition in the same precedence as `Mage_Cron_Model_Observer::dispatch()`:

1. **New (attribute) jobs** — look in `Maho::getCompiledAttributes()['crontab']` first, building `alias::method`.
2. **Legacy XML jobs** — fall back to both `crontab/jobs/{code}` and `default/crontab/jobs/{code}` nodes (guarding against `false`).
3. Unknown job → `null` → clean "Unknown mode/job" error instead of a fatal.

This keeps **both** the new attribute-based jobs and legacy XML-declared jobs (third-party/older modules) working.

## Verification

- `./maho cron:run api_session_cleanup` → `executed successfully` (the reported case)
- `./maho cron:run core_clean_cache` → works (attribute job with a `config_path` schedule)
- `./maho cron:run does_not_exist` → clean `Unknown mode/job` error
- Resolution unit-checked for both sources:
  ```
  api_session_cleanup => 'api/cron::cleanOldSessions'   (attribute)
  legacy_xml_job      => 'core/observer::cleanCache'    (injected XML <crontab><jobs>)
  nope_unknown        => NULL
  ```
- PHPStan passes clean.