### PR TITLE
Fixed bogus empty-src validation errors for CMS images using media directives

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
@@ -17,16 +17,24 @@ class Mage_Adminhtml_Cms_WysiwygController extends Mage_Adminhtml_Controller_Act
     public const ADMIN_RESOURCE = 'cms';
 
     /**
+     * Replace template directives with a non-empty placeholder before HTML validation.
+     *
+     * A directive used inside an attribute (e.g. src="{{media url="..."}}") would otherwise
+     * collapse to src="" once stripped, triggering a bogus "Must be non-empty" validator error.
+     * Match against the canonical directive pattern so exactly the constructs the template filter
+     * renders are blanked out, and the resulting placeholder (#) stays syntactically valid.
+     */
+    public static function blankDirectivesForValidation(string $html): string
+    {
+        return (string) preg_replace(\Maho\Filter\Template::CONSTRUCTION_PATTERN, '#', $html);
+    }
+
+    /**
      * Validate HTML fragment via the W3C Nu validator
      */
     public function validateHtmlAction(): void
     {
-        $html = $this->getRequest()->getPost('html', '');
-        // Replace template directives with a non-empty placeholder rather than stripping them:
-        // a directive inside an attribute (e.g. src="{{media url="..."}}") would otherwise collapse
-        // to src="" and trigger a bogus "Must be non-empty" error from the validator. Match against
-        // the canonical directive pattern so the validator blanks exactly what the filter renders.
-        $html = preg_replace(\Maho\Filter\Template::CONSTRUCTION_PATTERN, '#', $html);
+        $html = self::blankDirectivesForValidation($this->getRequest()->getPost('html', ''));
 
         $prefix = "<!DOCTYPE html>\n<html lang=\"en\">\n<head><meta charset=\"utf-8\"><title>v</title></head>\n<body>\n";
         $suffix = "\n</body>\n</html>";

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
@@ -22,7 +22,10 @@ class Mage_Adminhtml_Cms_WysiwygController extends Mage_Adminhtml_Controller_Act
     public function validateHtmlAction(): void
     {
         $html = $this->getRequest()->getPost('html', '');
-        $html = preg_replace('/\{\{[^{}]*\}\}/', '', $html);
+        // Replace template directives with a non-empty placeholder rather than stripping them:
+        // a directive inside an attribute (e.g. src="{{media url="..."}}") would otherwise collapse
+        // to src="" and trigger a bogus "Must be non-empty" error from the validator.
+        $html = preg_replace('/\{\{[^{}]*\}\}/', '#', $html);
 
         $prefix = "<!DOCTYPE html>\n<html lang=\"en\">\n<head><meta charset=\"utf-8\"><title>v</title></head>\n<body>\n";
         $suffix = "\n</body>\n</html>";

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
@@ -24,8 +24,9 @@ class Mage_Adminhtml_Cms_WysiwygController extends Mage_Adminhtml_Controller_Act
         $html = $this->getRequest()->getPost('html', '');
         // Replace template directives with a non-empty placeholder rather than stripping them:
         // a directive inside an attribute (e.g. src="{{media url="..."}}") would otherwise collapse
-        // to src="" and trigger a bogus "Must be non-empty" error from the validator.
-        $html = preg_replace('/\{\{[^{}]*\}\}/', '#', $html);
+        // to src="" and trigger a bogus "Must be non-empty" error from the validator. Match against
+        // the canonical directive pattern so the validator blanks exactly what the filter renders.
+        $html = preg_replace(\Maho\Filter\Template::CONSTRUCTION_PATTERN, '#', $html);
 
         $prefix = "<!DOCTYPE html>\n<html lang=\"en\">\n<head><meta charset=\"utf-8\"><title>v</title></head>\n<body>\n";
         $suffix = "\n</body>\n</html>";

--- a/tests/Backend/Unit/Adminhtml/Cms/WysiwygControllerTest.php
+++ b/tests/Backend/Unit/Adminhtml/Cms/WysiwygControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Mage_Adminhtml
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Tests the directive neutralization the "Validate HTML" action performs before
+ * sending CMS markup to the W3C validator. A {{...}} directive inside an attribute
+ * must be replaced by a non-empty placeholder so it does not collapse to an empty
+ * value (e.g. src="") and produce a bogus "Must be non-empty" validation error.
+ */
+
+function blankDirectives(string $html): string
+{
+    return Mage_Adminhtml_Cms_WysiwygController::blankDirectivesForValidation($html);
+}
+
+it('keeps an image src non-empty when it holds a media directive', function () {
+    $in = '<a href="/abby.html"><img src="{{media url="wysiwyg/egearD/abby.png"}}" alt="ABBY"></a>';
+    expect(blankDirectives($in))
+        ->toBe('<a href="/abby.html"><img src="#" alt="ABBY"></a>')
+        ->not->toContain('src=""');
+});
+
+it('neutralizes a store directive used in an href', function () {
+    expect(blankDirectives('<a href="{{store url="customer/account"}}">Account</a>'))
+        ->toBe('<a href="#">Account</a>');
+});
+
+it('replaces every directive on a line independently', function () {
+    expect(blankDirectives('<p>{{store url="foo"}} and {{block type="x"}}</p>'))
+        ->toBe('<p># and #</p>');
+});
+
+it('leaves markup without directives untouched', function () {
+    $in = '<img src="/media/wysiwyg/abby.png" alt="ABBY">';
+    expect(blankDirectives($in))->toBe($in);
+});
+
+it('does not touch a lone unclosed brace pair', function () {
+    expect(blankDirectives('<style>.foo { color: red }</style>'))
+        ->toBe('<style>.foo { color: red }</style>');
+});
+
+it('handles an empty string', function () {
+    expect(blankDirectives(''))->toBe('');
+});


### PR DESCRIPTION
When editing a CMS page or block that contains images referenced through a `{{media url="..."}}` directive, clicking **Validate HTML** reported a `Bad value "" for attribute "src" on element "img": Must be non-empty` error for every such image.

## Cause

`Mage_Adminhtml_Cms_WysiwygController::validateHtmlAction()` stripped all `{{...}}` template directives before sending the fragment to the W3C Nu validator:

```php
$html = preg_replace('/\{\{[^{}]*\}\}/', '', $html);
```

An attribute like `src="{{media url="wysiwyg/logo.png"}}"` therefore collapsed to `src=""`, and the validator correctly flagged the now-empty attribute — a false positive against markup that renders fine on the frontend.

## Fix

Replace directives with a non-empty placeholder (`#`) instead of removing them, so `src="{{...}}"` becomes `src="#"`. The placeholder is non-empty and always a syntactically valid URL, so it clears the empty-value error without introducing any new one, and requires no store/context resolution or block execution. The substitution only affects the copy sent to the validator; saved CMS content is untouched.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->