### PR TITLE
Made FeedManager's "Use Parent: always" strict for Dynamic Rule sources and added a currency_convert transformer

### DIFF
--- a/app/code/core/Maho/FeedManager/Model/Mapper.php
+++ b/app/code/core/Maho/FeedManager/Model/Mapper.php
@@ -476,10 +476,11 @@ class Maho_FeedManager_Model_Mapper
         if ($useParentMode === 'always') {
             $parent = $this->_getParentProductModel($product);
             if ($parent !== null) {
-                $value = $this->_evaluateRule($ruleCode, $rawData, $parent);
-                if ($value !== null && $value !== '') {
-                    return $value;
-                }
+                // Strict parent semantics: when a parent exists its result IS
+                // the answer, even when empty. Configurable storefront pricing
+                // ignores child specials entirely, so falling back to the
+                // child here would advertise sales the customer never gets.
+                return $this->_evaluateRule($ruleCode, $rawData, $parent);
             }
             return $this->_evaluateRule($ruleCode, $rawData, $product);
         }

--- a/app/code/core/Maho/FeedManager/Model/Transformer.php
+++ b/app/code/core/Maho/FeedManager/Model/Transformer.php
@@ -34,6 +34,7 @@ class Maho_FeedManager_Model_Transformer
         'combine_fields' => Maho_FeedManager_Model_Transformer_CombineFields::class, // Internal only - used by Mapper
         'conditional' => Maho_FeedManager_Model_Transformer_Conditional::class,
         'round' => Maho_FeedManager_Model_Transformer_Round::class,
+        'currency_convert' => Maho_FeedManager_Model_Transformer_CurrencyConvert::class,
         'uppercase' => Maho_FeedManager_Model_Transformer_Uppercase::class,
         'lowercase' => Maho_FeedManager_Model_Transformer_Lowercase::class,
         'capitalise' => Maho_FeedManager_Model_Transformer_Capitalise::class,
@@ -61,7 +62,7 @@ class Maho_FeedManager_Model_Transformer
     protected static array $_categories = [
         'text_formatting' => ['uppercase', 'lowercase', 'capitalise', 'strip_tags', 'truncate', 'replace'],
         'values_defaults' => ['default_value', 'map_values', 'conditional'],
-        'numbers_prices' => ['format_price', 'round'],
+        'numbers_prices' => ['format_price', 'round', 'currency_convert'],
         'dates_urls' => ['format_date', 'relative_date_range', 'url_encode'],
         'advanced' => ['prepend_append'],
     ];

--- a/app/code/core/Maho/FeedManager/Model/Transformer/CurrencyConvert.php
+++ b/app/code/core/Maho/FeedManager/Model/Transformer/CurrencyConvert.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Maho_FeedManager
+ */
+
+declare(strict_types=1);
+
+class Maho_FeedManager_Model_Transformer_CurrencyConvert extends Maho_FeedManager_Model_Transformer_AbstractTransformer
+{
+    protected string $_code = 'currency_convert';
+    protected string $_name = 'Convert Currency';
+    protected string $_description = 'Convert a numeric price from one currency to another using directory rates';
+
+    protected array $_optionDefinitions = [
+        'to' => [
+            'label' => 'Target Currency',
+            'type' => 'text',
+            'required' => true,
+            'note' => 'ISO currency code to convert to (e.g. NZD)',
+        ],
+        'from' => [
+            'label' => 'Source Currency',
+            'type' => 'text',
+            'required' => false,
+            'note' => 'ISO currency code to convert from (default: store base currency)',
+        ],
+    ];
+
+    #[\Override]
+    public function transform(mixed $value, array $options = [], array $productData = []): mixed
+    {
+        if (!is_numeric($value)) {
+            return $value;
+        }
+
+        $to = strtoupper(trim((string) ($options['to'] ?? '')));
+        if ($to === '') {
+            return $value;
+        }
+        $from = strtoupper(trim((string) ($options['from'] ?? '')));
+        if ($from === '') {
+            $from = (string) Mage::app()->getStore()->getBaseCurrencyCode();
+        }
+        if ($from === $to) {
+            return $value;
+        }
+
+        $rate = Mage::getModel('directory/currency')->load($from)->getRate($to);
+        if (!$rate) {
+            return $value;
+        }
+
+        return round((float) $value * (float) $rate, 4);
+    }
+}

--- a/tests/Backend/Unit/FeedManager/Model/TransformerTest.php
+++ b/tests/Backend/Unit/FeedManager/Model/TransformerTest.php
@@ -29,7 +29,8 @@ describe('Transformer Factory', function () {
             ->and($available)->toContain('lowercase')
             ->and($available)->toContain('capitalise')
             ->and($available)->toContain('relative_date_range')
-            ->and($available)->toHaveCount(16);
+            ->and($available)->toContain('currency_convert')
+            ->and($available)->toHaveCount(17);
     });
 
     test('getTransformer returns correct instance', function () {


### PR DESCRIPTION
Two follow-ups to #1088, found while continuing the same feed migration:

### 1. "Use Parent: always" should be strict for Dynamic Rule sources

The version merged in #1088 fell back to the child value when the parent produced nothing. That is wrong for configurable products: the storefront prices configurables from the **parent**, so a special price set only on a child variant is never what the customer actually pays. With the fallback, a child-only special produced a `<g:sale_price>` for a sale that does not exist on the site - Google flags these as price mismatches. With strict semantics the parent result is the answer, even when empty (products with no parent still use their own values).

### 2. New `currency_convert` transformer

FeedManager had no way to produce a converted-currency feed (e.g. an NZD Google feed from an AUD-base store) - `format_price` formats but never converts. The new transformer converts numeric values via the directory currency rates. Options: `to` (required, e.g. `NZD`), `from` (optional, defaults to the store base currency). Chain it before `format_price`:

```
currency_convert:to=NZD|format_price:currency=NZD,decimals=2
```

Verified on the same production-scale catalog as #1088: child-only specials no longer leak into sale_price (matches storefront pricing exactly), and the NZD feed produces converted values identical to the previous platform (rate-applied, 2dp).