### PR TITLE
Fixed Safari blocking the PayPal payment popup by starting the payment session synchronously on click

### DIFF
--- a/public/js/maho/paypal/standard-checkout.js
+++ b/public/js/maho/paypal/standard-checkout.js
@@ -65,10 +65,10 @@ class MahoPaypalStandardCheckout {
                 return;
             }
             try {
-                const orderId = await this.createOrder();
-                this._paymentSession.start(
+                // start() must run synchronously in the click, or Safari blocks the popup
+                await this._paymentSession.start(
                     { presentationMode: 'popup' },
-                    Promise.resolve({ orderId }),
+                    this.createOrder().then((orderId) => ({ orderId })),
                 );
             } catch (err) {
                 this.handleError(err);


### PR DESCRIPTION
## Problem

With PayPal Standard checkout, clicking the smart button in Safari did nothing: the payment popup never opened. Chrome and other browsers worked fine.

The click handler awaited the order-creation round-trip to Maho (plus an add-to-cart POST in the product-page shortcut case) before calling `paymentSession.start()`, which is what opens the popup. Popups are only allowed during transient user activation, and Safari's activation does not survive a network round-trip. Chrome keeps a multi-second grace window, which is why it only failed in Safari.

## Fix

Call `paymentSession.start()` synchronously within the click and pass `createOrder()` as a promise resolving to `{ orderId }`. The SDK opens the popup immediately during the user gesture, shows its own spinner, and awaits the order id itself.

This is the pattern PayPal documents for the v6 SDK (see the [JS SDK v6 setup docs](https://docs.paypal.ai/developer/how-to/sdk/js/v6/configuration)), and their [official v6 sample integration](https://github.com/paypal-examples/v6-web-sdk-sample-integration/blob/main/client/components/paypalPayments/oneTimePayment/html/src/recommended/app.js) warns about it explicitly:

```js
// get the promise reference by invoking createOrder()
// do not await this async function since it can cause transient activation issues
const createOrderPromise = createOrder();
await paypalPaymentSession.start(
  { presentationMode: "auto" },
  createOrderPromise,
);
```

Error handling is unchanged: a failed order creation rejects through `start()`, surfaces via `handleError()`, and the payment session is recreated.

Only PayPal Standard is affected. The advanced (inline card fields) and vault flows don't open popups.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->