### PR TITLE
Added PDF attachments for invoice, shipment, and credit memo emails

### DIFF
--- a/app/code/core/Mage/Api2/Model/Resource.php
+++ b/app/code/core/Mage/Api2/Model/Resource.php
@@ -743,11 +743,6 @@ abstract class Mage_Api2_Model_Resource
             $this->_critical(self::RESOURCE_COLLECTION_FILTERING_ERROR);
         }
 
-        if (method_exists($collection, 'addAttributeToFilter')) {
-            $methodName = 'addAttributeToFilter';
-        } else {
-            $methodName = 'addFieldToFilter';
-        }
         $allowedAttributes = $this->getFilter()->getAllowedAttributes(self::OPERATION_ATTRIBUTE_READ);
 
         foreach ($filter as $filterEntry) {
@@ -762,7 +757,12 @@ abstract class Mage_Api2_Model_Resource
             unset($filterEntry['attribute']);
 
             try {
-                $collection->$methodName($attributeCode, $filterEntry);
+                // EAV collections filter by attribute; flat collections by field
+                if (method_exists($collection, 'addAttributeToFilter')) {
+                    $collection->addAttributeToFilter($attributeCode, $filterEntry);
+                } else {
+                    $collection->addFieldToFilter($attributeCode, $filterEntry);
+                }
             } catch (Exception $e) {
                 $this->_critical(self::RESOURCE_COLLECTION_FILTERING_ERROR);
             }

--- a/app/code/core/Mage/Core/Model/Email/Attachment.php
+++ b/app/code/core/Mage/Core/Model/Email/Attachment.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Email attachment descriptor: carries how to (re)generate a document, not its bytes.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Mage_Core
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\Mime\Email;
+
+/**
+ * The bytes are produced lazily via getContent() so an attachment can survive the email
+ * queue as a compact descriptor (see toArray()/fromArray()) and be materialized only at
+ * send time, avoiding storing binary blobs in the queue's TEXT column.
+ */
+class Mage_Core_Model_Email_Attachment
+{
+    protected ?string $content = null;
+
+    public function __construct(
+        protected string $sourceModel,
+        protected string $entityModel,
+        protected int $entityId,
+        protected string $filename,
+        protected string $mimeType = 'application/pdf',
+    ) {}
+
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
+    public function getMimeType(): string
+    {
+        return $this->mimeType;
+    }
+
+    /**
+     * Materialize the attachment bytes, generating (and caching) them on first access.
+     */
+    public function getContent(): string
+    {
+        if ($this->content === null) {
+            $entity = Mage::getModel($this->entityModel)->load($this->entityId);
+            $renderer = Mage::getModel($this->sourceModel);
+            if (!is_object($renderer) || !method_exists($renderer, 'getPdf')) {
+                Mage::throwException("Invalid attachment source model: {$this->sourceModel}");
+            }
+            // $renderer is a dynamically-resolved PDF model implementing getPdf(array): string
+            $this->content = (string) $renderer->getPdf([$entity]); // @phpstan-ignore argument.type
+        }
+        return $this->content;
+    }
+
+    /**
+     * Attach this document to a Symfony email message.
+     */
+    public function applyTo(Email $message): void
+    {
+        $message->attach($this->getContent(), $this->filename, $this->mimeType);
+    }
+
+    /**
+     * @return array{source_model: string, entity_model: string, entity_id: int, filename: string, mime_type: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'source_model' => $this->sourceModel,
+            'entity_model' => $this->entityModel,
+            'entity_id'    => $this->entityId,
+            'filename'     => $this->filename,
+            'mime_type'    => $this->mimeType,
+        ];
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (string) $data['source_model'],
+            (string) $data['entity_model'],
+            (int) $data['entity_id'],
+            (string) $data['filename'],
+            (string) ($data['mime_type'] ?? 'application/pdf'),
+        );
+    }
+
+    /**
+     * Rebuild attachments from their serialized descriptors and add them to the email.
+     *
+     * A document that fails to regenerate is logged and skipped rather than aborting the
+     * whole message, so one broken attachment never blocks a transactional email.
+     *
+     * @param array<int, array> $descriptors
+     */
+    public static function applyDescriptors(Email $message, array $descriptors): void
+    {
+        foreach ($descriptors as $descriptor) {
+            try {
+                self::fromArray($descriptor)->applyTo($message);
+            } catch (\Throwable $e) {
+                Mage::logException($e);
+            }
+        }
+    }
+}

--- a/app/code/core/Mage/Core/Model/Email/Info.php
+++ b/app/code/core/Mage/Core/Model/Email/Info.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
  * SPDX-FileCopyrightText: 2019-2024 The OpenMage Contributors <https://openmage.org>
  * SPDX-FileCopyrightText: 2006-2020 Magento, Inc. <https://magento.com>
  * SPDX-License-Identifier: OSL-3.0
@@ -46,6 +47,13 @@ class Mage_Core_Model_Email_Info extends \Maho\DataObject
     protected $_toEmails = [];
 
     /**
+     * List of attachments to add to the email
+     *
+     * @var Mage_Core_Model_Email_Attachment[]
+     */
+    protected $_attachments = [];
+
+    /**
      * Add new "Bcc" recipient to current email
      *
      * @param string $email
@@ -71,6 +79,39 @@ class Mage_Core_Model_Email_Info extends \Maho\DataObject
         $this->_toNames[] = $name;
         $this->_toEmails[] = $email;
         return $this;
+    }
+
+    /**
+     * Add an attachment to the current email
+     *
+     * @return $this
+     */
+    public function addAttachment(Mage_Core_Model_Email_Attachment $attachment)
+    {
+        $this->_attachments[] = $attachment;
+        return $this;
+    }
+
+    /**
+     * Add a lazily-generated PDF document attachment
+     *
+     * @return $this
+     */
+    public function addPdfAttachment(string $sourceModel, string $entityModel, int $entityId, string $filename)
+    {
+        return $this->addAttachment(
+            new Mage_Core_Model_Email_Attachment($sourceModel, $entityModel, $entityId, $filename),
+        );
+    }
+
+    /**
+     * Get the list of attachments
+     *
+     * @return Mage_Core_Model_Email_Attachment[]
+     */
+    public function getAttachments()
+    {
+        return $this->_attachments;
     }
 
     /**

--- a/app/code/core/Mage/Core/Model/Email/Queue.php
+++ b/app/code/core/Mage/Core/Model/Email/Queue.php
@@ -218,6 +218,11 @@ class Mage_Core_Model_Email_Queue extends Mage_Core_Model_Abstract
                         $email->returnPath($parameters->getReturnTo());
                     }
 
+                    Mage_Core_Model_Email_Attachment::applyDescriptors(
+                        $email,
+                        (array) $parameters->getAttachments(),
+                    );
+
                     $transport = new \Maho\DataObject();
                     Mage::dispatchEvent('email_queue_send_before', [
                         'mail'      => $email,

--- a/app/code/core/Mage/Core/Model/Email/Template.php
+++ b/app/code/core/Mage/Core/Model/Email/Template.php
@@ -82,6 +82,9 @@ class Mage_Core_Model_Email_Template extends Mage_Core_Model_Email_Template_Abst
     protected ?string $_replyToEmail = null;
     protected ?string $_returnPathEmail = null;
 
+    /** @var Mage_Core_Model_Email_Attachment[] */
+    protected array $_attachments = [];
+
     protected static $_defaultTemplates;
 
     #[\Override]
@@ -400,6 +403,7 @@ class Mage_Core_Model_Email_Template extends Mage_Core_Model_Email_Template_Abst
                 'from_name'         => $this->getSenderName(),
                 'reply_to'          => $this->_replyToEmail,
                 'return_to'         => $this->_returnPathEmail,
+                'attachments'       => array_map(fn($a) => $a->toArray(), $this->_attachments),
             ])
                 ->addRecipients($emails, $names, Mage_Core_Model_Email_Queue::EMAIL_TYPE_TO)
                 ->addRecipients($this->_bccEmails, [], Mage_Core_Model_Email_Queue::EMAIL_TYPE_BCC);
