### PR TITLE
Fixed runtime `E_USER_DEPRECATED` from `#[\Deprecated] getSaveUrl()` on admin & customer form pages

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -3192,7 +3192,6 @@ parameters:
 			count: 2
 			path: app/code/core/Mage/Adminhtml/Block/Widget/Form.php
 
-
 		-
 			rawMessage: Property Mage_Adminhtml_Block_Widget_Form_Container::$_blockGroup has no type specified.
 			identifier: missingType.property

--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -3192,11 +3192,6 @@ parameters:
 			count: 2
 			path: app/code/core/Mage/Adminhtml/Block/Widget/Form.php
 
-		-
-			rawMessage: 'Call to deprecated method getSaveUrl() of class Mage_Adminhtml_Block_Widget_Form_Container.'
-			identifier: method.deprecated
-			count: 1
-			path: app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
 
 		-
 			rawMessage: Property Mage_Adminhtml_Block_Widget_Form_Container::$_blockGroup has no type specified.

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Edit.php
@@ -78,7 +78,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Attribute_Edit extends Mage_Adminhtml
      * @return string
      */
     #[\Override]
-    public function getSaveUrl()
+    public function getFormActionUrl()
     {
         return $this->getUrl('*/' . $this->_controller . '/save', ['_current' => true, 'back' => null]);
     }

--- a/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Variable/Edit.php
@@ -82,12 +82,12 @@ class Mage_Adminhtml_Block_System_Variable_Edit extends Mage_Adminhtml_Block_Wid
     }
 
     /**
-     * Return save url for edit form
+     * Return form action url for edit form
      *
      * @return string
      */
     #[\Override]
-    public function getSaveUrl()
+    public function getFormActionUrl()
     {
         return $this->getUrl('*/*/save', ['_current' => true, 'back' => null]);
     }

--- a/app/code/core/Mage/Adminhtml/Block/Tag/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Tag/Edit.php
@@ -125,12 +125,12 @@ class Mage_Adminhtml_Block_Tag_Edit extends Mage_Adminhtml_Block_Widget_Form_Con
     }
 
     /**
-     * Retrieve Tag Save URL
+     * Retrieve Tag form action URL
      *
      * @return string
      */
     #[\Override]
-    public function getSaveUrl()
+    public function getFormActionUrl()
     {
         return $this->getUrl('*/*/save', ['_current' => true]);
     }

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
@@ -171,7 +171,7 @@ class Mage_Adminhtml_Block_Widget_Form_Container extends Mage_Adminhtml_Block_Wi
      */
     public function getFormHtml()
     {
-        $this->getChild('form')->setData('action', $this->getSaveUrl());
+        $this->getChild('form')->setData('action', $this->getFormActionUrl());
         return $this->getChildHtml('form');
     }
 

--- a/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit.php
+++ b/app/code/core/Mage/Widget/Block/Adminhtml/Widget/Instance/Edit.php
@@ -76,12 +76,12 @@ class Mage_Widget_Block_Adminhtml_Widget_Instance_Edit extends Mage_Adminhtml_Bl
     }
 
     /**
-     * Return save url for edit form
+     * Return form action url for edit form
      *
      * @return string
      */
     #[\Override]
-    public function getSaveUrl()
+    public function getFormActionUrl()
     {
         return $this->getUrl('*/*/save', ['_current' => true, 'back' => null]);
     }

--- a/app/design/adminhtml/default/default/template/tag/edit/container.phtml
+++ b/app/design/adminhtml/default/default/template/tag/edit/container.phtml
@@ -18,7 +18,7 @@
     <?= $this->getStoreSwitcherHtml() ?>
 <?php endif ?>
 
-<form action="<?= $this->getSaveUrl() ?>" method="post" id="edit_form">
+<form action="<?= $this->getFormActionUrl() ?>" method="post" id="edit_form">
     <?= $this->getFormHtml() ?>
 
     <?= $this->getTagAssignAccordionHtml() ?>


### PR DESCRIPTION
Fixes #1066

`Container::getSaveUrl()` carries `#[\Deprecated]` (added in #1059). On PHP 8.4 that raises `E_USER_DEPRECATED` at runtime, which Maho turns into a hard error on every admin edit page.

The only live caller of a deprecated symbol is `Container::getFormHtml()` (line 174) calling its own `getSaveUrl()` alias. All other `getSaveUrl()` methods in the codebase are independent, non-deprecated overrides on unrelated blocks and are left untouched.
