### PR TITLE
Registered missing MCP, LSP, PayPal and feed CLI commands

### DIFF
--- a/maho
+++ b/maho
@@ -91,9 +91,17 @@ $application->addCommand(new \MahoCLI\Commands\TranslationsUnused());
 $application->addCommand(new \MahoCLI\Commands\CreateCommand());
 
 $application->addCommand(new \MahoCLI\Commands\DevModuleList());
+$application->addCommand(new \MahoCLI\Commands\DevLspStart());
+$application->addCommand(new \MahoCLI\Commands\DevMcpStart());
+$application->addCommand(new \MahoCLI\Commands\PaypalWebhookSimulate());
 
 $application->addCommand(new \MahoCLI\Commands\FrontendLayoutDebug());
 $application->addCommand(new \MahoCLI\Commands\FrontendThemeCreate());
+
+$application->addCommand(new \MahoCLI\Commands\FeedList());
+$application->addCommand(new \MahoCLI\Commands\FeedGenerate());
+$application->addCommand(new \MahoCLI\Commands\FeedGenerateAll());
+$application->addCommand(new \MahoCLI\Commands\FeedValidate());
 
 $discoverer = new CommandDiscoverer();
 $commands = array_merge(


### PR DESCRIPTION
## Problem

Seven core CLI commands were only reachable via `CommandDiscoverer` scanning the project root, and were **not** registered explicitly in the `maho` script like every other core command:

- `dev:mcp:start`
- `dev:lsp:start`
- `dev:paypal:webhook:simulate`
- `feed:list`
- `feed:generate`
- `feed:generate:all`
- `feed:validate`

In this repository they *appear* to work because the checkout root is the package itself, so the `discover(__DIR__)` scan finds them. But `CommandDiscoverer` deliberately skips `vendor/mahocommerce/maho`:

```php
if (str_contains($path, 'vendor/mahocommerce/maho')) {
    continue;
}
```

So in a real downstream installation, where Maho core lives under `vendor/mahocommerce/maho/lib/MahoCLI/Commands`, these commands are never discovered and are missing from `./maho list` entirely. Core commands are expected to be registered explicitly (which is why lines 26–96 exist); these seven simply slipped through.

## Fix

Register the seven commands explicitly alongside the existing core commands, following the established grouping/pattern. No behavioural change in the core-repo dev checkout; restores the commands in downstream installs.