### PR TITLE
Align wishlist item pricing with the products API (price + finalPrice)

### DIFF
--- a/app/code/core/Mage/Wishlist/Api/WishlistItem.php
+++ b/app/code/core/Mage/Wishlist/Api/WishlistItem.php
@@ -154,11 +154,15 @@ class WishlistItem extends CrudResource
 
         $dto->productName = $product->getName();
         $dto->productSku = $product->getSku();
-        // Mirrors the products API: productPrice = base price (null when the type has no own
-        // price, e.g. configurable parents), productFinalPrice = effective price after rules.
-        $basePrice = (float) $product->getPrice();
-        $dto->productPrice = $basePrice > 0.0 ? $basePrice : null;
-        $dto->productFinalPrice = (float) $product->getFinalPrice();
+        // Mirrors the products API: productPrice = base price (null when the type carries
+        // no own price, e.g. configurable parents), productFinalPrice = effective price
+        // after catalog rules and specials (null when the type yields none).
+        $dto->productPrice = $product->getData('price') !== null ? (float) $product->getPrice() : null;
+        try {
+            $dto->productFinalPrice = $product->getFinalPrice() ? (float) $product->getFinalPrice() : null;
+        } catch (\Throwable) {
+            $dto->productFinalPrice = $dto->productPrice;
+        }
         $dto->productImageUrl = self::getProductImageUrl($product);
         $dto->productUrl = '/' . ($product->getUrlKey() ?: $product->formatUrlKey($product->getName()));
         $dto->productType = $product->getTypeId();

--- a/app/code/core/Mage/Wishlist/Api/WishlistItem.php
+++ b/app/code/core/Mage/Wishlist/Api/WishlistItem.php
@@ -124,6 +124,9 @@ class WishlistItem extends CrudResource
     public ?float $productPrice = null;
 
     #[ApiProperty(writable: false, extraProperties: ['computed' => true])]
+    public ?float $productFinalPrice = null;
+
+    #[ApiProperty(writable: false, extraProperties: ['computed' => true])]
     public ?string $productImageUrl = null;
 
     #[ApiProperty(writable: false, extraProperties: ['computed' => true])]
@@ -151,7 +154,11 @@ class WishlistItem extends CrudResource
 
         $dto->productName = $product->getName();
         $dto->productSku = $product->getSku();
-        $dto->productPrice = (float) $product->getFinalPrice();
+        // Mirrors the products API: productPrice = base price (null when the type has no own
+        // price, e.g. configurable parents), productFinalPrice = effective price after rules.
+        $basePrice = (float) $product->getPrice();
+        $dto->productPrice = $basePrice > 0.0 ? $basePrice : null;
+        $dto->productFinalPrice = (float) $product->getFinalPrice();
         $dto->productImageUrl = self::getProductImageUrl($product);
         $dto->productUrl = '/' . ($product->getUrlKey() ?: $product->formatUrlKey($product->getName()));
         $dto->productType = $product->getTypeId();

--- a/app/code/core/Mage/Wishlist/Api/WishlistProvider.php
+++ b/app/code/core/Mage/Wishlist/Api/WishlistProvider.php
@@ -150,6 +150,7 @@ final class WishlistProvider extends \Maho\ApiPlatform\Provider
             'productName' => $item->productName,
             'productSku' => $item->productSku,
             'productPrice' => $item->productPrice,
+            'productFinalPrice' => $item->productFinalPrice,
             'productImageUrl' => $item->productImageUrl,
             'productUrl' => $item->productUrl,
             'productType' => $item->productType,
@@ -167,7 +168,8 @@ final class WishlistProvider extends \Maho\ApiPlatform\Provider
         $item->productId = (int) $data['productId'];
         $item->productName = $data['productName'];
         $item->productSku = $data['productSku'];
-        $item->productPrice = (float) $data['productPrice'];
+        $item->productPrice = isset($data['productPrice']) ? (float) $data['productPrice'] : null;
+        $item->productFinalPrice = isset($data['productFinalPrice']) ? (float) $data['productFinalPrice'] : null;
         $item->productImageUrl = $data['productImageUrl'] ?? '';
         $item->productUrl = $data['productUrl'] ?? '';
         $item->productType = $data['productType'] ?? 'simple';

