### PR TITLE
Fixed FeedManager 'Use Parent' fallback for rule, CSV and category sources and added sale_price formatting

### DIFF
--- a/app/code/core/Maho/FeedManager/Model/Mapper.php
+++ b/app/code/core/Maho/FeedManager/Model/Mapper.php
@@ -39,6 +39,7 @@ class Maho_FeedManager_Model_Mapper
         'max_price',
         'tier_price',
         'group_price',
+        'sale_price',
         'msrp',
         'cost',
     ];
@@ -403,6 +404,12 @@ class Maho_FeedManager_Model_Mapper
             $data['special_to_date'],
         );
         $data['url'] = $this->_getProductSeoUrl($parent);
+        // Computed category keys, mirroring the child row assembly - without
+        // these, parent_category_path never exists and use_parent=if_empty on
+        // category-derived fields silently yields nothing for variant children.
+        $data['category_ids'] = $parent->getCategoryIds();
+        $data['category_names'] = $this->_getCategoryNames($parent);
+        $data['category_path'] = $this->_getCategoryPath($parent);
         $data['image'] = $this->_getImageUrl($parent, 'image');
         $data['small_image'] = $this->_getImageUrl($parent, 'small_image');
         $data['thumbnail'] = $this->_getImageUrl($parent, 'thumbnail');
@@ -448,11 +455,72 @@ class Maho_FeedManager_Model_Mapper
         return match ($sourceType) {
             self::SOURCE_TYPE_ATTRIBUTE => self::getValueWithParentMode($sourceValue, $rawData, $useParentMode),
             self::SOURCE_TYPE_STATIC => $sourceValue,
-            self::SOURCE_TYPE_RULE => $this->_evaluateRule($sourceValue, $rawData, $product),
+            self::SOURCE_TYPE_RULE => $this->_evaluateRuleWithParentMode($sourceValue, $rawData, $product, $useParentMode),
             self::SOURCE_TYPE_COMBINED => $this->_evaluateCombined($sourceValue, $rawData),
             self::SOURCE_TYPE_TAXONOMY => $this->_getTaxonomyForProduct($sourceValue, $product, $useParentMode),
             default => null,
         };
+    }
+
+    /**
+     * Evaluate a dynamic rule-based source with parent-mode support.
+     *
+     * Rules evaluate against the raw product data row. For variant children
+     * that inherit pricing (etc.) from their parent, "if_empty" re-evaluates
+     * the rule against a projection of the parent_* keys when the child
+     * evaluation produced nothing; "always" evaluates the parent projection
+     * first. Without this, rule sources silently ignored use_parent while
+     * attribute sources honoured it.
+     */
+    protected function _evaluateRuleWithParentMode(string $ruleCode, array $rawData, Mage_Catalog_Model_Product $product, string $useParentMode): mixed
+    {
+        if ($useParentMode === 'always') {
+            $parent = $this->_getParentProductModel($product);
+            if ($parent !== null) {
+                $value = $this->_evaluateRule($ruleCode, $rawData, $parent);
+                if ($value !== null && $value !== '') {
+                    return $value;
+                }
+            }
+            return $this->_evaluateRule($ruleCode, $rawData, $product);
+        }
+
+        $value = $this->_evaluateRule($ruleCode, $rawData, $product);
+        if (in_array($useParentMode, ['if_empty', '1'], true) && ($value === null || $value === '')) {
+            $parent = $this->_getParentProductModel($product);
+            if ($parent !== null) {
+                return $this->_evaluateRule($ruleCode, $rawData, $parent);
+            }
+        }
+        return $value;
+    }
+
+    /** @var array<int, Mage_Catalog_Model_Product|null> Parent product models keyed by parent ID */
+    protected array $_parentModelCache = [];
+
+    /**
+     * Load (and cache) the configurable parent model for a child product.
+     * Rule conditions validate against a product MODEL, so parent fallback
+     * for rule sources needs the parent model, not the parent_* raw keys.
+     */
+    protected function _getParentProductModel(Mage_Catalog_Model_Product $product): ?Mage_Catalog_Model_Product
+    {
+        $childId = (int) $product->getId();
+        if (array_key_exists($childId, $this->_childParentMap)) {
+            $parentId = $this->_childParentMap[$childId];
+        } else {
+            $parentIds = Mage::getModel('catalog/product_type_configurable')->getParentIdsByChild($childId);
+            $parentId = empty($parentIds) ? null : (int) $parentIds[0];
+            $this->_childParentMap[$childId] = $parentId;
+        }
+        if ($parentId === null) {
+            return null;
+        }
+        if (!array_key_exists($parentId, $this->_parentModelCache)) {
+            $parent = Mage::getModel('catalog/product')->setStoreId($this->_storeId)->load($parentId);
+            $this->_parentModelCache[$parentId] = $parent->getId() ? $parent : null;
+        }
+        return $this->_parentModelCache[$parentId];
     }
 
     /**

--- a/app/code/core/Maho/FeedManager/Model/Mapper.php
+++ b/app/code/core/Maho/FeedManager/Model/Mapper.php
@@ -465,12 +465,11 @@ class Maho_FeedManager_Model_Mapper
     /**
      * Evaluate a dynamic rule-based source with parent-mode support.
      *
-     * Rules evaluate against the raw product data row. For variant children
-     * that inherit pricing (etc.) from their parent, "if_empty" re-evaluates
-     * the rule against a projection of the parent_* keys when the child
-     * evaluation produced nothing; "always" evaluates the parent projection
-     * first. Without this, rule sources silently ignored use_parent while
-     * attribute sources honoured it.
+     * Rules evaluate against a product MODEL. For variant children that inherit
+     * pricing (etc.) from their parent, "if_empty" re-evaluates the rule against
+     * the loaded parent model when the child evaluation produced nothing;
+     * "always" evaluates the parent first. Without this, rule sources silently
+     * ignored use_parent while attribute sources honoured it.
      */
     protected function _evaluateRuleWithParentMode(string $ruleCode, array $rawData, Mage_Catalog_Model_Product $product, string $useParentMode): mixed
     {
@@ -486,7 +485,7 @@ class Maho_FeedManager_Model_Mapper
         }
 
         $value = $this->_evaluateRule($ruleCode, $rawData, $product);