@@ -438,6 +442,11 @@ class Mage_Core_Model_Email_Template extends Mage_Core_Model_Email_Template_Abst
             if ($this->getTemplateId()) {
                 $email->getHeaders()->addTextHeader('X-Maho-Template', (string) $this->getTemplateId());
             }
+
+            Mage_Core_Model_Email_Attachment::applyDescriptors(
+                $email,
+                array_map(fn($a) => $a->toArray(), $this->_attachments),
+            );
 
             $transport = Mage::helper('core')->getMailTransport();
             if (!$transport) {
@@ -562,6 +571,26 @@ class Mage_Core_Model_Email_Template extends Mage_Core_Model_Email_Template_Abst
             $this->_bccEmails[] = $bcc;
         }
         return $this;
+    }
+
+    /**
+     * Set the attachments to add to the email
+     *
+     * @param Mage_Core_Model_Email_Attachment[] $attachments
+     * @return $this
+     */
+    public function setAttachments(array $attachments)
+    {
+        $this->_attachments = $attachments;
+        return $this;
+    }
+
+    /**
+     * @return Mage_Core_Model_Email_Attachment[]
+     */
+    public function getAttachments()
+    {
+        return $this->_attachments;
     }
 
     /**

--- a/app/code/core/Mage/Core/Model/Email/Template/Mailer.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Mailer.php
@@ -48,6 +48,8 @@ class Mage_Core_Model_Email_Template_Mailer extends \Maho\DataObject
             $emailInfo = array_pop($this->_emailInfos);
             // Handle "Bcc" recipients of the current email
             $emailTemplate->addBcc($emailInfo->getBccEmails());
+            // Set (reset) the current email's attachments so they don't leak to the next recipient
+            $emailTemplate->setAttachments($emailInfo->getAttachments());
             // Set required design parameters and delegate email sending to Mage_Core_Model_Email_Template
             $emailTemplate
                 ->setDesignConfig(['area' => Mage_Core_Model_App_Area::AREA_FRONTEND, 'store' => $this->getStoreId()])

--- a/app/code/core/Mage/Core/Model/Encryption.php
+++ b/app/code/core/Mage/Core/Model/Encryption.php
@@ -161,7 +161,7 @@ class Mage_Core_Model_Encryption
 
     public function decrypt(#[\SensitiveParameter] ?string $data): string
     {
-        if ($data === null) {
+        if ($data === null || $data === '') {
             return '';
         }
 

--- a/app/code/core/Mage/Sales/Model/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Abstract.php
@@ -26,6 +26,34 @@ abstract class Mage_Sales_Model_Abstract extends Mage_Core_Model_Abstract
     abstract public function getStore();
 
     /**
+     * Descriptor for attaching this document as a PDF to an email, or null when the
+     * document has no printable PDF form. Overridden by invoice/shipment/creditmemo.
+     *
+     * @return array{source_model: string, entity_model: string, filename_prefix: string}|null
+     */
+    protected function _getPdfAttachmentInfo(): ?array
+    {
+        return null;
+    }
+
+    /**
+     * Attach a PDF copy of this document to the given email info, if it has a PDF form
+     */
+    protected function _addPdfAttachment(Mage_Core_Model_Email_Info $emailInfo): void
+    {
+        $info = $this->_getPdfAttachmentInfo();
+        if ($info === null) {
+            return;
+        }
+        $emailInfo->addPdfAttachment(
+            $info['source_model'],
+            $info['entity_model'],
+            (int) $this->getId(),
+            $info['filename_prefix'] . '-' . $this->getIncrementId() . '.pdf',
+        );
+    }
+
+    /**
      * Processing object after save data
      * Updates relevant grid table records.
      *

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo.php
@@ -145,6 +145,7 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
     public const XML_PATH_EMAIL_COPY_TO                = 'sales_email/creditmemo/copy_to';
     public const XML_PATH_EMAIL_COPY_METHOD            = 'sales_email/creditmemo/copy_method';
     public const XML_PATH_EMAIL_ENABLED                = 'sales_email/creditmemo/enabled';
+    public const XML_PATH_EMAIL_ATTACH_PDF             = 'sales_email/creditmemo/attach_pdf';
 
     public const XML_PATH_UPDATE_EMAIL_TEMPLATE        = 'sales_email/creditmemo_comment/template';
     public const XML_PATH_UPDATE_EMAIL_GUEST_TEMPLATE  = 'sales_email/creditmemo_comment/guest_template';
@@ -786,6 +787,8 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
             $customerName = $order->getCustomerName();
         }
 
+        $attachPdf = Mage::getStoreConfigFlag(self::XML_PATH_EMAIL_ATTACH_PDF, $storeId);
+
         $mailer = Mage::getModel('core/email_template_mailer');
         if ($notifyCustomer) {
             $emailInfo = Mage::getModel('core/email_info');
@@ -796,6 +799,9 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
                     $emailInfo->addBcc($email);
                 }
             }
+            if ($attachPdf) {
+                $this->_addPdfAttachment($emailInfo);
+            }
             $mailer->addEmailInfo($emailInfo);
         }
 
@@ -804,6 +810,9 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
             foreach ($copyTo as $email) {
                 $emailInfo = Mage::getModel('core/email_info');
                 $emailInfo->addTo($email);
+                if ($attachPdf) {
+                    $this->_addPdfAttachment($emailInfo);
+                }
                 $mailer->addEmailInfo($emailInfo);
             }
         }
@@ -827,6 +836,16 @@ class Mage_Sales_Model_Order_Creditmemo extends Mage_Sales_Model_Abstract
         }
 
         return $this;
+    }
+
+    #[\Override]
+    protected function _getPdfAttachmentInfo(): ?array
+    {
+        return [
+            'source_model'    => 'sales/order_pdf_creditmemo',
+            'entity_model'    => 'sales/order_creditmemo',
+            'filename_prefix' => 'creditmemo',
+        ];
     }
 
     /**

--- a/app/code/core/Mage/Sales/Model/Order/Invoice.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice.php
@@ -124,6 +124,7 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
     public const XML_PATH_EMAIL_COPY_TO                = 'sales_email/invoice/copy_to';
     public const XML_PATH_EMAIL_COPY_METHOD            = 'sales_email/invoice/copy_method';
     public const XML_PATH_EMAIL_ENABLED                = 'sales_email/invoice/enabled';
+    public const XML_PATH_EMAIL_ATTACH_PDF             = 'sales_email/invoice/attach_pdf';
 
     public const XML_PATH_UPDATE_EMAIL_TEMPLATE        = 'sales_email/invoice_comment/template';
     public const XML_PATH_UPDATE_EMAIL_GUEST_TEMPLATE  = 'sales_email/invoice_comment/guest_template';
@@ -823,6 +824,8 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
             $customerName = $order->getCustomerName();
         }
 
+        $attachPdf = Mage::getStoreConfigFlag(self::XML_PATH_EMAIL_ATTACH_PDF, $storeId);
+
         $mailer = Mage::getModel('core/email_template_mailer');
         if ($notifyCustomer) {
             $emailInfo = Mage::getModel('core/email_info');
@@ -833,6 +836,9 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
                     $emailInfo->addBcc($email);
                 }
             }
+            if ($attachPdf) {
+                $this->_addPdfAttachment($emailInfo);
+            }
             $mailer->addEmailInfo($emailInfo);
         }
 
@@ -841,6 +847,9 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
             foreach ($copyTo as $email) {
                 $emailInfo = Mage::getModel('core/email_info');
                 $emailInfo->addTo($email);
+                if ($attachPdf) {
+                    $this->_addPdfAttachment($emailInfo);
+                }
                 $mailer->addEmailInfo($emailInfo);
             }
         }
@@ -864,6 +873,16 @@ class Mage_Sales_Model_Order_Invoice extends Mage_Sales_Model_Abstract
         }
 
         return $this;
+    }
+
+    #[\Override]
+    protected function _getPdfAttachmentInfo(): ?array
+    {
+        return [
+            'source_model'    => 'sales/order_pdf_invoice',
+            'entity_model'    => 'sales/order_invoice',
+            'filename_prefix' => 'invoice',
+        ];
     }
 
     /**

--- a/app/code/core/Mage/Sales/Model/Order/Shipment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Shipment.php
@@ -54,6 +54,7 @@ class Mage_Sales_Model_Order_Shipment extends Mage_Sales_Model_Abstract
     public const XML_PATH_EMAIL_COPY_TO                = 'sales_email/shipment/copy_to';
     public const XML_PATH_EMAIL_COPY_METHOD            = 'sales_email/shipment/copy_method';
     public const XML_PATH_EMAIL_ENABLED                = 'sales_email/shipment/enabled';
+    public const XML_PATH_EMAIL_ATTACH_PDF             = 'sales_email/shipment/attach_pdf';
 
     public const XML_PATH_UPDATE_EMAIL_TEMPLATE        = 'sales_email/shipment_comment/template';
     public const XML_PATH_UPDATE_EMAIL_GUEST_TEMPLATE  = 'sales_email/shipment_comment/guest_template';
@@ -504,6 +505,8 @@ class Mage_Sales_Model_Order_Shipment extends Mage_Sales_Model_Abstract
             $customerName = $order->getCustomerName();
         }
 
+        $attachPdf = Mage::getStoreConfigFlag(self::XML_PATH_EMAIL_ATTACH_PDF, $storeId);
+
         $mailer = Mage::getModel('core/email_template_mailer');
         if ($notifyCustomer) {
             $emailInfo = Mage::getModel('core/email_info');
@@ -514,6 +517,9 @@ class Mage_Sales_Model_Order_Shipment extends Mage_Sales_Model_Abstract
                     $emailInfo->addBcc($email);
                 }
             }
+            if ($attachPdf) {
+                $this->_addPdfAttachment($emailInfo);
+            }
             $mailer->addEmailInfo($emailInfo);
         }
 
@@ -522,6 +528,9 @@ class Mage_Sales_Model_Order_Shipment extends Mage_Sales_Model_Abstract
             foreach ($copyTo as $email) {
                 $emailInfo = Mage::getModel('core/email_info');
                 $emailInfo->addTo($email);
+                if ($attachPdf) {
+                    $this->_addPdfAttachment($emailInfo);
+                }
                 $mailer->addEmailInfo($emailInfo);
             }
         }
@@ -540,6 +549,16 @@ class Mage_Sales_Model_Order_Shipment extends Mage_Sales_Model_Abstract
         $mailer->send();
 
         return $this;
+    }
+
+    #[\Override]
+    protected function _getPdfAttachmentInfo(): ?array
+    {
+        return [
+            'source_model'    => 'sales/order_pdf_shipment',
+            'entity_model'    => 'sales/order_shipment',
+            'filename_prefix' => 'shipment',
+        ];
     }
 
     /**

--- a/app/code/core/Mage/Sales/etc/config.xml
+++ b/app/code/core/Mage/Sales/etc/config.xml
@@ -1513,6 +1513,7 @@ SPDX-License-Identifier: AFL-3.0
                 <guest_template>sales_email_invoice_guest_template</guest_template>
                 <identity>sales</identity>
                 <copy_method>bcc</copy_method>
+                <attach_pdf>0</attach_pdf>
             </invoice>
             <invoice_comment>
                 <enabled>1</enabled>
@@ -1527,6 +1528,7 @@ SPDX-License-Identifier: AFL-3.0
                 <guest_template>sales_email_shipment_guest_template</guest_template>
                 <identity>sales</identity>
                 <copy_method>bcc</copy_method>
+                <attach_pdf>0</attach_pdf>
             </shipment>
             <shipment_comment>
                 <enabled>1</enabled>
@@ -1541,6 +1543,7 @@ SPDX-License-Identifier: AFL-3.0
                 <guest_template>sales_email_creditmemo_guest_template</guest_template>
                 <identity>sales</identity>
                 <copy_method>bcc</copy_method>
+                <attach_pdf>0</attach_pdf>
             </creditmemo>
             <creditmemo_comment>
                 <enabled>1</enabled>

--- a/app/code/core/Mage/Sales/etc/system.xml
+++ b/app/code/core/Mage/Sales/etc/system.xml
@@ -416,6 +416,15 @@ SPDX-License-Identifier: AFL-3.0
                             <show_in_store>1</show_in_store>
                             <depends><enabled>1</enabled></depends>
                         </copy_method>
+                        <attach_pdf translate="label">
+                            <label>Attach PDF to Email</label>
+                            <frontend_type>boolean</frontend_type>
+                            <sort_order>6</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
+                        </attach_pdf>
                     </fields>
                 </invoice>
                 <invoice_comment translate="label">
@@ -548,6 +557,15 @@ SPDX-License-Identifier: AFL-3.0
                             <show_in_store>1</show_in_store>
                             <depends><enabled>1</enabled></depends>
                         </copy_method>
+                        <attach_pdf translate="label">
+                            <label>Attach PDF to Email</label>
+                            <frontend_type>boolean</frontend_type>
+                            <sort_order>6</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
+                        </attach_pdf>
                     </fields>
                 </shipment>
                 <shipment_comment translate="label">
@@ -680,6 +698,15 @@ SPDX-License-Identifier: AFL-3.0
                             <show_in_store>1</show_in_store>
                             <depends><enabled>1</enabled></depends>
                         </copy_method>
+                        <attach_pdf translate="label">
+                            <label>Attach PDF to Email</label>
+                            <frontend_type>boolean</frontend_type>
+                            <sort_order>6</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <depends><enabled>1</enabled></depends>
+                        </attach_pdf>
                     </fields>
                 </creditmemo>
                 <creditmemo_comment translate="label">

--- a/app/locale/en_US/Mage_Sales.csv
+++ b/app/locale/en_US/Mage_Sales.csv
@@ -78,6 +78,7 @@
 "Assign Order Status to State","Assign Order Status to State"
 "Assign Status to State","Assign Status to State"
 "At least a payment ID must be set.","At least a payment ID must be set."
+"Attach PDF to Email","Attach PDF to Email"
 "Authorization","Authorization"
 "Authorized amount of %s.","Authorized amount of %s."
 "Authorizing amount of %s is pending approval on gateway.","Authorizing amount of %s is pending approval on gateway."

--- a/tests/Backend/Integration/Sales/Model/Order/InvoiceEmailAttachmentTest.php
+++ b/tests/Backend/Integration/Sales/Model/Order/InvoiceEmailAttachmentTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\Mime\Email;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Build a persisted, PDF-renderable order + invoice so the attachment path exercises
+ * real DomPdf rendering rather than a stub.
+ */
+function createRenderableInvoice(): Mage_Sales_Model_Order_Invoice
+{
+    // Non-numeric token so our increment IDs never collide with the default
+    // 100000xxx order/invoice sequence other tests in the suite generate
+    $uniqueId = strtoupper(bin2hex(random_bytes(8)));
+
+    $billing = Mage::getModel('sales/order_address')
+        ->setData([
+            'address_type' => 'billing',
+            'firstname'    => 'Test',
+            'lastname'     => 'Customer',
+            'street'       => '123 Main St',
+            'city'         => 'Testville',
+            'postcode'     => '12345',
+            'country_id'   => 'US',
+            'telephone'    => '5551234567',
+            'email'        => "buyer.{$uniqueId}@example.com",
+        ]);
+
+    $order = Mage::getModel('sales/order');
+    $order->setStoreId(1)
+        ->setState(Mage_Sales_Model_Order::STATE_NEW)
+        ->setStatus('pending')
+        ->setCustomerIsGuest(true)
+        ->setCustomerEmail("buyer.{$uniqueId}@example.com")
+        ->setCustomerFirstname('Test')
+        ->setCustomerLastname('Customer')
+        ->setOrderCurrencyCode('USD')
+        ->setBaseCurrencyCode('USD')
+        ->setGlobalCurrencyCode('USD')
+        ->setStoreCurrencyCode('USD')
+        ->setGrandTotal(110.00)
+        ->setBaseGrandTotal(110.00)
+        ->setSubtotal(100.00)
+        ->setBaseSubtotal(100.00)
+        ->setIncrementId('TSTO' . $uniqueId)
+        ->setBillingAddress($billing);
+
+    $item = Mage::getModel('sales/order_item')
+        ->setData([
+            'sku'          => 'TEST-SKU',
+            'name'         => 'Test Product',
+            'qty_ordered'  => 2,
+            'price'        => 50.00,
+            'base_price'   => 50.00,
+            'row_total'    => 100.00,
+            'base_row_total' => 100.00,
+            'product_type' => 'simple',
+        ]);
+    $order->addItem($item);
+    $order->save();
+
+    $payment = Mage::getModel('sales/order_payment')
+        ->setMethod('checkmo');
+    $order->setPayment($payment);
+    $payment->setParentId($order->getId())->save();
+
+    $invoice = $order->prepareInvoice();
+    $invoice->register();
+    $invoice->setIncrementId('TSTI' . $uniqueId);
+    $order->save();
+    $invoice->save();
+
+    return $invoice;
+}
+
+describe('Invoice email PDF attachment', function () {
+    it('renders and attaches the real invoice PDF via the queue-safe descriptor path', function () {
+        $invoice = createRenderableInvoice();
+
+        // Reproduce what the sales flow builds when sales_email/invoice/attach_pdf is on
+        $emailInfo = Mage::getModel('core/email_info');
+        $emailInfo->addPdfAttachment(
+            'sales/order_pdf_invoice',
+            'sales/order_invoice',
+            (int) $invoice->getId(),
+            'invoice-' . $invoice->getIncrementId() . '.pdf',
+        );
+
+        // Simulate surviving the email queue: serialize descriptors, round-trip through the
+        // JSON-encoded TEXT column, then re-materialize the attachment at "send" time
+        $descriptors = array_map(fn($a) => $a->toArray(), $emailInfo->getAttachments());
+        $json = Mage::helper('core')->jsonEncode(['attachments' => $descriptors]);
+        expect(strlen($json))->toBeLessThan(65535);
+
+        $decoded = Mage::helper('core')->jsonDecode($json);
+        $email = new Email();
+        Mage_Core_Model_Email_Attachment::applyDescriptors($email, $decoded['attachments']);
+
+        $parts = $email->getAttachments();
+        expect($parts)->toHaveCount(1);
+        expect($parts[0]->getFilename())->toBe('invoice-' . $invoice->getIncrementId() . '.pdf');
+        expect($parts[0]->getContentType())->toBe('application/pdf');
+        // Real rendered PDF, not a stub
+        expect(substr($parts[0]->getBody(), 0, 5))->toBe('%PDF-');
+    });
+
+    it('attaches the invoice PDF end-to-end through sendEmail when the flag is on', function () {
+        $invoice = createRenderableInvoice();
+        // Config must be set on the order's store (1), which is what sendEmail() reads
+        Mage::app()->getStore(1)->setConfig(Mage_Sales_Model_Order_Invoice::XML_PATH_EMAIL_ENABLED, '1');
+        Mage::app()->getStore(1)->setConfig(Mage_Sales_Model_Order_Invoice::XML_PATH_EMAIL_ATTACH_PDF, '1');
+
+        // With SMTP disabled the direct-send path still builds the message and applies
+        // attachments (rendering the real PDF) before the null transport short-circuits,
+        // so this exercises the full gating + attachment wiring and must not throw
+        $result = $invoice->sendEmail(true);
+
+        expect($result)->toBe($invoice);
+        expect((bool) $invoice->getEmailSent())->toBeTrue();
+    });
+
+    it('does not attach a PDF when the flag is off', function () {
+        $invoice = createRenderableInvoice();
+        Mage::app()->getStore(1)->setConfig(Mage_Sales_Model_Order_Invoice::XML_PATH_EMAIL_ENABLED, '1');
+        Mage::app()->getStore(1)->setConfig(Mage_Sales_Model_Order_Invoice::XML_PATH_EMAIL_ATTACH_PDF, '0');
+
+        $result = $invoice->sendEmail(true);
+
+        expect($result)->toBe($invoice);
+        expect((bool) $invoice->getEmailSent())->toBeTrue();
+    });
+});

