### PR TITLE
Fixed bogus "content not supported" warning for tables in the WYSIWYG editor

### DIFF
--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
@@ -5,11 +5,27 @@ import { Editor, Node, Mark, Extension, mergeAttributes, ResizableNodeView } fro
 import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.27.1';
 import Image from 'https://esm.sh/@tiptap/extension-image@3.27.1';
 import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.27.1';
-import { Table, TableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.27.1';
+import { Table, TableRow as BaseTableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.27.1';
 import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.27.1';
 import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.27.1';
 import { MahoColumns, MahoColumn, COLUMN_PRESETS } from './extensions/columns.js';
 import { MahoBentoGrid, MahoBentoCell, BENTO_PRESETS } from './extensions/bento.js';
+
+// prosemirror-tables has no parse rules for the table wrappers browsers (and TipTap itself) emit,
+// so with `enableContentCheck` on TipTap's catch-all rule flags them and falsely warns that valid
+// tables are "not supported". `skip` keeps the rows inside the row-group sections; `ignore` drops
+// the presentational <colgroup> (and its <col> children) whose widths already live on the cells.
+const TableRow = BaseTableRow.extend({
+    parseHTML() {
+        return [
+            ...(this.parent?.() ?? [{ tag: 'tr' }]),
+            { tag: 'tbody', skip: true },
+            { tag: 'thead', skip: true },
+            { tag: 'tfoot', skip: true },
+            { tag: 'colgroup', ignore: true },
+        ];
+    },
+});
 
 export {
     Editor, Node, Mark, Extension, StarterKit, TextAlign,


### PR DESCRIPTION
## Problem

Opening a CMS page/block/etc. whose content contains a table triggered a *"Some content is not supported. Clean and continue?"* dialog in the TipTap WYSIWYG editor — even for tables the editor itself created. Confirming would strip the table.

## Cause

When the editor loads with `enableContentCheck: true`, TipTap appends a catch-all parse rule (`{ tag: '*' }`) that flags any element matching *no* real parse rule as "invalid content". `prosemirror-tables` has rules for `<table>`/`<tr>`/`<td>`/`<th>` but **none for the structural wrappers** `<tbody>`/`<thead>`/`<tfoot>`/`<colgroup>`. Normally ProseMirror silently descends through those wrappers, but the catch-all intercepts them first and reports e.g. `Invalid element found: <tbody>`.

Since both the browser's HTML parser and TipTap's own `renderHTML` emit `<tbody>` (and resizable tables add `<colgroup>`), **every saved table** produced this false warning.

## Fix

Extend the `TableRow` extension with explicit parse rules for the wrappers so they pre-empt the catch-all:

- `skip: true` for `<tbody>`/`<thead>`/`<tfoot>` — drops the wrapper node while keeping its rows/cells.
- `ignore: true` for `<colgroup>` — discards the purely presentational element (and its `<col>` children; column widths already live on the cells).

This changes nothing about how tables render or edit — ProseMirror already handled these wrappers transparently at runtime — it only stops the content check from false-flagging them.

## Testing

Verified against the live editor schema and end-to-end in the admin: a page with a 7×4 image table now loads directly into WYSIWYG mode with no warning and all rows/cells/images intact.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->