### PR TITLE
Modernized deprecation docblocks to `#[\Deprecated]` attributes and adopted PHP 8.4 `array_*` functions

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -18987,11 +18987,6 @@ parameters:
 			count: 1
 			path: app/design/adminhtml/default/default/template/system/autocomplete.phtml
 
-		-
-			rawMessage: 'Call to deprecated method getSaveUrl() of class Mage_Adminhtml_Block_Tag_Edit.'
-			identifier: method.deprecated
-			count: 1
-			path: app/design/adminhtml/default/default/template/tag/edit/container.phtml
 
 		-
 			rawMessage: Variable $this might not be defined.

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -27,24 +27,16 @@ final class Mage
     public const LOG_INFO      = Level::Info;
     public const LOG_DEBUG     = Level::Debug;
 
-    /**
-     * @deprecated Use LOG_EMERGENCY instead
-     */
+    #[\Deprecated(message: 'Use LOG_EMERGENCY instead')]
     public const LOG_EMERG = self::LOG_EMERGENCY;
 
-    /**
-     * @deprecated Use LOG_CRITICAL instead
-     */
+    #[\Deprecated(message: 'Use LOG_CRITICAL instead')]
     public const LOG_CRIT = self::LOG_CRITICAL;
 
-    /**
-     * @deprecated Use LOG_ERROR instead
-     */
+    #[\Deprecated(message: 'Use LOG_ERROR instead')]
     public const LOG_ERR = self::LOG_ERROR;
 
-    /**
-     * @deprecated Use LOG_WARNING instead
-     */
+    #[\Deprecated(message: 'Use LOG_WARNING instead')]
     public const LOG_WARN = self::LOG_WARNING;
 
     /**

--- a/app/code/core/Mage/Admin/Model/Resource/Rules/Collection.php
+++ b/app/code/core/Mage/Admin/Model/Resource/Rules/Collection.php
@@ -48,8 +48,8 @@ class Mage_Admin_Model_Resource_Rules_Collection extends Mage_Core_Model_Resourc
     /**
      * Generate and retrieve a resource - permissions map
      * @return array
-     * @deprecated since 26.5
      */
