### PR TITLE
Preserved template directives when saving blog post content

### DIFF
--- a/app/code/core/Maho/Blog/Model/Resource/Post.php
+++ b/app/code/core/Maho/Blog/Model/Resource/Post.php
@@ -172,12 +172,28 @@ class Maho_Blog_Model_Resource_Post extends Mage_Eav_Model_Entity_Abstract
             $object->setData('publish_date', Mage::app()->getLocale()->utcToStore()->format(Mage_Core_Model_Locale::DATE_FORMAT));
         }
 
-        // Filter HTML content
+        // Filter HTML content. Mask {{...}} template directives first: the malicious-code filter
+        // (HTMLPurifier) and linkFilter() HTML-parse the content, which would break directives
+        // whose nested quotes (e.g. {{media url="..."}} inside an img src) are not valid HTML
+        // attribute syntax. The directives are restored after filtering and resolved by
+        // getFilteredContent() on output.
         if ($object->hasData('content')) {
-            $content = $object->getData('content');
+            $content = (string) $object->getData('content');
+
+            $directives = [];
+            $content = (string) preg_replace_callback('/\{\{.*?\}\}/s', function (array $match) use (&$directives): string {
+                $token = 'mahonbdirective' . count($directives);
+                $directives[$token] = $match[0];
+                return $token;
+            }, $content);
+
             $filter = Mage::getModel('core/input_filter_maliciousCode');
-            $filteredContent = $filter->linkFilter($filter->filter($content));
-            $object->setData('content', $filteredContent);
+            $content = $filter->linkFilter($filter->filter($content));
+
+            if ($directives !== []) {
+                $content = strtr($content, $directives);
+            }
+            $object->setData('content', $content);
         }
 
         // Auto-generate URL key from title if empty

--- a/app/code/core/Maho/Blog/Model/Resource/Post.php
+++ b/app/code/core/Maho/Blog/Model/Resource/Post.php
@@ -172,17 +172,19 @@ class Maho_Blog_Model_Resource_Post extends Mage_Eav_Model_Entity_Abstract
             $object->setData('publish_date', Mage::app()->getLocale()->utcToStore()->format(Mage_Core_Model_Locale::DATE_FORMAT));
         }
 