--- a/tests/Api/V2/Write/GraphQLWishlistTest.php
+++ b/tests/Api/V2/Write/GraphQLWishlistTest.php
@@ -88,6 +88,7 @@ describe('GraphQL Wishlist - Add To Wishlist Mutation', function (): void {
                     productName
                     productSku
                     productPrice
+                    productFinalPrice
                     productType
                     qty
                     inStock
@@ -107,6 +108,7 @@ describe('GraphQL Wishlist - Add To Wishlist Mutation', function (): void {
         expect($item['productName'])->toBeString()->not->toBeEmpty();
         expect($item['productSku'])->toBeString()->not->toBeEmpty();
         expect($item['productPrice'])->toBeNumeric();
+        expect($item['productFinalPrice'])->toBeNumeric();
         expect($item['qty'])->toBeGreaterThanOrEqual(1);
 
         if ($item['_id'] ?? null) {

--- a/tests/Api/V2/Write/WishlistTest.php
+++ b/tests/Api/V2/Write/WishlistTest.php
@@ -68,6 +68,37 @@ describe('REST Wishlist - Add Item', function (): void {
         trackCreated('wishlist_item', (int) $item['id']);
     });
 
+    it('exposes base and final price separately for a discounted product', function (): void {
+        // Create a product with a special price, wish it, and verify the API returns
+        // the regular-vs-sale pair clients derive "on sale" from.
+        $token = serviceToken(['products/write', 'products/delete']);
+        $suffix = substr(uniqid(), -8);
+
+        $create = apiPost('/api/rest/v2/products', [
+            'sku' => "PEST-WISHSALE-{$suffix}",
+            'name' => 'Pest Wishlist Sale Product',
+            'price' => 49.99,
+            'specialPrice' => 39.99,
+            'websiteIds' => [1],
+        ], $token);
+
+        expect($create['status'])->toBeIn([200, 201]);
+        trackCreated('product', $create['json']['id']);
+
+        $response = apiPost('/api/rest/v2/customers/me/wishlist', [
+            'productId' => $create['json']['id'],
+            'qty' => 1,
+        ], customerToken());
+
+        expect($response['status'])->toBeSuccessful();
+        $item = $response['json'];
+        trackCreated('wishlist_item', (int) $item['id']);
+
+        expect($item['productPrice'])->toBe(49.99);
+        expect($item['productFinalPrice'])->toBe(39.99);
+        expect($item['productPrice'])->toBeGreaterThan($item['productFinalPrice']);
+    });
+
     it('rejects adding to wishlist without authentication', function (): void {
         $response = apiPost('/api/rest/v2/customers/me/wishlist', [
             'productId' => fixtures('product_id'),

--- a/tests/Api/V2/Write/WishlistTest.php
+++ b/tests/Api/V2/Write/WishlistTest.php
@@ -59,9 +59,10 @@ describe('REST Wishlist - Add Item', function (): void {
         $item = $response['json'];
         expect($item)->toHaveKeys([
             'id', 'productId', 'productName', 'productSku',
-            'productPrice', 'productType', 'qty', 'addedAt', 'inStock',
+            'productPrice', 'productFinalPrice', 'productType', 'qty', 'addedAt', 'inStock',
         ]);
         expect($item['productPrice'])->toBeNumeric();
+        expect($item['productFinalPrice'])->toBeNumeric();
         expect($item['inStock'])->toBeBool();
 
         trackCreated('wishlist_item', (int) $item['id']);


### PR DESCRIPTION
### Problem

A wishlist is one of the highest purchase-intent surfaces in a storefront, and the standard merchandising pattern there is "was $49.99 — now $39.99" with a sale badge: showing a customer that something they already want has dropped in price is one of the cheapest conversion wins available.

The wishlist API currently can't support it — and its one price field is also inconsistent with the products API:

| | products API | wishlist item |
|---|---|---|
| base price | `price` | — |
| effective price | `finalPrice` | `productPrice` |

`WishlistItem.productPrice` carries the *final* price while the products API uses `price` for the *base* price, and there is no second field, so a client can neither detect a discount nor render the regular-vs-sale pair.

### Proposed change

Adopt the products API naming on the wishlist item (with its usual `product` prefix):

- `productPrice` — now the **base** price, mirroring `price`; `null` when the product type carries no own price (e.g. configurable parents priced via their children).
- `productFinalPrice` — **new**, computed, read-only: the effective price after catalog rules and specials, mirroring `finalPrice`.

Clients display `productFinalPrice` and derive "on sale" from `productPrice > productFinalPrice`; no extra boolean is needed. Both fields appear on REST and GraphQL alike. The two wishlist API tests are extended to cover the new field.

```json
// GET /api/rest/v2/customers/me/wishlist  (item, after)
{
  "productName": "16GB Memory Card",
  "productPrice": 49.99,
  "productFinalPrice": 39.99,
  ...
}
```

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->