### PR TITLE
Added RFC 8058 one-click unsubscribe to newsletter

### DIFF
--- a/app/code/core/Mage/Newsletter/Model/Observer.php
+++ b/app/code/core/Mage/Newsletter/Model/Observer.php
@@ -13,12 +13,13 @@ use Symfony\Component\Mime\Email;
 class Mage_Newsletter_Model_Observer
 {
     /**
-     * Add RFC 8058 List-Unsubscribe headers to outgoing newsletter mails.
+     * Add RFC 8058 List-Unsubscribe headers to outgoing newsletter broadcasts.
      *
-     * List-Unsubscribe exposes the one-click endpoint, List-Unsubscribe-Post opts the URL
-     * into the one-click POST flow that Gmail/Yahoo require from bulk senders. The send()
-     * path is shared with transactional mail, so the only reliable discriminator is the
-     * 'subscriber' variable, which is set exclusively by the newsletter queue.
+     * List-Unsubscribe exposes the one-click endpoint, List-Unsubscribe-Post opts the URL into
+     * the one-click POST flow that Gmail/Yahoo require from bulk senders. The send() path is
+     * shared with transactional mail — including the newsletter confirmation and unsubscription
+     * notifications, which also carry a 'subscriber' variable — so the headers are added only
+     * when the sender explicitly marks the mail as a newsletter broadcast via 'is_newsletter'.
      */
     #[Maho\Config\Observer('email_template_send_before')]
     public function addListUnsubscribeHeaders(\Maho\Event\Observer $observer): void
@@ -28,10 +29,14 @@ class Mage_Newsletter_Model_Observer
             return;
         }
         $variables = $observer->getEvent()->getVariables();
