### PR TITLE
Made maho_paypal config namespace migration collision-safe

### DIFF
--- a/app/code/core/Maho/Paypal/data/paypal_setup/data-install-6.0.0.php
+++ b/app/code/core/Maho/Paypal/data/paypal_setup/data-install-6.0.0.php
@@ -13,15 +13,49 @@ declare(strict_types=1);
  * No-op for fresh installs and for case-3 legacy Mage_Paypal merchants since
  * neither has any maho_paypal/... rows.
  *
+ * A blind `REPLACE(path, 'maho_paypal/', 'paypal/')` update is unsafe: when a
+ * shop already holds a paypal/... row for the same scope (e.g. it re-saved the
+ * config under the new namespace after #877), renaming the stale maho_paypal/...
+ * row onto it violates the UNQ_CORE_CONFIG_DATA_SCOPE_SCOPE_ID_PATH unique key
+ * and aborts the whole migration. So we resolve per-row: the live code reads
+ * paypal/..., so an existing paypal/... row is authoritative and the colliding
+ * maho_paypal/... row is a stale duplicate we drop; non-colliding rows are
+ * promoted to the new namespace as before.
+ *
  * @var Mage_Core_Model_Resource_Setup $this
  */
 $installer = $this;
 $installer->startSetup();
 
-$installer->getConnection()->update(
-    $installer->getTable('core/config_data'),
-    ['path' => new Maho\Db\Expr("REPLACE(path, 'maho_paypal/', 'paypal/')")],
-    ['path LIKE ?' => 'maho_paypal/%'],
+$conn = $installer->getConnection();
+$table = $installer->getTable('core/config_data');
+
+$rows = $conn->fetchAll(
+    $conn->select()
+        ->from($table, ['config_id', 'scope', 'scope_id', 'path'])
+        ->where('path LIKE ?', 'paypal/%')
+        ->orWhere('path LIKE ?', 'maho_paypal/%'),
 );
+
+$existing = [];
+$legacy = [];
+foreach ($rows as $row) {
+    if (str_starts_with($row['path'], 'maho_paypal/')) {
+        $legacy[] = $row;
+    } else {
+        $existing[$row['scope'] . '|' . $row['scope_id'] . '|' . $row['path']] = true;
+    }
+}
+
+foreach ($legacy as $row) {
+    $newPath = 'paypal/' . substr($row['path'], strlen('maho_paypal/'));
+    $key = $row['scope'] . '|' . $row['scope_id'] . '|' . $newPath;
+    if (isset($existing[$key])) {
+        // Target already holds the live value; drop the stale pre-#877 duplicate.
+        $conn->delete($table, ['config_id = ?' => $row['config_id']]);
+    } else {
+        $conn->update($table, ['path' => $newPath], ['config_id = ?' => $row['config_id']]);
+    }
+}
 
 $installer->endSetup();


### PR DESCRIPTION
## Problem

`data/paypal_setup/data-install-6.0.0.php` migrates config from the pre-#877 `maho_paypal/…` namespace to `paypal/…` with a blind update:

```php
$installer->getConnection()->update(
    $installer->getTable('core/config_data'),
    ['path' => new Maho\Db\Expr("REPLACE(path, 'maho_paypal/', 'paypal/')")],
    ['path LIKE ?' => 'maho_paypal/%'],
);
```

When a shop already holds a `paypal/…` row for the same scope (e.g. it re-saved PayPal config under the new namespace after #877, so **both** namespaces exist), renaming the stale `maho_paypal/…` row onto the existing one violates the `UNQ_CORE_CONFIG_DATA_SCOPE_SCOPE_ID_PATH` unique key:

```
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry
'default-0-paypal/credentials/sandbox' for key 'UNQ_CORE_CONFIG_DATA_SCOPE_SCOPE_ID_PATH'
```

This aborts the whole setup run, so **every** subsequent `./maho migrate` / page load fails — including on shops that just need unrelated schema updates.

## Fix

Resolve the migration per-row instead of in one blind `REPLACE`:

- an existing `paypal/…` row is authoritative (it's what the live code reads), so a colliding `maho_paypal/…` row is a stale duplicate and gets dropped;
- non-colliding `maho_paypal/…` rows are promoted to the new namespace exactly as before.

Still a no-op for fresh installs and legacy `Mage_Paypal` merchants (no `maho_paypal/…` rows), and now idempotent/safe when both namespaces coexist.

`php-cs-fixer` and `phpstan` (level 6) pass on the changed file.