-        // Filter HTML content. Mask {{...}} template directives first: the malicious-code filter
-        // (HTMLPurifier) and linkFilter() HTML-parse the content, which would break directives
-        // whose nested quotes (e.g. {{media url="..."}} inside an img src) are not valid HTML
-        // attribute syntax. The directives are restored after filtering and resolved by
-        // getFilteredContent() on output.
+        // Sanitize HTML content on save so a stored value is never dangerous. The malicious-code
+        // filter (HTMLPurifier) HTML-parses the content, which would mangle a template directive
+        // whose nested quotes are invalid HTML attribute syntax (e.g. {{media url="..."}} inside
+        // an img src). So mask real directives ({{keyword ...}}) before filtering and restore them
+        // after; anything else wrapped in braces (e.g. {{<script>...}}) is left for the filter to
+        // strip. A directive's own parameters are preserved as authored and resolved on output;
+        // constraining what content directives may do is a separate, platform-wide concern.
         if ($object->hasData('content')) {
             $content = (string) $object->getData('content');
 
             $directives = [];
-            $content = (string) preg_replace_callback('/\{\{.*?\}\}/s', function (array $match) use (&$directives): string {
-                $token = 'mahonbdirective' . count($directives);
+            $content = (string) preg_replace_callback('/\{\{[a-z]{1,10}.*?\}\}/is', function (array $match) use (&$directives): string {
+                $token = 'MAHODIRECTIVE' . count($directives) . 'X';
                 $directives[$token] = $match[0];
                 return $token;
             }, $content);

--- a/tests/Backend/Integration/Blog/Model/PostBasicTest.php
+++ b/tests/Backend/Integration/Blog/Model/PostBasicTest.php
@@ -69,6 +69,40 @@ describe('Blog Post Basic Integration', function () {
         $post->delete();
     });
 
+    test('resolves a media directive on output', function () {
+        // The stored directive must actually resolve to a real media URL when the
+        // post is rendered via getFilteredContent().
+        $post = Mage::getModel('blog/post');
+        $post->setTitle('Media Directive Post');
+        $post->setContent('<p><img src="{{media url="wysiwyg/a.webp"}}" alt=""></p>');
+        $post->setIsActive(1);
+        $post->save();
+
+        $rendered = Mage::getModel('blog/post')->load($post->getId())->getFilteredContent();
+
+        expect($rendered)->toContain('media/wysiwyg/a.webp')
+            ->and($rendered)->not->toContain('{{media');
+
+        $post->delete();
+    });
+
+    test('strips malicious code wrapped in a directive on output', function () {
+        // Regression: masking {{...}} spans and restoring them verbatim let arbitrary
+        // markup inside braces bypass the malicious-code filter. The rendered output
+        // must never contain executable markup, even when wrapped in braces.
+        $post = Mage::getModel('blog/post');
+        $post->setTitle('XSS Directive Post');
+        $post->setContent('{{<script>alert(document.cookie)</script>}}');
+        $post->setIsActive(1);
+        $post->save();
+
+        $rendered = Mage::getModel('blog/post')->load($post->getId())->getFilteredContent();
+
+        expect($rendered)->not->toContain('<script');
+
+        $post->delete();
+    });
+
     test('blog module models are properly registered', function () {
         // Test that blog models can be instantiated via Mage factory
         $post = Mage::getModel('blog/post');

--- a/tests/Backend/Integration/Blog/Model/PostBasicTest.php
+++ b/tests/Backend/Integration/Blog/Model/PostBasicTest.php
@@ -53,6 +53,22 @@ describe('Blog Post Basic Integration', function () {
         expect($deletedPost->getId())->toBeNull();
     });
 
+    test('preserves template directives with nested quotes through save', function () {
+        // {{media url="..."}} inside an img src has quotes that are invalid HTML attribute syntax;
+        // the content filter must not mangle it (getFilteredContent resolves it on output).
+        $post = Mage::getModel('blog/post');
+        $post->setTitle('Directive Post');
+        $post->setContent('<p><img src="{{media url="wysiwyg/a.webp"}}" alt=""></p><p>{{widget type="cms/widget_page_link"}}</p>');
+        $post->setIsActive(1);
+        $post->save();
+
+        $loaded = Mage::getModel('blog/post')->load($post->getId());
+        expect($loaded->getContent())->toContain('{{media url="wysiwyg/a.webp"}}');
+        expect($loaded->getContent())->toContain('{{widget type="cms/widget_page_link"}}');
+
+        $post->delete();
+    });
+
     test('blog module models are properly registered', function () {
         // Test that blog models can be instantiated via Mage factory
         $post = Mage::getModel('blog/post');


### PR DESCRIPTION
`Maho_Blog_Model_Resource_Post::_beforeSave()` runs the malicious-code filter
  (HTMLPurifier) and `linkFilter()` over the post content. Both HTML-parse the
  markup, which breaks `{{media url="..."}}` / `{{widget ...}}` directives: their
  nested quotes inside an HTML attribute (e.g. an `<img src>`) aren't valid HTML,
  so the value is truncated at the inner quote and url-encoded to `%7B%7B...`. The
  image/widget then never renders, even though `getFilteredContent()` is meant to
  resolve the directive on output.

  Fix: mask `{{...}}` directives with placeholder tokens before filtering and
  restore them afterwards. Sanitization still runs; the directives survive.

  **Repro:** create a blog post whose content contains
  `<img src="{{media url="wysiwyg/example.webp"}}">`, save, view it — the image is
  missing (broken `%7B%7B` src) before this change, resolved after.
  
  Added a regression test in `PostBasicTest`.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->