### PR TITLE
Fixed PayPal webhook signature verification for payloads containing empty objects

### DIFF
--- a/app/code/core/Maho/Paypal/Model/Api/Client.php
+++ b/app/code/core/Maho/Paypal/Model/Api/Client.php
@@ -269,22 +269,18 @@ class Maho_Paypal_Model_Api_Client
     {
         $certUrl = $headers['PAYPAL-CERT-URL'] ?? '';
         if (!preg_match('#^https://api(-m)?\.(?:sandbox\.)?paypal\.com/#', $certUrl)) {
+            $this->_log('Webhook verification rejected', ['reason' => 'cert_url', 'cert_url' => $certUrl]);
             return false;
         }
 
-        $verifyBody = [
-            'auth_algo' => $headers['PAYPAL-AUTH-ALGO'] ?? '',
-            'cert_url' => $certUrl,
-            'transmission_id' => $headers['PAYPAL-TRANSMISSION-ID'] ?? '',
-            'transmission_sig' => $headers['PAYPAL-TRANSMISSION-SIG'] ?? '',
-            'transmission_time' => $headers['PAYPAL-TRANSMISSION-TIME'] ?? '',
-            'webhook_id' => $webhookId,
-            'webhook_event' => Mage::helper('core')->jsonDecode($body),
-        ];
+        if (!json_validate($body)) {
+            $this->_log('Webhook verification rejected', ['reason' => 'malformed_body']);
+            return false;
+        }
 
         $client = $this->_createHttpClient();
         $response = $client->request('POST', $this->_getApiUrl('/v1/notifications/verify-webhook-signature'), [
-            'json' => $verifyBody,
+            'body' => self::buildVerificationRequest($headers, $webhookId, $body),
             'headers' => $this->_getAuthHeaders(),
         ]);
 
@@ -295,7 +291,37 @@ class Maho_Paypal_Model_Api_Client
         }
 
         $result = Mage::helper('core')->jsonDecode($response->getContent(false));