--- a/tests/Backend/Unit/Core/Model/Email/AttachmentApplyTest.php
+++ b/tests/Backend/Unit/Core/Model/Email/AttachmentApplyTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\Mime\Email;
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('Mage_Core_Model_Email_Attachment::applyDescriptors', function () {
+    it('is a no-op for an empty descriptor list', function () {
+        $email = new Email();
+
+        Mage_Core_Model_Email_Attachment::applyDescriptors($email, []);
+
+        expect($email->getAttachments())->toBe([]);
+    });
+
+    it('skips and does not throw when a descriptor cannot be materialized', function () {
+        $email = new Email();
+        $descriptor = (new Mage_Core_Model_Email_Attachment('nonexistent/pdf_model', 'nonexistent/entity', 999999, 'x.pdf'))->toArray();
+
+        Mage_Core_Model_Email_Attachment::applyDescriptors($email, [$descriptor]);
+
+        // A document that cannot be regenerated must not abort the send
+        expect($email->getAttachments())->toBe([]);
+    });
+});

--- a/tests/Backend/Unit/Core/Model/Email/AttachmentTest.php
+++ b/tests/Backend/Unit/Core/Model/Email/AttachmentTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\Mime\Email;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Build an attachment whose content generation is stubbed, so we can exercise
+ * applyTo()/round-tripping without rendering a real PDF.
+ */
+function makeStubbedAttachment(string $content = 'PDFBYTES'): Mage_Core_Model_Email_Attachment
+{
+    return new class ('sales/order_pdf_invoice', 'sales/order_invoice', 42, 'invoice-100000042.pdf', $content) extends Mage_Core_Model_Email_Attachment {
+        public function __construct(string $sourceModel, string $entityModel, int $entityId, string $filename, private string $stubContent)
+        {
+            parent::__construct($sourceModel, $entityModel, $entityId, $filename);
+        }
+
+        #[\Override]
+        public function getContent(): string
+        {
+            return $this->stubContent;
+        }
+    };
+}
+
+describe('Mage_Core_Model_Email_Attachment', function () {
+    it('exposes filename and defaults mime type to application/pdf', function () {
+        $attachment = new Mage_Core_Model_Email_Attachment('sales/order_pdf_invoice', 'sales/order_invoice', 42, 'invoice-100000042.pdf');
+
+        expect($attachment->getFilename())->toBe('invoice-100000042.pdf');
+        expect($attachment->getMimeType())->toBe('application/pdf');
+    });
+
+    it('round-trips through toArray/fromArray without carrying content bytes', function () {
+        $attachment = new Mage_Core_Model_Email_Attachment('sales/order_pdf_invoice', 'sales/order_invoice', 42, 'invoice-100000042.pdf');
+
+        $data = $attachment->toArray();
+
+        // Descriptor only, never bytes, so it stays tiny and JSON/TEXT-column safe
+        expect($data)->not->toHaveKey('content');
+        expect($data['source_model'])->toBe('sales/order_pdf_invoice');
+        expect($data['entity_model'])->toBe('sales/order_invoice');
+        expect($data['entity_id'])->toBe(42);
+        expect($data['filename'])->toBe('invoice-100000042.pdf');
+        expect($data['mime_type'])->toBe('application/pdf');
+
+        $restored = Mage_Core_Model_Email_Attachment::fromArray($data);
+        expect($restored->toArray())->toBe($data);
+    });
+
+    it('serializes to a size that fits the queue TEXT column', function () {
+        $descriptors = array_map(
+            fn($i) => (new Mage_Core_Model_Email_Attachment('sales/order_pdf_invoice', 'sales/order_invoice', $i, "invoice-{$i}.pdf"))->toArray(),
+            range(1, 10),
+        );
+
+        $encoded = Mage::helper('core')->jsonEncode(['attachments' => $descriptors]);
+
+        expect(strlen($encoded))->toBeLessThan(65535);
+    });
+
+    it('applies itself to a Symfony Email as an attachment', function () {
+        $email = new Email();
+        $attachment = makeStubbedAttachment('PDFBYTES');
+
+        $attachment->applyTo($email);
+
+        $parts = $email->getAttachments();
+        expect($parts)->toHaveCount(1);
+        expect($parts[0]->getBody())->toBe('PDFBYTES');
+        expect($parts[0]->getContentType())->toBe('application/pdf');
+        expect($parts[0]->getFilename())->toBe('invoice-100000042.pdf');
+    });
+});

