### PR TITLE
Fixed the table toolbar appearing in the top-left corner of the WYSIWYG editor

### DIFF
--- a/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
@@ -296,7 +296,10 @@ class tiptapWysiwygSetup {
                     shouldShow: ({ editor, view, state, oldState }) => {
                         const isInTable = editor.isActive('table');
                         const isInCell = editor.isActive('tableCell') || editor.isActive('tableHeader');
-                        const shouldShow = isInTable && isInCell;
+                        // Require focus: TipTap only positions the menu while the editor is focused,
+                        // so without this the menu shows unpositioned (top-left) whenever the initial
+                        // selection happens to land in a table cell (e.g. a doc ending with a table).
+                        const shouldShow = editor.isFocused && isInTable && isInCell;
                         tableBubbleMenu.style.display = shouldShow ? 'flex' : 'none';
                         return shouldShow;
                     },
@@ -504,6 +507,7 @@ class tiptapWysiwygSetup {
 
         bubbleMenu.id = `${this.id}_table_bubble_menu`;
         bubbleMenu.className = 'tiptap-bubble-menu';
+        bubbleMenu.style.display = 'none';
         return bubbleMenu;
     }
 


### PR DESCRIPTION
## Problem

When a CMS page/block whose content **ends with a table** was opened in the WYSIWYG editor, the table toolbar (Columns / Rows / Alignment / Cells / Delete) appeared floating in the **top-left corner of the screen** instead of being hidden.

This became visible after #1083 (tables now actually render in WYSIWYG mode rather than being kept in plain-text mode by a bogus content-check warning), which exposed this pre-existing bubble-menu bug.

## Cause

The table bubble menu's `shouldShow` callback only checked `editor.isActive('table')`, not whether the editor was **focused**:

- On load, ProseMirror's default selection lands at the end of the document. When the doc ends with a table, that position is inside the last table cell, so `isActive('table')` is `true`.
- TipTap only *positions* a bubble menu while the editor has focus. With no focus, `shouldShow` still returned `true`, so the menu was displayed but never positioned — rendering at `(0, 0)`.

## Fix

- Add `editor.isFocused` to the `shouldShow` condition so the menu only shows when the user is actually editing a table (this is the real fix).
- Set the table menu's initial `display: none`, matching the existing `createColumnsBubbleMenu` / `createBentoBubbleMenu` factories which already do this — the table one was the only one missing it.

No change to how the menu behaves once you click into a table.

## Testing

Verified end-to-end in the admin: on load the menu stays hidden even though the selection is in a table; clicking into a cell shows it correctly anchored above the cell.