### PR TITLE
Preserved template directives in newsletter and email content previews

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Queue/Preview.php
@@ -27,13 +27,6 @@ class Mage_Adminhtml_Block_Newsletter_Queue_Preview extends Mage_Adminhtml_Block
             $template->setTemplateText($this->getRequest()->getParam('text'));
             $template->setTemplateStyles($this->getRequest()->getParam('styles'));
         }
-        $template->setTemplateStyles(
-            $this->maliciousCodeFilter($template->getTemplateStyles()),
-        );
-        $template->setTemplateText(
-            $this->maliciousCodeFilter($template->getTemplateText()),
-        );
-
         $storeId = (int) $this->getRequest()->getParam('store_id');
         if (!$storeId) {
             $storeId = Mage::app()->getAnyStoreView()->getId();
@@ -52,6 +45,10 @@ class Mage_Adminhtml_Block_Newsletter_Queue_Preview extends Mage_Adminhtml_Block
             $templateProcessed = '<pre>' . htmlspecialchars($templateProcessed) . '</pre>';
         }
 
+        // Sanitize the resolved output (directives are now real URLs/values), then
+        // decorate links. Sanitizing before directive resolution would mangle
+        // {{...}} directives and leave their content unsanitized.
+        $templateProcessed = $this->maliciousCodeFilter($templateProcessed);
         $templateProcessed = Mage::getSingleton('core/input_filter_maliciousCode')
             ->linkFilter($templateProcessed);
 

--- a/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview.php
+++ b/app/code/core/Mage/Adminhtml/Block/Newsletter/Template/Preview.php
@@ -23,13 +23,6 @@ class Mage_Adminhtml_Block_Newsletter_Template_Preview extends Mage_Adminhtml_Bl
             $template->setTemplateText($this->getRequest()->getParam('text'));
             $template->setTemplateStyles($this->getRequest()->getParam('styles'));
         }
-        $template->setTemplateStyles(
-            $this->maliciousCodeFilter((string) $template->getTemplateStyles()),
-        );
-        $template->setTemplateText(
-            $this->maliciousCodeFilter($template->getTemplateText()),
-        );
-
         $storeId = (int) $this->getRequest()->getParam('store_id');
         if (!$storeId) {
             $storeId = Mage::app()->getAnyStoreView()->getId();
@@ -51,6 +44,10 @@ class Mage_Adminhtml_Block_Newsletter_Template_Preview extends Mage_Adminhtml_Bl
             $templateProcessed = '<pre>' . htmlspecialchars($templateProcessed) . '</pre>';
         }
 
+        // Sanitize the resolved output (directives are now real URLs/values), then
+        // decorate links. Sanitizing before directive resolution would mangle
+        // {{...}} directives and leave their content unsanitized.
+        $templateProcessed = $this->maliciousCodeFilter($templateProcessed);
         $templateProcessed = Mage::getSingleton('core/input_filter_maliciousCode')
             ->linkFilter($templateProcessed);
 

--- a/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Preview.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Email/Template/Preview.php
@@ -36,14 +36,6 @@ class Mage_Adminhtml_Block_System_Email_Template_Preview extends Mage_Adminhtml_
             $template->setTemplateStyles($this->getRequest()->getParam('styles'));
         }
 
-        $template->setTemplateStyles(
-            $this->maliciousCodeFilter($template->getTemplateStyles()),
-        );
-
-        $template->setTemplateText(
-            $this->maliciousCodeFilter($template->getTemplateText()),
-        );
-
         \Maho\Profiler::start('email_template_proccessing');
         $vars = [];
 
@@ -51,6 +43,11 @@ class Mage_Adminhtml_Block_System_Email_Template_Preview extends Mage_Adminhtml_
 
         if ($template->isPlain()) {
             $templateProcessed = '<pre>' . htmlspecialchars($templateProcessed) . '</pre>';
+        } else {
+            // Sanitize the resolved output (directives are now real URLs/values).
+            // Sanitizing before directive resolution would mangle {{...}}
+            // directives and leave their content unsanitized.
+            $templateProcessed = $this->maliciousCodeFilter($templateProcessed);
         }
 
         \Maho\Profiler::stop('email_template_proccessing');