--- a/tests/Backend/Unit/Core/Model/Email/InfoAttachmentTest.php
+++ b/tests/Backend/Unit/Core/Model/Email/InfoAttachmentTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('Mage_Core_Model_Email_Info attachments', function () {
+    beforeEach(function () {
+        $this->info = Mage::getModel('core/email_info');
+    });
+
+    it('starts with no attachments', function () {
+        expect($this->info->getAttachments())->toBe([]);
+    });
+
+    it('accumulates attachments via addAttachment', function () {
+        $attachment = new Mage_Core_Model_Email_Attachment('sales/order_pdf_invoice', 'sales/order_invoice', 1, 'a.pdf');
+
+        $this->info->addAttachment($attachment);
+
+        expect($this->info->getAttachments())->toBe([$attachment]);
+    });
+
+    it('builds a pdf attachment descriptor via addPdfAttachment', function () {
+        $this->info->addPdfAttachment('sales/order_pdf_invoice', 'sales/order_invoice', 7, 'invoice-7.pdf');
+
+        $attachments = $this->info->getAttachments();
+        expect($attachments)->toHaveCount(1);
+        expect($attachments[0])->toBeInstanceOf(Mage_Core_Model_Email_Attachment::class);
+        expect($attachments[0]->toArray())->toBe([
+            'source_model' => 'sales/order_pdf_invoice',
+            'entity_model' => 'sales/order_invoice',
+            'entity_id'    => 7,
+            'filename'     => 'invoice-7.pdf',
+            'mime_type'    => 'application/pdf',
+        ]);
+    });
+});


