### PR TITLE
Fixed Catalog > Categories and System > Configuration redirecting to the dashboard after an internal forward

### DIFF
--- a/app/code/core/Mage/Adminhtml/Model/Url.php
+++ b/app/code/core/Mage/Adminhtml/Model/Url.php
@@ -106,15 +106,22 @@ class Mage_Adminhtml_Model_Url extends Mage_Core_Model_Url
     {
         $salt = Mage::getSingleton('core/session')->getFormKey();
 
-        // Prefer the dispatched request names; positional path parsing assumes the classic
+        // Validate against what the user actually requested: after _forward() the dispatched
+        // names change (e.g. catalog_category/index forwards to edit) but the URL's key was
+        // minted for the original action, so the before-forward snapshot takes precedence.
+        // Dispatched names come next; positional path parsing assumes the classic
         // admin/<controller>/<action> shape and mis-slices legacy:migrate-routes routes that
-        // carry an extra frontName segment. The path fallback stays for pre-dispatch calls.
+        // carry an extra frontName segment, so it stays only as a pre-dispatch fallback.
         $p = explode('/', trim($this->getRequest()->getOriginalPathInfo(), '/'));
         if (!$controller) {
-            $controller = $this->getRequest()->getControllerName() ?: (empty($p[1]) ? null : $p[1]);
+            $controller = $this->getRequest()->getBeforeForwardInfo('controller_name')
+                ?: $this->getRequest()->getControllerName()
+                ?: (empty($p[1]) ? null : $p[1]);
         }
         if (!$action) {
-            $action = $this->getRequest()->getActionName() ?: (empty($p[2]) ? null : $p[2]);
+            $action = $this->getRequest()->getBeforeForwardInfo('action_name')
+                ?: $this->getRequest()->getActionName()
+                ?: (empty($p[2]) ? null : $p[2]);
         }
 
         // Normalize case so the hash matches regardless of how the caller cased the

--- a/tests/Backend/Unit/Adminhtml/Model/UrlTest.php
+++ b/tests/Backend/Unit/Adminhtml/Model/UrlTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Regression coverage for secret key validation across `_forward()` (#1091).
+ *
+ * Bug: `getSecretKey()` with no arguments preferred the *dispatched* controller/action
+ * names. After `indexAction()` calls `_forward('edit')` (Catalog > Categories,
+ * System > Configuration), preDispatch re-runs `_validateSecretKey()` with the request
+ * now pointing at `edit`, while the URL's key was minted for `index`: mismatch,
+ * silent 302 to the dashboard.
+ *
+ * Fix: prefer the before-forward snapshot (`getBeforeForwardInfo()`), i.e. validate
+ * against what the user actually requested.
+ */
+
+describe('Mage_Adminhtml_Model_Url::getSecretKey()', function () {
+    beforeEach(function () {
+        $this->url = Mage::getModel('adminhtml/url');
+        $this->request = Mage::app()->getRequest();
+        $this->request
+            ->setControllerName('catalog_category')
+            ->setActionName('index');
+    });
+
+    it('derives the key from the dispatched request when no forward happened', function () {
+        expect($this->url->getSecretKey())
+            ->toBe($this->url->getSecretKey('catalog_category', 'index'));
+    });
+
+    it('keeps validating against the originally requested action after _forward (regression #1091)', function () {
+        $keyInUrl = $this->url->getSecretKey('catalog_category', 'index');
+
+        // What Mage_Core_Controller_Varien_Action::_forward('edit') does to the request
+        $this->request->initForward();
+        $this->request->setActionName('edit');
+
+        expect($this->url->getSecretKey())->toBe($keyInUrl);
+    });
+
+    it('keeps validating against the original controller and action when _forward changes both', function () {
+        $keyInUrl = $this->url->getSecretKey('catalog_category', 'index');
+
+        // e.g. the ACL _forward('denied') re-dispatch
+        $this->request->initForward();
+        $this->request->setControllerName('index');
+        $this->request->setActionName('denied');
+
+        expect($this->url->getSecretKey())->toBe($keyInUrl);
+    });
+
+    it('lets explicit arguments override any request state', function () {
+        $this->request->initForward();
+        $this->request->setActionName('edit');
+
+        expect($this->url->getSecretKey('cms_page', 'save'))
+            ->toBe(Mage::getModel('adminhtml/url')->getSecretKey('cms_page', 'save'));
+    });
+});
+
+/**
+ * Regression coverage for #1089: routes migrated by legacy:migrate-routes carry an
+ * extra frontName segment (/admin/<frontName>/<controller>/<action>), so positional
+ * path parsing read the frontName as the controller and the controller as the action.
+ * The dispatched request names must win over path slicing.
+ */
+describe('Mage_Adminhtml_Model_Url::getSecretKey() path handling', function () {
+    beforeEach(function () {
+        $this->url = Mage::getModel('adminhtml/url');
+        $this->request = Mage::app()->getRequest();
+    });
+
+    it('prefers dispatched names over positional path segments for migrated routes (regression #1089)', function () {
+        // legacy:migrate-routes shape: admin/<frontName>/<controller>/<action>
+        $this->request->setOriginalPathInfo('/admin/feedmanager/feed/index/key/abc123/');
+        $this->request
+            ->setControllerName('feedmanager_feed')
+            ->setActionName('index');
+
+        // Positional parsing would hash 'feedmanager' + 'feed' here, the wrong pair.
+        expect($this->url->getSecretKey())
+            ->toBe($this->url->getSecretKey('feedmanager_feed', 'index'));
+    });
+
+    it('agrees with the path segments on classic admin/<controller>/<action> routes', function () {
+        $this->request->setOriginalPathInfo('/admin/catalog_product/edit/id/5/key/abc123/');
+        $this->request
+            ->setControllerName('catalog_product')
+            ->setActionName('edit');
+
+        expect($this->url->getSecretKey())
+            ->toBe($this->url->getSecretKey('catalog_product', 'edit'));
+    });
+
+    it('falls back to positional path segments before dispatch populates the request names', function () {
+        $this->request->setOriginalPathInfo('/admin/cms_page/edit/page_id/3/key/abc123/');
+
+        expect($this->url->getSecretKey())
+            ->toBe($this->url->getSecretKey('cms_page', 'edit'));
+    });
+});


### PR DESCRIPTION
Fixes #1091.

## Problem

Since #1090, clicking **Catalog > Categories** or **System > Configuration** in the admin silently 302s back to the dashboard. These are the only two menu entries whose `indexAction()` unconditionally calls `_forward('edit')`.

The sequence:

1. The menu URL carries a secret key hashed from `catalog_category` + `index`.
2. First dispatch validates fine, then `indexAction()` forwards to `edit`, which rewrites the request's action name and marks it undispatched.
3. The dispatch loop re-runs `preDispatch()` and `_validateSecretKey()`, which recomputes `getSecretKey()` with no arguments. After #1090 that prefers the *dispatched* names, now `edit`, while the URL's key was minted for `index`. Mismatch, then `FLAG_NO_DISPATCH`, then a silent redirect to the startup page.

Before #1090 the forward case only passed by accident: positional path parsing ignored forwards (the path doesn't change), but it had the mirror bug #1090 fixed. The tests added here prove the pre-#1090 code was broken in both directions: the forward case failed there too whenever path info was empty.

## Fix

`getSecretKey()` now resolves the controller/action in this order:

1. **Before-forward snapshot** (`getBeforeForwardInfo()`): validate against what the user actually requested, since that's what the URL's key was minted for. Also keeps the ACL `_forward('denied')` re-dispatch passing.
2. **Dispatched request names**: the #1090 behavior, so migrated multi-segment routes keep validating correctly.
3. **Positional path segments**: pre-dispatch fallback only.

## Tests

New `tests/Backend/Unit/Adminhtml/Model/UrlTest.php` covering both this regression and #1089:

- key derivation from the dispatched request (no forward)
- key stability across `_forward()` changing the action, and changing controller + action
- explicit arguments overriding request state
- migrated-route shape (`/admin/<frontName>/<controller>/<action>`) preferring dispatched names over mis-sliced path segments (#1089)
- classic-route path/name agreement
- positional fallback before dispatch populates the request names

Verified against history: the forward tests fail on `main` (post-#1090), and the #1089 + forward tests fail on pre-#1090 code, so the suite guards both bugs.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->