### PR TITLE
Fix: Caught Throwable in import validate/start so the admin loader always clears

### DIFF
--- a/app/code/core/Mage/ImportExport/controllers/Adminhtml/ImportController.php
+++ b/app/code/core/Mage/ImportExport/controllers/Adminhtml/ImportController.php
@@ -78,7 +78,7 @@ class Mage_ImportExport_Adminhtml_ImportController extends Mage_Adminhtml_Contro
                 $importModel->invalidateIndex();
                 $resultBlock->addAction('show', 'import_validation_container')
                     ->addAction('innerHTML', 'import_validation_container_header', $this->__('Status'));
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 $resultBlock->addError($e->getMessage());
                 $this->renderLayout();
                 return;
@@ -158,7 +158,7 @@ class Mage_ImportExport_Adminhtml_ImportController extends Mage_Adminhtml_Contro
                     $resultBlock->addNotice($import->getNotices());
                     $resultBlock->addNotice($this->__('Checked rows: %d, checked entities: %d, invalid rows: %d, total errors: %d', $import->getProcessedRowsCount(), $import->getProcessedEntitiesCount(), $import->getInvalidRowsCount(), $import->getErrorsCount()));
                 }
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 $resultBlock->addNotice($this->__('Please fix errors and re-upload file'))
                     ->addError($e->getMessage());
             }


### PR DESCRIPTION
The import form posts to a hidden iframe whose result frame calls
`postToFrameComplete()` to hide the "Please wait" loader. `validateAction()` and
`startAction()` only caught `Exception`, so a fatal `Error` (e.g. a `TypeError` from
`uploadSource()`) escaped, PHP rendered the 500 page into the iframe, the callback never
fired, and the loader spun forever with no feedback.

Widened both catches to `Throwable` so any error is shown in the result frame and the
loader clears.