### PR TITLE
Retired the customer-address fax field from forms and new installs

### DIFF
--- a/app/code/core/Mage/Checkout/data/checkout_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Checkout/data/checkout_setup/data-install-1.6.0.0.php
@@ -161,12 +161,6 @@ $setup->insert($installer->getTable('eav/form_element'), [
     'attribute_id'  => $installer->getAttributeId($addressEntityTypeId, 'telephone'),
     'sort_order'    => $elementSort++,
 ]);
-$setup->insert($installer->getTable('eav/form_element'), [
-    'type_id'       => $formTypeId,
-    'fieldset_id'   => null,
-    'attribute_id'  => $installer->getAttributeId($addressEntityTypeId, 'fax'),
-    'sort_order'    => $elementSort++,
-]);
 if ($showDob) {
     $setup->insert($installer->getTable('eav/form_element'), [
         'type_id'       => $formTypeId,
@@ -293,12 +287,6 @@ $setup->insert($installer->getTable('eav/form_element'), [
     'attribute_id'  => $installer->getAttributeId($addressEntityTypeId, 'telephone'),
     'sort_order'    => $elementSort++,
 ]);
-$setup->insert($installer->getTable('eav/form_element'), [
-    'type_id'       => $formTypeId,
-    'fieldset_id'   => null,
-    'attribute_id'  => $installer->getAttributeId($addressEntityTypeId, 'fax'),
-    'sort_order'    => $elementSort++,
-]);
 if ($showDob) {
     $setup->insert($installer->getTable('eav/form_element'), [
         'type_id'       => $formTypeId,
@@ -415,12 +403,6 @@ $setup->insert($installer->getTable('eav/form_element'), [
     'attribute_id'  => $installer->getAttributeId($addressEntityTypeId, 'telephone'),
     'sort_order'    => $elementSort++,
 ]);
-$setup->insert($installer->getTable('eav/form_element'), [
-    'type_id'       => $formTypeId,
-    'fieldset_id'   => null,
-    'attribute_id'  => $installer->getAttributeId($addressEntityTypeId, 'fax'),
-    'sort_order'    => $elementSort++,
-]);
 
 /**
  *****************************************************************************
@@ -519,12 +501,6 @@ $setup->insert($installer->getTable('eav/form_element'), [
     'type_id'       => $formTypeId,
     'fieldset_id'   => null,
     'attribute_id'  => $installer->getAttributeId($addressEntityTypeId, 'telephone'),
-    'sort_order'    => $elementSort++,
-]);
-$setup->insert($installer->getTable('eav/form_element'), [
-    'type_id'       => $formTypeId,
-    'fieldset_id'   => null,
-    'attribute_id'  => $installer->getAttributeId($addressEntityTypeId, 'fax'),
     'sort_order'    => $elementSort++,
 ]);
 

--- a/app/code/core/Mage/Core/etc/jstranslator.xml
+++ b/app/code/core/Mage/Core/etc/jstranslator.xml
@@ -49,9 +49,6 @@ SPDX-License-Identifier: AFL-3.0
         <validate-phone-lax translate="message">
             <message>Please enter a valid phone number. For example (123) 456-7890 or 123-456-7890.</message>
         </validate-phone-lax>
-        <validate-fax translate="message">
-            <message>Please enter a valid fax number. For example (123) 456-7890 or 123-456-7890.</message>
-        </validate-fax>
         <validate-date translate="message">
             <message>Please enter a valid date.</message>
         </validate-date>

--- a/app/code/core/Mage/Customer/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Setup.php
@@ -427,15 +427,6 @@ class Mage_Customer_Model_Resource_Setup extends Mage_Eav_Model_Entity_Setup
                         'validate_rules'     => 'a:2:{s:15:"max_text_length";i:255;s:15:"min_text_length";i:1;}',
                         'position'           => 120,
                     ],
-                    'fax'                => [
-                        'type'               => 'varchar',
-                        'label'              => 'Fax',
-                        'input'              => 'text',
-                        'required'           => false,
-                        'sort_order'         => 130,
-                        'validate_rules'     => 'a:2:{s:15:"max_text_length";i:255;s:15:"min_text_length";i:1;}',
-                        'position'           => 130,
-                    ],
                 ],
             ],
         ];

--- a/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-2.0.1-2.0.2.php
+++ b/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-2.0.1-2.0.2.php
@@ -12,10 +12,11 @@ declare(strict_types=1);
 $installer = $this;
 $installer->startSetup();
 
-// The customer-address "fax" field is an anachronism. We stop offering it, but we must never
-// drop merchant data. So: on installs that hold stored fax values, keep the attribute and just
-// hide it; on installs with no fax data (fresh installs, or existing ones that never used it),
-// remove the attribute entirely. Either way it stops rendering in every EAV form.
+// The customer-address "fax" field is an anachronism, no longer created on fresh installs (it was
+// removed from Mage_Customer_Model_Resource_Setup::getDefaultEntities()). This upgrade cleans up
+// existing installs without ever dropping merchant data: where stored fax values exist we keep the
+// attribute and just hide it; where none exist (never used) we remove the attribute entirely. Fresh
+// installs never created the attribute, so this simply no-ops for them.
 $attributeId = $installer->getAttribute('customer_address', 'fax', 'attribute_id');
 if ($attributeId) {
     $connection = $installer->getConnection();

--- a/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-2.0.1-2.0.2.php
+++ b/app/code/core/Mage/Customer/data/customer_setup/data-upgrade-2.0.1-2.0.2.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Mage_Customer
+ */
+
+declare(strict_types=1);
+
+/** @var Mage_Customer_Model_Resource_Setup $this */
+$installer = $this;
+$installer->startSetup();
+
+// The customer-address "fax" field is an anachronism. We stop offering it, but we must never
+// drop merchant data. So: on installs that hold stored fax values, keep the attribute and just
+// hide it; on installs with no fax data (fresh installs, or existing ones that never used it),
+// remove the attribute entirely. Either way it stops rendering in every EAV form.
+$attributeId = $installer->getAttribute('customer_address', 'fax', 'attribute_id');
+if ($attributeId) {
+    $connection = $installer->getConnection();
+
+    // Drop it from every customer/address form (admin + frontend) regardless of the branch below.
+    $connection->delete(
+        $installer->getTable('customer/form_attribute'),
+        ['attribute_id = ?' => $attributeId],
+    );
+
+    $valueTable = $installer->getTable('customer/address_entity') . '_varchar';
+    $hasStoredData = (int) $connection->fetchOne(
+        $connection->select()
+            ->from($valueTable, 'COUNT(*)')
+            ->where('attribute_id = ?', $attributeId),
+    );
+
+    if ($hasStoredData > 0) {
+        // Preserve the data, but hide the field. is_system=1 + is_visible=0 is the canonical
+        // "hidden system attribute" state (see the historical customer_setup data scripts).
+        $installer->updateAttribute('customer_address', 'fax', 'is_visible', 0);
+    } else {
+        $installer->removeAttribute('customer_address', 'fax');
+    }
+}
+
+$installer->endSetup();

--- a/app/code/core/Mage/Customer/etc/config.xml
+++ b/app/code/core/Mage/Customer/etc/config.xml
@@ -169,10 +169,6 @@ SPDX-License-Identifier: AFL-3.0
                     <billing>1</billing>
                     <shipping>1</shipping>
                 </company>
-                <fax>
-                    <billing>1</billing>
-                    <shipping>1</shipping>
-                </fax>
             </customer_dataflow>
         </fieldsets>
     </admin>

--- a/app/code/core/Mage/Customer/etc/config.xml
+++ b/app/code/core/Mage/Customer/etc/config.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AFL-3.0
 <config>
     <modules>
         <Mage_Customer>
-            <version>2.0.1</version>
+            <version>2.0.2</version>
         </Mage_Customer>
     </modules>
     <admin>

--- a/app/code/core/Mage/Customer/etc/config.xml
+++ b/app/code/core/Mage/Customer/etc/config.xml
@@ -532,7 +532,6 @@ SPDX-License-Identifier: AFL-3.0
 {{if city}}{{var city}},  {{/if}}{{if region}}{{var region}}, {{/if}}{{if postcode}}{{var postcode}}{{/if}}
 {{var country}}
 T: {{var telephone}}
-{{depend fax}}F: {{var fax}}{{/depend}}
 {{depend vat_id}}VAT: {{var vat_id}}{{/depend}}</text>
                 <oneline>{{depend prefix}}{{var prefix}} {{/depend}}{{var firstname}} {{depend middlename}}{{var middlename}} {{/depend}}{{var lastname}}{{depend suffix}} {{var suffix}}{{/depend}}, {{var street}}, {{var city}}, {{var region}} {{var postcode}}, {{var country}}</oneline>
                 <html><![CDATA[{{depend prefix}}{{var prefix}} {{/depend}}{{var firstname}} {{depend middlename}}{{var middlename}} {{/depend}}{{var lastname}}{{depend suffix}} {{var suffix}}{{/depend}}<br/>
@@ -544,7 +543,6 @@ T: {{var telephone}}
 {{if city}}{{var city}},  {{/if}}{{if region}}{{var region}}, {{/if}}{{if postcode}}{{var postcode}}{{/if}}<br/>
 {{var country}}<br/>
 {{depend telephone}}T: {{var telephone}}{{/depend}}
-{{depend fax}}<br/>F: {{var fax}}{{/depend}}
 {{depend vat_id}}<br/>VAT: {{var vat_id}}{{/depend}}]]></html>
                 <pdf><![CDATA[{{depend prefix}}{{var prefix}} {{/depend}}{{var firstname}} {{depend middlename}}{{var middlename}} {{/depend}}{{var lastname}}{{depend suffix}} {{var suffix}}{{/depend}}|
 {{depend company}}{{var company}}|{{/depend}}
@@ -557,9 +555,8 @@ T: {{var telephone}}
 {{if region}}{{var region}}, {{/if}}{{if postcode}}{{var postcode}}{{/if}}|
 {{var country}}|
 {{depend telephone}}T: {{var telephone}}{{/depend}}|
-{{depend fax}}<br/>F: {{var fax}}{{/depend}}|
 {{depend vat_id}}<br/>VAT: {{var vat_id}}{{/depend}}|]]></pdf>
-                <js_template><![CDATA[#{prefix} #{firstname} #{middlename} #{lastname} #{suffix}<br/>#{company}<br/>#{street0}<br/>#{street1}<br/>#{street2}<br/>#{street3}<br/>#{city}, #{region}, #{postcode}<br/>#{country_id}<br/>T: #{telephone}<br/>F: #{fax}<br/>VAT: #{vat_id}]]></js_template>
+                <js_template><![CDATA[#{prefix} #{firstname} #{middlename} #{lastname} #{suffix}<br/>#{company}<br/>#{street0}<br/>#{street1}<br/>#{street2}<br/>#{street3}<br/>#{city}, #{region}, #{postcode}<br/>#{country_id}<br/>T: #{telephone}<br/>VAT: #{vat_id}]]></js_template>
             </address_templates>
         </customer>
         <admin>

--- a/app/code/core/Mage/Sales/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Setup.php
@@ -288,7 +288,6 @@ class Mage_Sales_Model_Resource_Setup extends Mage_Eav_Model_Entity_Setup
                     'postcode'                  => ['type' => 'static'],
                     'country_id'                => ['type' => 'static'],
                     'telephone'                 => ['type' => 'static'],
-                    'fax'                       => ['type' => 'static'],
 
                     'same_as_billing'           => ['type' => 'static'],
                     'free_shipping'             => ['type' => 'static'],
@@ -543,7 +542,6 @@ class Mage_Sales_Model_Resource_Setup extends Mage_Eav_Model_Entity_Setup
                     'postcode'              => [],
                     'country_id'            => ['type' => 'varchar'],
                     'telephone'             => [],
-                    'fax'                   => [],
 
                 ],
             ],

--- a/app/code/core/Mage/Sales/etc/config.xml
+++ b/app/code/core/Mage/Sales/etc/config.xml
@@ -60,9 +60,6 @@ SPDX-License-Identifier: AFL-3.0
                 <telephone>
                     <to_order>*</to_order>
                 </telephone>
-                <fax>
-                    <to_order>*</to_order>
-                </fax>
                 <region_id>
                     <to_order>*</to_order>
                 </region_id>
@@ -107,9 +104,6 @@ SPDX-License-Identifier: AFL-3.0
                 <telephone>
                     <to_order>*</to_order>
                 </telephone>
-                <fax>
-                    <to_order>*</to_order>
-                </fax>
                 <region_id>
                     <to_order>*</to_order>
                 </region_id>
@@ -339,10 +333,6 @@ SPDX-License-Identifier: AFL-3.0
                     <to_order_address>*</to_order_address>
                     <to_customer_address>*</to_customer_address>
                 </telephone>
-                <fax>
-                    <to_order_address>*</to_order_address>
-                    <to_customer_address>*</to_customer_address>
-                </fax>
                 <email>
                     <to_order_address>*</to_order_address>
                     <to_customer_address>*</to_customer_address>
@@ -681,9 +671,6 @@ SPDX-License-Identifier: AFL-3.0
                 <telephone>
                     <to_quote_address>*</to_quote_address>
                 </telephone>
-                <fax>
-                    <to_quote_address>*</to_quote_address>
-                </fax>
             </sales_convert_order_address>
             <sales_convert_order_payment>
                 <method>
@@ -883,9 +870,6 @@ SPDX-License-Identifier: AFL-3.0
                 <telephone>
                     <to_quote_address>*</to_quote_address>
                 </telephone>
-                <fax>
-                    <to_quote_address>*</to_quote_address>
-                </fax>
             </customer_address>
         </fieldsets>
         <models>

--- a/app/code/core/Mage/Sales/sql/schema.php
+++ b/app/code/core/Mage/Sales/sql/schema.php
@@ -212,7 +212,6 @@ return function (Schema $schema): void {
     $orderAddress->addColumn('quote_address_id', Types::INTEGER, ['notnull' => false]);
     $orderAddress->addColumn('region_id', Types::INTEGER, ['notnull' => false]);
     $orderAddress->addColumn('customer_id', Types::INTEGER, ['notnull' => false]);
-    $orderAddress->addColumn('fax', Types::STRING, ['length' => 255, 'notnull' => false]);
     $orderAddress->addColumn('region', Types::STRING, ['length' => 255, 'notnull' => false]);
     $orderAddress->addColumn('postcode', Types::STRING, ['length' => 255, 'notnull' => false]);
     $orderAddress->addColumn('lastname', Types::STRING, ['length' => 255, 'notnull' => false]);
@@ -897,7 +896,6 @@ return function (Schema $schema): void {
     $quoteAddress->addColumn('postcode', Types::STRING, ['length' => 255, 'notnull' => false]);
     $quoteAddress->addColumn('country_id', Types::STRING, ['length' => 255, 'notnull' => false]);
     $quoteAddress->addColumn('telephone', Types::STRING, ['length' => 255, 'notnull' => false]);
-    $quoteAddress->addColumn('fax', Types::STRING, ['length' => 255, 'notnull' => false]);
     $quoteAddress->addColumn('same_as_billing', Types::SMALLINT, ['unsigned' => true, 'default' => 0]);
     $quoteAddress->addColumn('free_shipping', Types::SMALLINT, ['unsigned' => true, 'default' => 0]);
     $quoteAddress->addColumn('collect_shipping_rates', Types::SMALLINT, ['unsigned' => true, 'default' => 0]);

--- a/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/billing.phtml
@@ -108,12 +108,6 @@
                             <input type="tel" name="billing[telephone]" value="<?= $this->escapeHtml($this->getAddress()->getTelephone()) ?>" title="<?= $this->quoteEscape($this->__('Telephone')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('telephone') ?>" id="billing:telephone">
                         </div>
                     </div>
-                    <div class="field">
-                        <label for="billing:fax"><?= $this->__('Fax') ?></label>
-                        <div class="input-box">
-                            <input type="tel" name="billing[fax]" value="<?= $this->escapeHtml($this->getAddress()->getFax()) ?>" title="<?= $this->quoteEscape($this->__('Fax')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('fax') ?>" id="billing:fax">
-                        </div>
-                    </div>
                 </li>
                 <?php if(!$this->isCustomerLoggedIn()): ?>
                 <input type="hidden" name="checkout_method" value="guest">

--- a/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/onepage/shipping.phtml
@@ -99,12 +99,6 @@
                                 <input type="tel" name="shipping[telephone]" value="<?= $this->escapeHtml($this->getAddress()->getTelephone()) ?>" title="<?= $this->quoteEscape($this->__('Telephone')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('telephone') ?>" id="shipping:telephone" onchange="shipping.setSameAsBilling(false);">
                             </div>
                         </div>
-                        <div class="field">
-                            <label for="shipping:fax"><?= $this->__('Fax') ?></label>
-                            <div class="input-box">
-                                <input type="tel" name="shipping[fax]" value="<?= $this->escapeHtml($this->getAddress()->getFax()) ?>" title="<?= $this->quoteEscape($this->__('Fax')) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('fax') ?>" id="shipping:fax" onchange="shipping.setSameAsBilling(false);">
-                            </div>
-                        </div>
                     </li>
                 <?php if ($this->isCustomerLoggedIn() && $this->customerHasAddresses()):?>
                     <li class="control">

--- a/app/design/frontend/base/default/template/customer/address/edit.phtml
+++ b/app/design/frontend/base/default/template/customer/address/edit.phtml
@@ -44,12 +44,6 @@
                         <input type="tel" name="telephone" value="<?= $this->escapeHtml($this->getAddress()->getTelephone()) ?>" title="<?= $this->quoteEscape($this->__('Telephone')) ?>" class="input-text  <?= $this->helper('customer/address')->getAttributeValidationClass('telephone') ?>" id="telephone">
                     </div>
                 </div>
-                <div class="field">
-                    <label for="fax"><?= $this->__('Fax') ?></label>
-                    <div class="input-box">
-                        <input type="tel" name="fax" id="fax" title="<?= $this->quoteEscape($this->__('Fax')) ?>" value="<?= $this->escapeHtml($this->getAddress()->getFax()) ?>" class="input-text <?= $this->helper('customer/address')->getAttributeValidationClass('fax') ?>">
-                    </div>
-                </div>
             </li>
         </ul>
     </div>

--- a/app/locale/en_US/Mage_Checkout.csv
+++ b/app/locale/en_US/Mage_Checkout.csv
@@ -102,7 +102,6 @@
 "Estimate Shipping and Tax","Estimate Shipping and Tax"
 "Excl. Tax","Excl. Tax"
 "Failed to save billing address. Please try again.","Failed to save billing address. Please try again."
-"Fax","Fax"
 "Forgot your password?","Forgot your password?"
 "Get list of available payment methods","Get list of available payment methods"
 "Get list of available shipping methods","Get list of available shipping methods"

--- a/app/locale/en_US/Mage_Core.csv
+++ b/app/locale/en_US/Mage_Core.csv
@@ -345,6 +345,7 @@
 "Sender Email","Sender Email"
 "Sender Name","Sender Name"
 "Sent","Sent"
+"Server returned status %s","Server returned status %s"
 "Services","Services"
 "Session Cookie Management","Session Cookie Management"
 "Session Lifetime (seconds)","Session Lifetime (seconds)"

--- a/app/locale/en_US/Mage_Core.csv
+++ b/app/locale/en_US/Mage_Core.csv
@@ -283,7 +283,6 @@
 "Please enter a valid date less than or equal to %s","Please enter a valid date less than or equal to %s"
 "Please enter a valid day (1-%d).","Please enter a valid day (1-%d)."
 "Please enter a valid email address. For example johndoe@domain.com.","Please enter a valid email address. For example johndoe@domain.com."
-"Please enter a valid fax number. For example (123) 456-7890 or 123-456-7890.","Please enter a valid fax number. For example (123) 456-7890 or 123-456-7890."
 "Please enter a valid full date","Please enter a valid full date"
 "Please enter a valid month (1-12).","Please enter a valid month (1-12)."
 "Please enter a valid number in this field.","Please enter a valid number in this field."

--- a/app/locale/en_US/Mage_Customer.csv
+++ b/app/locale/en_US/Mage_Customer.csv
@@ -162,7 +162,6 @@
 "Enter the 6-digit code from your authenticator app to finish signing in.","Enter the 6-digit code from your authenticator app to finish signing in."
 "Excel XML","Excel XML"
 "Failed to confirm customer account.","Failed to confirm customer account."
-"Fax","Fax"
 "First Name","First Name"
 "Force all customers to set up two-factor authentication before they can use their account.","Force all customers to set up two-factor authentication before they can use their account."
 "Forgot and Remind Email Sender","Forgot and Remind Email Sender"

--- a/public/js/validation.js
+++ b/public/js/validation.js
@@ -486,9 +486,6 @@ Validation.addAllThese([
     ['validate-phoneLax', 'Please enter a valid phone number. For example (123) 456-7890 or 123-456-7890.', v => {
         return Validation.get('IsEmpty').test(v) || /^((\d[-. ]?)?((\(\d{3}\))|\d{3}))?[-. ]?\d{3}[-. ]?\d{4}$/.test(v);
     }],
-    ['validate-fax', 'Please enter a valid fax number. For example (123) 456-7890 or 123-456-7890.', v => {
-        return Validation.get('IsEmpty').test(v) || /^(\()?\d{3}(\))?(-|\s)?\d{3}(-|\s)\d{4}$/.test(v);
-    }],
     ['validate-date', 'Please enter a valid date.', v => {
         const test = new Date(v);
         return Validation.get('IsEmpty').test(v) || !isNaN(test);


### PR DESCRIPTION
## What & why

The customer-address **fax** field is a Magento 1-era anachronism. This retires it end to end (storefront, admin, new installs) while guaranteeing no existing merchant data is ever dropped.

## Changes

**Removed the field from customer-facing forms:**
- `customer/address/edit.phtml` (My Account address book)
- `checkout/onepage/billing.phtml`
- `checkout/onepage/shipping.phtml`

**Removed from the address-format templates** (`Customer/etc/config.xml`):
- Dropped the `{{depend fax}}` blocks from `text` / `html` / `pdf` and `F: #{fax}` from `js_template`, so rendered address blocks (frontend, PDF invoices, admin) no longer print a fax line. Only shipped defaults change; stores with customized templates keep their persisted DB values.

**Customer attribute, no longer created on fresh installs:**
- Removed the `fax` definition from `Mage_Customer_Model_Resource_Setup::getDefaultEntities()`. On a fresh install that is the only thing that creates the attribute; the two historical 1.4.x data scripts that reference `fax` sit below the `data-install-1.6.0.0` baseline, so they never run on a fresh install.
- Removed the four fax `eav_form_element` inserts from the Checkout baseline install (`Checkout/data/checkout_setup/data-install-1.6.0.0.php`). That script builds the address forms via `getAttributeId(..., 'fax')`; with the attribute gone the lookup returns an empty id, and PostgreSQL rejects `''` for the NOT NULL smallint `attribute_id` (MySQL silently coerced it to 0). This edits a baseline install rather than adding an upgrade because the crash happens during the install itself, which no later upgrade can prevent.
- Migration `data-upgrade-2.0.1-2.0.2.php` (version bump `2.0.1` to `2.0.2`) cleans up existing installs: it clears `fax` from every `customer/address` EAV form (so it also disappears from admin); where stored fax values exist it keeps the attribute plus data and sets `is_visible = 0`; where none exist it removes the attribute entirely. It no-ops on fresh installs. The `eav_form_element` FK to `eav_attribute` is ON DELETE CASCADE, so removing the attribute also cleans up any leftover form-element rows on existing installs.

**Sales flat columns, no longer created on fresh installs (existing data preserved):**
- Removed the `fax` column from `sales_flat_order_address` / `sales_flat_quote_address` in the declarative `Sales/sql/schema.php`, plus the matching vestigial static-attribute declarations in `Sales/Model/Resource/Setup.php`.
- The schema applier's additive-merge policy (`Maho\Db\Schema\Canonicalizer::preserveUndeclaredColumns`) re-merges any live-but-undeclared column into the target, so the diff never drops it. Existing installs keep the columns and all their data; only fresh installs omit them. The flat resource filters saves to real table columns, so a fresh install without the column silently ignores any fax value instead of erroring.

**Dead-code and mapping cleanup:**
- Removed the `validate-fax` JS validator (`validation.js`) and its `jstranslator.xml` plus `Mage_Core.csv` message, dead once no form uses it.
- Removed `fax` from the `customer_dataflow` import/export fieldset.
- Removed `fax` from the `sales_copy_*` / `sales_convert_*` fieldset-copy config, so quote-to-order and address-to-customer conversions no longer copy it.
- Removed the now-unused `Fax` labels from `Mage_Customer.csv` and `Mage_Checkout.csv`.
- Added the missing `Server returned status %s` en_US entry surfaced by the jstranslator lint.

## Left intact for backward compatibility
- SOAP `wsdl.xml` / `wsi.xml` address `fax` elements (Customer / Checkout / Sales), for API contract stability.
- Unrelated `fax` references that are not our field: FedEx carrier API WSDLs (FedEx's own contact-fax schema), the Authorize.net `x_fax` protocol parameter, and the `image/g3fax` MIME type in the uploader helper.