### PR TITLE
Fixed schema convergence re-emitting no-op charset CHANGEs (utf8/utf8mb3)

### DIFF
--- a/lib/Maho/Db/Schema/Canonicalizer.php
+++ b/lib/Maho/Db/Schema/Canonicalizer.php
@@ -57,6 +57,7 @@ final class Canonicalizer
     {
         self::stripPhantomIndexes($live, $physicalLiveIndexNames);
         self::alignIndexNames($live, $target);
+        self::alignTableCharset($live, $target);
         self::stripColumnComments($live);
         self::stripColumnComments($target);
         self::reconcileColumns($live, $target);
@@ -154,6 +155,56 @@ final class Canonicalizer
                 break;
             }
         }
+    }
+
+    /**
+     * Copy the live table's charset/collation onto the target when the two name
+     * the same physical charset, so MySQL's Comparator strips column-level
+     * charset symmetrically on both sides.
+     *
+     * MySQL's Comparator (Doctrine\DBAL\Platforms\MySQL\Comparator::normalizeTable)
+     * drops a column's charset/collation when it equals the *table's* — by a
+     * strict string compare (array_diff_assoc). A legacy install reports its
+     * tables as 'utf8mb3', while the declarative target sets the legacy adapter's
+     * historical alias 'utf8' (see Collector::applyTableDefaults). The two are
+     * the same charset, but the literal strings differ, so for a column added to
+     * a legacy core table by a third-party module (introspected as utf8mb3, then
+     * merged into the target by preserveUndeclaredColumns) the Comparator strips
+     * the charset on the live side (column utf8mb3 == table utf8mb3) but keeps it
+     * on the target side (column utf8mb3 != table 'utf8'), re-emitting a no-op
+     * CHANGE forever. Aligning the table option strings makes the strip
+     * symmetric and the diff converge.
+     *
+     * Only same-charset pairs are aligned (utf8 and its utf8mb3 synonym); a
+     * genuine table charset migration (e.g. utf8mb3 to utf8mb4) keeps differing
+     * strings so the Comparator still emits it.
+     */
+    private static function alignTableCharset(Table $live, Table $target): void
+    {
+        foreach (['charset', 'collation'] as $option) {
+            if (!$live->hasOption($option) || !$target->hasOption($option)) {
+                continue;
+            }
+            $liveValue = (string) $live->getOption($option);
+            $targetValue = (string) $target->getOption($option);
+            if ($liveValue !== $targetValue && self::charsetSynonyms($liveValue, $targetValue)) {
+                $target->addOption($option, $liveValue);
+            }
+        }
+    }
+
+    /**
+     * Do two charset/collation names denote the same physical charset, differing
+     * only as historical synonyms? MySQL renamed the original 'utf8' to 'utf8mb3'
+     * (and its 'utf8_*' collations to 'utf8mb3_*'); both spellings still resolve
+     * to the same 3-byte charset. Anything else (a real charset change) is not a
+     * synonym.
+     */
+    private static function charsetSynonyms(string $a, string $b): bool
+    {
+        $canonical = static fn(string $name): string => preg_replace('/^utf8(?=_|$)/', 'utf8mb3', strtolower($name)) ?? strtolower($name);
+
+        return $canonical($a) === $canonical($b);
     }
 
     /**

--- a/tests/Backend/Unit/Maho/Db/Schema/CanonicalizerTest.php
+++ b/tests/Backend/Unit/Maho/Db/Schema/CanonicalizerTest.php
@@ -147,3 +147,42 @@ it('aligns a legacy SERIAL column to the target identity form', function () {
     expect($live->getColumn('id')->getAutoincrement())->toBeTrue();
     expect($live->getColumn('id')->getDefault())->toBeNull();
 });
+
+it('aligns the target table charset to a utf8/utf8mb3 synonym so the diff converges', function () {
+    // A legacy install reports its tables as 'utf8mb3'; the declarative target
+    // carries the historical alias 'utf8'. They are the same physical charset, so
+    // the option strings must be aligned or the Comparator re-emits a no-op CHANGE
+    // forever for every undeclared column merged onto the table.
+    $live = canonTable('t');
+    $live->addColumn('id', Types::INTEGER, ['unsigned' => true]);
+    $live->addOption('charset', 'utf8mb3');
+    $live->addOption('collation', 'utf8mb3_general_ci');
+
+    $target = canonTable('t');
+    $target->addColumn('id', Types::INTEGER, ['unsigned' => true]);
+    $target->addOption('charset', 'utf8');
+    $target->addOption('collation', 'utf8_general_ci');
+
+    Canonicalizer::reconcile($live, $target, []);
+
+    expect($target->getOption('charset'))->toBe('utf8mb3');
+    expect($target->getOption('collation'))->toBe('utf8mb3_general_ci');
+});
+
+it('keeps a genuine table charset migration (utf8mb3 to utf8mb4)', function () {
+    $live = canonTable('t');
+    $live->addColumn('id', Types::INTEGER, ['unsigned' => true]);
+    $live->addOption('charset', 'utf8mb3');
+    $live->addOption('collation', 'utf8mb3_general_ci');
+
+    $target = canonTable('t');
+    $target->addColumn('id', Types::INTEGER, ['unsigned' => true]);
+    $target->addOption('charset', 'utf8mb4');
+    $target->addOption('collation', 'utf8mb4_general_ci');
+
+    Canonicalizer::reconcile($live, $target, []);
+
+    // A real charset change must survive — not aligned away.
+    expect($target->getOption('charset'))->toBe('utf8mb4');
+    expect($target->getOption('collation'))->toBe('utf8mb4_general_ci');
+});


### PR DESCRIPTION
## Problem

On a legacy install, declarative schema reconciliation never converges: every
`maho migrate` re-applies a batch of `ALTER TABLE ... CHANGE` statements that
change nothing. On the database where this was found, ~23 such statements (≈70
columns) were re-emitted on every run, each altering only a column's
charset/collation to the value it already had (`utf8mb3` → `utf8mb3`). The deploy
is not blocked, but `migrate` is not idempotent and each run touches dozens of
columns for no reason.

The affected columns are all undeclared columns added to managed **core** tables
by third-party modules (legacy installs accumulate these). No indexes/FKs are
involved — it is purely column charset churn.

## Root cause

An asymmetry in how MySQL's DBAL `Comparator` strips column-level charset
(`Doctrine\DBAL\Platforms\MySQL\Comparator::normalizeTable` drops a column's
charset when it equals the *table's*, by a strict string compare).

- A legacy table is introspected as `utf8mb3`.
- The declarative target carries the legacy adapter's historical alias `utf8`
  (`Collector::applyTableDefaults`).

`utf8` and `utf8mb3` are the **same physical charset**, but the literal strings
differ. For a column merged onto the table by `preserveUndeclaredColumns`
(introspected as `utf8mb3`), the Comparator strips the charset on the **live**
side (`column utf8mb3 == table utf8mb3`) but keeps it on the **target** side
(`column utf8mb3 != table 'utf8'`), so it emits a `CHANGE` that can never
converge.

## Fix

`Canonicalizer::reconcile()` now aligns the target table's `charset`/`collation`
to the live value when the two are synonyms (`utf8` ≡ `utf8mb3`), making the
Comparator's strip symmetric on both sides. A genuine charset migration (e.g.
`utf8mb3` → `utf8mb4`) keeps differing strings and is still emitted.

## Validation

- New unit coverage in `CanonicalizerTest` for both the synonym case (no `CHANGE`,
  converges) and a real migration (`CHANGE` preserved). Full `CanonicalizerTest`
  green (11 passed).
- `composer lint:cs-fixer`, `composer lint:rector`, `composer lint:phpstan`
  (level 6) pass on the changed files.
- On a real legacy install (clone), `maho migrate` went from re-applying ~23
  statements on every run to "already up to date" on the first and second run —
  idempotent, converges to zero.