-        if (!isset($variables['subscriber'])) {
+        if (empty($variables['is_newsletter'])) {
             return;
         }
-        $url = Mage::helper('newsletter')->getUnsubscribeUrl($variables['subscriber']);
+        $subscriber = $variables['subscriber'] ?? null;
+        if (!$subscriber instanceof Mage_Newsletter_Model_Subscriber) {
+            return;
+        }
+        $url = Mage::helper('newsletter')->getUnsubscribeUrl($subscriber);
         $headers = $mail->getHeaders();
         $headers->addTextHeader('List-Unsubscribe', '<' . $url . '>');
         $headers->addTextHeader('List-Unsubscribe-Post', 'List-Unsubscribe=One-Click');

--- a/app/code/core/Mage/Newsletter/Model/Observer.php
+++ b/app/code/core/Mage/Newsletter/Model/Observer.php
@@ -8,8 +8,35 @@
  * @package Mage_Newsletter
  */
 
+use Symfony\Component\Mime\Email;
+
 class Mage_Newsletter_Model_Observer
 {
+    /**
+     * Add RFC 8058 List-Unsubscribe headers to outgoing newsletter mails.
+     *
+     * List-Unsubscribe exposes the one-click endpoint, List-Unsubscribe-Post opts the URL
+     * into the one-click POST flow that Gmail/Yahoo require from bulk senders. The send()
+     * path is shared with transactional mail, so the only reliable discriminator is the
+     * 'subscriber' variable, which is set exclusively by the newsletter queue.
+     */
+    #[Maho\Config\Observer('email_template_send_before')]
+    public function addListUnsubscribeHeaders(\Maho\Event\Observer $observer): void
+    {
+        $mail = $observer->getEvent()->getMail();
+        if (!$mail instanceof Email) {
+            return;
+        }
+        $variables = $observer->getEvent()->getVariables();
+        if (!isset($variables['subscriber'])) {
+            return;
+        }
+        $url = Mage::helper('newsletter')->getUnsubscribeUrl($variables['subscriber']);
+        $headers = $mail->getHeaders();
+        $headers->addTextHeader('List-Unsubscribe', '<' . $url . '>');
+        $headers->addTextHeader('List-Unsubscribe-Post', 'List-Unsubscribe=One-Click');
+    }
+
     /**
      * @return $this
      */

--- a/app/code/core/Mage/Newsletter/Model/Queue.php
+++ b/app/code/core/Mage/Newsletter/Model/Queue.php
@@ -163,7 +163,7 @@ class Mage_Newsletter_Model_Queue extends Mage_Core_Model_Template
             $name = $item->getSubscriberFullName();
 
             $sender->emulateDesign($item->getStoreId());
-            $successSend = $sender->send($email, $name, ['subscriber' => $item]);
+            $successSend = $sender->send($email, $name, ['subscriber' => $item, 'is_newsletter' => true]);
             $sender->revertDesign();
 
             if ($successSend) {

--- a/app/code/core/Mage/Newsletter/controllers/SubscriberController.php
+++ b/app/code/core/Mage/Newsletter/controllers/SubscriberController.php
@@ -92,12 +92,23 @@ class Mage_Newsletter_SubscriberController extends Mage_Core_Controller_Front_Ac
 
     /**
      * Unsubscribe newsletter
+     *
+     * Accepts POST in addition to GET for RFC 8058 one-click unsubscribe. Mail clients that
+     * honour the List-Unsubscribe-Post header send a server-to-server POST (no cookies, no
+     * referer) with body "List-Unsubscribe=One-Click"; that request is answered with a bare
+     * status code, not a redirect. A regular GET (the link a human clicks) keeps redirecting.
+     *
+     * POST status policy: 200 on success and on an invalid/expired code alike, so the endpoint
+     * is not an enumeration oracle and a stale link does not surface as an error to the mail
+     * client. Only an unexpected server-side failure returns 503, so the mail client retries
+     * (unsubscribe is idempotent) rather than reporting a success that never happened.
      */
-    #[Maho\Config\Route('/newsletter/subscriber/unsubscribe', name: 'newsletter.subscriber.unsubscribe', methods: ['GET'])]
+    #[Maho\Config\Route('/newsletter/subscriber/unsubscribe', name: 'newsletter.subscriber.unsubscribe', methods: ['GET', 'POST'])]
     public function unsubscribeAction(): void
     {
         $id    = (int) $this->getRequest()->getParam('id');
         $code  = (string) $this->getRequest()->getParam('code');
+        $isPost = $this->getRequest()->isPost();
 
         if ($id && $code) {
             $session = Mage::getSingleton('core/session');
@@ -105,12 +116,27 @@ class Mage_Newsletter_SubscriberController extends Mage_Core_Controller_Front_Ac
                 Mage::getModel('newsletter/subscriber')->load($id)
                     ->setCheckCode($code)
                     ->unsubscribe();
-                $session->addSuccess($this->__('You have been unsubscribed.'));
+                if (!$isPost) {
+                    $session->addSuccess($this->__('You have been unsubscribed.'));
+                }
             } catch (Mage_Core_Exception $e) {
-                $session->addException($e, $e->getMessage());
+                // Invalid/expired code: a client-side condition, not a server failure.
+                if (!$isPost) {
+                    $session->addException($e, $e->getMessage());
+                }
             } catch (Exception $e) {
+                Mage::logException($e);
+                if ($isPost) {
+                    $this->getResponse()->setHttpResponseCode(503)->setBody('');
+                    return;
+                }
                 $session->addException($e, $this->__('There was a problem with the un-subscription.'));
             }
+        }
+
+        if ($isPost) {
+            $this->getResponse()->setHttpResponseCode(200)->setBody('');
+            return;
         }
         $this->_redirectReferer();
     }

--- a/tests/Backend/Unit/Maho/Routing/NewsletterUnsubscribeMethodsTest.php
+++ b/tests/Backend/Unit/Maho/Routing/NewsletterUnsubscribeMethodsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * The newsletter unsubscribe route must accept POST in addition to GET so that
+ * RFC 8058 one-click unsubscribe works: a mail client that honours the
+ * List-Unsubscribe-Post header sends a server-to-server POST to the URL, which
+ * would 405 against a GET-only route. The compiled matcher is asserted directly
+ * (no dispatch/session) for both verbs.
+ */
+
+function unsubscribeRouteMatches(string $httpMethod): array
+{
+    $context = new \Symfony\Component\Routing\RequestContext();
+    $context->setMethod($httpMethod);
+    $matcher = \Maho\Routing\RouteCollectionBuilder::createMatcher($context);
+
+    return $matcher->match('/newsletter/subscriber/unsubscribe');
+}
+
+describe('Newsletter unsubscribe route accepts both GET and POST', function () {
+    it('matches under GET (the link a human clicks)', function () {
+        $params = unsubscribeRouteMatches('GET');
+
+        expect($params)->toBeArray();
+        expect($params['_route'] ?? null)->toBe('newsletter.subscriber.unsubscribe');
+    });
+
+    it('matches under POST (RFC 8058 one-click)', function () {
+        $params = unsubscribeRouteMatches('POST');
+
+        expect($params)->toBeArray();
+        expect($params['_route'] ?? null)->toBe('newsletter.subscriber.unsubscribe');
+    });
+});

--- a/tests/Frontend/Integration/Newsletter/UnsubscribeOneClickTest.php
+++ b/tests/Frontend/Integration/Newsletter/UnsubscribeOneClickTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+uses(Tests\MahoFrontendTestCase::class);
+
+/**
+ * Behavioural coverage for RFC 8058 one-click unsubscribe on
+ * Mage_Newsletter_SubscriberController::unsubscribeAction.
+ *
+ * The routing-level guard lives in MethodNotAllowedTest / NewsletterUnsubscribeMethodsTest
+ * (the route must accept POST). This test exercises the action end to end: a POST must
+ * actually flip the subscriber to UNSUBSCRIBED and return 200, and a POST with a wrong code
+ * must leave the subscriber untouched while still returning 200 (no enumeration oracle, no
+ * client-side error for a stale link).
+ */
+
+function createOneClickSubscriber(int $status): Mage_Newsletter_Model_Subscriber
+{
+    $store = Mage::app()->getDefaultStoreView();
+    $uniqueId = uniqid('oneclick_', true);
+
+    $subscriber = Mage::getModel('newsletter/subscriber');
+    $subscriber->setEmail("oneclick.{$uniqueId}@newsletter.test");
+    $subscriber->setStoreId((int) $store->getId());
+    $subscriber->setSubscriberStatus($status);
+    $subscriber->setSubscriberConfirmCode(substr(md5($uniqueId), 0, 32));
+    $subscriber->save();
+
+    return $subscriber;
+}
+
+function postUnsubscribe(int $id, string $code): Mage_Core_Controller_Response_Http
+{
+    Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
+    // Keep the action self-contained: a non-empty unsubscribe-email template would make
+    // unsubscribe() attempt a transactional send. Disabling it pins the test to the status
+    // transition and HTTP code, not the mail transport.
+    Mage::app()->getStore()->setConfig('newsletter/subscription/un_email_template', '');
+
+    $session = new Session(new MockArraySessionStorage());
+    $session->start();
+    Mage::register('symfony_session', $session);
+
+    $symfonyRequest = SymfonyRequest::create(
+        '/newsletter/subscriber/unsubscribe/?id=' . $id . '&code=' . $code,
+        'POST',
+    );
+    $request = new Mage_Core_Controller_Request_Http($symfonyRequest);
+    $request->setPathInfo('/newsletter/subscriber/unsubscribe');
+    $request->setRouteName('newsletter');
+    $request->setControllerName('subscriber');
+    $request->setActionName('unsubscribe');
+    $request->setControllerModule('Mage_Newsletter');
+    $request->setDispatched(true);
+
+    $response = new Mage_Core_Controller_Response_Http();
+    (new Mage_Newsletter_SubscriberController($request, $response))->unsubscribeAction();
+
+    return $response;
+}
+
+it('unsubscribes the subscriber and returns 200 on a one-click POST with a valid code', function () {
+    $subscriber = createOneClickSubscriber(Mage_Newsletter_Model_Subscriber::STATUS_SUBSCRIBED);
+
+    $response = postUnsubscribe((int) $subscriber->getId(), (string) $subscriber->getCode());
+
+    expect($response->getHttpResponseCode())->toBe(200);
+
+    $reloaded = Mage::getModel('newsletter/subscriber')->load($subscriber->getId());
+    expect((int) $reloaded->getSubscriberStatus())
+        ->toBe(Mage_Newsletter_Model_Subscriber::STATUS_UNSUBSCRIBED);
+});
+
+it('returns 200 but leaves the subscriber subscribed on a POST with a wrong code', function () {
+    $subscriber = createOneClickSubscriber(Mage_Newsletter_Model_Subscriber::STATUS_SUBSCRIBED);
+
+    $response = postUnsubscribe((int) $subscriber->getId(), 'definitely-not-the-real-code');
+
+    expect($response->getHttpResponseCode())->toBe(200);
+
+    $reloaded = Mage::getModel('newsletter/subscriber')->load($subscriber->getId());
+    expect((int) $reloaded->getSubscriberStatus())
+        ->toBe(Mage_Newsletter_Model_Subscriber::STATUS_SUBSCRIBED);
+});


### PR DESCRIPTION
Newsletter mails carried no List-Unsubscribe header, and the unsubscribe endpoint was GET-only, so the one-click POST that Gmail/Yahoo require from bulk senders could not work.

- Mage_Newsletter_Model_Observer emits List-Unsubscribe (the existing unsubscribe URL) plus List-Unsubscribe-Post on email_template_send_before, gated on the 'subscriber' variable so transactional mail is untouched.
- unsubscribeAction now also accepts POST and answers the one-click request with a bare status code instead of a redirect; the human GET link is unchanged. POST returns 200 on success and on an invalid/expired code alike (no enumeration oracle, no client-side error on stale links); only an unexpected server-side failure returns 503 so the client retries.
- NewsletterUnsubscribeMethodsTest asserts the compiled matcher resolves /newsletter/subscriber/unsubscribe under both GET and POST (405 regression guard); UnsubscribeOneClickTest exercises the action end to end: a valid POST flips the subscriber to UNSUBSCRIBED and returns 200, a wrong-code POST leaves it subscribed and still returns 200.