-        return ($result['verification_status'] ?? '') === 'SUCCESS';
+        $verdict = $result['verification_status'] ?? '';
+        if ($verdict !== 'SUCCESS') {
+            $this->_log('Webhook signature verification failed', [
+                'reason' => 'verdict',
+                'verification_status' => $verdict,
+                'transmission_id' => $headers['PAYPAL-TRANSMISSION-ID'] ?? '',
+            ]);
+        }
+
+        return $verdict === 'SUCCESS';
+    }
+
+    /**
+     * The transmission signature covers the exact bytes PayPal delivered, so the event
+     * must be spliced into the request verbatim — a decode/encode round-trip changes
+     * JSON semantics (PHP folds {} into []), which fails verification for any payload
+     * containing an empty object, e.g. every CHECKOUT.ORDER.APPROVED event.
+     */
+    public static function buildVerificationRequest(array $headers, string $webhookId, string $rawBody): string
+    {
+        return sprintf(
+            '{"auth_algo":%s,"cert_url":%s,"transmission_id":%s,"transmission_sig":%s,'
+            . '"transmission_time":%s,"webhook_id":%s,"webhook_event":%s}',
+            json_encode($headers['PAYPAL-AUTH-ALGO'] ?? ''),
+            json_encode($headers['PAYPAL-CERT-URL'] ?? ''),
+            json_encode($headers['PAYPAL-TRANSMISSION-ID'] ?? ''),
+            json_encode($headers['PAYPAL-TRANSMISSION-SIG'] ?? ''),
+            json_encode($headers['PAYPAL-TRANSMISSION-TIME'] ?? ''),
+            json_encode($webhookId),
+            $rawBody,
+        );
     }
 
     /**

--- a/tests/Backend/Unit/Maho/Paypal/WebhookVerificationRequestTest.php
+++ b/tests/Backend/Unit/Maho/Paypal/WebhookVerificationRequestTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class)->group('backend', 'paypal');
+
+const WEBHOOK_TEST_HEADERS = [
+    'PAYPAL-AUTH-ALGO' => 'SHA256withRSA',
+    'PAYPAL-CERT-URL' => 'https://api.sandbox.paypal.com/v1/notifications/certs/CERT-360caa42',
+    'PAYPAL-TRANSMISSION-ID' => '01c539a3-82b5-11f1-966b-d7607e33a153',
+    'PAYPAL-TRANSMISSION-SIG' => 'dGVzdC1zaWduYXR1cmU=',
+    'PAYPAL-TRANSMISSION-TIME' => '2026-07-18T14:02:47Z',
+];
+
+it('splices the raw webhook body into the verify request verbatim', function () {
+    $rawBody = '{"id":"WH-1","event_type":"CHECKOUT.ORDER.APPROVED","resource":{"amount":{"value":"13.64","breakdown":{}}}}';
+
+    $request = Maho_Paypal_Model_Api_Client::buildVerificationRequest(WEBHOOK_TEST_HEADERS, 'WEBHOOK-ID-1', $rawBody);
+
+    expect($request)->toEndWith(',"webhook_event":' . $rawBody . '}');
+});
+
+it('preserves empty JSON objects that a decode/encode round-trip would fold into arrays', function () {
+    $rawBody = '{"resource":{"breakdown":{},"supplementary_data":{}}}';
+
+    // The failure mode this guards against: PHP's associative decode turns {} into [].
+    expect(json_encode(json_decode($rawBody, true)))->not->toBe($rawBody);
+
+    $request = Maho_Paypal_Model_Api_Client::buildVerificationRequest(WEBHOOK_TEST_HEADERS, 'WEBHOOK-ID-1', $rawBody);
+
+    expect($request)->toContain('"breakdown":{}')
+        ->and($request)->not->toContain('"breakdown":[]');
+});
+
+it('produces valid JSON carrying the metadata fields and the untouched event', function () {
+    $rawBody = '{"id":"WH-1","links":[{"href":"https://api.sandbox.paypal.com/v1/notifications"}]}';
+
+    $request = Maho_Paypal_Model_Api_Client::buildVerificationRequest(WEBHOOK_TEST_HEADERS, 'WEBHOOK-ID-1', $rawBody);
+
+    expect(json_validate($request))->toBeTrue();
+
+    $decoded = json_decode($request, true);
+    expect($decoded['auth_algo'])->toBe('SHA256withRSA')
+        ->and($decoded['cert_url'])->toBe(WEBHOOK_TEST_HEADERS['PAYPAL-CERT-URL'])
+        ->and($decoded['transmission_id'])->toBe(WEBHOOK_TEST_HEADERS['PAYPAL-TRANSMISSION-ID'])
+        ->and($decoded['transmission_sig'])->toBe(WEBHOOK_TEST_HEADERS['PAYPAL-TRANSMISSION-SIG'])
+        ->and($decoded['transmission_time'])->toBe(WEBHOOK_TEST_HEADERS['PAYPAL-TRANSMISSION-TIME'])
+        ->and($decoded['webhook_id'])->toBe('WEBHOOK-ID-1')
+        ->and($decoded['webhook_event'])->toBe(json_decode($rawBody, true));
+});
+
+it('escapes metadata values that contain JSON-significant characters', function () {
+    $headers = ['PAYPAL-AUTH-ALGO' => 'algo"with\quotes'] + WEBHOOK_TEST_HEADERS;
+
+    $request = Maho_Paypal_Model_Api_Client::buildVerificationRequest($headers, 'WEBHOOK-ID-1', '{}');
+
+    expect(json_validate($request))->toBeTrue()
+        ->and(json_decode($request, true)['auth_algo'])->toBe('algo"with\quotes');
+});
+
+it('treats missing transmission headers as empty strings', function () {
+    $request = Maho_Paypal_Model_Api_Client::buildVerificationRequest([], 'WEBHOOK-ID-1', '{}');
+
+    $decoded = json_decode($request, true);
+    expect(json_validate($request))->toBeTrue()
+        ->and($decoded['auth_algo'])->toBe('')
+        ->and($decoded['cert_url'])->toBe('')
+        ->and($decoded['webhook_event'])->toBe([]);
+});


### PR DESCRIPTION
`verifyWebhookSignature()` decodes the delivered webhook body and lets the HTTP client re-encode it into the `verify-webhook-signature` request. PHP's associative decode collapses empty JSON objects to empty arrays, so `{}` is re-encoded as `[]`. PayPal's transmission signature covers the exact bytes it delivered — one folded `{}` and verification returns `FAILURE` deterministically.

Minimal repro of the mutation:

```php
json_encode(json_decode('{"breakdown":{}}', true)); // '{"breakdown":[]}'
```

In practice this means every `CHECKOUT.ORDER.APPROVED` event fails verification (its `amount.breakdown` is an empty object), so the `Webhook_Handler_OrderApproved` browser-died failsafe can never run — the webhook endpoint 401s the delivery and all retries. `PAYMENT.CAPTURE.COMPLETED` happens to contain no empty object and passes, which disguises the bug as event-type-specific flakiness. Verified against the live sandbox by replaying a captured delivery with identical transmission headers: raw body spliced verbatim → `SUCCESS`; decode→re-encode → `FAILURE`.

Reproducible with curl against any real delivery you capture at your webhook endpoint — fill the five values from the delivery's `PAYPAL-*` headers and paste the raw request body as `webhook_event`:

```bash
# 1. webhook_event = the delivered bytes, verbatim (note "breakdown":{})  →  SUCCESS
curl -s https://api-m.sandbox.paypal.com/v1/notifications/verify-webhook-signature \
  -u "$CLIENT_ID:$CLIENT_SECRET" \
  -H 'Content-Type: application/json' \
  -d '{
    "auth_algo":        "<PAYPAL-AUTH-ALGO>",
    "cert_url":         "<PAYPAL-CERT-URL>",
    "transmission_id":  "<PAYPAL-TRANSMISSION-ID>",
    "transmission_sig": "<PAYPAL-TRANSMISSION-SIG>",
    "transmission_time":"<PAYPAL-TRANSMISSION-TIME>",
    "webhook_id":       "<registered webhook id>",
    "webhook_event":    {"id":"WH-…","event_type":"CHECKOUT.ORDER.APPROVED", …, "amount":{"value":"13.64","breakdown":{}}, …}
  }'
# → {"verification_status":"SUCCESS"}

# 2. identical call, but with the one-byte-pair PHP round-trip artifact:
#    "breakdown":{}  →  "breakdown":[]   (what the client currently sends)
# → {"verification_status":"FAILURE"}
```

The two requests differ only in those two bytes; PayPal's verify API accepts the first and rejects the second, which pins the failure to the body mutation rather than the headers, credentials, or webhook configuration.