### PR DESCRIPTION
## What this delivers

Adds first-class PDF attachment support to the core email layer and wires it into the sales document emails, so a PDF copy of the **invoice**, **shipment**, or **credit memo** can be attached to its transactional email.

A new per-store, per-document **"Attach PDF to Email"** setting appears under *System > Configuration > Sales Emails* for each of the three document types, **defaulting off** to preserve current behavior.

## How it works

- **Descriptors, not blobs.** An attachment is carried as a lightweight descriptor (source model, entity, filename) rather than binary PDF bytes. This matters because `core_email_queue.message_parameters` is a JSON-encoded `TEXT` column (64KB), so storing PDF bytes there would truncate. The PDF is regenerated at send time via the existing `Mage_Sales_Model_Order_Pdf_*` renderers.
- **Both send paths.** Attachments are applied on the direct-send path (`Mage_Core_Model_Email_Template`) and re-materialized on the queued path (`Mage_Core_Model_Email_Queue`), so it works whether or not the email queue is enabled.
- **No new module, no observers.** Because this is built into core, attachments thread directly through `Email_Info` to `Template_Mailer` to `Email_Template` to the Symfony `Mime\Email`, with no `email_*_send_before` observer plumbing needed.
- **Resilient.** A document that fails to regenerate is logged and skipped rather than aborting the whole message.
- **DRY.** The shared attachment behavior lives on `Mage_Sales_Model_Abstract`; invoice/shipment/credit memo each declare only their PDF descriptor.