+    #[\Deprecated(message: 'since 26.5')]
     public function getResourcesPermissionsArray()
     {
         $resourcesPermissionsArray = [];

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Data.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Create/Data.php
@@ -38,8 +38,8 @@ class Mage_Adminhtml_Block_Sales_Order_Create_Data extends Mage_Adminhtml_Block_
      *
      * @param   string $code
      * @return  string
-     * @deprecated since 25.9.0
      */
+    #[\Deprecated(message: 'since 25.9.0')]
     public function getCurrencyName($code)
     {
         return $code;

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
@@ -144,10 +144,10 @@ class Mage_Adminhtml_Block_Widget_Form_Container extends Mage_Adminhtml_Block_Wi
     /**
      * Get form save URL
      *
-     * @deprecated
      * @see getFormActionUrl()
      * @return string
      */
+    #[\Deprecated]
     public function getSaveUrl()
     {
         return $this->getFormActionUrl();

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
@@ -431,8 +431,8 @@ class Mage_Adminhtml_Cms_Wysiwyg_ImagesController extends Mage_Adminhtml_Control
      * Save current path in session
      *
      * @return $this
-     * @deprecated since 25.7.0 current path is no longer stored in session
      */
+    #[\Deprecated(message: 'since 25.7.0 current path is no longer stored in session')]
     protected function _saveSessionCurrentPath()
     {
         return $this;

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
@@ -60,13 +60,7 @@ class Mage_Adminhtml_Cms_WysiwygController extends Mage_Adminhtml_Controller_Act
                     continue;
                 }
                 $text = (string) ($msg['message'] ?? '');
-                $skip = false;
-                foreach ($ignoreList as $needle) {
-                    if (str_contains($text, $needle)) {
-                        $skip = true;
-                        break;
-                    }
-                }
+                $skip = array_any($ignoreList, fn($needle) => str_contains($text, $needle));
                 if ($skip) {
                     $ignoredCount++;
                     continue;

--- a/app/code/core/Mage/Api/Helper/Data.php
+++ b/app/code/core/Mage/Api/Helper/Data.php
@@ -175,13 +175,7 @@ class Mage_Api_Helper_Data extends Mage_Core_Helper_Abstract
     {
         if (is_array($mixed)) {
             $arrKeys = array_keys($mixed);
-            $isDigit = false;
-            foreach ($arrKeys as $key) {
-                if (is_int($key)) {
-                    $isDigit = true;
-                    break;
-                }
-            }
+            $isDigit = array_any($arrKeys, fn($key) => is_int($key));
             if ($isDigit) {
                 $mixed = $this->packArrayToObject($mixed);
             } else {

--- a/app/code/core/Mage/Catalog/Block/Product/Abstract.php
+++ b/app/code/core/Mage/Catalog/Block/Product/Abstract.php
@@ -109,8 +109,8 @@ abstract class Mage_Catalog_Block_Product_Abstract extends Mage_Core_Block_Templ
      * @param string $className
      * @param array $arguments
      * @return Mage_Core_Model_Abstract|false
-     * @deprecated use Mage::getSingleton()
      */
+    #[\Deprecated(message: 'use Mage::getSingleton()')]
     protected function _getSingletonModel($className, $arguments = [])
     {
         return Mage::getSingleton($className, $arguments);

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Date.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Date.php
@@ -26,8 +26,8 @@ class Mage_Catalog_Block_Product_View_Options_Type_Date extends Mage_Catalog_Blo
      * Use JS calendar settings
      *
      * @return bool
-     * @deprecated since 25.9.0
      */
+    #[\Deprecated(message: 'since 25.9.0')]
     public function useCalendar()
     {
         return true; // Always use native date inputs

--- a/app/code/core/Mage/Catalog/Helper/Product/Configuration.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Configuration.php
@@ -118,13 +118,7 @@ class Mage_Catalog_Helper_Product_Configuration extends Mage_Core_Helper_Abstrac
         }
 
         $options = array_merge($options, $this->getCustomOptions($item));
-        $isUnConfigured = true;
-        foreach ($options as &$option) {
-            if ($option['value']) {
-                $isUnConfigured = false;
-                break;
-            }
-        }
+        $isUnConfigured = array_all($options, fn($option) => !$option['value']);
         return $isUnConfigured ? [] : $options;
     }
 

--- a/app/code/core/Mage/Catalog/Model/Convert/Parser/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Parser/Product.php
@@ -226,10 +226,8 @@ class Mage_Catalog_Model_Convert_Parser_Product extends Mage_Eav_Model_Convert_P
         return $this->_attributes[$code];
     }
 
-    /**
-     * @deprecated not used anymore
-     */
     #[\Override]
+    #[\Deprecated(message: 'not used anymore')]
     public function parse()
     {
         $data            = $this->getData();

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -2126,12 +2126,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     {
         $products = $this->_getResource()->getProductsSku($productIds);
         if (count($products)) {
-            foreach ($products as $product) {
-                if (!strlen($product['sku'])) {
-                    return false;
-                }
-            }
-            return true;
+            return array_all($products, fn($product) => $product['sku'] !== '');
         }
         return null;
     }

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
@@ -259,8 +259,8 @@ class Mage_Catalog_Model_Product_Option_Type_Date extends Mage_Catalog_Model_Pro
      * Always returns true as we only use native inputs now
      *
      * @return bool
-     * @deprecated since 25.9.0
      */
+    #[\Deprecated(message: 'since 25.9.0')]
     public function useCalendar()
     {
         return true;
@@ -271,8 +271,8 @@ class Mage_Catalog_Model_Product_Option_Type_Date extends Mage_Catalog_Model_Pro
      * Always returns true for 24h format as native inputs handle this
      *
      * @return bool
-     * @deprecated since 25.9.0
      */
+    #[\Deprecated(message: 'since 25.9.0')]
     public function is24hTimeFormat()
     {
         return true;

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
@@ -329,14 +329,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
         if (isset($optionValue['order_path']) && !$this->getUseQuotePath()) {
             $checkPaths[] = Mage::getBaseDir() . $optionValue['order_path'];
         }
-
-        $fileFullPath = null;
-        foreach ($checkPaths as $path) {
-            if (is_file($path)) {
-                $fileFullPath = $path;
-                break;
-            }
-        }
+        $fileFullPath = array_find($checkPaths, fn($path) => is_file($path));
 
         if ($fileFullPath === null) {
             return false;

--- a/app/code/core/Mage/Catalog/Model/Product/Visibility.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Visibility.php
@@ -32,9 +32,9 @@ class Mage_Catalog_Model_Product_Visibility extends \Maho\DataObject
     }
 
     /**
-     * @deprecated since 26.5 Use $collection->setVisibility($this->getVisibleInCatalogIds()) instead
      * @return $this
      */
+    #[\Deprecated(message: 'since 26.5 Use $collection->setVisibility($this->getVisibleInCatalogIds()) instead')]
     public function addVisibleInCatalogFilterToCollection(Mage_Catalog_Model_Resource_Product_Collection $collection)
     {
         $collection->setVisibility(static::getVisibleInCatalogIds());
@@ -42,9 +42,9 @@ class Mage_Catalog_Model_Product_Visibility extends \Maho\DataObject
     }
 
     /**
-     * @deprecated since 26.5 Use $collection->setVisibility($this->getVisibleInSearchIds()) instead
      * @return $this
      */
+    #[\Deprecated(message: 'since 26.5 Use $collection->setVisibility($this->getVisibleInSearchIds()) instead')]
     public function addVisibleInSearchFilterToCollection(Mage_Catalog_Model_Resource_Product_Collection $collection)
     {
         $collection->setVisibility(static::getVisibleInSearchIds());
@@ -52,9 +52,9 @@ class Mage_Catalog_Model_Product_Visibility extends \Maho\DataObject
     }
 
     /**
-     * @deprecated since 26.5 Use $collection->setVisibility($this->getVisibleInSiteIds()) instead
      * @return $this
      */
+    #[\Deprecated(message: 'since 26.5 Use $collection->setVisibility($this->getVisibleInSiteIds()) instead')]
     public function addVisibleInSiteFilterToCollection(Mage_Catalog_Model_Resource_Product_Collection $collection)
     {
         $collection->setVisibility(static::getVisibleInSiteIds());

--- a/app/code/core/Mage/Catalog/Model/Resource/Eav/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Eav/Attribute.php
@@ -293,9 +293,9 @@ class Mage_Catalog_Model_Resource_Eav_Attribute extends Mage_Eav_Model_Entity_At
 
     /**
      * @return string
-     * @deprecated since 26.1 use getDefaultSourceModel() instead
      */
     #[\Override]
+    #[\Deprecated(message: 'since 26.1 use getDefaultSourceModel() instead')]
     protected function _getDefaultSourceModel()
     {
         return $this->getDefaultSourceModel();

--- a/app/code/core/Mage/CatalogInventory/Helper/Minsaleqty.php
+++ b/app/code/core/Mage/CatalogInventory/Helper/Minsaleqty.php
@@ -86,12 +86,7 @@ class Mage_CatalogInventory_Helper_Minsaleqty extends Mage_Core_Helper_Abstract
             return false;
         }
         unset($value['__empty']);
-        foreach ($value as $_id => $row) {
-            if (!is_array($row) || !array_key_exists('customer_group_id', $row) || !array_key_exists('min_sale_qty', $row)) {
-                return false;
-            }
-        }
-        return true;
+        return array_all($value, fn($row) => !(!is_array($row) || !array_key_exists('customer_group_id', $row) || !array_key_exists('min_sale_qty', $row)));
     }
 
     /**

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
@@ -32,7 +32,7 @@ class Mage_ConfigurableSwatches_Helper_Productimg extends Mage_Core_Helper_Abstr
     public const SWATCH_FALLBACK_MEDIA_DIR = 'wysiwyg/swatches';
     public const SWATCH_CACHE_DIR = 'catalog/swatches';
 
-    /** @deprecated since 26.3 — use {@see getSwatchFileExt()} instead */
+    #[\Deprecated(message: 'since 26.3 — use {@see getSwatchFileExt()} instead')]
     public const SWATCH_FILE_EXT = '.png';
 
     /**

--- a/app/code/core/Mage/Core/Controller/Front/Action.php
+++ b/app/code/core/Mage/Core/Controller/Front/Action.php
@@ -152,8 +152,8 @@ class Mage_Core_Controller_Front_Action extends Mage_Core_Controller_Varien_Acti
      * Check if form key validation is enabled.
      *
      * @return bool
-     * @deprecated since 25.5.0
      */
+    #[\Deprecated(message: 'since 25.5.0')]
     protected function _isFormKeyEnabled()
     {
         return true;

--- a/app/code/core/Mage/Core/Controller/Response/Http.php
+++ b/app/code/core/Mage/Core/Controller/Response/Http.php
@@ -564,13 +564,7 @@ class Mage_Core_Controller_Response_Http implements \Stringable
      */
     public function hasExceptionOfType(string $type): bool
     {
-        foreach ($this->_exceptions as $e) {
-            if ($e instanceof $type) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->_exceptions, fn($e) => $e instanceof $type);
     }
 
     /**
@@ -578,13 +572,7 @@ class Mage_Core_Controller_Response_Http implements \Stringable
      */
     public function hasExceptionOfMessage(string $message): bool
     {
-        foreach ($this->_exceptions as $e) {
-            if ($message == $e->getMessage()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->_exceptions, fn($e) => $message == $e->getMessage());
     }
 
     /**
@@ -593,13 +581,7 @@ class Mage_Core_Controller_Response_Http implements \Stringable
     public function hasExceptionOfCode(int $code): bool
     {
         $code = (int) $code;
-        foreach ($this->_exceptions as $e) {
-            if ($code == $e->getCode()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->_exceptions, fn($e) => $code == $e->getCode());
     }
 
     /**

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -839,9 +839,7 @@ XML;
         return $data;
     }
 
-    /**
-     * @deprecated since 25.5.0
-     */
+    #[\Deprecated(message: 'since 25.5.0')]
     public function isFormKeyEnabled(): bool
     {
         return true;

--- a/app/code/core/Mage/Core/Helper/Security.php
+++ b/app/code/core/Mage/Core/Helper/Security.php
@@ -35,9 +35,7 @@ class Mage_Core_Helper_Security extends Mage_Core_Helper_Abstract
         }
     }
 
-    /**
-     * @deprecated since 26.1, use ensureBlockMethodAllowed() instead
-     */
+    #[\Deprecated(message: 'since 26.1, use ensureBlockMethodAllowed() instead')]
     public function validateAgainstBlockMethodBlacklist(Mage_Core_Block_Abstract $block, string $method, array $args): void
     {
         $this->ensureBlockMethodAllowed($block, $method, $args);

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -1110,9 +1110,7 @@ class Mage_Core_Model_App
         return $this->_frontController;
     }
 
-    /**
-     * @deprecated since 25.5, use getCache()
-     */
+    #[\Deprecated(message: 'since 25.5, use getCache()')]
     public function getCacheInstance(): Mage_Core_Model_Cache
     {
         return $this->getCache();

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -1112,12 +1112,12 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      *
      * If $moduleName is specified retrieves specific value for the module.
      *
-     * @deprecated in favor of Mage_Core_Model_Config_Options
      * @todo get global dir config
      * @param string $type
      * @return string
      * @throws Mage_Core_Exception
      */
+    #[\Deprecated(message: 'in favor of Mage_Core_Model_Config_Options')]
     public function getBaseDir($type = 'base')
     {
         return $this->getOptions()->getDir($type);
@@ -1356,9 +1356,9 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      *
      * @param string $moduleAlias
      * @return Mage_Core_Model_Resource_Helper_Abstract|false
-     * @deprecated Use getResourceHelperInstance() method instead
      * @see Mage_Core_Model_Config::getResourceHelperInstance()
      */
+    #[\Deprecated(message: 'Use getResourceHelperInstance() method instead')]
     public function getResourceHelper($moduleAlias)
     {
         return $this->getResourceHelperInstance($moduleAlias);

--- a/app/code/core/Mage/Core/Model/Date.php
+++ b/app/code/core/Mage/Core/Model/Date.php
@@ -72,12 +72,13 @@ class Mage_Core_Model_Date
      * @param  string $format
      * @param  int|string $input date in current timezone
      * @return false|string
-     *
-     * @deprecated since 26.5 For DB-bound strings use Mage::app()->getLocale()->formatDateForDb('now')
-     *             (or formatDateForDb('now', withTime: false) for date-only). For non-DB use, use
-     *             Mage::app()->getLocale()->nowUtc() / todayUtc(). When converting a store-TZ input
-     *             to a UTC string, use Mage::app()->getLocale()->storeToUtc($store, $input)->format($format).
      */
+    #[\Deprecated(message: <<<'TXT'
+    since 26.5 For DB-bound strings use Mage::app()->getLocale()->formatDateForDb('now')
+                 (or formatDateForDb('now', withTime: false) for date-only). For non-DB use, use
+                 Mage::app()->getLocale()->nowUtc() / todayUtc(). When converting a store-TZ input
+                 to a UTC string, use Mage::app()->getLocale()->storeToUtc($store, $input)->format($format).
+    TXT)]
     public function gmtDate($format = null, $input = null)
     {
         if (is_null($format)) {
@@ -100,10 +101,11 @@ class Mage_Core_Model_Date
      * @param  string $format
      * @param  int|string $input date in GMT timezone
      * @return string
-     *
-     * @deprecated since 26.5 Use Mage::app()->getLocale()->utcToStore($store, $input)->format($format).
-     *             For "now" in store TZ, omit the second argument: utcToStore()->format($format).
      */
+    #[\Deprecated(message: <<<'TXT'
+    since 26.5 Use Mage::app()->getLocale()->utcToStore($store, $input)->format($format).
+                 For "now" in store TZ, omit the second argument: utcToStore()->format($format).
+    TXT)]
     public function date($format = null, $input = null)
     {
         if (is_null($format)) {
@@ -118,11 +120,12 @@ class Mage_Core_Model_Date
      *
      * @param  int|string $input date in current timezone
      * @return string|false|int
-     *
-     * @deprecated since 26.5 For "now" use the native time() — Unix epochs are timezone-agnostic.
-     *             For converting a store-TZ input to a UTC epoch, use
-     *             Mage::app()->getLocale()->storeToUtc($store, $input)->getTimestamp().
      */
+    #[\Deprecated(message: <<<'TXT'
+    since 26.5 For "now" use the native time() — Unix epochs are timezone-agnostic.
+                 For converting a store-TZ input to a UTC epoch, use
+                 Mage::app()->getLocale()->storeToUtc($store, $input)->getTimestamp().
+    TXT)]
     public function gmtTimestamp($input = null)
     {
         if (is_null($input)) {
@@ -157,12 +160,13 @@ class Mage_Core_Model_Date
      *
      * @param  int|string $input date in GMT timezone
      * @return int
-     *
-     * @deprecated since 26.5 The "store-shifted timestamp" this method returns is not a real epoch
-     *             and was used by legacy code as a stepping stone to extract store-local components.
-     *             Prefer Mage::app()->getLocale()->utcToStore($store, $input) and call ->format(...) /
-     *             ->getTimestamp() on the result. For "now" use time().
      */
+    #[\Deprecated(message: <<<'TXT'
+    since 26.5 The "store-shifted timestamp" this method returns is not a real epoch
+                 and was used by legacy code as a stepping stone to extract store-local components.
+                 Prefer Mage::app()->getLocale()->utcToStore($store, $input) and call ->format(...) /
+                 ->getTimestamp() on the result. For "now" use time().
+    TXT)]
     public function timestamp($input = null)
     {
         if (is_null($input)) {
@@ -190,10 +194,11 @@ class Mage_Core_Model_Date
      *
      * @param  string $type
      * @return int
-     *
-     * @deprecated since 26.5 Use a DateTimeZone directly:
-     *             (new DateTimeZone($store->getConfig('general/locale/timezone')))->getOffset(new DateTimeImmutable())
      */
+    #[\Deprecated(message: <<<'TXT'
+    since 26.5 Use a DateTimeZone directly:
+                 (new DateTimeZone($store->getConfig('general/locale/timezone')))->getOffset(new DateTimeImmutable())
+    TXT)]
     public function getGmtOffset($type = 'seconds')
     {
         $result = $this->_offset;

--- a/app/code/core/Mage/Core/Model/File/Storage.php
+++ b/app/code/core/Mage/Core/Model/File/Storage.php
@@ -22,9 +22,7 @@ class Mage_Core_Model_File_Storage extends Mage_Core_Model_Abstract
     public const XML_PATH_MEDIA_RESOURCE_IGNORED   = 'default/system/media_storage_configuration/ignored_resources';
     public const XML_PATH_MEDIA_LOADED_MODULES     = 'default/system/media_storage_configuration/loaded_modules';
 
-    /**
-     * @deprecated since 26.1, use XML_PATH_MEDIA_RESOURCE_ALLOWLIST instead
-     */
+    #[\Deprecated(message: 'since 26.1, use XML_PATH_MEDIA_RESOURCE_ALLOWLIST instead')]
     public const XML_PATH_MEDIA_RESOURCE_WHITELIST = self::XML_PATH_MEDIA_RESOURCE_ALLOWLIST;
 
     /**

--- a/app/code/core/Mage/Core/Model/Locale.php
+++ b/app/code/core/Mage/Core/Model/Locale.php
@@ -531,11 +531,11 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
 
 
     /**
-     * @deprecated since 26.5 Use utcToStore() or storeToUtc() instead
      * @see utcToStore()
      * @see storeToUtc()
      * @param string             $part
      */
+    #[\Deprecated(message: 'since 26.5 Use utcToStore() or storeToUtc() instead')]
     public function date(string|int|DateTime|DateTimeImmutable|null $date = null, ?string $part = null, ?string $locale = null, bool $useTimezone = true): DateTime
     {
         if (!is_int($date) && empty($date)) {
@@ -567,10 +567,10 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
      * Create mutable DateTime object for current locale
      * Alias for date() method with explicit name
      *
-     * @deprecated since 26.5 Use utcToStore() or storeToUtc() instead
      * @see utcToStore()
      * @see storeToUtc()
      */
+    #[\Deprecated(message: 'since 26.5 Use utcToStore() or storeToUtc() instead')]
     public function dateMutable(
         string|int|DateTime|null $date = null,
         ?string $part = null,
@@ -583,10 +583,10 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
     /**
      * Create immutable DateTime object for current locale
      *
-     * @deprecated since 26.5 Use utcToStore() or storeToUtc() with DateTimeImmutable::createFromMutable() instead
      * @see utcToStore()
      * @see storeToUtc()
      */
+    #[\Deprecated(message: 'since 26.5 Use utcToStore() or storeToUtc() with DateTimeImmutable::createFromMutable() instead')]
     public function dateImmutable(
         string|int|DateTime|null $date = null,
         ?string $part = null,
@@ -600,7 +600,6 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
     /**
      * Create DateTime object with date converted to store timezone and store Locale
      *
-     * @deprecated since 26.5 Use utcToStore() instead. Callers should format the result themselves.
      * @see utcToStore()
      *
      * @param   null|string|bool|int|Mage_Core_Model_Store $store Information about store
@@ -613,6 +612,7 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
      *                                * type="datetime-local": YYYY-MM-DDTHH:mm (e.g., "2024-12-25T14:30")
      *                              - PHP format strings: 'Y-m-d H:i:s', etc. (returns DateTime)
      */
+    #[\Deprecated(message: 'since 26.5 Use utcToStore() instead. Callers should format the result themselves.')]
     public function storeDate(mixed $store = null, string|int|DateTime|DateTimeImmutable|null $date = null, bool $includeTime = false, ?string $format = null): DateTime|string|null
     {
         // Special handling for HTML5 format output when format is 'html5'
@@ -671,7 +671,6 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
      * to UTC time zone. Date can be passed in format of store's locale
      * or in format which was passed as parameter.
      *
-     * @deprecated since 26.5 Use storeToUtc() instead. Callers should format the result themselves.
      * @see storeToUtc()
      *
      * @param mixed $store Information about store
@@ -684,6 +683,7 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
      *                               * Returns: YYYY-MM-DD HH:mm:ss (MySQL datetime format)
      *                             - PHP format strings: 'Y-m-d H:i:s', etc. (returns DateTime)
      */
+    #[\Deprecated(message: 'since 26.5 Use storeToUtc() instead. Callers should format the result themselves.')]
     public function utcDate(mixed $store, string|int|DateTime|DateTimeImmutable|null $date = null, bool $includeTime = false, ?string $format = null): DateTime|string|null
     {
         // Special handling for HTML5 native input formats
@@ -766,9 +766,9 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
      *
      * Timestamp will be built with store timezone settings
      *
-     * @deprecated since 26.5 Use utcToStore($store) for store-local dates, or time() for real timestamps
      * @see utcToStore()
      */
+    #[\Deprecated(message: 'since 26.5 Use utcToStore($store) for store-local dates, or time() for real timestamps')]
     public function storeTimeStamp(mixed $store = null): int
     {
         return $this->utcToStore($store)->getTimestamp();

--- a/app/code/core/Mage/Core/Model/Logger.php
+++ b/app/code/core/Mage/Core/Model/Logger.php
@@ -366,12 +366,7 @@ class Mage_Core_Model_Logger
      */
     protected static function isRotatingFileHandler(Logger $logger): bool
     {
-        foreach ($logger->getHandlers() as $handler) {
-            if ($handler instanceof \Monolog\Handler\RotatingFileHandler) {
-                return true;
-            }
-        }
-        return false;
+        return array_any($logger->getHandlers(), fn($handler) => $handler instanceof \Monolog\Handler\RotatingFileHandler);
     }
 
     /**

--- a/app/code/core/Mage/Core/Model/Resource/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Abstract.php
@@ -110,13 +110,13 @@ abstract class Mage_Core_Model_Resource_Abstract
     /**
      * Format date to internal format
      *
-     * @deprecated since 26.5 Use Mage::app()->getLocale()->formatDateForDb() instead
      * @see Mage_Core_Model_Locale::formatDateForDb()
      *
      * @param int|string|DateTime|bool|null $date
      * @param bool $withTime
      * @return string|null
      */
+    #[\Deprecated(message: 'since 26.5 Use Mage::app()->getLocale()->formatDateForDb() instead')]
     public function formatDate($date, $withTime = true)
     {
         if ($date === true) {

--- a/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Abstract.php
@@ -551,13 +551,7 @@ abstract class Mage_Core_Model_Resource_Db_Abstract extends Mage_Core_Model_Reso
         }
 
         $fields = $this->_getReadAdapter()->describeTable($this->getMainTable());
-        foreach (array_keys($fields) as $field) {
-            if ($object->getOrigData($field) != $object->getData($field)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(array_keys($fields), fn($field) => $object->getOrigData($field) != $object->getData($field));
     }
 
     /**

--- a/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Resource/Db/Collection/Abstract.php
@@ -687,13 +687,13 @@ abstract class Mage_Core_Model_Resource_Db_Collection_Abstract extends \Maho\Dat
     /**
      * Format Date to internal database date format
      *
-     * @deprecated since 26.5 Use Mage::app()->getLocale()->formatDateForDb() or now() instead
      * @see Mage_Core_Model_Locale::formatDateForDb()
      *
      * @param int|string|DateTime|bool $date
      * @param bool $withTime
      * @return string|null
      */
+    #[\Deprecated(message: 'since 26.5 Use Mage::app()->getLocale()->formatDateForDb() or now() instead')]
     public function formatDate($date, $withTime = true)
     {
         if ($date === true) {

--- a/app/code/core/Mage/Core/Model/Session/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract.php
@@ -871,12 +871,7 @@ class Mage_Core_Model_Session_Abstract extends \Maho\DataObject
             && $sessionData[self::VALIDATOR_HTTP_USER_AGENT_KEY] != $validatorData[self::VALIDATOR_HTTP_USER_AGENT_KEY]
         ) {
             $userAgentValidated = $this->getValidateHttpUserAgentSkip();
-            foreach ($userAgentValidated as $agent) {
-                if (preg_match('/' . $agent . '/iu', $validatorData[self::VALIDATOR_HTTP_USER_AGENT_KEY])) {
-                    return true;
-                }
-            }
-            return false;
+            return array_any($userAgentValidated, fn($agent) => preg_match('/' . $agent . '/iu', $validatorData[self::VALIDATOR_HTTP_USER_AGENT_KEY]));
         }
 
         $session = $this->getSymfonySession();

--- a/app/code/core/Mage/Cron/Model/Schedule.php
+++ b/app/code/core/Mage/Cron/Model/Schedule.php
@@ -118,12 +118,7 @@ class Mage_Cron_Model_Schedule extends Mage_Core_Model_Abstract
 
         // handle multiple options
         if (str_contains($expr, ',')) {
-            foreach (explode(',', $expr) as $e) {
-                if ($this->matchCronExpression($e, $num)) {
-                    return true;
-                }
-            }
-            return false;
+            return array_any(explode(',', $expr), fn($e) => $this->matchCronExpression($e, $num));
         }
 
         // handle modulus

--- a/app/code/core/Mage/Customer/Helper/Data.php
+++ b/app/code/core/Mage/Customer/Helper/Data.php
@@ -25,9 +25,7 @@ class Mage_Customer_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public const XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD = 'customer/login/redirect_dashboard';
 
-    /**
-     * @deprecated Since 26.1.0. Use XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD instead
-     */
+    #[\Deprecated(message: 'Since 26.1.0. Use XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD instead')]
     public const XML_PATH_CUSTOMER_STARTUP_REDIRECT_TO_DASHBOARD = self::XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD;
 
     /**

--- a/app/code/core/Mage/Customer/Model/Convert/Parser/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Convert/Parser/Customer.php
@@ -414,10 +414,8 @@ class Mage_Customer_Model_Convert_Parser_Customer extends Mage_Eav_Model_Convert
         return $this->_customerGroups[$customer->getGroupId()] ?? null;
     }
 
-    /**
-     * @deprecated not used anymore
-     */
     #[\Override]
+    #[\Deprecated(message: 'not used anymore')]
     public function parse()
     {
         $data = $this->getData();

--- a/app/code/core/Mage/Customer/Model/Observer.php
+++ b/app/code/core/Mage/Customer/Model/Observer.php
@@ -283,13 +283,7 @@ class Mage_Customer_Model_Observer
             Mage_Core_Model_Encryption::HASH_VERSION_SHA512,
             Mage_Core_Model_Encryption::HASH_VERSION_LATEST,
         ];
-        $currentVersionHash = null;
-        foreach ($hashVersionArray as $hashVersion) {
-            if ($encryptor->validateHashByVersion($password, $model->getPasswordHash(), $hashVersion)) {
-                $currentVersionHash = $hashVersion;
-                break;
-            }
-        }
+        $currentVersionHash = array_find($hashVersionArray, fn($hashVersion) => $encryptor->validateHashByVersion($password, $model->getPasswordHash(), $hashVersion));
         if (Mage_Core_Model_Encryption::HASH_VERSION_SHA256 !== $currentVersionHash) {
             $model->changePassword($password, false);
         }

--- a/app/code/core/Mage/Directory/Block/Data.php
+++ b/app/code/core/Mage/Directory/Block/Data.php
@@ -19,8 +19,8 @@ class Mage_Directory_Block_Data extends Mage_Core_Block_Template
     /**
      * @codeCoverageIgnore
      * @return string
-     * @deprecated
      */
+    #[\Deprecated]
     public function getLoadrRegionUrl()
     {
         return $this->getUrl('directory/json/childRegion');

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute.php
@@ -90,9 +90,9 @@ class Mage_Eav_Model_Entity_Attribute extends Mage_Eav_Model_Entity_Attribute_Ab
      * Retrieve default attribute source model
      *
      * @return string
-     * @deprecated since 26.1 use getDefaultSourceModel() instead
      */
     #[\Override]
+    #[\Deprecated(message: 'since 26.1 use getDefaultSourceModel() instead')]
     protected function _getDefaultSourceModel()
     {
         return $this->getDefaultSourceModel();

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Abstract.php
@@ -505,8 +505,8 @@ abstract class Mage_Eav_Model_Entity_Attribute_Abstract extends Mage_Core_Model_
 
     /**
      * @return string
-     * @deprecated since 26.1 use getDefaultSourceModel() instead
      */
+    #[\Deprecated(message: 'since 26.1 use getDefaultSourceModel() instead')]
     protected function _getDefaultSourceModel()
     {
         return $this->getDefaultSourceModel();

--- a/app/code/core/Mage/ImportExport/Helper/Data.php
+++ b/app/code/core/Mage/ImportExport/Helper/Data.php
@@ -34,9 +34,9 @@ class Mage_ImportExport_Helper_Data extends Mage_Core_Helper_Data
     /**
      * Get valid path masks to files for importing/exporting
      *
-     * @deprecated since 26.1 Use Maho\Io::allowedPath() for path validation instead
      * @return array
      */
+    #[\Deprecated(message: 'since 26.1 Use Maho\Io::allowedPath() for path validation instead')]
     public function getLocalValidPaths()
     {
         return Mage::getStoreConfig(self::XML_PATH_EXPORT_LOCAL_VALID_PATH);

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer/Address.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Customer/Address.php
@@ -312,12 +312,7 @@ class Mage_ImportExport_Model_Import_Entity_Customer_Address extends Mage_Import
      */
     protected function _isRowWithAddress(array $rowData)
     {
-        foreach (array_keys($this->_attributes) as $colName) {
-            if (isset($rowData[$colName]) && strlen($rowData[$colName])) {
-                return true;
-            }
-        }
-        return false;
+        return array_any(array_keys($this->_attributes), fn($colName) => isset($rowData[$colName]) && strlen($rowData[$colName]));
     }
 
     /**

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment/Packaging.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Shipment/Packaging.php
@@ -70,8 +70,8 @@ class Mage_Sales_Model_Order_Pdf_Shipment_Packaging extends Mage_Sales_Model_Ord
     /**
      * @param mixed $page
      * @return $this
-     * @deprecated No longer used with HTML/CSS approach
      */
+    #[\Deprecated(message: 'No longer used with HTML/CSS approach')]
     protected function _drawHeaderBlock($page = null): self
     {
         // Legacy method - no longer used with HTML/CSS approach
@@ -81,8 +81,8 @@ class Mage_Sales_Model_Order_Pdf_Shipment_Packaging extends Mage_Sales_Model_Ord
     /**
      * @param mixed $page
      * @return $this
-     * @deprecated No longer used with HTML/CSS approach
      */
+    #[\Deprecated(message: 'No longer used with HTML/CSS approach')]
     protected function _drawPackageBlock($page = null): self
     {
         // Legacy method - no longer used with HTML/CSS approach

--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -1039,9 +1039,9 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
     /**
      * Retrieve total models
      *
-     * @deprecated
      * @return array
      */
+    #[\Deprecated]
     public function getTotalModels()
     {
         return $this->getTotalCollector()->getRetrievers();

--- a/app/code/core/Mage/Sales/Model/Quote/Address/Total/Msrp.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address/Total/Msrp.php
@@ -30,20 +30,12 @@ class Mage_Sales_Model_Quote_Address_Total_Msrp extends Mage_Sales_Model_Quote_A
         if (!count($items)) {
             return $this;
         }
-
-        $canApplyMsrp = false;
-        foreach ($items as $item) {
-            if (!$item->getParentItemId()
-                && Mage::helper('catalog')->canApplyMsrp(
-                    $item->getProductId(),
-                    Mage_Catalog_Model_Product_Attribute_Source_Msrp_Type::TYPE_BEFORE_ORDER_CONFIRM,
-                    true,
-                )
-            ) {
-                $canApplyMsrp = true;
-                break;
-            }
-        }
+        $canApplyMsrp = array_any($items, fn($item) => !$item->getParentItemId()
+            && Mage::helper('catalog')->canApplyMsrp(
+                $item->getProductId(),
+                Mage_Catalog_Model_Product_Attribute_Source_Msrp_Type::TYPE_BEFORE_ORDER_CONFIRM,
+                true,
+            ));
 
         $address->setCanApplyMsrp($canApplyMsrp);
 

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
@@ -735,9 +735,9 @@ abstract class Mage_Sales_Model_Quote_Item_Abstract extends Mage_Core_Model_Abst
     /**
      * Calculate item tax amount
      *
-     * @deprecated logic moved to tax totals calculation model
      * @return  $this
      */
+    #[\Deprecated(message: 'logic moved to tax totals calculation model')]
     public function calcTaxAmount()
     {
         $store = $this->getStore();

--- a/app/code/core/Mage/SalesRule/Model/Validator.php
+++ b/app/code/core/Mage/SalesRule/Model/Validator.php
@@ -1031,8 +1031,8 @@ class Mage_SalesRule_Model_Validator extends Mage_Core_Model_Abstract
      *
      * @param string $name
      * @return Mage_Core_Model_Abstract|false
-     * @deprecated use Mage::getSingleton()
      */
+    #[\Deprecated(message: 'use Mage::getSingleton()')]
     protected function _getSingleton($name)
     {
         return Mage::getSingleton($name);
@@ -1043,8 +1043,8 @@ class Mage_SalesRule_Model_Validator extends Mage_Core_Model_Abstract
      *
      * @param string $name
      * @return Mage_Core_Helper_Abstract|false
-     * @deprecated use Mage::helper()
      */
+    #[\Deprecated(message: 'use Mage::helper()')]
     protected function _getHelper($name)
     {
         return Mage::helper($name);

--- a/app/code/core/Mage/Tax/Model/Config.php
+++ b/app/code/core/Mage/Tax/Model/Config.php
@@ -89,9 +89,7 @@ class Mage_Tax_Model_Config
     public const FPT_TAXED = 1;
     public const FPT_LOADED_DISPLAY_WITH_TAX = 2;
 
-    /**
-     * @deprecated
-     */
+    #[\Deprecated]
     public const CONFIG_XML_PATH_DISPLAY_TAX_COLUMN = 'tax/display/column_in_summary';
 
     /**
@@ -308,10 +306,10 @@ class Mage_Tax_Model_Config
     /**
      * Get shopping cart prices display type
      *
-     * @deprecated please use displayCartPrice or displaySalesZeroTax
      * @param   null|string|bool|int|Mage_Core_Model_Store $store
      * @return  bool
      */
+    #[\Deprecated(message: 'please use displayCartPrice or displaySalesZeroTax')]
     public function displayTaxColumn($store = null)
     {
         return (bool) $this->_getStoreConfig(self::CONFIG_XML_PATH_DISPLAY_TAX_COLUMN, $store);

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
@@ -1945,17 +1945,13 @@ class Mage_Usa_Model_Shipping_Carrier_Usps extends Mage_Usa_Model_Shipping_Carri
         return [$zip5, $zip4];
     }
 
-    /**
-     * @deprecated
-     */
+    #[\Deprecated]
     protected function _methodsMapper($method, $valuesToLabels = true)
     {
         return $method;
     }
 
-    /**
-     * @deprecated
-     */
+    #[\Deprecated]
     public function getMethodLabel($value)
     {
         return $this->_methodsMapper($value, true);
@@ -1963,16 +1959,14 @@ class Mage_Usa_Model_Shipping_Carrier_Usps extends Mage_Usa_Model_Shipping_Carri
 
     /**
      * Get value of method by its label
-     * @deprecated
      */
+    #[\Deprecated]
     public function getMethodValue($label)
     {
         return $this->_methodsMapper($label, false);
     }
 
-    /**
-     * @deprecated
-     */
+    #[\Deprecated]
     protected function setTrackingReqeust()
     {
         $this->setTrackingRequest();

--- a/app/code/core/Maho/ContentVersion/Helper/Data.php
+++ b/app/code/core/Maho/ContentVersion/Helper/Data.php
@@ -42,13 +42,7 @@ class Maho_ContentVersion_Helper_Data extends Mage_Core_Helper_Abstract
 
         // Skip if nothing meaningful has changed
         if ($hasOrigData) {
-            $changed = false;
-            foreach ($snapshot as $field => $origValue) {
-                if ($model->getData($field) != $origValue) {
-                    $changed = true;
-                    break;
-                }
-            }
+            $changed = array_any($snapshot, fn($origValue, $field) => $model->getData($field) != $origValue);
             if (!$changed) {
                 return;
             }

--- a/app/code/core/Maho/FeedManager/Model/Platform/AbstractAdapter.php
+++ b/app/code/core/Maho/FeedManager/Model/Platform/AbstractAdapter.php
@@ -183,15 +183,7 @@ abstract class Maho_FeedManager_Model_Platform_AbstractAdapter implements Maho_F
             // Parse line - format depends on taxonomy file
             // Google format: "id - Category > Subcategory > ..." or just "Category > Subcategory > ..."
             $lineLower = strtolower($line);
-
-            // Check if all query parts match
-            $allMatch = true;
-            foreach ($queryParts as $part) {
-                if (!str_contains($lineLower, $part)) {
-                    $allMatch = false;
-                    break;
-                }
-            }
+            $allMatch = array_all($queryParts, fn($part) => str_contains($lineLower, $part));
 
             if ($allMatch) {
                 // Extract ID and path

--- a/app/code/core/Maho/Giftcard/Model/Product/Type/Giftcard.php
+++ b/app/code/core/Maho/Giftcard/Model/Product/Type/Giftcard.php
@@ -161,15 +161,7 @@ class Maho_Giftcard_Model_Product_Type_Giftcard extends Mage_Catalog_Model_Produ
                 if ($allowedAmounts) {
                     $amounts = array_map('trim', explode(',', $allowedAmounts));
                     $amounts = array_map('floatval', $amounts);
-
-                    // Use float comparison with small epsilon for precision issues
-                    $isValid = false;
-                    foreach ($amounts as $allowedAmount) {
-                        if (abs($amount - $allowedAmount) < 0.01) {
-                            $isValid = true;
-                            break;
-                        }
-                    }
+                    $isValid = array_any($amounts, fn($allowedAmount) => abs($amount - $allowedAmount) < 0.01);
 
                     if (!$isValid) {
                         return Mage::helper('giftcard')->__('Please select a valid gift card amount');

--- a/app/code/core/Maho/MediaCleaner/Helper/Data.php
+++ b/app/code/core/Maho/MediaCleaner/Helper/Data.php
@@ -91,12 +91,6 @@ class Maho_MediaCleaner_Helper_Data extends Mage_Core_Helper_Abstract
 
     public function isBlacklisted(string $path, array $blacklistedPatterns): bool
     {
-        foreach ($blacklistedPatterns as $blacklistedPattern) {
-            if (fnmatch('*/' . $blacklistedPattern, $path)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($blacklistedPatterns, fn($blacklistedPattern) => fnmatch('*/' . $blacklistedPattern, $path));
     }
 }

--- a/lib/Maho/DataObject/Mapper.php
+++ b/lib/Maho/DataObject/Mapper.php
@@ -43,11 +43,12 @@ class Mapper
      * @param array|DataObject|callable $from
      * @param array|DataObject|callable $to
      * @return array|DataObject
-     *
-     * @deprecated since 26.5 For DataObject-to-DataObject copies use $target->addData($source->toArray($map)).
-     *             For arrays use array_intersect_key() / direct assignment. The callable-array source/target
-     *             form has no remaining callers in Maho core.
      */
+    #[\Deprecated(message: <<<'TXT'
+    since 26.5 For DataObject-to-DataObject copies use $target->addData($source->toArray($map)).
+                 For arrays use array_intersect_key() / direct assignment. The callable-array source/target
+                 form has no remaining callers in Maho core.
+    TXT)]
     public static function &accumulateByMap($from, $to, array $map, array $defaults = [])
     {
         $get = 'getData';

--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -688,12 +688,7 @@ class Mysql extends AbstractPdoAdapter
     public function tableColumnExists(string $tableName, string $columnName, ?string $schemaName = null): bool
     {
         $describe = $this->describeTable($tableName, $schemaName);
-        foreach ($describe as $column) {
-            if ($column['COLUMN_NAME'] == $columnName) {
-                return true;
-            }
-        }
-        return false;
+        return array_any($describe, fn($column) => $column['COLUMN_NAME'] == $columnName);
     }
 
     /**

--- a/lib/Maho/Db/Adapter/Pdo/Pgsql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Pgsql.php
@@ -1670,12 +1670,7 @@ class Pgsql extends AbstractPdoAdapter
     public function tableColumnExists(string $tableName, string $columnName, ?string $schemaName = null): bool
     {
         $describe = $this->describeTable($tableName, $schemaName);
-        foreach ($describe as $column) {
-            if ($column['COLUMN_NAME'] == $columnName) {
-                return true;
-            }
-        }
-        return false;
+        return array_any($describe, fn($column) => $column['COLUMN_NAME'] == $columnName);
     }
 
     /**

--- a/lib/Maho/Db/Adapter/Pdo/Sqlite.php
+++ b/lib/Maho/Db/Adapter/Pdo/Sqlite.php
@@ -1483,12 +1483,7 @@ class Sqlite extends AbstractPdoAdapter
     public function tableColumnExists(string $tableName, string $columnName, ?string $schemaName = null): bool
     {
         $describe = $this->describeTable($tableName, $schemaName);
-        foreach ($describe as $column) {
-            if (strcasecmp($column['COLUMN_NAME'], $columnName) === 0) {
-                return true;
-            }
-        }
-        return false;
+        return array_any($describe, fn($column) => strcasecmp($column['COLUMN_NAME'], $columnName) === 0);
     }
 
     /**
@@ -2287,14 +2282,7 @@ class Sqlite extends AbstractPdoAdapter
 
         // Add composite PRIMARY KEY if no identity column and multiple primary columns
         if (!$hasIdentity && !empty($primary) && count($primary) > 0) {
-            // Check if we didn't already add it inline
-            $hasInlinePrimary = false;
-            foreach ($definition as $def) {
-                if (str_contains($def, 'PRIMARY KEY')) {
-                    $hasInlinePrimary = true;
-                    break;
-                }
-            }
+            $hasInlinePrimary = array_any($definition, fn($def) => str_contains($def, 'PRIMARY KEY'));
             if (!$hasInlinePrimary) {
                 asort($primary, SORT_NUMERIC);
                 $primaryCols = array_map([$this, 'quoteIdentifier'], array_keys($primary));

--- a/lib/Maho/Db/Ddl/Table.php
+++ b/lib/Maho/Db/Ddl/Table.php
@@ -69,14 +69,15 @@ class Table
 
     /**
      * Default values for timestamp columns: fill with current timestamp on insert, on update, or both.
-     *
-     * @deprecated TIMESTAMP_INIT_UPDATE is unsafe for cross-engine use: PgSQL and SQLite
-     * silently downgrade it to plain CURRENT_TIMESTAMP (no on-update auto-bump), and the
-     * surgical modifyColumn path drops the ON UPDATE clause across all adapters because
-     * Doctrine DBAL's column model has no on-update concept. Use TIMESTAMP_INIT plus an
-     * explicit _beforeSave() that calls setUpdatedAt(Mage::app()->getLocale()->formatDateForDb('now'))
-     * for cross-engine parity.
      */
+    #[\Deprecated(message: <<<'TXT'
+    TIMESTAMP_INIT_UPDATE is unsafe for cross-engine use: PgSQL and SQLite
+     silently downgrade it to plain CURRENT_TIMESTAMP (no on-update auto-bump), and the
+     surgical modifyColumn path drops the ON UPDATE clause across all adapters because
+     Doctrine DBAL's column model has no on-update concept. Use TIMESTAMP_INIT plus an
+     explicit _beforeSave() that calls setUpdatedAt(Mage::app()->getLocale()->formatDateForDb('now'))
+     for cross-engine parity.
+    TXT)]
     public const TIMESTAMP_INIT_UPDATE = 'TIMESTAMP_INIT_UPDATE';
     public const TIMESTAMP_INIT        = 'TIMESTAMP_INIT';
     /**


### PR DESCRIPTION
## Summary

Applies Rector 2.5.2's polyfill-set rules across core:

- **`@deprecated` docblocks → `#[\Deprecated]` attributes** (`DeprecatedAnnotationToDeprecatedAttributeRector`) — 58 occurrences.
- **`foreach` → `array_all()` / `array_any()` / `array_find()`** (`ForeachToArrayAll/Any/Find`) — 24 call-sites.

These are PHP 8.4 features, but **they run on PHP 8.3** because Maho already requires `symfony/polyfill-php84` (and `-php85`) directly in `composer.json`. The polyfill's `bootstrap.php` is in Composer's `files` autoload (loaded every request) and defines the `array_*` functions globally, and `\Deprecated` is a classmapped global-namespace stub. So there is **no minimum-version bump** — the minimum stays PHP 8.3.

Rector applies these correctly (not "ahead of version") because both rules implement `RelatedPolyfillInterface → PolyfillPackage::PHP_84`, and Rector detects the polyfill is installed.

## Fixes for two issues the run surfaced

- **`Mage_Catalog_Model_Product::isProductsHasSku()`** — the generated `array_all()` callback returned `int` (`strlen($sku)`) where a `callable(): bool` is required. Changed to `$product['sku'] !== ''`.
- **PHPStan baseline** — removed a now-stale entry for `Tag_Edit::getSaveUrl()`. Unlike the old `@deprecated` docblock, the `#[\Deprecated]` attribute does not propagate deprecation to the un-annotated override, so that call is no longer flagged.

## Verification

- `composer lint` (cs-fixer + rector + phpstan) — all green.
- No 8.3-incompatible constructs remain; everything is polyfill-backed.