### PR TITLE
Added attribute-based controller overrides, eliminating the last routing XML

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,9 +134,17 @@ public function viewAction() { ... }
 - Back-compat: modules still declaring `<frontend><routers>` in `config.xml` keep working via a legacy-XML match path that runs **before** the Symfony matcher, preserving M1's "first declared wins" precedence. A single `LOG_NOTICE` is emitted once per process listing legacy frontNames, encouraging migration.
 
 #### Overriding controllers
-- **Admin**: register your module under `<admin><routers><adminhtml><args><modules><MyMod before|after="Mage_Adminhtml"/>` in `config.xml`. The runtime walks this chain at dispatch time, so admin controllers (subclasses of `Mage_Adminhtml_Controller_Action` / `Maho\Controller\AdminAction`) override core controllers without redeclaring routes.
-- **Frontend**: same pattern via `<frontend><routers><{routerCode}><args><modules><MyMod before|after="Mage_Customer"/>` (the router code must equal the frontName you're overriding, or supply `<args><frontName>` explicitly). Subclasses of the core controller win over the base when present; M1 chain semantics are preserved.
-- **Install**: no chain support; override by redeclaring `#[Route]` attributes on a custom controller.
+Preferred (no XML): **subclass the controller you want to override.** The compiler detects, at `composer dump-autoload`, any controller that extends a route-owning controller and declares no `#[Route]` of its own, and points the route at the subclass. This works in every area (frontend, admin, install).
+
+```php
+// Just works — no XML, no attribute. Run `composer dump-autoload` after adding it.
+class My_Module_Checkout_CartController extends Mage_Checkout_CartController { /* override actions */ }
+```
+
+- **Precedence is structural.** When several modules override the same controller they should form a single inheritance chain (B extends A extends Core); the most-derived class wins, deterministically and regardless of module load order. Two *sibling* subclasses extending the same base independently are a conflict: the compiler logs an error and falls back to module load order (local/community over core) — resolve it by having one override extend the other.
+- A subclass that adds **new** actions needs its own `#[Route]` for those actions (inheritance only carries over the base's existing routes).
+
+Legacy XML chain (still honored for BC, wins over the compiled override): register your module under `<{area}><routers><{routerCode}><args><modules><MyMod before|after="Mage_X"/>`. Migrate existing chains with `./maho legacy:migrate-routes` (it drops a `<modules>` chain once the overrides are clean subclasses). Use the inheritance approach for new code.
 
 ## Development Guidelines
 
@@ -173,7 +181,7 @@ All Zend Framework and Varien components have been completely removed. **NEVER**
 - New modules: `app/code/core/Maho/` namespace, declared in `app/etc/modules/`
 - Follow existing module patterns; use `declare(strict_types=1)` (placed *after* the file-level docblock, not before) and PHP 8.3+ features
 - Use `#[\Override]` attribute for overridden methods
-- When overriding admin routes in Maho modules, use `before="Mage_Adminhtml"` pattern
+- To override an existing controller, subclass it (see "Overriding controllers" above) — no XML needed
 
 ### Modifying Existing Features
 - Feel free to modify core files directly

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "laminas/laminas-permissions-acl": "^2.17",
         "lbuchs/webauthn": "^2.2",
         "mahocommerce/icons": "^3",
-        "mahocommerce/maho-composer-plugin": "^4",
+        "mahocommerce/maho-composer-plugin": "^4.1.1",
         "matthiasmullie/minify": "^1.3",
         "monolog/monolog": "^3.9",
         "paypal/paypal-server-sdk": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e29b4da480537dfe26290a9f68bb5804",
+    "content-hash": "959f0fa2c25f257068b61b7823733719",
     "packages": [
         {
             "name": "altcha-org/altcha",
@@ -1223,16 +1223,16 @@
         },
         {
             "name": "mahocommerce/maho-composer-plugin",
-            "version": "v4.0.32",
+            "version": "v4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MahoCommerce/maho-composer-plugin.git",
-                "reference": "5db07db7b897493a1f4ea40c3c4542019e5503a4"
+                "reference": "3e03a6130e98d143dea139be90cfcdd179f8daa1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MahoCommerce/maho-composer-plugin/zipball/5db07db7b897493a1f4ea40c3c4542019e5503a4",
-                "reference": "5db07db7b897493a1f4ea40c3c4542019e5503a4",
+                "url": "https://api.github.com/repos/MahoCommerce/maho-composer-plugin/zipball/3e03a6130e98d143dea139be90cfcdd179f8daa1",
+                "reference": "3e03a6130e98d143dea139be90cfcdd179f8daa1",
                 "shasum": ""
             },
             "require": {
@@ -1267,7 +1267,7 @@
             "description": "Extension for Composer to copy assets and enable autoloading for Maho projects.",
             "support": {
                 "issues": "https://github.com/MahoCommerce/maho-composer-plugin/issues",
-                "source": "https://github.com/MahoCommerce/maho-composer-plugin/tree/v4.0.32"
+                "source": "https://github.com/MahoCommerce/maho-composer-plugin/tree/v4.1.1"
             },
             "funding": [
                 {
@@ -1283,7 +1283,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-16T18:25:35+00:00"
+            "time": "2026-06-25T13:27:16+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/lib/Maho/Routing/ControllerDispatcher.php
+++ b/lib/Maho/Routing/ControllerDispatcher.php
@@ -280,6 +280,13 @@ class ControllerDispatcher
 
         if ($area === 'adminhtml') {
             foreach ($this->buildAdminModuleChain() as $realModule) {
+                // The chain is seeded with the Mage_Adminhtml base; skip it so the base
+                // (and any inheritance-based override of it) is resolved via the compiled
+                // lookup below, mirroring the override-only frontend chain. Only XML
+                // `<args><modules>` overrides win here.
+                if ($realModule === 'Mage_Adminhtml') {
+                    continue;
+                }
                 $className = $realModule . '_' . uc_words($controllerName) . 'Controller';
                 if (class_exists($className)) {
                     return $className;

--- a/lib/Maho/Routing/ControllerDispatcher.php
+++ b/lib/Maho/Routing/ControllerDispatcher.php
@@ -256,9 +256,18 @@ class ControllerDispatcher
     }
 
     /**
-     * Walk the area's module override chain. Both admin and frontend honor
-     * <args><modules> declarations from third-party config.xml — admin via
-     * `admin/routers/adminhtml`, frontend via `frontend/routers/<frontName>`.
+     * Resolve the controller class for a Symfony-matched route, honoring overrides.
+     *
+     * Precedence:
+     *  1. XML `<args><modules>` chain (M1 BC) — admin via `admin/routers/adminhtml`,
+     *     frontend via `frontend/routers/<frontName>`. A config.xml override wins.
+     *  2. Compiled `controllerLookup` — resolves attribute/inheritance-based overrides
+     *     (a subclass of a route-owning controller automatically supersedes it) and, when
+     *     no override exists, the route-owning base controller itself.
+     *
+     * Returning null lets the caller fall back to the route's `_maho_controller` default.
+     * For admin/install the incoming frontName is already the sentinel; normalizeFrontName()
+     * inside the lookup is idempotent on sentinels, so it keys correctly either way.
      */
     protected function resolveAttributeControllerClass(
         string $controllerName,
@@ -276,16 +285,18 @@ class ControllerDispatcher
                     return $className;
                 }
             }
-            return null;
-        }
-
-        if ($area === 'frontend') {
+        } elseif ($area === 'frontend') {
             foreach ($this->buildFrontendModuleChain($frontName) as $chainModule) {
                 $className = $chainModule . '_' . uc_words($controllerName) . 'Controller';
                 if (class_exists($className)) {
                     return $className;
                 }
             }
+        }
+
+        $className = RouteCollectionBuilder::lookupCompiledControllerClass($frontName, $controllerName);
+        if ($className !== null && class_exists($className)) {
+            return $className;
         }
 
         return null;

--- a/lib/MahoCLI/Commands/LegacyMigrateRoutes.php
+++ b/lib/MahoCLI/Commands/LegacyMigrateRoutes.php
@@ -9,7 +9,11 @@ declare(strict_types=1);
 
 namespace MahoCLI\Commands;
 
+use DOMDocument;
 use DOMElement;
+use Maho\Config\Route;
+use ReflectionClass;
+use ReflectionMethod;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -55,6 +59,8 @@ class LegacyMigrateRoutes extends BaseMahoCommand
         $totalRoutes = 0;
         $totalSkipped = 0;
         $totalRouters = 0;
+        $totalOverridesRemoved = 0;
+        $totalOverridesSkipped = 0;
 
         foreach ($this->findUserConfigXmlFiles() as $entry) {
             $module = $entry['module'];
@@ -66,12 +72,21 @@ class LegacyMigrateRoutes extends BaseMahoCommand
                 continue;
             }
 
-            $routerEntries = $this->findRouterNodes($dom, $module);
-            if ($routerEntries === []) {
-                continue;
-            }
+            // Header is printed lazily so override-only modules (no <use> router) still show up.
+            $headerPrinted = false;
+            $ensureHeader = function () use (&$headerPrinted, $output, $module, $configPath): void {
+                if (!$headerPrinted) {
+                    $output->writeln(sprintf('<info>%s</info> (%s)', $module, $configPath));
+                    $headerPrinted = true;
+                }
+            };
+            $fileChanged = false;
 
-            $output->writeln(sprintf('<info>%s</info> (%s)', $module, $configPath));
+            $routerEntries = $this->findRouterNodes($dom, $module);
+            if ($routerEntries !== []) {
+                $ensureHeader();
+                $fileChanged = true;
+            }
 
             foreach ($routerEntries as $routerEntry) {
                 $totalRouters++;
@@ -152,24 +167,41 @@ class LegacyMigrateRoutes extends BaseMahoCommand
                 $this->detachAndPrune($routerNode);
             }
 
-            if (!$dryRun) {
+            // Override <modules> chains → drop the XML; inheritance now auto-registers them.
+            $this->migrateControllerOverrides(
+                $dom,
+                $output,
+                $dryRun,
+                $ensureHeader,
+                $totalOverridesRemoved,
+                $totalOverridesSkipped,
+                $fileChanged,
+            );
+
+            if (!$dryRun && $fileChanged) {
                 $this->saveConfigXml($dom, $configPath);
             }
 
-            $output->writeln('');
+            if ($headerPrinted) {
+                $output->writeln('');
+            }
         }
 
         $output->writeln(sprintf(
-            '<info>Done.</info> Routers processed: %d, route attributes added: %d, skipped: %d.',
+            '<info>Done.</info> Routers processed: %d, route attributes added: %d, skipped: %d. '
+            . 'Override chains removed: %d, skipped: %d.',
             $totalRouters,
             $totalRoutes,
             $totalSkipped,
+            $totalOverridesRemoved,
+            $totalOverridesSkipped,
         ));
 
-        if ($dryRun && $totalRoutes > 0) {
+        $changed = $totalRoutes > 0 || $totalOverridesRemoved > 0;
+        if ($dryRun && $changed) {
             $output->writeln('Re-run without --dry-run to apply.');
             $output->writeln('<comment>Tip: review the generated routes carefully; controller-method scanning is best-effort.</comment>');
-        } elseif (!$dryRun && $totalRoutes > 0) {
+        } elseif (!$dryRun && $changed) {
             $output->writeln('Run <info>composer dump-autoload</info> to compile the new attributes.');
             $output->writeln('<comment>Tip: review the generated routes carefully; controller-method scanning is best-effort.</comment>');
         }
@@ -177,6 +209,257 @@ class LegacyMigrateRoutes extends BaseMahoCommand
         $this->migrateLocalXmlAdminPath($output, $dryRun);
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Migrate legacy controller-override chains to the attribute era.
+     *
+     * `<{scope}><routers><{code}><args><modules><My_Module .../></modules>` piggybacks a
+     * module onto an existing frontName purely to override its controllers. Because override
+     * controllers already extend the core controller, Maho now auto-registers them as
+     * overrides at `composer dump-autoload`, so migrating just means deleting the XML.
+     *
+     * A `<modules>` node is removed only when every declared override is a clean
+     * re-implementation of inherited, routed actions. Anything needing a human — a controller
+     * that isn't a subclass of a routed controller, one adding un-routed actions, or sibling
+     * modules overriding the same controller with no shared inheritance chain — is reported
+     * and the XML left untouched, so re-running after a manual fix is safe.
+     */
+    private function migrateControllerOverrides(
+        DOMDocument $dom,
+        OutputInterface $output,
+        bool $dryRun,
+        callable $ensureHeader,
+        int &$removed,
+        int &$skipped,
+        bool &$fileChanged,
+    ): void {
+        $config = $dom->documentElement;
+        if ($config === null) {
+            return;
+        }
+
+        foreach (['frontend', 'admin', 'install'] as $scope) {
+            $scopeNode = $this->firstChildElement($config, $scope);
+            if ($scopeNode === null) {
+                continue;
+            }
+            $routersNode = $this->firstChildElement($scopeNode, 'routers');
+            if ($routersNode === null) {
+                continue;
+            }
+
+            // Snapshot children: detachAndPrune() mutates the tree as we go.
+            foreach (iterator_to_array($routersNode->childNodes) as $routerNode) {
+                if (!$routerNode instanceof DOMElement) {
+                    continue;
+                }
+                $argsNode = $this->firstChildElement($routerNode, 'args');
+                if ($argsNode === null) {
+                    continue;
+                }
+                $modulesNode = $this->firstChildElement($argsNode, 'modules');
+                if ($modulesNode === null) {
+                    continue;
+                }
+
+                $this->migrateOverrideModulesNode(
+                    $modulesNode,
+                    $scope . '/' . $routerNode->localName,
+                    $output,
+                    $dryRun,
+                    $ensureHeader,
+                    $removed,
+                    $skipped,
+                    $fileChanged,
+                );
+            }
+        }
+    }
+
+    /**
+     * Analyze and (when safe) remove a single `<args><modules>` override chain.
+     */
+    private function migrateOverrideModulesNode(
+        DOMElement $modulesNode,
+        string $routerLabel,
+        OutputInterface $output,
+        bool $dryRun,
+        callable $ensureHeader,
+        int &$removed,
+        int &$skipped,
+        bool &$fileChanged,
+    ): void {
+        $modulePrefixes = [];
+        foreach ($modulesNode->childNodes as $child) {
+            if ($child instanceof DOMElement) {
+                $prefix = trim($child->textContent);
+                if ($prefix !== '') {
+                    $modulePrefixes[] = $prefix;
+                }
+            }
+        }
+        if ($modulePrefixes === []) {
+            return;
+        }
+
+        $ensureHeader();
+
+        /** @var list<string> $blockers */
+        $blockers = [];
+        $overrideClasses = [];
+        /** @var array<string, list<string>> $byBase */
+        $byBase = [];
+
+        foreach ($modulePrefixes as $prefix) {
+            $controllers = $this->findControllers($prefix);
+            if ($controllers === []) {
+                $blockers[] = sprintf('module %s declares no controllers', $prefix);
+                continue;
+            }
+            foreach ($controllers as $controller) {
+                $class = $controller['className'];
+                $analysis = $this->analyzeOverrideController($class);
+                if (!$analysis['pure']) {
+                    $blockers[] = sprintf('%s %s', $class, $analysis['reason']);
+                    continue;
+                }
+                if ($analysis['newActions'] !== []) {
+                    $actions = implode(', ', array_map(fn(string $a): string => $a . 'Action', $analysis['newActions']));
+                    $blockers[] = sprintf(
+                        '%s adds un-routed action(s) [%s] — add #[Maho\\Config\\Route] for them first',
+                        $class,
+                        $actions,
+                    );
+                    continue;
+                }
+                $overrideClasses[] = $class;
+                $byBase[(string) $analysis['base']][] = $class;
+            }
+        }
+
+        // Sibling conflict: two overrides of the same base with no shared inheritance chain.
+        foreach ($byBase as $base => $classes) {
+            if (count($classes) > 1 && $this->hasSiblingConflict($classes)) {
+                $blockers[] = sprintf(
+                    'overrides of %s have no shared inheritance chain (%s) — make one extend the other',
+                    $base,
+                    implode(', ', $classes),
+                );
+            }
+        }
+
+        if ($blockers !== []) {
+            $output->writeln(sprintf('  <comment>skip</comment> %s override chain:', $routerLabel));
+            foreach ($blockers as $reason) {
+                $output->writeln(sprintf('    - %s', $reason));
+            }
+            $skipped++;
+            return;
+        }
+
+        if ($dryRun) {
+            $output->writeln(sprintf(
+                '  would remove %s override chain (%d override(s) now auto-registered by inheritance)',
+                $routerLabel,
+                count($overrideClasses),
+            ));
+            $removed++;
+            return;
+        }
+
+        $this->detachAndPrune($modulesNode);
+        $fileChanged = true;
+        $removed++;
+        $output->writeln(sprintf(
+            '  <info>migrated</info> removed %s override chain (%d override(s) auto-registered by inheritance)',
+            $routerLabel,
+            count($overrideClasses),
+        ));
+    }
+
+    /**
+     * Classify an override controller: is it a clean subclass of a routed controller that
+     * only re-implements inherited actions (safe to drop from XML), and which routed base
+     * does it extend?
+     *
+     * @return array{pure: bool, base: ?string, reason: string, newActions: list<string>}
+     */
+    private function analyzeOverrideController(string $className): array
+    {
+        $fail = fn(string $reason): array => ['pure' => false, 'base' => null, 'reason' => $reason, 'newActions' => []];
+
+        if ($this->findClassFile($className) === null) {
+            return $fail('is not autoloadable');
+        }
+
+        $reflection = new ReflectionClass($className);
+        $parent = $reflection->getParentClass();
+        if ($parent === false) {
+            return $fail('extends no controller (needs its own #[Maho\\Config\\Route])');
+        }
+
+        $base = null;
+        for ($ancestor = $parent; $ancestor !== false; $ancestor = $ancestor->getParentClass()) {
+            if ($this->controllerOwnsRoutes($ancestor)) {
+                $base = $ancestor->getName();
+                break;
+            }
+        }
+        if ($base === null) {
+            return $fail('extends no routed controller (needs its own #[Maho\\Config\\Route])');
+        }
+
+        // Public *Action methods the subclass declares that its parent chain doesn't have are
+        // brand-new, un-routed actions — inheritance can't register a route that doesn't exist.
+        $newActions = [];
+        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->getDeclaringClass()->getName() !== $className) {
+                continue;
+            }
+            $name = $method->getName();
+            if (str_ends_with($name, 'Action') && !method_exists($parent->getName(), $name)) {
+                $newActions[] = substr($name, 0, -strlen('Action'));
+            }
+        }
+
+        return ['pure' => true, 'base' => $base, 'reason' => '', 'newActions' => $newActions];
+    }
+
+    /**
+     * Whether the class declares at least one `#[Maho\Config\Route]` of its own.
+     *
+     * @param ReflectionClass<object> $class
+     */
+    private function controllerOwnsRoutes(ReflectionClass $class): bool
+    {
+        foreach ($class->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->getDeclaringClass()->getName() !== $class->getName()) {
+                continue;
+            }
+            if ($method->getAttributes(Route::class) !== []) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * True when the override classes don't reduce to a single most-derived class — i.e. two or
+     * more are mutually incomparable (siblings), mirroring the compiler's conflict detection.
+     *
+     * @param list<string> $classes
+     */
+    private function hasSiblingConflict(array $classes): bool
+    {
+        $maximal = 0;
+        foreach ($classes as $candidate) {
+            $isMaximal = array_all($classes, fn($other) => !($other !== $candidate && is_subclass_of($other, $candidate)));
+            if ($isMaximal) {
+                $maximal++;
+            }
+        }
+        return $maximal > 1;
     }
 
     /**

--- a/lib/MahoCLI/Commands/LegacyMigrateRoutes.php
+++ b/lib/MahoCLI/Commands/LegacyMigrateRoutes.php
@@ -88,6 +88,20 @@ class LegacyMigrateRoutes extends BaseMahoCommand
                 $fileChanged = true;
             }
 
+            // Override <modules> chains → drop the XML; inheritance now auto-registers them.
+            // Run before the route loop: a router carrying BOTH a <use> route declaration and a
+            // <modules> override chain must be classified (clean → removed, blocker → warned)
+            // before detachAndPrune() below would otherwise drop the whole router silently.
+            $this->migrateControllerOverrides(
+                $dom,
+                $output,
+                $dryRun,
+                $ensureHeader,
+                $totalOverridesRemoved,
+                $totalOverridesSkipped,
+                $fileChanged,
+            );
+
             foreach ($routerEntries as $routerEntry) {
                 $totalRouters++;
                 $routerNode = $routerEntry['node'];
@@ -163,20 +177,14 @@ class LegacyMigrateRoutes extends BaseMahoCommand
                     }
                 }
 
-                // Bubble up through <routers> and the area scope if they become empty.
-                $this->detachAndPrune($routerNode);
+                // Bubble up through <routers> and the area scope if they become empty — but
+                // never when a <modules> override chain survived classification (a blocker kept
+                // it): pruning the whole router would silently drop that preserved override XML.
+                $argsNode = $this->firstChildElement($routerNode, 'args');
+                if ($argsNode === null || $this->firstChildElement($argsNode, 'modules') === null) {
+                    $this->detachAndPrune($routerNode);
+                }
             }
-
-            // Override <modules> chains → drop the XML; inheritance now auto-registers them.
-            $this->migrateControllerOverrides(
-                $dom,
-                $output,
-                $dryRun,
-                $ensureHeader,
-                $totalOverridesRemoved,
-                $totalOverridesSkipped,
-                $fileChanged,
-            );
 
             if (!$dryRun && $fileChanged) {
                 $this->saveConfigXml($dom, $configPath);
@@ -300,6 +308,13 @@ class LegacyMigrateRoutes extends BaseMahoCommand
             }
         }
         if ($modulePrefixes === []) {
+            // Empty <modules> wrapper carries nothing — drop the dead XML.
+            if (!$dryRun) {
+                $ensureHeader();
+                $this->detachAndPrune($modulesNode);
+                $fileChanged = true;
+                $output->writeln(sprintf('  <info>migrated</info> removed empty %s override chain', $routerLabel));
+            }
             return;
         }
 
@@ -452,6 +467,9 @@ class LegacyMigrateRoutes extends BaseMahoCommand
      */
     private function hasSiblingConflict(array $classes): bool
     {
+        // Dedup first: the same class discovered twice (e.g. a module present in two code dirs)
+        // would otherwise each count as "maximal" and fake a conflict.
+        $classes = array_values(array_unique($classes));
         $maximal = 0;
         foreach ($classes as $candidate) {
             $isMaximal = array_all($classes, fn($other) => !($other !== $candidate && is_subclass_of($other, $candidate)));

--- a/lib/MahoCLI/Commands/LegacyMigrateRoutes.php
+++ b/lib/MahoCLI/Commands/LegacyMigrateRoutes.php
@@ -309,8 +309,10 @@ class LegacyMigrateRoutes extends BaseMahoCommand
         }
         if ($modulePrefixes === []) {
             // Empty <modules> wrapper carries nothing — drop the dead XML.
-            if (!$dryRun) {
-                $ensureHeader();
+            $ensureHeader();
+            if ($dryRun) {
+                $output->writeln(sprintf('  would remove empty %s override chain', $routerLabel));
+            } else {
                 $this->detachAndPrune($modulesNode);
                 $fileChanged = true;
                 $output->writeln(sprintf('  <info>migrated</info> removed empty %s override chain', $routerLabel));

--- a/lib/MahoCLI/Commands/LegacyMigrateRoutes.php
+++ b/lib/MahoCLI/Commands/LegacyMigrateRoutes.php
@@ -249,6 +249,66 @@ class LegacyMigrateRoutes extends BaseMahoCommand
     }
 
     /**
+     * Yield every `<{scope}><routers><{code}><args><modules>` node in a config.xml, paired with a
+     * human-readable `{scope}/{code}` label. Shared by the cross-file pre-pass (read-only) and the
+     * migration pass (mutating) so both walk the tree identically. Router children are snapshotted,
+     * so callers may detach nodes while iterating.
+     *
+     * @return iterable<array{node: DOMElement, label: string}>
+     */
+    private function iterateOverrideModulesNodes(DOMDocument $dom): iterable
+    {
+        $config = $dom->documentElement;
+        if ($config === null) {
+            return;
+        }
+
+        foreach (['frontend', 'admin', 'install'] as $scope) {
+            $scopeNode = $this->firstChildElement($config, $scope);
+            if ($scopeNode === null) {
+                continue;
+            }
+            $routersNode = $this->firstChildElement($scopeNode, 'routers');
+            if ($routersNode === null) {
+                continue;
+            }
+            foreach (iterator_to_array($routersNode->childNodes) as $routerNode) {
+                if (!$routerNode instanceof DOMElement) {
+                    continue;
+                }
+                $argsNode = $this->firstChildElement($routerNode, 'args');
+                if ($argsNode === null) {
+                    continue;
+                }
+                $modulesNode = $this->firstChildElement($argsNode, 'modules');
+                if ($modulesNode === null) {
+                    continue;
+                }
+                yield ['node' => $modulesNode, 'label' => $scope . '/' . $routerNode->localName];
+            }
+        }
+    }
+
+    /**
+     * The non-empty module prefixes declared inside a `<modules>` override node, in document order.
+     *
+     * @return list<string>
+     */
+    private function overrideModulePrefixes(DOMElement $modulesNode): array
+    {
+        $prefixes = [];
+        foreach ($modulesNode->childNodes as $child) {
+            if ($child instanceof DOMElement) {
+                $prefix = trim($child->textContent);
+                if ($prefix !== '') {
+                    $prefixes[] = $prefix;
+                }
+            }
+        }
+        return $prefixes;
+    }
+
+    /**
      * Collect, grouped by routed base class, every clean override declared in a config.xml's
      * `<args><modules>` chains. Read-only (no output, no DOM mutation) — used by the pre-pass to
      * detect sibling conflicts that span two separate files before any XML is removed. Only
@@ -260,40 +320,13 @@ class LegacyMigrateRoutes extends BaseMahoCommand
      */
     private function collectCleanOverridesByBase(DOMDocument $dom): array
     {
-        $config = $dom->documentElement;
-        if ($config === null) {
-            return [];
-        }
-
         $byBase = [];
-        foreach (['frontend', 'admin', 'install'] as $scope) {
-            $scopeNode = $this->firstChildElement($config, $scope);
-            $routersNode = $scopeNode === null ? null : $this->firstChildElement($scopeNode, 'routers');
-            if ($routersNode === null) {
-                continue;
-            }
-            foreach ($routersNode->childNodes as $routerNode) {
-                if (!$routerNode instanceof DOMElement) {
-                    continue;
-                }
-                $argsNode = $this->firstChildElement($routerNode, 'args');
-                $modulesNode = $argsNode === null ? null : $this->firstChildElement($argsNode, 'modules');
-                if ($modulesNode === null) {
-                    continue;
-                }
-                foreach ($modulesNode->childNodes as $child) {
-                    if (!$child instanceof DOMElement) {
-                        continue;
-                    }
-                    $prefix = trim($child->textContent);
-                    if ($prefix === '') {
-                        continue;
-                    }
-                    foreach ($this->findControllers($prefix) as $controller) {
-                        $analysis = $this->analyzeOverrideController($controller['className']);
-                        if ($analysis['pure'] && $analysis['newActions'] === []) {
-                            $byBase[(string) $analysis['base']][] = $controller['className'];
-                        }
+        foreach ($this->iterateOverrideModulesNodes($dom) as $entry) {
+            foreach ($this->overrideModulePrefixes($entry['node']) as $prefix) {
+                foreach ($this->findControllers($prefix) as $controller) {
+                    $analysis = $this->analyzeOverrideController($controller['className']);
+                    if ($analysis['pure'] && $analysis['newActions'] === []) {
+                        $byBase[(string) $analysis['base']][] = $controller['className'];
                     }
                 }
             }
@@ -329,47 +362,18 @@ class LegacyMigrateRoutes extends BaseMahoCommand
         bool &$fileChanged,
         array $conflictedBases,
     ): void {
-        $config = $dom->documentElement;
-        if ($config === null) {
-            return;
-        }
-
-        foreach (['frontend', 'admin', 'install'] as $scope) {
-            $scopeNode = $this->firstChildElement($config, $scope);
-            if ($scopeNode === null) {
-                continue;
-            }
-            $routersNode = $this->firstChildElement($scopeNode, 'routers');
-            if ($routersNode === null) {
-                continue;
-            }
-
-            // Snapshot children: detachAndPrune() mutates the tree as we go.
-            foreach (iterator_to_array($routersNode->childNodes) as $routerNode) {
-                if (!$routerNode instanceof DOMElement) {
-                    continue;
-                }
-                $argsNode = $this->firstChildElement($routerNode, 'args');
-                if ($argsNode === null) {
-                    continue;
-                }
-                $modulesNode = $this->firstChildElement($argsNode, 'modules');
-                if ($modulesNode === null) {
-                    continue;
-                }
-
-                $this->migrateOverrideModulesNode(
-                    $modulesNode,
-                    $scope . '/' . $routerNode->localName,
-                    $output,
-                    $dryRun,
-                    $ensureHeader,
-                    $removed,
-                    $skipped,
-                    $fileChanged,
-                    $conflictedBases,
-                );
-            }
+        foreach ($this->iterateOverrideModulesNodes($dom) as $entry) {
+            $this->migrateOverrideModulesNode(
+                $entry['node'],
+                $entry['label'],
+                $output,
+                $dryRun,
+                $ensureHeader,
+                $removed,
+                $skipped,
+                $fileChanged,
+                $conflictedBases,
+            );
         }
     }
 
@@ -389,15 +393,7 @@ class LegacyMigrateRoutes extends BaseMahoCommand
         bool &$fileChanged,
         array $conflictedBases,
     ): void {
-        $modulePrefixes = [];
-        foreach ($modulesNode->childNodes as $child) {
-            if ($child instanceof DOMElement) {
-                $prefix = trim($child->textContent);
-                if ($prefix !== '') {
-                    $modulePrefixes[] = $prefix;
-                }
-            }
-        }
+        $modulePrefixes = $this->overrideModulePrefixes($modulesNode);
         if ($modulePrefixes === []) {
             // Empty <modules> wrapper carries nothing — drop the dead XML.
             $ensureHeader();

--- a/lib/MahoCLI/Commands/LegacyMigrateRoutes.php
+++ b/lib/MahoCLI/Commands/LegacyMigrateRoutes.php
@@ -62,6 +62,34 @@ class LegacyMigrateRoutes extends BaseMahoCommand
         $totalOverridesRemoved = 0;
         $totalOverridesSkipped = 0;
 
+        // Pre-pass: detect sibling conflicts spanning two separate modules' config.xml. Each
+        // file's per-<modules> check only sees overrides declared in the same node, so two
+        // modules independently overriding the same base each look clean in isolation. We must
+        // know about such cross-file conflicts BEFORE removing any XML, otherwise apply mode
+        // would delete both protective <modules> nodes and only warn afterwards — too late, the
+        // safety net is gone. Bases found in conflict here are treated as blockers below (left
+        // untouched), keeping dry-run and apply behavior identical.
+        /** @var array<string, list<string>> $globalByBase */
+        $globalByBase = [];
+        foreach ($this->findUserConfigXmlFiles() as $entry) {
+            $dom = $this->loadConfigXmlAsDom($entry['path']);
+            if ($dom === null) {
+                continue;
+            }
+            foreach ($this->collectCleanOverridesByBase($dom) as $base => $classes) {
+                foreach ($classes as $class) {
+                    $globalByBase[$base][] = $class;
+                }
+            }
+        }
+        /** @var list<string> $conflictedBases */
+        $conflictedBases = [];
+        foreach ($globalByBase as $base => $classes) {
+            if (count($classes) > 1 && $this->hasSiblingConflict($classes)) {
+                $conflictedBases[] = $base;
+            }
+        }
+
         foreach ($this->findUserConfigXmlFiles() as $entry) {
             $module = $entry['module'];
             $configPath = $entry['path'];
@@ -100,6 +128,7 @@ class LegacyMigrateRoutes extends BaseMahoCommand
                 $totalOverridesRemoved,
                 $totalOverridesSkipped,
                 $fileChanged,
+                $conflictedBases,
             );
 
             foreach ($routerEntries as $routerEntry) {
@@ -220,6 +249,60 @@ class LegacyMigrateRoutes extends BaseMahoCommand
     }
 
     /**
+     * Collect, grouped by routed base class, every clean override declared in a config.xml's
+     * `<args><modules>` chains. Read-only (no output, no DOM mutation) — used by the pre-pass to
+     * detect sibling conflicts that span two separate files before any XML is removed. Only
+     * overrides that would actually be removed (pure subclasses of a routed base that add no
+     * un-routed actions) are reported; anything that is itself a per-file blocker is irrelevant
+     * to cross-file conflict detection since its node is never removed.
+     *
+     * @return array<string, list<string>>
+     */
+    private function collectCleanOverridesByBase(DOMDocument $dom): array
+    {
+        $config = $dom->documentElement;
+        if ($config === null) {
+            return [];
+        }
+
+        $byBase = [];
+        foreach (['frontend', 'admin', 'install'] as $scope) {
+            $scopeNode = $this->firstChildElement($config, $scope);
+            $routersNode = $scopeNode === null ? null : $this->firstChildElement($scopeNode, 'routers');
+            if ($routersNode === null) {
+                continue;
+            }
+            foreach ($routersNode->childNodes as $routerNode) {
+                if (!$routerNode instanceof DOMElement) {
+                    continue;
+                }
+                $argsNode = $this->firstChildElement($routerNode, 'args');
+                $modulesNode = $argsNode === null ? null : $this->firstChildElement($argsNode, 'modules');
+                if ($modulesNode === null) {
+                    continue;
+                }
+                foreach ($modulesNode->childNodes as $child) {
+                    if (!$child instanceof DOMElement) {
+                        continue;
+                    }
+                    $prefix = trim($child->textContent);
+                    if ($prefix === '') {
+                        continue;
+                    }
+                    foreach ($this->findControllers($prefix) as $controller) {
+                        $analysis = $this->analyzeOverrideController($controller['className']);
+                        if ($analysis['pure'] && $analysis['newActions'] === []) {
+                            $byBase[(string) $analysis['base']][] = $controller['className'];
+                        }
+                    }
+                }
+            }
+        }
+
+        return $byBase;
+    }
+
+    /**
      * Migrate legacy controller-override chains to the attribute era.
      *
      * `<{scope}><routers><{code}><args><modules><My_Module .../></modules>` piggybacks a
@@ -230,8 +313,11 @@ class LegacyMigrateRoutes extends BaseMahoCommand
      * A `<modules>` node is removed only when every declared override is a clean
      * re-implementation of inherited, routed actions. Anything needing a human — a controller
      * that isn't a subclass of a routed controller, one adding un-routed actions, or sibling
-     * modules overriding the same controller with no shared inheritance chain — is reported
-     * and the XML left untouched, so re-running after a manual fix is safe.
+     * modules overriding the same controller with no shared inheritance chain (whether in this
+     * file or across files, via $conflictedBases) — is reported and the XML left untouched, so
+     * re-running after a manual fix is safe.
+     *
+     * @param list<string> $conflictedBases routed base classes with a cross-file sibling conflict
      */
     private function migrateControllerOverrides(
         DOMDocument $dom,
@@ -241,6 +327,7 @@ class LegacyMigrateRoutes extends BaseMahoCommand
         int &$removed,
         int &$skipped,
         bool &$fileChanged,
+        array $conflictedBases,
     ): void {
         $config = $dom->documentElement;
         if ($config === null) {
@@ -280,6 +367,7 @@ class LegacyMigrateRoutes extends BaseMahoCommand
                     $removed,
                     $skipped,
                     $fileChanged,
+                    $conflictedBases,
                 );
             }
         }
@@ -287,6 +375,8 @@ class LegacyMigrateRoutes extends BaseMahoCommand
 
     /**
      * Analyze and (when safe) remove a single `<args><modules>` override chain.
+     *
+     * @param list<string> $conflictedBases routed base classes with a cross-file sibling conflict
      */
     private function migrateOverrideModulesNode(
         DOMElement $modulesNode,
@@ -297,6 +387,7 @@ class LegacyMigrateRoutes extends BaseMahoCommand
         int &$removed,
         int &$skipped,
         bool &$fileChanged,
+        array $conflictedBases,
     ): void {
         $modulePrefixes = [];
         foreach ($modulesNode->childNodes as $child) {
@@ -310,6 +401,7 @@ class LegacyMigrateRoutes extends BaseMahoCommand
         if ($modulePrefixes === []) {
             // Empty <modules> wrapper carries nothing — drop the dead XML.
             $ensureHeader();
+            $removed++;
             if ($dryRun) {
                 $output->writeln(sprintf('  would remove empty %s override chain', $routerLabel));
             } else {
@@ -356,12 +448,20 @@ class LegacyMigrateRoutes extends BaseMahoCommand
         }
 
         // Sibling conflict: two overrides of the same base with no shared inheritance chain.
+        // Check both within this node ($byBase) and across files ($conflictedBases, computed in
+        // the pre-pass) so the conflicting XML is left in place rather than silently removed.
         foreach ($byBase as $base => $classes) {
             if (count($classes) > 1 && $this->hasSiblingConflict($classes)) {
                 $blockers[] = sprintf(
                     'overrides of %s have no shared inheritance chain (%s) — make one extend the other',
                     $base,
                     implode(', ', $classes),
+                );
+            } elseif (in_array($base, $conflictedBases, true)) {
+                $blockers[] = sprintf(
+                    'overrides of %s across modules have no shared inheritance chain — make one '
+                    . 'extend the other before running composer dump-autoload',
+                    $base,
                 );
             }
         }
@@ -427,15 +527,16 @@ class LegacyMigrateRoutes extends BaseMahoCommand
             return $fail('extends no routed controller (needs its own #[Maho\\Config\\Route])');
         }
 
-        // Public *Action methods the subclass declares that its parent chain doesn't have are
-        // brand-new, un-routed actions — inheritance can't register a route that doesn't exist.
+        // Public *Action methods the subclass declares that the routed base doesn't have are
+        // brand-new, un-routed actions — inheritance only carries routes from $base, so an
+        // action absent there (even if an intermediate override added it) can't be auto-routed.
         $newActions = [];
         foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
             if ($method->getDeclaringClass()->getName() !== $className) {
                 continue;
             }
             $name = $method->getName();
-            if (str_ends_with($name, 'Action') && !method_exists($parent->getName(), $name)) {
+            if (str_ends_with($name, 'Action') && !method_exists($base, $name)) {
                 $newActions[] = substr($name, 0, -strlen('Action'));
             }
         }

--- a/tests/Backend/Unit/Maho/Routing/ControllerOverrideDispatchTest.php
+++ b/tests/Backend/Unit/Maho/Routing/ControllerOverrideDispatchTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Maho\Routing\ControllerDispatcher;
+
+uses(Tests\MahoBackendTestCase::class);
+
+require_once __DIR__ . '/_fixtures/ControllerOverrideFixtures.php';
+
+/**
+ * Runtime side of inheritance-based controller overrides: ControllerDispatcher's
+ * Symfony-matched dispatch path (resolveAttributeControllerClass) must consult the
+ * compiled controllerLookup so an attribute/inheritance override supersedes the route's
+ * `_maho_controller` default — while a legacy XML `<args><modules>` override still wins.
+ */
+function callResolveAttributeControllerClass(
+    ControllerDispatcher $dispatcher,
+    string $controllerName,
+    string $area,
+    string $frontName,
+): ?string {
+    $ref = new ReflectionMethod(ControllerDispatcher::class, 'resolveAttributeControllerClass');
+    return $ref->invoke($dispatcher, $controllerName, $area, $frontName);
+}
+
+describe('ControllerDispatcher::resolveAttributeControllerClass()', function () {
+    it('resolves a frontend route to its compiled controller when no XML override exists', function () {
+        // Previously returned null (no XML chain) and the caller fell back to the route
+        // default; now it consults the compiled lookup directly.
+        expect(callResolveAttributeControllerClass(new ControllerDispatcher(), 'cart', 'frontend', 'checkout'))
+            ->toBe(Mage_Checkout_CartController::class);
+    });
+
+    it('resolves an admin route to its compiled controller via the admin sentinel frontName', function () {
+        expect(callResolveAttributeControllerClass(
+            new ControllerDispatcher(),
+            'dashboard',
+            'adminhtml',
+            \Maho\Routing\RouteCollectionBuilder::ADMIN_SENTINEL,
+        ))->toBe(Mage_Adminhtml_DashboardController::class);
+    });
+
+    it('returns null for an unknown frontend controller', function () {
+        expect(callResolveAttributeControllerClass(new ControllerDispatcher(), 'nosuchcontroller', 'frontend', 'checkout'))
+            ->toBeNull();
+    });
+
+    it('lets a legacy XML <args><modules> override win over the compiled lookup', function () {
+        // Register Fixture_Xml as a checkout override the M1 way.
+        Mage::getConfig()->setNode('frontend/routers/checkout/args/modules', '', false);
+        $modulesNode = Mage::getConfig()->getNode('frontend/routers/checkout/args/modules');
+        $modulesNode->addChild('fixture_xml', 'Fixture_Xml');
+
+        expect(callResolveAttributeControllerClass(new ControllerDispatcher(), 'cart', 'frontend', 'checkout'))
+            ->toBe(Fixture_Xml_CartController::class);
+    });
+});

--- a/tests/Backend/Unit/Maho/Routing/ControllerOverrideTest.php
+++ b/tests/Backend/Unit/Maho/Routing/ControllerOverrideTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Maho\ComposerPlugin\AttributeCompiler;
+
+uses(Tests\MahoBackendTestCase::class);
+
+require_once __DIR__ . '/_fixtures/ControllerOverrideFixtures.php';
+
+/**
+ * Implicit, inheritance-based controller overrides compiled at `composer dump-autoload`.
+ *
+ * A controller subclass of a route-owning controller that declares no route of its own
+ * supersedes the base in `controllerLookup` — replacing the legacy `<routers><args><modules>`
+ * XML chain for the attribute-routed case. These tests drive the compiler's detection
+ * (collectControllerOverrides) and precedence (resolveMostDerived) directly via reflection,
+ * since the compiler has no standalone test harness.
+ */
+
+/** Seed AttributeCompiler::$data['routes'] so the given classes are route-owners. */
+function seedRouteOwners(array $classes): void
+{
+    $routes = [];
+    foreach ($classes as $i => $class) {
+        $routes['route_' . $i] = [
+            'path' => '/testfront/index',
+            'class' => $class,
+            'action' => 'indexAction',
+            'methods' => [],
+            'defaults' => [],
+            'requirements' => [],
+            'area' => 'frontend',
+            'module' => 'Test_Override',
+            'controllerName' => 'index',
+            'pathVariables' => [],
+        ];
+    }
+    $prop = new ReflectionProperty(AttributeCompiler::class, 'data');
+    $prop->setValue(null, [
+        'observers' => [],
+        'crontab' => [],
+        'routes' => $routes,
+        'reverseLookup' => [],
+        'controllerLookup' => [],
+    ]);
+
+    $overrides = new ReflectionProperty(AttributeCompiler::class, 'controllerOverrides');
+    $overrides->setValue(null, []);
+}
+
+/** @return array<class-string, class-string> base → override winner */
+function runCollectOverrides(array $scannedClassesInOrder, ?Closure $log = null): array
+{
+    // collectControllerOverrides takes a class => path map; only the keys (in order) matter.
+    $scanned = [];
+    foreach ($scannedClassesInOrder as $class) {
+        $scanned[$class] = 'fixture://' . $class;
+    }
+    $method = new ReflectionMethod(AttributeCompiler::class, 'collectControllerOverrides');
+    $method->invoke(null, $scanned, $log);
+
+    return (new ReflectionProperty(AttributeCompiler::class, 'controllerOverrides'))->getValue();
+}
+
+describe('AttributeCompiler::collectControllerOverrides()', function () {
+    it('records a subclass that declares no route as an override of its base', function () {
+        seedRouteOwners([Test_Override_BaseController::class]);
+
+        $overrides = runCollectOverrides([
+            Test_Override_BaseController::class,
+            Test_Override_ChildController::class,
+        ]);
+
+        expect($overrides)->toBe([
+            Test_Override_BaseController::class => Test_Override_ChildController::class,
+        ]);
+    });
+
+    it('picks the most-derived class along a single inheritance chain', function () {
+        seedRouteOwners([Test_Override_BaseController::class]);
+
+        $overrides = runCollectOverrides([
+            Test_Override_BaseController::class,
+            Test_Override_ChildController::class,
+            Test_Override_GrandchildController::class,
+        ]);
+
+        expect($overrides[Test_Override_BaseController::class])
+            ->toBe(Test_Override_GrandchildController::class);
+    });
+
+    it('resolves the chain structurally, independent of scan order', function () {
+        seedRouteOwners([Test_Override_BaseController::class]);
+
+        // Grandchild scanned before its parent — the winner is still the deepest class.
+        $overrides = runCollectOverrides([
+            Test_Override_GrandchildController::class,
+            Test_Override_ChildController::class,
+            Test_Override_BaseController::class,
+        ]);
+
+        expect($overrides[Test_Override_BaseController::class])
+            ->toBe(Test_Override_GrandchildController::class);
+    });
+
+    it('skips abstract links but still attributes a concrete descendant to the base', function () {
+        seedRouteOwners([Test_Override_BaseController::class]);
+
+        $overrides = runCollectOverrides([
+            Test_Override_BaseController::class,
+            Test_Override_AbstractController::class,
+            Test_Override_ConcreteController::class,
+        ]);
+
+        expect($overrides[Test_Override_BaseController::class])
+            ->toBe(Test_Override_ConcreteController::class);
+    });
+
+    it('records no override when the base has no route-less subclass', function () {
+        seedRouteOwners([Test_Override_BaseController::class]);
+
+        $overrides = runCollectOverrides([
+            Test_Override_BaseController::class,
+            Test_Override_UnrelatedController::class,
+        ]);
+
+        expect($overrides)->toBe([]);
+    });
+
+    it('does not treat a subclass that owns its own routes as an override', function () {
+        // Both base and child declare routes → child is its own controller, not an override.
+        seedRouteOwners([
+            Test_Override_BaseController::class,
+            Test_Override_ChildController::class,
+        ]);
+
+        $overrides = runCollectOverrides([
+            Test_Override_BaseController::class,
+            Test_Override_ChildController::class,
+        ]);
+
+        expect($overrides)->toBe([]);
+    });
+});
+
+describe('AttributeCompiler::collectControllerOverrides() — sibling conflicts', function () {
+    it('reports a conflict and falls back to the last sibling in scan order', function () {
+        seedRouteOwners([Test_Override_BaseController::class]);
+
+        $logged = [];
+        $log = function (string $level, string $message) use (&$logged): void {
+            $logged[] = [$level, $message];
+        };
+
+        $overrides = runCollectOverrides([
+            Test_Override_BaseController::class,
+            Test_Override_SiblingAController::class,
+            Test_Override_SiblingBController::class,
+        ], $log);
+
+        // Deterministic fallback: later in scan order (module load order) wins.
+        expect($overrides[Test_Override_BaseController::class])
+            ->toBe(Test_Override_SiblingBController::class);
+
+        expect($logged)->toHaveCount(1);
+        expect($logged[0][0])->toBe('error');
+        expect($logged[0][1])->toContain('Controller override conflict');
+        expect($logged[0][1])->toContain(Test_Override_SiblingAController::class);
+        expect($logged[0][1])->toContain(Test_Override_SiblingBController::class);
+    });
+
+    it('reverses the fallback winner when scan order is reversed', function () {
+        seedRouteOwners([Test_Override_BaseController::class]);
+
+        $overrides = runCollectOverrides([
+            Test_Override_BaseController::class,
+            Test_Override_SiblingBController::class,
+            Test_Override_SiblingAController::class,
+        ]);
+
+        expect($overrides[Test_Override_BaseController::class])
+            ->toBe(Test_Override_SiblingAController::class);
+    });
+});
+
+describe('AttributeCompiler::buildReverseLookup() — override application', function () {
+    it('points controllerLookup at the override winner, not the base', function () {
+        seedRouteOwners([Test_Override_BaseController::class]);
+
+        // Record an override, then build the lookup.
+        (new ReflectionProperty(AttributeCompiler::class, 'controllerOverrides'))
+            ->setValue(null, [Test_Override_BaseController::class => Test_Override_ChildController::class]);
+
+        (new ReflectionMethod(AttributeCompiler::class, 'buildReverseLookup'))->invoke(null, null);
+
+        $data = (new ReflectionProperty(AttributeCompiler::class, 'data'))->getValue();
+
+        expect($data['controllerLookup']['testfront/index'])
+            ->toBe(Test_Override_ChildController::class);
+    });
+
+    it('keeps controllerLookup on the base when no override is recorded', function () {
+        seedRouteOwners([Test_Override_BaseController::class]);
+
+        (new ReflectionMethod(AttributeCompiler::class, 'buildReverseLookup'))->invoke(null, null);
+
+        $data = (new ReflectionProperty(AttributeCompiler::class, 'data'))->getValue();
+
+        expect($data['controllerLookup']['testfront/index'])
+            ->toBe(Test_Override_BaseController::class);
+    });
+});

--- a/tests/Backend/Unit/Maho/Routing/_fixtures/ControllerOverrideFixtures.php
+++ b/tests/Backend/Unit/Maho/Routing/_fixtures/ControllerOverrideFixtures.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Controller fixtures for ControllerOverrideTest — inheritance shapes the compiler reflects.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+// Route-owning base controller (the class an override targets).
+class Test_Override_BaseController {}
+
+// Simple override: extends the base, declares no route of its own.
+class Test_Override_ChildController extends Test_Override_BaseController {}
+
+// Chained override: extends another override → deepest in the chain.
+class Test_Override_GrandchildController extends Test_Override_ChildController {}
+
+// Abstract link in the chain — must be skipped as a candidate, but a concrete
+// descendant still resolves the base as its nearest route-owning ancestor.
+abstract class Test_Override_AbstractController extends Test_Override_BaseController {}
+class Test_Override_ConcreteController extends Test_Override_AbstractController {}
+
+// Two independent siblings extending the base → genuine cross-module conflict.
+class Test_Override_SiblingAController extends Test_Override_BaseController {}
+class Test_Override_SiblingBController extends Test_Override_BaseController {}
+
+// Unrelated controller — not a subclass of the base, never an override.
+class Test_Override_UnrelatedController {}
+
+// Stands in for a third-party XML `<args><modules>` override of Mage_Checkout_CartController.
+// The dispatcher builds this class name as `<module>_<Controller>Controller`, so the module
+// node must be "Fixture_Xml" for frontName/controller "checkout"/"cart".
+class Fixture_Xml_CartController extends Mage_Checkout_CartController {}
+
+// Override of a real routed controller that adds a brand-new, un-routed action — the
+// migrator must refuse to drop the XML for it (the new action would 404 without a route).
+class Fixture_NewAction_CartController extends Mage_Checkout_CartController
+{
+    public function brandNewAction(): void {}
+}

--- a/tests/Backend/Unit/Maho/Routing/_fixtures/ControllerOverrideFixtures.php
+++ b/tests/Backend/Unit/Maho/Routing/_fixtures/ControllerOverrideFixtures.php
@@ -41,3 +41,9 @@ class Fixture_NewAction_CartController extends Mage_Checkout_CartController
 {
     public function brandNewAction(): void {}
 }
+
+// Two clean sibling overrides of the same routed core controller, living in *separate*
+// modules — stand-ins for a cross-file sibling conflict the migrator's pre-pass must detect
+// (each module looks clean in isolation; only the global view reveals the clash).
+class Fixture_SiblingX_CartController extends Mage_Checkout_CartController {}
+class Fixture_SiblingY_CartController extends Mage_Checkout_CartController {}

--- a/tests/Backend/Unit/MahoCLI/Commands/LegacyMigrateRoutesOverrideTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/LegacyMigrateRoutesOverrideTest.php
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use MahoCLI\Commands\LegacyMigrateRoutes;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 uses(Tests\MahoBackendTestCase::class);
 
@@ -96,5 +97,146 @@ describe('LegacyMigrateRoutes::hasSiblingConflict()', function () {
     it('is false for a single class', function () {
         expect(invokeMigratePrivate('hasSiblingConflict', [[Test_Override_ChildController::class]]))
             ->toBeFalse();
+    });
+});
+
+describe('LegacyMigrateRoutes::migrateOverrideModulesNode() — empty <modules>', function () {
+    function callMigrateOverrideModulesNode(
+        LegacyMigrateRoutes $cmd,
+        DOMElement $modulesNode,
+        bool $dryRun,
+        array $conflictedBases,
+        int &$removed,
+        int &$skipped,
+        bool &$fileChanged,
+        BufferedOutput $output,
+    ): void {
+        $ref = new ReflectionMethod(LegacyMigrateRoutes::class, 'migrateOverrideModulesNode');
+        $ref->invokeArgs($cmd, [
+            $modulesNode,
+            'frontend/checkout',
+            $output,
+            $dryRun,
+            function (): void {},
+            &$removed,
+            &$skipped,
+            &$fileChanged,
+            $conflictedBases,
+        ]);
+    }
+
+    function modulesNodeFromXml(string $xml): DOMElement
+    {
+        $dom = new DOMDocument();
+        $dom->loadXML($xml);
+        /** @var DOMElement $node */
+        $node = $dom->getElementsByTagName('modules')->item(0);
+        return $node;
+    }
+
+    it('counts an empty <modules> wrapper as removed (not skipped) in dry-run', function () {
+        $node = modulesNodeFromXml('<config><frontend><routers><checkout><args><modules></modules></args></checkout></routers></frontend></config>');
+        $removed = 0;
+        $skipped = 0;
+        $fileChanged = false;
+        callMigrateOverrideModulesNode(overrideCommand(), $node, true, [], $removed, $skipped, $fileChanged, new BufferedOutput());
+
+        expect($removed)->toBe(1);
+        expect($skipped)->toBe(0);
+        expect($fileChanged)->toBeFalse();
+        // Dry-run leaves the XML in place.
+        expect($node->parentNode)->not->toBeNull();
+    });
+
+    it('removes an empty <modules> wrapper and counts it as removed in apply mode', function () {
+        $node = modulesNodeFromXml('<config><frontend><routers><checkout><args><modules></modules></args></checkout></routers></frontend></config>');
+        $removed = 0;
+        $skipped = 0;
+        $fileChanged = false;
+        callMigrateOverrideModulesNode(overrideCommand(), $node, false, [], $removed, $skipped, $fileChanged, new BufferedOutput());
+
+        expect($removed)->toBe(1);
+        expect($skipped)->toBe(0);
+        expect($fileChanged)->toBeTrue();
+        // Apply mode detaches the dead node.
+        expect($node->parentNode)->toBeNull();
+    });
+});
+
+describe('LegacyMigrateRoutes — cross-file sibling conflict pre-pass', function () {
+    it('blocks removal when two modules independently override the same base across files', function () {
+        // Stand up two throwaway modules on disk so findControllers() discovers the sibling
+        // override classes (already loaded as fixtures). Point userCodeDirs at the temp pool.
+        // findControllers() builds paths from MAHO_ROOT_DIR, which only the CLI/web entry points
+        // define — the test process doesn't, so seed it with the repo root.
+        if (!defined('MAHO_ROOT_DIR')) {
+            define('MAHO_ROOT_DIR', dirname(__DIR__, 5));
+        }
+        $tmpRel = 'var/legacy-override-test-' . uniqid();
+        $tmpAbs = MAHO_ROOT_DIR . '/' . $tmpRel;
+        foreach (['SiblingX', 'SiblingY'] as $mod) {
+            $dir = "$tmpAbs/Fixture/$mod/controllers";
+            mkdir($dir, 0o777, true);
+            file_put_contents("$dir/CartController.php", "<?php\n");
+        }
+
+        try {
+            $cmd = overrideCommand();
+            (new ReflectionProperty(LegacyMigrateRoutes::class, 'userCodeDirs'))->setValue($cmd, [$tmpRel]);
+
+            $configXml = fn(string $prefix): string => sprintf(
+                '<config><frontend><routers><checkout><args><modules><m>%s</m></modules></args></checkout></routers></frontend></config>',
+                $prefix,
+            );
+            $domX = new DOMDocument();
+            $domX->loadXML($configXml('Fixture_SiblingX'));
+            $domY = new DOMDocument();
+            $domY->loadXML($configXml('Fixture_SiblingY'));
+
+            // Reproduce execute()'s pre-pass: accumulate clean overrides across both files.
+            $collect = new ReflectionMethod(LegacyMigrateRoutes::class, 'collectCleanOverridesByBase');
+            $hasConflict = new ReflectionMethod(LegacyMigrateRoutes::class, 'hasSiblingConflict');
+            $global = [];
+            foreach ([$domX, $domY] as $dom) {
+                foreach ($collect->invoke($cmd, $dom) as $base => $classes) {
+                    foreach ($classes as $class) {
+                        $global[$base][] = $class;
+                    }
+                }
+            }
+            $conflictedBases = [];
+            foreach ($global as $base => $classes) {
+                if (count($classes) > 1 && $hasConflict->invoke($cmd, $classes)) {
+                    $conflictedBases[] = $base;
+                }
+            }
+
+            expect($conflictedBases)->toContain(Mage_Checkout_CartController::class);
+
+            // Feed one file's <modules> node into the per-node migrator with the cross-file
+            // conflict known: it must be left in place (skipped), not silently removed.
+            /** @var DOMElement $node */
+            $node = $domX->getElementsByTagName('modules')->item(0);
+            $removed = 0;
+            $skipped = 0;
+            $fileChanged = false;
+            $output = new BufferedOutput();
+            callMigrateOverrideModulesNode($cmd, $node, false, $conflictedBases, $removed, $skipped, $fileChanged, $output);
+
+            expect($skipped)->toBe(1);
+            expect($removed)->toBe(0);
+            expect($fileChanged)->toBeFalse();
+            expect($node->parentNode)->not->toBeNull();
+            expect($output->fetch())->toContain('across modules');
+        } finally {
+            $it = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($tmpAbs, FilesystemIterator::SKIP_DOTS),
+                RecursiveIteratorIterator::CHILD_FIRST,
+            );
+            foreach ($it as $file) {
+                $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+            }
+            rmdir($tmpAbs);
+        }
     });
 });

--- a/tests/Backend/Unit/MahoCLI/Commands/LegacyMigrateRoutesOverrideTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/LegacyMigrateRoutesOverrideTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use MahoCLI\Commands\LegacyMigrateRoutes;
+
+uses(Tests\MahoBackendTestCase::class);
+
+require_once __DIR__ . '/../../Maho/Routing/_fixtures/ControllerOverrideFixtures.php';
+
+/**
+ * Classification logic behind `legacy:migrate-routes`' controller-override migration.
+ *
+ * The command drops a `<routers><X><args><modules>` chain only when every declared override
+ * is a clean subclass of a routed controller that re-implements inherited actions. These tests
+ * drive the private classifiers (analyzeOverrideController / controllerOwnsRoutes /
+ * hasSiblingConflict) directly, matching how the repo's other CLI command tests are written.
+ */
+function overrideCommand(): LegacyMigrateRoutes
+{
+    return new LegacyMigrateRoutes('legacy:migrate-routes');
+}
+
+function invokeMigratePrivate(string $method, array $args): mixed
+{
+    $ref = new ReflectionMethod(LegacyMigrateRoutes::class, $method);
+    return $ref->invokeArgs(overrideCommand(), $args);
+}
+
+describe('LegacyMigrateRoutes::controllerOwnsRoutes()', function () {
+    it('is true for a controller that declares #[Route] attributes', function () {
+        expect(invokeMigratePrivate('controllerOwnsRoutes', [new ReflectionClass(Mage_Checkout_CartController::class)]))
+            ->toBeTrue();
+    });
+
+    it('is false for a plain controller with no route attributes', function () {
+        expect(invokeMigratePrivate('controllerOwnsRoutes', [new ReflectionClass(Test_Override_BaseController::class)]))
+            ->toBeFalse();
+    });
+});
+
+describe('LegacyMigrateRoutes::analyzeOverrideController()', function () {
+    it('classifies a clean override of a routed controller as pure', function () {
+        $result = invokeMigratePrivate('analyzeOverrideController', [Fixture_Xml_CartController::class]);
+
+        expect($result['pure'])->toBeTrue();
+        expect($result['base'])->toBe(Mage_Checkout_CartController::class);
+        expect($result['newActions'])->toBe([]);
+    });
+
+    it('flags un-routed actions the subclass introduces', function () {
+        $result = invokeMigratePrivate('analyzeOverrideController', [Fixture_NewAction_CartController::class]);
+
+        expect($result['pure'])->toBeTrue();
+        expect($result['base'])->toBe(Mage_Checkout_CartController::class);
+        expect($result['newActions'])->toBe(['brandNew']);
+    });
+
+    it('is not pure when the class extends nothing', function () {
+        $result = invokeMigratePrivate('analyzeOverrideController', [Test_Override_UnrelatedController::class]);
+
+        expect($result['pure'])->toBeFalse();
+        expect($result['base'])->toBeNull();
+        expect($result['reason'])->toContain('extends no controller');
+    });
+
+    it('is not pure when the parent chain owns no routes', function () {
+        $result = invokeMigratePrivate('analyzeOverrideController', [Test_Override_ChildController::class]);
+
+        expect($result['pure'])->toBeFalse();
+        expect($result['base'])->toBeNull();
+        expect($result['reason'])->toContain('no routed controller');
+    });
+});
+
+describe('LegacyMigrateRoutes::hasSiblingConflict()', function () {
+    it('is false for a single inheritance chain', function () {
+        expect(invokeMigratePrivate('hasSiblingConflict', [[
+            Test_Override_ChildController::class,
+            Test_Override_GrandchildController::class,
+        ]]))->toBeFalse();
+    });
+
+    it('is true for two incomparable siblings', function () {
+        expect(invokeMigratePrivate('hasSiblingConflict', [[
+            Test_Override_SiblingAController::class,
+            Test_Override_SiblingBController::class,
+        ]]))->toBeTrue();
+    });
+
+    it('is false for a single class', function () {
+        expect(invokeMigratePrivate('hasSiblingConflict', [[Test_Override_ChildController::class]]))
+            ->toBeFalse();
+    });
+});


### PR DESCRIPTION
## Summary

Closes the last routing concern that still required XML: **overriding an existing controller.** After #808/#809 (routes) and #781 (observers/cron), routes/observers/cron/new-controllers all register via PHP attributes — but overriding a core controller still needed the legacy `<routers><args><modules>` chain. Now you just subclass it:

```php
// No XML, no attribute. Run composer dump-autoload.
class My_Module_Checkout_CartController extends Mage_Checkout_CartController { /* override actions */ }
```

Implements MahoCommerce/maho#1063, but **without** the `#[ControllerOverride(priority:)]` attribute the RFC proposed — inheritance already expresses intent, and precedence is resolved structurally rather than with a hand-tuned integer.

## How it works

- The compiler (maho-composer-plugin **v4.1.1**, MahoCommerce/maho-composer-plugin#45) detects, at `composer dump-autoload`, any controller that extends a route-owning controller and declares no `#[Route]` of its own, and points the `controllerLookup` entry at the most-derived such subclass.
- `ControllerDispatcher::resolveAttributeControllerClass()` (the Symfony-matched dispatch path) now consults `controllerLookup` after the XML chain. Precedence: **legacy XML `<modules>` (BC) → inheritance override → route default.**

## Cross-module precedence

Resolved **structurally** via inheritance. Several modules overriding the same controller should form a single chain (most-derived wins, independent of module load order). Two *sibling* subclasses extending the base independently are a conflict: the compiler logs an error naming both and falls back deterministically to module load order (local/community over core). It never throws.

## `legacy:migrate-routes`

Extended to also migrate override `<modules>` chains. It removes a chain only when every declared override is a clean subclass of a routed controller that re-implements inherited actions; otherwise it reports the blocker and leaves the XML untouched (a controller that isn't a routed subclass, one adding un-routed actions, or a sibling conflict). Sibling conflicts are detected even when the competing overrides live in *separate module config.xml files* — a read-only pre-pass collects every clean override per base before any XML is touched, so a cross-file conflict blocks removal in both dry-run and apply (no asymmetry). Dry-run supported; the summary now counts override chains removed/skipped.

## Compatibility

Purely additive. The `<routers><args><modules>` runtime chain still wins over the compiled override, so existing modules behave identically and migrate when they choose. Verified against a full tree: zero drift in the compiled `controllerLookup` for core.

## Tests

26 new tests (compiler detection/precedence via the plugin's reflection API, the dispatcher's lookup consultation incl. XML precedence, and the migrator's classifiers — including cross-file sibling-conflict detection and empty-`<modules>` counter parity). Full routing suite green (151 passing); lint (cs-fixer/rector/phpstan) clean.

## Docs

`AGENTS.md` "Overriding controllers" now leads with the subclass approach; the XML chain is documented as BC-only with a pointer to `legacy:migrate-routes`.