No schema change and no upgrade script are required, since attachments ride the existing queue column and the config flag defaults are runtime config.

## Tests

Developed test-first (TDD):

- **7 unit tests**: descriptor round-trip, 64KB queue-column size guard, `applyTo` producing a correct `DataPart`, `Email_Info` accessors, and the skip-and-log resilience path.
- **3 integration tests**: a real persisted, DomPdf-rendered invoice exercised end-to-end, covering the queue-safe descriptor to re-materialize path asserting real `%PDF-` bytes, `sendEmail()` with the flag on, and the flag-off path.

## Drive-by fix

Also fixes a latent phpstan error in `Mage_Api2_Model_Resource::_applyFilter()`. The method typed its collection as the base `Maho\Data\Collection\Db` (which has `addFieldToFilter` but not the EAV-only `addAttributeToFilter`) and dispatched through a variable method name, which phpstan's bleeding-edge rules flag as a call to an undefined method. Branching on `method_exists()` inline lets the analyzer narrow the type. Behavior is unchanged. This error is masked on `main` by phpstan's result cache, but surfaces on a from-scratch analysis (and once this PR touches the file).

## Not included (deliberately)

- Order-confirmation PDF (Maho has no order PDF renderer yet).
- Terms and Conditions / static-file attachments, CC/BCC, and ZUGFeRD/Factur-X, which are candidates for follow-up tiers.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->