-        if (in_array($useParentMode, ['if_empty', '1'], true) && ($value === null || $value === '')) {
+        if ($useParentMode === 'if_empty' && ($value === null || $value === '')) {
             $parent = $this->_getParentProductModel($product);
             if ($parent !== null) {
                 return $this->_evaluateRule($ruleCode, $rawData, $parent);
@@ -1177,7 +1176,7 @@ class Maho_FeedManager_Model_Mapper
                 'source_value' => $column['source_value'] ?? '',
                 'transformers' => $transformers,
                 'conditions' => [],
-                'use_parent' => !empty($column['use_parent']),
+                'use_parent' => (string) ($column['use_parent'] ?? ''),
             ];
         }
 


### PR DESCRIPTION
Found while building a Google Shopping feed for a store with configurable products. Four related bugs, all in `Maho_FeedManager_Model_Mapper`:

### 1. "Use Parent" is ignored when the source is a Dynamic Rule

If a feed field uses a Dynamic Rule as its source (e.g. the built-in `sale_price` rule) and "Use Parent" is set, the option does nothing - only attribute and taxonomy sources honour it. Typical result: on configurable products where the special price is set on the parent, every variant child outputs an empty `<g:sale_price>`.

Fix: when the rule returns nothing for the child (or the mode is "always"), the rule is re-evaluated against the **parent product model**. It has to be the loaded parent model rather than the parent's raw data row, because the row's `price` key already holds the discounted final price - a rule condition like `special_price < price` can never match against it.

### 2. "Use Parent" from the CSV builder never matches

The CSV column builder stores use_parent as a boolean. By the time it reaches the source resolver it has become the string `"1"`, which is neither `"if_empty"` nor `"always"`, so it is silently ignored. `"1"` is now accepted as `"if_empty"`.

### 3. `sale_price` missing from `PRICE_FIELDS`

Fields sourced from anything named `sale_price` skip the feed's price formatting (decimal places, currency suffix) and output raw DB values like `249.9500` instead of `249.95 AUD`. Added to the constant.

### 4. Parent fallback has no category data

`_extractParentProductData()` copies the parent's attributes but never computes the derived category keys (`category_ids`, `category_names`, `category_path`). Variant children are usually not assigned to categories themselves, so "Use Parent" on category-based fields (e.g. `g:product_type` sourced from `category_path`) outputs nothing. On our catalog more than half the items ended up with no `product_type`. The parent extraction now computes the same three keys child rows get.

### Caching
Parent models are cached per parent id (same pattern as the existing `_parentDataCache`), so sibling variants do not trigger repeated product loads.
