### PR TITLE
Returned 404 for routes of disabled modules

### DIFF
--- a/lib/Maho/Routing/ControllerDispatcher.php
+++ b/lib/Maho/Routing/ControllerDispatcher.php
@@ -195,6 +195,17 @@ class ControllerDispatcher
             return false;
         }
 
+        // Honor the runtime module-enabled state. The compiled matcher only refreshes
+        // on `composer dump-autoload`, so a route can survive in the table after its
+        // module was disabled in app/etc/modules/*.xml. Without this guard the request
+        // would dispatch a controller whose module config never loaded (fatal error);
+        // returning false here lets the router fall through to the no-route handler.
+        // $module is the canonical declaration name (e.g. Maho_Blog), stored verbatim
+        // in maho_attributes.php as `module` and exposed here as `_maho_module`.
+        if ($module !== '' && !Mage::helper('core')->isModuleEnabled($module)) {
+            return false;
+        }
+
         // Admin area: verify the matched frontName matches the runtime admin frontName.
         // Without this, a request like /notadmin/... would match admin routes with any
         // segment for `{_adminFrontName}` and dispatch as admin — rejecting at this point

--- a/tests/Backend/Unit/Maho/Routing/DisabledModuleRouteTest.php
+++ b/tests/Backend/Unit/Maho/Routing/DisabledModuleRouteTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Maho\Routing\ControllerDispatcher;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * A route can linger in the compiled matcher after its module is disabled in
+ * app/etc/modules/*.xml (the compiled table only refreshes on `composer
+ * dump-autoload`). The dispatcher must treat such routes as a miss and let the
+ * router fall through to the no-route handler, rather than instantiating a
+ * controller whose module config never loaded. See issue #1053.
+ */
+
+describe('Disabled module routes do not dispatch', function () {
+    it('returns false for a route whose module is not enabled', function () {
+        $dispatcher = new ControllerDispatcher();
+        $request = new Mage_Core_Controller_Request_Http(SymfonyRequest::create('/'));
+        $response = new Mage_Core_Controller_Response_Http();
+
+        // Valid, dispatchable controller + action so the only reason dispatch can
+        // fail is the module-enabled guard, not class/action resolution.
+        $params = [
+            '_maho_controller' => Mage_Cms_IndexController::class,
+            '_maho_action' => 'indexAction',
+            '_maho_module' => 'Maho_NotInstalledModule',
+            '_maho_controller_name' => 'index',
+            '_maho_front_name' => 'cms',
+            '_maho_area' => 'frontend',
+        ];
+
+        expect($dispatcher->dispatch($params, $request, $response))->toBeFalse();
+        expect($request->isDispatched())->toBeFalse();
+    });
+});


### PR DESCRIPTION
Fixes #1053.

## Problem

With attribute-based routing, a route is compiled into the Symfony matcher at `composer dump-autoload` time. After disabling a module in `app/etc/modules/*.xml` (and even re-running `composer dump-autoload`), visiting one of its routes dispatched into the controller whose module config was never loaded, raising:

```
Fatal error: Uncaught Error: Call to a member function isEnabled() on false
in .../Maho/Blog/controllers/IndexController.php on line 14
```

instead of returning a clean 404.

## Fix

`ControllerDispatcher::dispatch()` now honors the **runtime** module-enabled state. Before resolving/instantiating the controller, it checks `isModuleEnabled()` for the matched route's module (stored verbatim as `module` in `maho_attributes.php`, exposed as `_maho_module`). If the module is disabled, `dispatch()` returns `false` and the router falls through to the configured no-route handler.

Keeping this at the **runtime** layer (rather than filtering at compile time) means:

- The compiled artifacts stay identical regardless of a module's active flag, so enabling/disabling a module takes effect immediately — no `composer dump-autoload` needed just to fix routing.
- It is consistent with how the rest of Maho gates module behavior (`isModuleEnabled` / `isModuleOutputEnabled`).
- It is defense-in-depth against a stale compiled table.

## Test

`tests/Backend/Unit/Maho/Routing/DisabledModuleRouteTest.php` dispatches a valid controller/action with a disabled `_maho_module` and asserts `dispatch()` returns `false` and the request stays undispatched.

PHPStan clean; full backend routing suite green (126 tests).