### PR TITLE
Made admin frontName matching case-sensitive and restored controllerModule on the legacy dispatch path

### DIFF
--- a/lib/Maho/Routing/ControllerDispatcher.php
+++ b/lib/Maho/Routing/ControllerDispatcher.php
@@ -64,20 +64,22 @@ class ControllerDispatcher
             return false;
         }
 
+        $controllerInstance = Mage::getControllerInstance($controllerClass, $request, $response);
+        if (!$controllerInstance->hasAction($actionName)) {
+            return false;
+        }
+
         // M1 BC: the standard router recorded the resolving module's class prefix (e.g.
         // 'Mage_Adminhtml' or 'Buddy_LogViewer_Adminhtml') via setControllerModule(), and
-        // third-party code dispatched through this path may read it back. Every resolution
+        // third-party code dispatched through this path may read it back. Set only after all
+        // checks pass, like M1's standard router — a dispatch that bails must not leak a
+        // module onto a request that falls through to another handler. Every resolution
         // branch assembles or stores the class as <modulePrefix>_<UcWordsController>Controller,
         // so the prefix is recovered by stripping the suffix (case-insensitively — PHP class
         // names are case-insensitive, so the URL casing may differ from the declared one).
         $suffix = '_' . uc_words($controllerName) . 'Controller';
         if (strcasecmp(substr($controllerClass, -strlen($suffix)), $suffix) === 0) {
             $request->setControllerModule(substr($controllerClass, 0, -strlen($suffix)));
-        }
-
-        $controllerInstance = Mage::getControllerInstance($controllerClass, $request, $response);
-        if (!$controllerInstance->hasAction($actionName)) {
-            return false;
         }
 
         // Set routeName for event dispatching (controller_action_predispatch_<routeName>).
@@ -115,17 +117,6 @@ class ControllerDispatcher
         $frontName = $parts[0];
         $controllerName = $parts[1] ?? 'index';
         $actionName = $parts[2] ?? 'index';
-
-        // A mis-cased admin frontName must fall through to noroute — M1 matched frontNames
-        // case-sensitively, so /Admin/... 404s rather than half-dispatching with a mis-cased
-        // route name that breaks adminhtml_* layout handles and predispatch observers.
-        // Without this guard the compiled lookup below would still resolve admin controllers
-        // (normalizeFrontName() maps any casing to the admin sentinel). Frontend frontNames
-        // stay case-insensitive: DB-persisted rewrites may carry mixed-case targets.
-        $adminFrontName = RouteCollectionBuilder::getAdminFrontName();
-        if ($frontName !== $adminFrontName && strcasecmp($frontName, $adminFrontName) === 0) {
-            return false;
-        }
 
         $controllerClass = $this->resolveControllerClass($frontName, $controllerName);
         if (!$controllerClass || !class_exists($controllerClass)) {
@@ -185,9 +176,9 @@ class ControllerDispatcher
         }
 
         // 4. Admin module chain — third-party admin extensions without `#[Route]`.
