### PR TITLE
Updated TipTap editor to 3.27.1

### DIFF
--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2025-2026 Maho <https://mahocommerce.com>
 // SPDX-License-Identifier: AFL-3.0
 
-import { Editor, Node, Mark, Extension, mergeAttributes, ResizableNodeView } from 'https://esm.sh/@tiptap/core@3.26.0';
-import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.26.0';
-import Image from 'https://esm.sh/@tiptap/extension-image@3.26.0';
-import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.26.0';
-import { Table, TableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.26.0';
-import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.26.0';
-import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.26.0';
+import { Editor, Node, Mark, Extension, mergeAttributes, ResizableNodeView } from 'https://esm.sh/@tiptap/core@3.27.1';
+import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.27.1';
+import Image from 'https://esm.sh/@tiptap/extension-image@3.27.1';
+import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.27.1';
+import { Table, TableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.27.1';
+import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.27.1';
+import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.27.1';
 import { MahoColumns, MahoColumn, COLUMN_PRESETS } from './extensions/columns.js';
 import { MahoBentoGrid, MahoBentoCell, BENTO_PRESETS } from './extensions/bento.js';
 

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/bento.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/bento.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
 // SPDX-License-Identifier: AFL-3.0
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.26.0';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.27.1';
 import { findParentNodeOfType, createGridNodeView } from './grid-utils.js';
 
 /**

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025-2026 Maho <https://mahocommerce.com>
 // SPDX-License-Identifier: AFL-3.0
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.26.0';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.27.1';
 import { findParentNodeOfType, createGridNodeView } from './grid-utils.js';
 
 /**


### PR DESCRIPTION
Bumped the WYSIWYG editor's TipTap dependency from 3.26.0 to 3.27.1 (current latest) across all esm.sh imports:

- `public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js` (core, starter-kit, image, text-align, table, bubble-menu, drag-handle)
- `public/js/mage/adminhtml/wysiwyg/tiptap/extensions/bento.js` (core)
- `public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js` (core)

### Release notes reviewed (3.26.0 → 3.27.1)

- **3.26.1** — drag/collaboration fixes (node-range block duplication, multi-block drag selection restore).
- **3.27.0** — ordered-list `type` attribute support, suggestion-popup improvements, `isAllowedUri` hyphen-protocol fix, `parseAttributes` accepting any word char at start of class/id. The only breaking change removed legacy exports from `@tiptap/server-ai-toolkit`, which we don't use.
- **3.27.1** — drag-handle `dragImageProperties` margin fix, ordered-list parsing fix, placeholder flicker-under-modal fix.

None of the changes require adjustments to our custom extensions, and no custom code became redundant. Pure version bump.