### PR TITLE
Prevented duplicate PayPal button click bindings when re-selecting the payment method

### DIFF
--- a/public/js/maho/paypal/standard-checkout.js
+++ b/public/js/maho/paypal/standard-checkout.js
@@ -60,6 +60,14 @@ class MahoPaypalStandardCheckout {
         button.removeAttribute('hidden');
         await new Promise(r => setTimeout(r, 500));
         hideLoader();
+
+        // Never bind twice on the same button.
+        if (button._mahoPaypalBound) {
+            this._mounted = true;
+            return;
+        }
+        button._mahoPaypalBound = true;
+
         button.addEventListener('click', async () => {
             if (this.reviewMode && !this._validateAgreements()) {
                 return;
@@ -214,9 +222,12 @@ document.addEventListener('payment-method:switched', function(e) {
     if (!isPaypalStandard || !isOnestep) return;
 
     const formDiv = e.target;
-    // Always re-create on new DOM elements (checkout may re-render payment HTML)
-    const checkout = new MahoPaypalStandardCheckout(formDiv);
-    formDiv._paypalCheckout = checkout;
+    // Reuse the instance bound to this element; re-creating stacks a second click listener.
+    let checkout = formDiv._paypalCheckout;
+    if (!checkout) {
+        checkout = new MahoPaypalStandardCheckout(formDiv);
+        formDiv._paypalCheckout = checkout;
+    }
     checkout.loadSdkAndMount();
 }, true);
 


### PR DESCRIPTION
## Problem

In onestep checkout, re-selecting PayPal as the payment method attached a second click listener to the same `<paypal-button>`. One click then started two PayPal payment sessions — the browser popup-blocks the second, the customer sees an error, and an orphan PayPal order is left behind.

Root cause: the `payment-method:switched` handler created a new `MahoPaypalStandardCheckout` on every switch, but the payment form is not re-rendered (`changeVisible()` only toggles CSS display), so the same button accumulated a click listener per re-selection. The per-instance `_mounted` flag didn't stop this.

Only onestep is affected — multistep re-renders the review block (new element + button) each visit, and shortcut buttons mount once on load.

## Fix

- **Listener idempotency:** reuse the instance already stored on `formDiv._paypalCheckout` instead of re-creating; `loadSdkAndMount()` is idempotent via `_mounted`. A genuinely re-rendered element has no property, so it still re-creates correctly.
- **Button-bind guard:** `button._mahoPaypalBound` guarantees the same button element never receives two click listeners, regardless of upstream instance churn. Harmless to the multistep and shortcut paths.

## Testing

Checkout → select PayPal → select card → select PayPal again → click the button: a single popup opens; no orphan order.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->