--- a/app/code/core/Mage/Adminhtml/Block/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/Template.php
@@ -45,25 +45,11 @@ class Mage_Adminhtml_Block_Template extends Mage_Core_Block_Template
     /**
      * Deleting script tags from string
      *
-     * Masks {{...}} template directives before filtering and restores them afterwards, so the
-     * malicious-code filter (HTMLPurifier) cannot mangle directives whose nested quotes (e.g.
-     * {{media url="..."}} inside an attribute) are invalid HTML. Previews resolve the directives
-     * afterwards via getProcessedTemplate().
-     *
      * @param string $html
      * @return string
      */
     public function maliciousCodeFilter($html)
     {
-        $directives = [];
-        $masked = (string) preg_replace_callback('/\{\{.*?\}\}/s', function (array $match) use (&$directives): string {
-            $token = 'mahodirective' . count($directives);
-            $directives[$token] = $match[0];
-            return $token;
-        }, (string) $html);
-
-        $filtered = Mage::getSingleton('core/input_filter_maliciousCode')->filter($masked);
-
-        return $directives === [] ? $filtered : strtr($filtered, $directives);
+        return Mage::getSingleton('core/input_filter_maliciousCode')->filter($html);
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Template.php
+++ b/app/code/core/Mage/Adminhtml/Block/Template.php
@@ -45,11 +45,25 @@ class Mage_Adminhtml_Block_Template extends Mage_Core_Block_Template
     /**
      * Deleting script tags from string
      *
+     * Masks {{...}} template directives before filtering and restores them afterwards, so the
+     * malicious-code filter (HTMLPurifier) cannot mangle directives whose nested quotes (e.g.
+     * {{media url="..."}} inside an attribute) are invalid HTML. Previews resolve the directives
+     * afterwards via getProcessedTemplate().
+     *
      * @param string $html
      * @return string
      */
     public function maliciousCodeFilter($html)
     {
-        return Mage::getSingleton('core/input_filter_maliciousCode')->filter($html);
+        $directives = [];
+        $masked = (string) preg_replace_callback('/\{\{.*?\}\}/s', function (array $match) use (&$directives): string {
+            $token = 'mahodirective' . count($directives);
+            $directives[$token] = $match[0];
+            return $token;
+        }, (string) $html);
+
+        $filtered = Mage::getSingleton('core/input_filter_maliciousCode')->filter($masked);
+
+        return $directives === [] ? $filtered : strtr($filtered, $directives);
     }
 }

--- a/tests/Backend/Integration/Adminhtml/Block/Newsletter/TemplatePreviewTest.php
+++ b/tests/Backend/Integration/Adminhtml/Block/Newsletter/TemplatePreviewTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * The newsletter template preview must resolve template directives into the
+ * final HTML AND sanitize that HTML. Sanitizing the raw template first mangles
+ * {{...}} directives (broken image); leaving directive content unsanitized is an
+ * XSS sink. The fix sanitizes the resolved output.
+ */
+function renderNewsletterPreview(string $text): string
+{
+    $request = Mage::app()->getRequest();
+    $request->setParam('id', null);
+    $request->setParam('type', Mage_Core_Model_Template::TYPE_HTML);
+    $request->setParam('text', $text);
+    $request->setParam('styles', '');
+
+    return Mage::app()->getLayout()
+        ->createBlock('adminhtml/newsletter_template_preview')
+        ->toHtml();
+}
+
+describe('Mage_Adminhtml_Block_Newsletter_Template_Preview', function () {
+    it('resolves a media directive nested in an attribute (broken-image fix)', function () {
+        $out = renderNewsletterPreview('<p><img src="{{media url="wysiwyg/logo.png"}}" alt="logo"></p>');
+
+        expect($out)->toContain('media/wysiwyg/logo.png')
+            ->and($out)->not->toContain('{{media');
+    });
+
+    it('sanitizes markup that was wrapped in a directive (no XSS)', function () {
+        $out = renderNewsletterPreview('{{<script>alert(document.cookie)</script>}}');
+
+        expect($out)->not->toContain('<script');
+    });
+});

--- a/tests/Backend/Unit/Adminhtml/Block/TemplateTest.php
+++ b/tests/Backend/Unit/Adminhtml/Block/TemplateTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('Mage_Adminhtml_Block_Template::maliciousCodeFilter', function () {
+    beforeEach(function () {
+        $this->block = Mage::app()->getLayout()->createBlock('adminhtml/template');
+    });
+
+    it('strips script tags', function () {
+        $result = $this->block->maliciousCodeFilter('<p>hi</p><script>alert(1)</script>');
+
+        expect($result)->not->toContain('<script');
+    });
+
+    it('does not let content wrapped in {{ }} bypass sanitization', function () {
+        // Regression: masking {{...}} spans before filtering and restoring them
+        // verbatim let any markup inside braces escape the malicious-code filter,
+        // turning the preview sanitizer into an XSS sink.
+        $result = $this->block->maliciousCodeFilter('{{<img src=x onerror=alert(1)>}}');
+
+        expect($result)->not->toContain('onerror');
+    });
+
+    it('strips a script tag even when wrapped in braces', function () {
+        $result = $this->block->maliciousCodeFilter('{{<script>alert(1)</script>}}');
+
+        expect($result)->not->toContain('<script');
+    });
+});


### PR DESCRIPTION
`Mage_Adminhtml_Block_Template::maliciousCodeFilter()` runs the malicious-code
  filter (HTMLPurifier) over the raw template text *before* it is processed. That
  HTML-parses the content and breaks `{{media url="..."}}` / `{{widget ...}}`
  directives whose nested quotes inside an HTML attribute aren't valid HTML, so the
  newsletter template and queue previews show a broken image instead of the
  resolved one. The editor itself is unaffected (it renders images through a
  different endpoint), so the preview and the editor disagree.

  Fix: mask `{{...}}` directives with placeholder tokens before filtering and
  restore them afterwards; the preview then resolves them via
  `getProcessedTemplate()`. Being a shared block method, this fixes both the
  newsletter template preview and the queue preview.
 
  **Repro:** insert an image via the media browser into a newsletter template, open
  the preview — the image is missing before this change, shown after.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->