-        //    Exact-case comparison: mis-cased admin URLs are rejected before resolution
-        //    (see dispatchLegacyPath), and internal callers pass the configured frontName
-        //    verbatim, so a case-insensitive match here could only mask a broken dispatch.
+        //    Exact-case comparison (M1 semantics), matching normalizeFrontName() in the
+        //    compiled lookup above: a mis-cased admin frontName resolves nothing on any
+        //    dispatch path and falls through to the noroute handler.
         if ($frontName === RouteCollectionBuilder::getAdminFrontName()) {
             foreach ($this->buildAdminModuleChain() as $chainModule) {
                 $className = $chainModule . '_' . uc_words($controllerName) . 'Controller';

--- a/lib/Maho/Routing/ControllerDispatcher.php
+++ b/lib/Maho/Routing/ControllerDispatcher.php
@@ -64,6 +64,17 @@ class ControllerDispatcher
             return false;
         }
 
+        // M1 BC: the standard router recorded the resolving module's class prefix (e.g.
+        // 'Mage_Adminhtml' or 'Buddy_LogViewer_Adminhtml') via setControllerModule(), and
+        // third-party code dispatched through this path may read it back. Every resolution
+        // branch assembles or stores the class as <modulePrefix>_<UcWordsController>Controller,
+        // so the prefix is recovered by stripping the suffix (case-insensitively — PHP class
+        // names are case-insensitive, so the URL casing may differ from the declared one).
+        $suffix = '_' . uc_words($controllerName) . 'Controller';
+        if (strcasecmp(substr($controllerClass, -strlen($suffix)), $suffix) === 0) {
+            $request->setControllerModule(substr($controllerClass, 0, -strlen($suffix)));
+        }
+
         $controllerInstance = Mage::getControllerInstance($controllerClass, $request, $response);
         if (!$controllerInstance->hasAction($actionName)) {
             return false;
@@ -104,6 +115,17 @@ class ControllerDispatcher
         $frontName = $parts[0];
         $controllerName = $parts[1] ?? 'index';
         $actionName = $parts[2] ?? 'index';
+
+        // A mis-cased admin frontName must fall through to noroute — M1 matched frontNames
+        // case-sensitively, so /Admin/... 404s rather than half-dispatching with a mis-cased
+        // route name that breaks adminhtml_* layout handles and predispatch observers.
+        // Without this guard the compiled lookup below would still resolve admin controllers
+        // (normalizeFrontName() maps any casing to the admin sentinel). Frontend frontNames
+        // stay case-insensitive: DB-persisted rewrites may carry mixed-case targets.
+        $adminFrontName = RouteCollectionBuilder::getAdminFrontName();
+        if ($frontName !== $adminFrontName && strcasecmp($frontName, $adminFrontName) === 0) {
+            return false;
+        }
 
         $controllerClass = $this->resolveControllerClass($frontName, $controllerName);
         if (!$controllerClass || !class_exists($controllerClass)) {
@@ -163,7 +185,10 @@ class ControllerDispatcher
         }
 
         // 4. Admin module chain — third-party admin extensions without `#[Route]`.
-        if (strtolower($frontName) === strtolower(RouteCollectionBuilder::getAdminFrontName())) {
+        //    Exact-case comparison: mis-cased admin URLs are rejected before resolution
+        //    (see dispatchLegacyPath), and internal callers pass the configured frontName
+        //    verbatim, so a case-insensitive match here could only mask a broken dispatch.
+        if ($frontName === RouteCollectionBuilder::getAdminFrontName()) {
             foreach ($this->buildAdminModuleChain() as $chainModule) {
                 $className = $chainModule . '_' . uc_words($controllerName) . 'Controller';
                 if (class_exists($className)) {
@@ -206,13 +231,14 @@ class ControllerDispatcher
             return false;
         }
 
-        // Admin area: verify the matched frontName matches the runtime admin frontName.
-        // Without this, a request like /notadmin/... would match admin routes with any
-        // segment for `{_adminFrontName}` and dispatch as admin — rejecting at this point
-        // simply falls through to the noroute handler.
+        // Admin area: verify the matched frontName matches the runtime admin frontName
+        // exactly, including case (M1 semantics — /Admin/... 404s rather than dispatching
+        // with a mis-cased route name). Without this, a request like /notadmin/... would
+        // match admin routes with any segment for `{_adminFrontName}` and dispatch as
+        // admin — rejecting at this point simply falls through to the noroute handler.
         if ($area === 'adminhtml') {
             $matchedAdminFrontName = $params['_adminFrontName'] ?? '';
-            if (strtolower($matchedAdminFrontName) !== strtolower(RouteCollectionBuilder::getAdminFrontName())) {
+            if ($matchedAdminFrontName !== RouteCollectionBuilder::getAdminFrontName()) {
                 return false;
             }
         }

--- a/lib/Maho/Routing/RouteCollectionBuilder.php
+++ b/lib/Maho/Routing/RouteCollectionBuilder.php
@@ -143,13 +143,20 @@ class RouteCollectionBuilder
 
     /**
      * Translate a URL frontName to its reverse-lookup key (sentinel for admin/install, identity otherwise).
+     *
+     * The admin comparison is exact-case (M1 semantics): a mis-cased admin frontName must not
+     * normalize to the sentinel, so /Admin/... misses every compiled lookup and falls through
+     * to the noroute handler on all dispatch paths — rather than half-dispatching with a
+     * mis-cased route name that breaks adminhtml_* layout handles and predispatch observers.
+     * Frontend frontNames stay case-insensitive: DB-persisted URL rewrites may carry
+     * mixed-case targets.
      */
     public static function normalizeFrontName(string $frontName): string
     {
-        $lower = strtolower($frontName);
-        if ($lower === strtolower(self::getAdminFrontName())) {
+        if ($frontName === self::getAdminFrontName()) {
             return self::ADMIN_SENTINEL;
         }
+        $lower = strtolower($frontName);
         if ($lower === 'install') {
             return self::INSTALL_SENTINEL;
         }

--- a/tests/Backend/Unit/Maho/Routing/CustomAdminPathTest.php
+++ b/tests/Backend/Unit/Maho/Routing/CustomAdminPathTest.php
@@ -59,14 +59,17 @@ describe('RouteCollectionBuilder::normalizeFrontName()', function () {
     beforeEach(fn() => resetAdminFrontNameCache());
     afterEach(fn() => resetAdminFrontNameCache());
 
-    it('maps the configured admin frontName to the sentinel regardless of case', function () {
+    it('maps the configured admin frontName to the sentinel only on an exact-case match', function () {
         Mage::getConfig()->setNode(AdminhtmlHelper::XML_PATH_USE_CUSTOM_ADMIN_PATH, '1');
         Mage::getConfig()->setNode(AdminhtmlHelper::XML_PATH_CUSTOM_ADMIN_PATH, 'BackOffice');
 
-        expect(RouteCollectionBuilder::normalizeFrontName('backoffice'))
+        expect(RouteCollectionBuilder::normalizeFrontName('BackOffice'))
             ->toBe(RouteCollectionBuilder::ADMIN_SENTINEL);
-        expect(RouteCollectionBuilder::normalizeFrontName('BACKOFFICE'))
-            ->toBe(RouteCollectionBuilder::ADMIN_SENTINEL);
+        // M1 semantics: a mis-cased admin frontName must not normalize to the sentinel,
+        // so it misses every compiled lookup and falls through to the noroute handler
+        // on all dispatch paths (Symfony, legacy path, forward).
+        expect(RouteCollectionBuilder::normalizeFrontName('backoffice'))->toBe('backoffice');
+        expect(RouteCollectionBuilder::normalizeFrontName('BACKOFFICE'))->toBe('backoffice');
     });
 
     it('leaves non-admin frontNames as-is (lowercased)', function () {

--- a/tests/Backend/Unit/Maho/Routing/CustomAdminPathTest.php
+++ b/tests/Backend/Unit/Maho/Routing/CustomAdminPathTest.php
@@ -123,6 +123,27 @@ describe('ControllerDispatcher::dispatch() admin frontName forgery rejection', f
         expect($result)->toBeFalse();
     });
 
+    it('rejects an admin frontName that differs only by case', function () {
+        // Exact-case match (M1 semantics): /Admin/... must fall through to noroute rather
+        // than dispatch — a lenient match would still be caught later by the mis-cased
+        // route name breaking adminhtml_* layout handles, just with a worse failure mode.
+        $dispatcher = new ControllerDispatcher();
+        $request = makeRequest();
+        $response = new Mage_Core_Controller_Response_Http();
+
+        $params = [
+            '_maho_controller' => Mage_Adminhtml_IndexController::class,
+            '_maho_action' => 'indexAction',
+            '_maho_module' => 'Mage_Adminhtml',
+            '_maho_controller_name' => 'index',
+            '_maho_area' => 'adminhtml',
+            '_adminFrontName' => 'Admin',
+        ];
+
+        expect($dispatcher->dispatch($params, $request, $response))->toBeFalse();
+        expect($request->isDispatched())->toBeFalse();
+    });
+
     it('rejects the default admin frontName when a custom path is configured', function () {
         Mage::getConfig()->setNode(AdminhtmlHelper::XML_PATH_USE_CUSTOM_ADMIN_PATH, '1');
         Mage::getConfig()->setNode(AdminhtmlHelper::XML_PATH_CUSTOM_ADMIN_PATH, 'backoffice');

--- a/tests/Backend/Unit/Maho/Routing/LegacyPathDispatchTest.php
+++ b/tests/Backend/Unit/Maho/Routing/LegacyPathDispatchTest.php
@@ -111,6 +111,31 @@ describe('ControllerDispatcher::dispatchLegacyPath()', function () {
         expect($request->getControllerName())->toBe('Index');
     });
 
+    it('rejects a mis-cased admin frontName instead of dispatching with a broken route name', function () {
+        // M1 matched frontNames case-sensitively: /ADMIN/... must fall through to noroute
+        // rather than resolve admin controllers (normalizeFrontName() is case-insensitive)
+        // and dispatch with routeName 'ADMIN', which would break adminhtml_* layout handles.
+        $dispatcher = new ControllerDispatcher();
+        $result = $dispatcher->dispatchLegacyPath(
+            legacyRequest('/ADMIN/dashboard/index'),
+            new Mage_Core_Controller_Response_Http(),
+        );
+
+        expect($result)->toBeFalse();
+    });
+
+    it('records the resolving module class prefix as controllerModule (M1 BC)', function () {
+        // M1's standard router exposed the matched module via setControllerModule();
+        // third-party code dispatched through the legacy path may read it back.
+        // Dispatch bails at hasAction(), but the module is recorded at resolution time.
+        $dispatcher = new ControllerDispatcher();
+        $request = legacyRequest('/catalog/index/nonexistentAction');
+
+        $dispatcher->dispatchLegacyPath($request, new Mage_Core_Controller_Response_Http());
+
+        expect($request->getControllerModule())->toBe('Mage_Catalog');
+    });
+
     it('tolerates leading and trailing slashes', function () {
         $dispatcher = new ControllerDispatcher();
         $request = legacyRequest('/catalog/index/nonexistentAction/');

--- a/tests/Backend/Unit/Maho/Routing/LegacyPathDispatchTest.php
+++ b/tests/Backend/Unit/Maho/Routing/LegacyPathDispatchTest.php
@@ -80,11 +80,13 @@ describe('ControllerDispatcher::dispatchLegacyPath()', function () {
         $request = legacyRequest('/catalog');
 
         // Mage_Catalog_IndexController::indexAction() exists, so dispatch succeeds.
-        // We only care that parsing defaults kick in — parse is observable pre-dispatch.
         $dispatcher->dispatchLegacyPath($request, new Mage_Core_Controller_Response_Http());
 
         expect($request->getControllerName())->toBe('index');
         expect($request->getActionName())->toBe('index');
+        // M1 BC: a successful dispatch records the resolving module's class prefix via
+        // setControllerModule(); third-party code on the legacy path may read it back.
+        expect($request->getControllerModule())->toBe('Mage_Catalog');
     });
 
     it('handles a trailing key without a value by storing an empty string', function () {
@@ -113,8 +115,9 @@ describe('ControllerDispatcher::dispatchLegacyPath()', function () {
 
     it('rejects a mis-cased admin frontName instead of dispatching with a broken route name', function () {
         // M1 matched frontNames case-sensitively: /ADMIN/... must fall through to noroute
-        // rather than resolve admin controllers (normalizeFrontName() is case-insensitive)
-        // and dispatch with routeName 'ADMIN', which would break adminhtml_* layout handles.
+        // rather than resolve admin controllers and dispatch with routeName 'ADMIN', which
+        // would break adminhtml_* layout handles. normalizeFrontName() is exact-case on the
+        // admin frontName, so a mis-cased one misses every resolution step.
         $dispatcher = new ControllerDispatcher();
         $result = $dispatcher->dispatchLegacyPath(
             legacyRequest('/ADMIN/dashboard/index'),
@@ -124,16 +127,32 @@ describe('ControllerDispatcher::dispatchLegacyPath()', function () {
         expect($result)->toBeFalse();
     });
 
-    it('records the resolving module class prefix as controllerModule (M1 BC)', function () {
-        // M1's standard router exposed the matched module via setControllerModule();
-        // third-party code dispatched through the legacy path may read it back.
-        // Dispatch bails at hasAction(), but the module is recorded at resolution time.
+    it('rejects a mis-cased admin frontName on the forward path', function () {
+        // dispatchForward() has no path parsing of its own — a _forward() or custom router
+        // presetting a case-variant admin module name must not resolve admin controllers
+        // via the compiled lookup either.
+        $dispatcher = new ControllerDispatcher();
+        $request = legacyRequest('/');
+        $request->setModuleName('ADMIN');
+        $request->setControllerName('dashboard');
+        $request->setActionName('index');
+
+        $result = $dispatcher->dispatchForward($request, new Mage_Core_Controller_Response_Http());
+
+        expect($result)->toBeFalse();
+        expect($request->isDispatched())->toBeFalse();
+    });
+
+    it('does not leak controllerModule onto a request whose dispatch bails at hasAction()', function () {
+        // M1's standard router set request values only after all checks passed — a failed
+        // dispatch falls through to another handler, which must not see a stale module.
+        // (The success case is asserted in the "defaults controller/action" test above.)
         $dispatcher = new ControllerDispatcher();
         $request = legacyRequest('/catalog/index/nonexistentAction');
 
         $dispatcher->dispatchLegacyPath($request, new Mage_Core_Controller_Response_Http());
 
-        expect($request->getControllerModule())->toBe('Mage_Catalog');
+        expect($request->getControllerModule())->toBeNull();
     });
 
     it('tolerates leading and trailing slashes', function () {


### PR DESCRIPTION
## Summary

Two hardening fixes to Maho's routing, follow-ups to the route-name normalization fixed in efc09ca432.

### Strict-case admin frontName matching

A mis-cased admin URL (`/Admin/dashboard` instead of `/admin/dashboard`) previously half-dispatched: the controller resolved through the case-insensitive lookups, but the request kept the mis-cased route name, so the `adminhtml_*` layout handles and predispatch observers never matched and the page rendered blank.

The fix makes admin frontName matching case-sensitive, which is the internally consistent behavior rather than a special case. **The compiled Symfony matcher is already case-sensitive for every static path segment** — its regex carries the `sD` flags, no `i` — so a mis-cased frontend URL simply misses the matcher. The admin frontName is the *only* segment that escaped this, because `use_custom_admin_path` forces it to compile as a variable placeholder (`{_adminFrontName}` → `([^/]++)`) that matches any segment in any case. This PR brings that one variable segment back in line with the case-sensitivity the matcher enforces everywhere else. As corroborating bonuses it also matches M1 (which resolved admin frontNames through a case-sensitive router lookup) and treats the custom admin path as the exact-match secret it's meant to be.

The case check is enforced at the single normalization choke point instead of per-dispatch-path:

- `RouteCollectionBuilder::normalizeFrontName()` now maps the admin frontName to the admin sentinel only on an **exact-case** match. Since both the compiled controller lookup and route resolution key admin routes through this one function, a mis-cased admin frontName misses resolution on **all three** dispatch paths (Symfony match, legacy path, and `dispatchForward()` for internal forwards and custom routers) and falls through to the noroute handler.
- `ControllerDispatcher::dispatch()` keeps its own exact comparison of the matched `{_adminFrontName}` segment: the compiled matcher's placeholder accepts any segment, so this check is what rejects `/notadmin/...` and mis-cased variants on Symfony-matched routes.
- `resolveControllerClass()` step 4 (admin XML `<modules>` chain) uses the same exact-case comparison, so third-party admin extensions without `#[Route]` follow the same policy.

Frontend frontNames stay case-insensitive: the compiled matcher already rejects a mis-cased frontend URL, and the legacy-path fallback then lowercases it, because DB-persisted URL rewrites may carry mixed-case targets (covered by an existing test). Admin authentication was never affected either way: the auth observer listens on the area-gated `controller_action_predispatch` event, not the route-name-suffixed one.

### `setControllerModule()` on the legacy/forward path

M1's standard router always recorded the resolving module's class prefix (e.g. `Mage_Adminhtml`, `Buddy_LogViewer_Adminhtml`) via `setControllerModule()`, and the Symfony dispatch path still sets it, but `dispatchForward()` / `dispatchLegacyPath()` never did. Third-party M1 modules dispatched through the legacy BC path (exactly the modules most likely to read this API) got `null` back. The prefix is now recovered from the resolved controller class, matching M1's value in every resolution branch.

Following M1's standard-router contract ("set values only after all the checks are done"), the module is recorded only after the `hasAction()` check passes, so a failed dispatch doesn't leak a stale module onto a request that falls through to another handler.

## Testing

- New tests: mis-cased admin frontName rejection on all three dispatch paths (Symfony, legacy, forward), exact-case sentinel mapping in `normalizeFrontName()`, `controllerModule` recording on a successful legacy dispatch and no leakage on a failed one
- Full Backend suite passes (2239 tests), PHPStan and php-cs-fixer clean

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->
