### PR TITLE
fix(core): poll config cache save lock instead of blocking on it

### DIFF
--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -452,12 +452,6 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     /**
      * Call before building and saving cache to ensure only one process can save the cache
      *
-     * Acquires the lock by polling with non-blocking GET_LOCK attempts and
-     * sleeping in PHP between tries, rather than one blocking GET_LOCK that
-     * parks a DB connection in "User lock" wait for the whole timeout. Under a
-     * post-flush stampede the blocking form keeps one busy DB thread per waiting
-     * request, which can overwhelm the server (see issue #1050).
-     *
      * If failed to get cache lock:
      *   - CLI: throws exception
      *   - Other: 503 error
@@ -475,9 +469,11 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         if (!$connection) {
             return;
         }
-        $deadline = microtime(true) + (float) $waitTime;
+        // Poll with non-blocking GET_LOCK + sleep instead of one blocking call, which
+        // would park a busy DB thread per waiting request and pile up under load (#1050).
+        $deadline = time() + $waitTime;
         while (!$connection->getLock('core_config_cache_save_lock', 0)) {
-            if (microtime(true) >= $deadline) {
+            if (time() >= $deadline) {
                 if ($ignoreFailure) {
                     return;
                 }

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -470,7 +470,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
             return;
         }
         // Poll with non-blocking GET_LOCK + sleep instead of one blocking call, which
-        // would park a busy DB thread per waiting request and pile up under load (#1050).
+        // would park a busy DB thread per waiting request and pile up under load.
         $deadline = time() + $waitTime;
         while (!$connection->getLock('core_config_cache_save_lock', 0)) {
             if (time() >= $deadline) {

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -452,6 +452,12 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     /**
      * Call before building and saving cache to ensure only one process can save the cache
      *
+     * Acquires the lock by polling with non-blocking GET_LOCK attempts and
+     * sleeping in PHP between tries, rather than one blocking GET_LOCK that
+     * parks a DB connection in "User lock" wait for the whole timeout. Under a
+     * post-flush stampede the blocking form keeps one busy DB thread per waiting
+     * request, which can overwhelm the server (see issue #1050).
+     *
      * If failed to get cache lock:
      *   - CLI: throws exception
      *   - Other: 503 error
@@ -469,16 +475,20 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         if (!$connection) {
             return;
         }
-        if (!$connection->getLock('core_config_cache_save_lock', $waitTime)) {
-            if ($ignoreFailure) {
-                return;
+        $deadline = microtime(true) + (float) $waitTime;
+        while (!$connection->getLock('core_config_cache_save_lock', 0)) {
+            if (microtime(true) >= $deadline) {
+                if ($ignoreFailure) {
+                    return;
+                }
+                if (PHP_SAPI === 'cli') {
+                    throw new Exception('Could not get lock on cache save operation.');
+                }
+                Mage::log(sprintf('Failed to get cache save lock in %d seconds.', $waitTime), Mage::LOG_NOTICE);
+                Maho::errorReport();
+                die();
             }
-            if (PHP_SAPI === 'cli') {
-                throw new Exception('Could not get lock on cache save operation.');
-            }
-            Mage::log(sprintf('Failed to get cache save lock in %d seconds.', $waitTime), Mage::LOG_NOTICE);
-            Maho::errorReport();
-            die();
+            sleep(1);
         }
     }
 


### PR DESCRIPTION
## Problem

Closes #1050.

After a config cache flush, a stampede of concurrent requests each call:

```php
$connection->getLock('core_config_cache_save_lock', $waitTime);
```

A blocking `GET_LOCK` parks the request inside MySQL in a **"User lock"** wait state, holding one busy DB thread per waiting request for the entire timeout. Under load this saturates DB threads/connections — the reporter saw the processlist fill with `GET_LOCK` queries and had to restart the database to recover.

## Change

Acquire the lock by **polling** with non-blocking `GET_LOCK(..., 0)` attempts and sleeping 1s in PHP between tries, instead of one long blocking acquire:

```php
$deadline = microtime(true) + (float) $waitTime;
while (!$connection->getLock('core_config_cache_save_lock', 0)) {
    if (microtime(true) >= $deadline) {
        // ...existing failure handling (ignoreFailure / CLI throw / 503)...
    }
    sleep(1);
}
```

External behavior is unchanged — it still blocks until the lock is held or the deadline passes, with the same `ignoreFailure` / CLI-throw / 503 paths. The difference is that a waiting request no longer pins a busy DB thread in lock-wait; between tries it sleeps in PHP, so the DB only sees one trivial non-blocking lock check per waiter per second instead of a continuously parked thread.

## Scope

- Single method touched: `Mage_Core_Model_Config::getCacheSaveLock()`.
- No call-site changes; the double-checked locking, `applyAllUpdates()` under the lock, and the lock staying on the DB (required for multi-frontend coordination) are all untouched.

## Note

This narrows the failure mode but doesn't make cache-miss bootstraps free — the rebuild wait is inherent. The most effective operational mitigation remains warming the config cache on deploy (one bootstrap with no concurrency) rather than flushing into live traffic.