### PR TITLE
Fixed TypeError in `EavConfig::getAttributes()` when called before store initialization

### DIFF
--- a/app/code/core/Mage/Eav/Model/Config.php
+++ b/app/code/core/Mage/Eav/Model/Config.php
@@ -521,8 +521,12 @@ class Mage_Eav_Model_Config
         $entityType = $this->getEntityType($entityType);
         $attributes = [];
         $storeId = $this->_storeId();
+        // Ensure the per-store attribute index is loaded (getAttribute() does the same). Without
+        // this, a caller in a context that has not yet initialized the store — e.g. an API request
+        // whose first EAV access is getAttributes() — hits array_keys(null) below.
+        $this->_initializeStore($storeId);
         // need to access attributes to ensure they are hydrated and initialized
-        foreach (array_keys($this->_entityTypeAttributes[$storeId][$entityType->getId()]) as $attributeId) {
+        foreach (array_keys($this->_entityTypeAttributes[$storeId][$entityType->getId()] ?? []) as $attributeId) {
             $attributes[] = $this->getAttribute($entityType, $attributeId, $storeId);
         }
 

--- a/tests/Backend/Integration/Eav/Model/ConfigTest.php
+++ b/tests/Backend/Integration/Eav/Model/ConfigTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Regression coverage for Mage_Eav_Model_Config::getAttributes().
+ *
+ * getAttributes() used to read $_entityTypeAttributes[$storeId][$entityTypeId]
+ * and call array_keys() on it WITHOUT first calling _initializeStore($storeId) —
+ * the guard its sibling getAttribute() has always had.
+ *
+ * The catch: _entityTypes is a GLOBAL list, but _entityTypeAttributes is keyed
+ * per store id. Once any earlier EAV access has populated _entityTypes (e.g. an
+ * admin-scope lookup during rest.php's Mage::init('admin')), getEntityType()
+ * inside getAttributes() stops triggering initialization. getAttributes() then
+ * called under a DIFFERENT, not-yet-initialized store scope hit array_keys(null)
+ * -> TypeError, 500-ing the request. This is why the API Platform layer (a cold
+ * library-mode boot that inits the admin store, then serves a frontend-scoped
+ * request) surfaced it, while ordinary frontend requests — which almost always
+ * initialize the current store first — did not.
+ */
+
+it('does not throw when getAttributes() is the first access for the current store scope', function (): void {
+    $store = Mage::app()->getDefaultStoreView();
+    if (!$store) {
+        foreach (Mage::app()->getStores() as $candidate) {
+            $store = $candidate;
+            break;
+        }
+    }
+    if (!$store) {
+        $this->markTestSkipped('No frontend store view available');
+    }
+    $frontendStoreId = (int) $store->getId();
+    expect($frontendStoreId)->toBeGreaterThan(0);
+
+    // Fresh, uninitialized config — mirrors a cold per-request singleton.
+    $config = new Mage_Eav_Model_Config();
+
+    // Prime the GLOBAL entity-type list under the ADMIN store scope (store 0),
+    // exactly like rest.php's Mage::init('admin') does before any frontend work.
+    // This populates _entityTypes and _entityTypeAttributes[0], but NOT the
+    // frontend store's per-store index.
+    $config->setCurrentStoreId(0);
+    $config->getAttribute('catalog_product', 'name');
+
+    // Switch to the frontend store whose per-store index was never built, then
+    // make getAttributes() the first access for that scope. Before the fix this
+    // threw "array_keys(): Argument #1 must be of type array, null given".
+    $config->setCurrentStoreId($frontendStoreId);
+    $attributes = $config->getAttributes('catalog_product');
+
+    expect($attributes)->toBeArray()->not->toBeEmpty();
+    expect($attributes[0])->toBeInstanceOf(Mage_Eav_Model_Entity_Attribute_Abstract::class);
+});
+
+it('returns the same attribute set whether or not the store was pre-initialized', function (): void {
+    $storeId = (int) Mage::app()->getStore()->getId();
+
+    // Path A: getAttributes() is the very first access on a cold config.
+    $cold = new Mage_Eav_Model_Config();
+    $cold->setCurrentStoreId($storeId);
+    $coldCodes = array_map(
+        static fn(Mage_Eav_Model_Entity_Attribute_Abstract $a) => $a->getAttributeCode(),
+        $cold->getAttributes('catalog_product'),
+    );
+
+    // Path B: the store is explicitly initialized first, then getAttributes().
+    $warm = new Mage_Eav_Model_Config();
+    $warm->setCurrentStoreId($storeId);
+    $warm->getAttribute('catalog_product', 'name');
+    $warmCodes = array_map(
+        static fn(Mage_Eav_Model_Entity_Attribute_Abstract $a) => $a->getAttributeCode(),
+        $warm->getAttributes('catalog_product'),
+    );
+
+    sort($coldCodes);
+    sort($warmCodes);
+    expect($coldCodes)->toBe($warmCodes);
+    expect($coldCodes)->not->toBeEmpty();
+});


### PR DESCRIPTION
### Problem

Any request whose *first* EAV access goes through `Mage_Eav_Model_Config::getAttributes()` fails with

```
TypeError: array_keys(): Argument #1 ($array) must be of type array, null given
```

and the whole request 500s.

This surfaces easily with the new API Platform layer: `rest.php` boots Maho in library mode, so nothing has touched EAV before the resource provider runs. For example, loading a wishlist item collection pulls the product listing attributes through `getAttributes()` as the very first EAV access of the request, and the endpoint returns a 500.

### Environment

- Maho: `mahocommerce/maho` `dev-main` (`5e9c0512a`)
- PHP 8.5.7 
- MySQL 8.4.9

### Steps to reproduce (vanilla `main`)

1. Enable the REST API (all protocols are off by default): System > Configuration > Services > API → enable REST v2.
2. Use any customer account that has **at least one wishlist item** (add one in the storefront if needed — the collection must hydrate products to reach the attribute index).
3. Request the wishlist over the API so `getAttributes()` is the first EAV access of the request:

```bash
BASE=https://your-maho.test

TOKEN=$(curl -s -X POST "$BASE/api/rest/v2/auth/token" \
  -H "Content-Type: application/json" \
  -d '{"grant_type":"customer","email":"customer@example.com","password":"..."}' \
  | jq -r .token)

curl -s -i "$BASE/api/rest/v2/customers/me/wishlist" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Accept: application/json"
```

**Actual:** `HTTP/1.1 500` with `{"error":"internal_server_error","message":"An internal error occurred","code":500}`; on a developer-mode install the debug block shows the underlying `TypeError` from `Mage_Eav_Model_Config::getAttributes()`.

**Expected (with this fix):** `HTTP/1.1 200` and the wishlist items.

### Root cause

`getAttributes()` reads `$this->_entityTypeAttributes[$storeId][$entityTypeId]` and calls `array_keys()` on it directly, but never ensures the per-store attribute index has been built for `$storeId`. Its sibling `getAttribute()` calls `$this->_initializeStore($storeId)` before touching the same index; `getAttributes()` is missing that guard, so the index is still `null` for any store not yet initialized in the current request.

On regular frontend requests this is masked because earlier code has almost always initialized the store by the time `getAttributes()` runs. In a fresh library-mode context (an API Platform request) nothing has.
