### PR TITLE
Fixed admin secret key validation failing with a silent 302 for routes migrated with legacy:migrate-routes

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/Url.php
+++ b/app/code/core/Mage/Adminhtml/Model/Url.php
@@ -106,12 +106,17 @@ class Mage_Adminhtml_Model_Url extends Mage_Core_Model_Url
     {
         $salt = Mage::getSingleton('core/session')->getFormKey();
 
+        // Prefer the dispatched request's controller/action over positional path
+        // parsing. The path heuristic assumes the classic admin/<controller>/<action>
+        // shape and breaks for routes migrated with legacy:migrate-routes, which carry
+        // an extra leading frontName segment (e.g. /admin/<frontName>/<controller>/<action>).
+        // The path fallback stays for early calls made before the request is dispatched.
         $p = explode('/', trim($this->getRequest()->getOriginalPathInfo(), '/'));
         if (!$controller) {
-            $controller = empty($p[1]) ? $this->getRequest()->getControllerName() : $p[1];
+            $controller = $this->getRequest()->getControllerName() ?: (empty($p[1]) ? null : $p[1]);
         }
         if (!$action) {
-            $action = empty($p[2]) ? $this->getRequest()->getActionName() : $p[2];
+            $action = $this->getRequest()->getActionName() ?: (empty($p[2]) ? null : $p[2]);
         }
 
         // Normalize case so the hash matches regardless of how the caller cased the

--- a/app/code/core/Mage/Adminhtml/Model/Url.php
+++ b/app/code/core/Mage/Adminhtml/Model/Url.php
@@ -106,11 +106,9 @@ class Mage_Adminhtml_Model_Url extends Mage_Core_Model_Url
     {
         $salt = Mage::getSingleton('core/session')->getFormKey();
 
-        // Prefer the dispatched request's controller/action over positional path
-        // parsing. The path heuristic assumes the classic admin/<controller>/<action>
-        // shape and breaks for routes migrated with legacy:migrate-routes, which carry
-        // an extra leading frontName segment (e.g. /admin/<frontName>/<controller>/<action>).
-        // The path fallback stays for early calls made before the request is dispatched.
+        // Prefer the dispatched request names; positional path parsing assumes the classic
+        // admin/<controller>/<action> shape and mis-slices legacy:migrate-routes routes that
+        // carry an extra frontName segment. The path fallback stays for pre-dispatch calls.
         $p = explode('/', trim($this->getRequest()->getOriginalPathInfo(), '/'));
         if (!$controller) {
             $controller = $this->getRequest()->getControllerName() ?: (empty($p[1]) ? null : $p[1]);


### PR DESCRIPTION
Fixes #1089.

## Problem

`Mage_Adminhtml_Model_Url::getSecretKey()` derives the controller/action from **positional URL path segments** when called with no explicit arguments (the validation path). This assumes the classic `admin/<controller>/<action>` two-segment shape.

Routes generated by `legacy:migrate-routes` for third-party admin modules carry an extra leading frontName segment, e.g. dispatched at `/admin/<frontName>/<controller>/<action>/...`. The positional parsing then reads the frontName as the controller and the controller as the action, so the validation hash never matches the one embedded at generation time. `_validateSecretKey()` fails → `FLAG_NO_DISPATCH` → a silent 302 back to the dashboard with no error logged, which is hard to diagnose.

## Fix

Prefer the already-dispatched request's `getControllerName()`/`getActionName()` over positional path parsing when no explicit controller/action is passed. Validation always runs after routing, so those names are authoritative; the path fallback stays for any pre-dispatch call.

- Migrated multi-segment admin routes now validate correctly.
- Classic core routes are unaffected — the request names and the path segments already agreed there.

The bug is in core (both the migration tool and the secret-key check are Maho-owned), so fixing it here retroactively repairs every already-migrated install with no re-migration needed.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->