### PR TITLE
Added Meta Pixel Advanced Matching

### DIFF
--- a/app/code/core/Mage/GoogleAnalytics/Block/Metapixel.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Metapixel.php
@@ -275,7 +275,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
                     'ge' => $this->_getGenderCode((int) $order->getCustomerGender()),
                     'ph' => $address ? (string) $address->getTelephone() : '',
                     'ct' => $address ? (string) $address->getCity() : '',
-                    'st' => $address ? (string) $address->getRegionCode() : '',
+                    'st' => $this->_getRegionForMatching($address ?: null),
                     'zp' => $address ? (string) $address->getPostcode() : '',
                     'country' => $address ? (string) $address->getCountryId() : '',
                     'external_id' => (string) $order->getCustomerId(),
@@ -297,7 +297,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
             'ge' => $this->_getGenderCode((int) $customer->getGender()),
             'ph' => $address ? (string) $address->getTelephone() : '',
             'ct' => $address ? (string) $address->getCity() : '',
-            'st' => $address ? (string) $address->getRegionCode() : '',
+            'st' => $this->_getRegionForMatching($address),
             'zp' => $address ? (string) $address->getPostcode() : '',
             'country' => $address ? (string) $address->getCountryId() : '',
             'external_id' => (string) $customer->getId(),
@@ -306,6 +306,9 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
 
     /**
      * Map the customer gender attribute option id to Meta's 'm'/'f' codes.
+     *
+     * Matches against the admin (default) option labels so store-level
+     * translations of the gender options don't break the mapping.
      */
     protected function _getGenderCode(int $optionId): string
     {
@@ -313,18 +316,44 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
             return '';
         }
         try {
-            $label = Mage::getResourceModel('customer/customer')
+            $source = Mage::getResourceModel('customer/customer')
                 ->getAttribute('gender')
-                ->getSource()
-                ->getOptionText($optionId);
+                ->getSource();
+            // Admin (default) labels when available, so store-level translations
+            // of the option labels don't break the mapping
+            $options = $source instanceof Mage_Eav_Model_Entity_Attribute_Source_Table
+                ? $source->getAllOptions(false, true)
+                : $source->getAllOptions();
         } catch (Throwable $e) {
             return '';
         }
-        return match (mb_strtolower((string) $label)) {
-            'male' => 'm',
-            'female' => 'f',
-            default => '',
-        };
+        foreach ($options as $option) {
+            if ((int) ($option['value'] ?? 0) === $optionId) {
+                return match (mb_strtolower(trim((string) ($option['label'] ?? '')))) {
+                    'male', 'm' => 'm',
+                    'female', 'f' => 'f',
+                    default => '',
+                };
+            }
+        }
+        return '';
+    }
+
+    /**
+     * Region value for Meta's `st` parameter: the 2-letter region code where one
+     * exists (e.g. US/CA); otherwise the full region name, which Meta matches
+     * better than internal 3+ letter directory codes.
+     */
+    protected function _getRegionForMatching(?Mage_Customer_Model_Address_Abstract $address): string
+    {
+        if (!$address) {
+            return '';
+        }
+        $code = (string) $address->getRegionCode();
+        if (preg_match('/^[A-Za-z]{2}$/', $code)) {
+            return $code;
+        }
+        return (string) $address->getRegion();
     }
 
     /**
@@ -345,8 +374,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
             }
             $normalized[$key] = match ($key) {
                 'em' => mb_strtolower($value),
-                // Digits only, no leading zeros; the country code is kept as entered
-                'ph' => ltrim((string) preg_replace('/\D+/', '', $value), '0'),
+                'ph' => $this->_normalizePhone($value, trim((string) ($raw['country'] ?? ''))),
                 'fn', 'ln', 'ct', 'st' => (string) preg_replace('/[^\p{L}\p{N}]+/u', '', mb_strtolower($value)),
                 'zp' => str_replace(' ', '', mb_strtolower(explode('-', $value)[0])),
                 'country' => mb_strtolower(substr($value, 0, 2)),
@@ -367,8 +395,94 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
     protected function _normalizeDob(string $dob): string
     {
         $timestamp = strtotime($dob);
-        return $timestamp === false ? '' : date('Ymd', $timestamp);
+        if ($timestamp === false) {
+            return '';
+        }
+        $date = date('Ymd', $timestamp);
+        // Reject non-real dates: strtotime() rolls the legacy '0000-00-00'
+        // sentinel back to year -1 instead of failing, yielding '-00011130'
+        return preg_match('/^\d{8}$/', $date) ? $date : '';
     }
+
+    /**
+     * Normalize a phone number to digits with a country calling code, per the
+     * Meta spec ("include the country code, even if all of your data is from
+     * the same country").
+     *
+     * Numbers entered in international format ('+' or '00' prefix) are kept as
+     * entered; national-format numbers get their trunk '0' dropped (kept for
+     * Italy, where it is part of the number) and the billing country's calling
+     * code prepended. Unknown country: digits are sent as entered (best effort).
+     */
+    protected function _normalizePhone(string $phone, string $countryId): string
+    {
+        $digits = (string) preg_replace('/\D+/', '', $phone);
+        if ($digits === '') {
+            return '';
+        }
+        if (str_starts_with(trim($phone), '+')) {
+            return $digits;
+        }
+        if (str_starts_with($digits, '00')) {
+            return substr($digits, 2);
+        }
+        $callingCode = self::COUNTRY_CALLING_CODES[strtoupper($countryId)] ?? '';
+        if ($callingCode === '') {
+            return $digits;
+        }
+        if (strtoupper($countryId) !== 'IT') {
+            $digits = ltrim($digits, '0');
+            if ($digits === '') {
+                return '';
+            }
+        }
+        // Long enough to already include the country code it starts with
+        if (str_starts_with($digits, $callingCode) && strlen($digits) >= strlen($callingCode) + 9) {
+            return $digits;
+        }
+        return $callingCode . $digits;
+    }
+
+    /**
+     * ITU-T E.164 country calling codes by ISO 3166-1 alpha-2 country.
+     */
+    private const COUNTRY_CALLING_CODES = [
+        'AD' => '376', 'AE' => '971', 'AF' => '93', 'AG' => '1', 'AI' => '1', 'AL' => '355', 'AM' => '374',
+        'AO' => '244', 'AR' => '54', 'AS' => '1', 'AT' => '43', 'AU' => '61', 'AW' => '297', 'AX' => '358',
+        'AZ' => '994', 'BA' => '387', 'BB' => '1', 'BD' => '880', 'BE' => '32', 'BF' => '226', 'BG' => '359',
+        'BH' => '973', 'BI' => '257', 'BJ' => '229', 'BL' => '590', 'BM' => '1', 'BN' => '673', 'BO' => '591',
+        'BQ' => '599', 'BR' => '55', 'BS' => '1', 'BT' => '975', 'BW' => '267', 'BY' => '375', 'BZ' => '501',
+        'CA' => '1', 'CC' => '61', 'CD' => '243', 'CF' => '236', 'CG' => '242', 'CH' => '41', 'CI' => '225',
+        'CK' => '682', 'CL' => '56', 'CM' => '237', 'CN' => '86', 'CO' => '57', 'CR' => '506', 'CU' => '53',
+        'CV' => '238', 'CW' => '599', 'CX' => '61', 'CY' => '357', 'CZ' => '420', 'DE' => '49', 'DJ' => '253',
+        'DK' => '45', 'DM' => '1', 'DO' => '1', 'DZ' => '213', 'EC' => '593', 'EE' => '372', 'EG' => '20',
+        'EH' => '212', 'ER' => '291', 'ES' => '34', 'ET' => '251', 'FI' => '358', 'FJ' => '679', 'FK' => '500',
+        'FM' => '691', 'FO' => '298', 'FR' => '33', 'GA' => '241', 'GB' => '44', 'GD' => '1', 'GE' => '995',
+        'GF' => '594', 'GG' => '44', 'GH' => '233', 'GI' => '350', 'GL' => '299', 'GM' => '220', 'GN' => '224',
+        'GP' => '590', 'GQ' => '240', 'GR' => '30', 'GT' => '502', 'GU' => '1', 'GW' => '245', 'GY' => '592',
+        'HK' => '852', 'HN' => '504', 'HR' => '385', 'HT' => '509', 'HU' => '36', 'ID' => '62', 'IE' => '353',
+        'IL' => '972', 'IM' => '44', 'IN' => '91', 'IO' => '246', 'IQ' => '964', 'IR' => '98', 'IS' => '354',
+        'IT' => '39', 'JE' => '44', 'JM' => '1', 'JO' => '962', 'JP' => '81', 'KE' => '254', 'KG' => '996',
+        'KH' => '855', 'KI' => '686', 'KM' => '269', 'KN' => '1', 'KP' => '850', 'KR' => '82', 'KW' => '965',
+        'KY' => '1', 'KZ' => '7', 'LA' => '856', 'LB' => '961', 'LC' => '1', 'LI' => '423', 'LK' => '94',
+        'LR' => '231', 'LS' => '266', 'LT' => '370', 'LU' => '352', 'LV' => '371', 'LY' => '218', 'MA' => '212',
+        'MC' => '377', 'MD' => '373', 'ME' => '382', 'MF' => '590', 'MG' => '261', 'MH' => '692', 'MK' => '389',
+        'ML' => '223', 'MM' => '95', 'MN' => '976', 'MO' => '853', 'MP' => '1', 'MQ' => '596', 'MR' => '222',
+        'MS' => '1', 'MT' => '356', 'MU' => '230', 'MV' => '960', 'MW' => '265', 'MX' => '52', 'MY' => '60',
+        'MZ' => '258', 'NA' => '264', 'NC' => '687', 'NE' => '227', 'NF' => '672', 'NG' => '234', 'NI' => '505',
+        'NL' => '31', 'NO' => '47', 'NP' => '977', 'NR' => '674', 'NU' => '683', 'NZ' => '64', 'OM' => '968',
+        'PA' => '507', 'PE' => '51', 'PF' => '689', 'PG' => '675', 'PH' => '63', 'PK' => '92', 'PL' => '48',
+        'PM' => '508', 'PR' => '1', 'PS' => '970', 'PT' => '351', 'PW' => '680', 'PY' => '595', 'QA' => '974',
+        'RE' => '262', 'RO' => '40', 'RS' => '381', 'RU' => '7', 'RW' => '250', 'SA' => '966', 'SB' => '677',
+        'SC' => '248', 'SD' => '249', 'SE' => '46', 'SG' => '65', 'SH' => '290', 'SI' => '386', 'SJ' => '47',
+        'SK' => '421', 'SL' => '232', 'SM' => '378', 'SN' => '221', 'SO' => '252', 'SR' => '597', 'SS' => '211',
+        'ST' => '239', 'SV' => '503', 'SX' => '1', 'SY' => '963', 'SZ' => '268', 'TC' => '1', 'TD' => '235',
+        'TG' => '228', 'TH' => '66', 'TJ' => '992', 'TK' => '690', 'TL' => '670', 'TM' => '993', 'TN' => '216',
+        'TO' => '676', 'TR' => '90', 'TT' => '1', 'TV' => '688', 'TW' => '886', 'TZ' => '255', 'UA' => '380',
+        'UG' => '256', 'US' => '1', 'UY' => '598', 'UZ' => '998', 'VA' => '379', 'VC' => '1', 'VE' => '58',
+        'VG' => '1', 'VI' => '1', 'VN' => '84', 'VU' => '678', 'WF' => '681', 'WS' => '685', 'XK' => '383',
+        'YE' => '967', 'YT' => '262', 'ZA' => '27', 'ZM' => '260', 'ZW' => '263',
+    ];
 
     #[\Override]
     protected function _toHtml(): string

--- a/app/code/core/Mage/GoogleAnalytics/Block/Metapixel.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Metapixel.php
@@ -226,6 +226,150 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
         return implode("\n", $eventStrings);
     }
 
+    /**
+     * Advanced Matching parameters for fbq('init'), SHA-256 hashed per Meta spec.
+     *
+     * Listeners of the dispatched event receive already-hashed values and must
+     * keep any value they add SHA-256 hashed as well.
+     *
+     * @return array<string, string> param => hashed value, empty when disabled or no data
+     */
+    public function getAdvancedMatchingData(): array
+    {
+        if (!Mage::helper('googleanalytics')->isMetaPixelAdvancedMatchingEnabled()) {
+            return [];
+        }
+
+        $data = $this->buildAdvancedMatchingData($this->_collectRawCustomerData());
+
+        $transport = new \Maho\DataObject();
+        $transport->setData($data);
+        Mage::dispatchEvent('googleanalytics_metapixel_advanced_matching_data', [
+            'transport' => $transport,
+            'block' => $this,
+        ]);
+        return $transport->getData();
+    }
+
+    /**
+     * Raw customer values keyed by Meta parameter name, preferring the just-placed
+     * order (success page, covers guest checkout) over the logged-in customer.
+     *
+     * @return array<string, string>
+     */
+    protected function _collectRawCustomerData(): array
+    {
+        $orderIds = $this->getOrderIds();
+        if (!empty($orderIds) && is_array($orderIds)) {
+            /** @var Mage_Sales_Model_Order $order */
+            $order = Mage::getResourceModel('sales/order_collection')
+                ->addFieldToFilter('entity_id', ['in' => $orderIds])
+                ->getFirstItem();
+            if ($order->getId()) {
+                $address = $order->getBillingAddress();
+                return array_filter([
+                    'em' => (string) $order->getCustomerEmail(),
+                    'fn' => (string) $order->getCustomerFirstname(),
+                    'ln' => (string) $order->getCustomerLastname(),
+                    'db' => (string) $order->getCustomerDob(),
+                    'ge' => $this->_getGenderCode((int) $order->getCustomerGender()),
+                    'ph' => $address ? (string) $address->getTelephone() : '',
+                    'ct' => $address ? (string) $address->getCity() : '',
+                    'st' => $address ? (string) $address->getRegionCode() : '',
+                    'zp' => $address ? (string) $address->getPostcode() : '',
+                    'country' => $address ? (string) $address->getCountryId() : '',
+                    'external_id' => (string) $order->getCustomerId(),
+                ]);
+            }
+        }
+
+        $session = Mage::getSingleton('customer/session');
+        if (!$session->isLoggedIn()) {
+            return [];
+        }
+        $customer = $session->getCustomer();
+        $address = $customer->getDefaultBillingAddress() ?: null;
+        return array_filter([
+            'em' => (string) $customer->getEmail(),
+            'fn' => (string) $customer->getFirstname(),
+            'ln' => (string) $customer->getLastname(),
+            'db' => (string) $customer->getDob(),
+            'ge' => $this->_getGenderCode((int) $customer->getGender()),
+            'ph' => $address ? (string) $address->getTelephone() : '',
+            'ct' => $address ? (string) $address->getCity() : '',
+            'st' => $address ? (string) $address->getRegionCode() : '',
+            'zp' => $address ? (string) $address->getPostcode() : '',
+            'country' => $address ? (string) $address->getCountryId() : '',
+            'external_id' => (string) $customer->getId(),
+        ]);
+    }
+
+    /**
+     * Map the customer gender attribute option id to Meta's 'm'/'f' codes.
+     */
+    protected function _getGenderCode(int $optionId): string
+    {
+        if (!$optionId) {
+            return '';
+        }
+        try {
+            $label = Mage::getResourceModel('customer/customer')
+                ->getAttribute('gender')
+                ->getSource()
+                ->getOptionText($optionId);
+        } catch (Throwable $e) {
+            return '';
+        }
+        return match (mb_strtolower((string) $label)) {
+            'male' => 'm',
+            'female' => 'f',
+            default => '',
+        };
+    }
+
+    /**
+     * Normalize raw values per the Meta Advanced Matching spec and SHA-256 hash
+     * them. Pure function of its input: empty or invalid values are omitted.
+     *
+     * @see https://developers.facebook.com/docs/meta-pixel/advanced/advanced-matching
+     * @param array<string, string> $raw
+     * @return array<string, string>
+     */
+    public function buildAdvancedMatchingData(array $raw): array
+    {
+        $normalized = [];
+        foreach ($raw as $key => $value) {
+            $value = trim((string) $value);
+            if ($value === '') {
+                continue;
+            }
+            $normalized[$key] = match ($key) {
+                'em' => mb_strtolower($value),
+                // Digits only, no leading zeros; the country code is kept as entered
+                'ph' => ltrim((string) preg_replace('/\D+/', '', $value), '0'),
+                'fn', 'ln', 'ct', 'st' => (string) preg_replace('/[^\p{L}\p{N}]+/u', '', mb_strtolower($value)),
+                'zp' => str_replace(' ', '', mb_strtolower(explode('-', $value)[0])),
+                'country' => mb_strtolower(substr($value, 0, 2)),
+                'ge' => in_array($value, ['m', 'f'], true) ? $value : '',
+                'db' => $this->_normalizeDob($value),
+                default => $value,
+            };
+            if ($normalized[$key] === '') {
+                unset($normalized[$key]);
+            }
+        }
+        return array_map(static fn(string $v): string => hash('sha256', $v), $normalized);
+    }
+
+    /**
+     * Meta expects birthdates as YYYYMMDD; dob is stored as 'Y-m-d' or 'Y-m-d H:i:s'.
+     */
+    protected function _normalizeDob(string $dob): string
+    {
+        $timestamp = strtotime($dob);
+        return $timestamp === false ? '' : date('Ymd', $timestamp);
+    }
+
     #[\Override]
     protected function _toHtml(): string
     {

--- a/app/code/core/Mage/GoogleAnalytics/Block/Metapixel.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Metapixel.php
@@ -40,7 +40,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
         if ($addedProducts) {
             foreach ($addedProducts as $_addedProduct) {
                 $eventData = [];
-                $eventData['value'] = $helper->formatPrice($_addedProduct['price'] * $_addedProduct['qty']);
+                $eventData['value'] = (float) $helper->formatPrice($_addedProduct['price'] * $_addedProduct['qty']);
                 $eventData['currency'] = Mage::app()->getStore()->getCurrentCurrencyCode();
                 $eventData['content_name'] = $_addedProduct['name'];
                 $eventData['content_type'] = 'product';
@@ -48,7 +48,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
                     [
                         'id' => $_addedProduct['sku'],
                         'quantity' => (int) $_addedProduct['qty'],
-                        'item_price' => $helper->formatPrice($_addedProduct['price']),
+                        'item_price' => (float) $helper->formatPrice($_addedProduct['price']),
                     ],
                 ];
                 $result[] = ['AddToCart', $eventData];
@@ -62,7 +62,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
             $productViewed = Mage::registry('current_product');
             if ($productViewed) {
                 $eventData = [];
-                $eventData['value'] = $helper->formatPrice($productViewed->getFinalPrice());
+                $eventData['value'] = (float) $helper->formatPrice($productViewed->getFinalPrice());
                 $eventData['currency'] = Mage::app()->getStore()->getCurrentCurrencyCode();
                 $eventData['content_name'] = $productViewed->getName();
                 $eventData['content_ids'] = [$productViewed->getSku()];
@@ -71,7 +71,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
                     [
                         'id' => $productViewed->getSku(),
                         'quantity' => 1,
-                        'item_price' => $helper->formatPrice($productViewed->getFinalPrice()),
+                        'item_price' => (float) $helper->formatPrice($productViewed->getFinalPrice()),
                     ],
                 ];
                 $category = Mage::registry('current_category');
@@ -108,7 +108,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
 
                     foreach ($productCollection as $productViewed) {
                         $productId = $productViewed->getSku();
-                        $productPrice = $helper->formatPrice($productViewed->getFinalPrice());
+                        $productPrice = (float) $helper->formatPrice($productViewed->getFinalPrice());
                         $contentIds[] = $productId;
                         $contents[] = [
                             'id' => $productId,
@@ -119,7 +119,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
                     }
 
                     $eventData = [];
-                    $eventData['value'] = $helper->formatPrice($totalValue); // Sum of displayed product prices
+                    $eventData['value'] = (float) $helper->formatPrice($totalValue); // Sum of displayed product prices
                     $eventData['currency'] = Mage::app()->getStore()->getCurrentCurrencyCode();
                     ;
                     $eventData['content_name'] = $category->getName();
@@ -154,14 +154,14 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
                         $contents[] = [
                             'id' => $productId,
                             'quantity' => (int) $item->getQty(),
-                            'item_price' => $helper->formatPrice($item->getBasePrice()),
+                            'item_price' => (float) $helper->formatPrice($item->getBasePrice()),
                         ];
                         $totalValue += $item->getBaseRowTotal();
                         $numItems += (int) $item->getQty();
                     }
 
                     $eventData = [];
-                    $eventData['value'] = $helper->formatPrice($totalValue);
+                    $eventData['value'] = (float) $helper->formatPrice($totalValue);
                     $eventData['currency'] = Mage::app()->getStore()->getCurrentCurrencyCode();
                     $eventData['content_ids'] = $contentIds;
                     $eventData['content_type'] = 'product';
@@ -174,7 +174,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
 
         // This event signifies when one or more items is purchased by a user.
         // @see https://developers.facebook.com/docs/meta-pixel/reference#standard-events
-        $orderIds = $this->getOrderIds(); // Assuming this method retrieves order IDs from the success page
+        $orderIds = $this->getOrderIds();
         if (!empty($orderIds) && is_array($orderIds)) {
             $collection = Mage::getResourceModel('sales/order_collection')
                 ->addFieldToFilter('entity_id', ['in' => $orderIds]);
@@ -193,14 +193,14 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
                     $contents[] = [
                         'id' => $productId,
                         'quantity' => (int) $item->getQtyOrdered(),
-                        'item_price' => $helper->formatPrice($item->getBasePrice()),
+                        'item_price' => (float) $helper->formatPrice($item->getBasePrice()),
                     ];
                     $numItems += (int) $item->getQtyOrdered();
                 }
 
                 if (!empty($contents)) {
                     $eventData = [];
-                    $eventData['value'] = $helper->formatPrice($order->getBaseGrandTotal());
+                    $eventData['value'] = (float) $helper->formatPrice($order->getBaseGrandTotal());
                     $eventData['currency'] = $order->getBaseCurrencyCode();
                     $eventData['content_ids'] = $contentIds;
                     $eventData['content_type'] = 'product';
@@ -219,7 +219,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
 
         $eventStrings = [];
         foreach ($result as $metaEvent) {
-            $eventDataJson = json_encode($metaEvent[1], JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK);
+            $eventDataJson = Mage::helper('core')->jsonEncode($metaEvent[1]);
             $eventDataJsonEscaped = str_replace("'", "\\'", $eventDataJson);
             $eventStrings[] = "fbq('track', '{$metaEvent[0]}', {$eventDataJsonEscaped});";
         }
@@ -376,7 +376,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
                 'em' => mb_strtolower($value),
                 'ph' => $this->_normalizePhone($value, trim((string) ($raw['country'] ?? ''))),
                 'fn', 'ln', 'ct', 'st' => (string) preg_replace('/[^\p{L}\p{N}]+/u', '', mb_strtolower($value)),
-                'zp' => str_replace(' ', '', mb_strtolower(explode('-', $value)[0])),
+                'zp' => $this->_normalizeZip($value, trim((string) ($raw['country'] ?? ''))),
                 'country' => mb_strtolower(substr($value, 0, 2)),
                 'ge' => in_array($value, ['m', 'f'], true) ? $value : '',
                 'db' => $this->_normalizeDob($value),
@@ -387,6 +387,22 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
             }
         }
         return array_map(static fn(string $v): string => hash('sha256', $v), $normalized);
+    }
+
+    /**
+     * Normalize a postal code per the Meta spec: lowercase, with spaces and
+     * dashes stripped for every country. US ZIP codes are additionally
+     * truncated to the 5-digit base (dropping the +4 extension); elsewhere all
+     * digits are kept, since a hyphen there separates parts of one complete
+     * code (e.g. JP 123-4567 → 1234567) rather than an optional suffix.
+     */
+    protected function _normalizeZip(string $zip, string $countryId): string
+    {
+        $zip = str_replace([' ', '-'], '', mb_strtolower($zip));
+        if (strtoupper($countryId) === 'US') {
+            return substr($zip, 0, 5);
+        }
+        return $zip;
     }
 
     /**

--- a/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
+++ b/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
@@ -42,6 +42,11 @@ class Mage_GoogleAnalytics_Helper_Data extends Mage_Core_Helper_Abstract
         return Mage::getStoreConfig('google/meta_pixel/account');
     }
 
+    public function isMetaPixelAdvancedMatchingEnabled(): bool
+    {
+        return Mage::getStoreConfigFlag('google/meta_pixel/advanced_matching');
+    }
+
     /**
      * Whether GTM is ready to use
      *

--- a/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
+++ b/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
@@ -20,9 +20,14 @@ class Mage_GoogleAnalytics_Model_Observer
         if (empty($orderIds) || !is_array($orderIds)) {
             return;
         }
-        $block = Mage::app()->getFrontController()->getAction()->getLayout()->getBlock('google_analytics');
+        $layout = Mage::app()->getFrontController()->getAction()->getLayout();
+        $block = $layout->getBlock('google_analytics');
         if ($block) {
             $block->setOrderIds($orderIds);
+        }
+        $metaPixelBlock = $layout->getBlock('meta_pixel');
+        if ($metaPixelBlock) {
+            $metaPixelBlock->setOrderIds($orderIds);
         }
     }
 

--- a/app/code/core/Mage/GoogleAnalytics/etc/system.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/system.xml
@@ -125,6 +125,7 @@ SPDX-License-Identifier: AFL-3.0
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends><active>1</active></depends>
                         </account>
                         <advanced_matching translate="label comment">
                             <label>Advanced Matching</label>

--- a/app/code/core/Mage/GoogleAnalytics/etc/system.xml
+++ b/app/code/core/Mage/GoogleAnalytics/etc/system.xml
@@ -126,6 +126,16 @@ SPDX-License-Identifier: AFL-3.0
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </account>
+                        <advanced_matching translate="label comment">
+                            <label>Advanced Matching</label>
+                            <frontend_type>boolean</frontend_type>
+                            <sort_order>30</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>Send hashed customer data (email, phone, name, etc.) with the pixel to improve event matching. Values are SHA-256 hashed server side.</comment>
+                            <depends><active>1</active></depends>
+                        </advanced_matching>
                     </fields>
                 </meta_pixel>
             </groups>

--- a/app/design/frontend/base/default/template/googleanalytics/metapixel.phtml
+++ b/app/design/frontend/base/default/template/googleanalytics/metapixel.phtml
@@ -20,7 +20,7 @@ $_helper = $this->helper('googleanalytics');
             s.parentNode.insertBefore(t,s)}(window, document,'script',
             'https://connect.facebook.net/en_US/fbevents.js');
         <?php $_amData = $this->getAdvancedMatchingData(); ?>
-        fbq('init', '<?= $_helper->getMetaPixelId() ?>'<?= $_amData ? ', ' . json_encode($_amData, JSON_THROW_ON_ERROR) : '' ?>);
+        fbq('init', '<?= $_helper->getMetaPixelId() ?>'<?= $_amData ? ', ' . Mage::helper('core')->jsonEncode($_amData) : '' ?>);
         fbq('track', 'PageView');
     </script>
     <script>

--- a/app/design/frontend/base/default/template/googleanalytics/metapixel.phtml
+++ b/app/design/frontend/base/default/template/googleanalytics/metapixel.phtml
@@ -19,7 +19,8 @@ $_helper = $this->helper('googleanalytics');
             t.src=v;s=b.getElementsByTagName(e)[0];
             s.parentNode.insertBefore(t,s)}(window, document,'script',
             'https://connect.facebook.net/en_US/fbevents.js');
-        fbq('init', '<?= $_helper->getMetaPixelId() ?>');
+        <?php $_amData = $this->getAdvancedMatchingData(); ?>
+        fbq('init', '<?= $_helper->getMetaPixelId() ?>'<?= $_amData ? ', ' . json_encode($_amData, JSON_THROW_ON_ERROR) : '' ?>);
         fbq('track', 'PageView');
     </script>
     <script>

--- a/app/locale/en_US/Mage_GoogleAnalytics.csv
+++ b/app/locale/en_US/Mage_GoogleAnalytics.csv
@@ -1,4 +1,5 @@
 "Account Number","Account Number"
+"Advanced Matching","Advanced Matching"
 "Container ID","Container ID"
 "Enable","Enable"
 "Enable GA4 Debug Real Time view for Development IP.","Enable GA4 Debug Real Time view for Development IP."
@@ -9,5 +10,6 @@
 "Google API","Google API"
 "Google Tag Manager","Google Tag Manager"
 "Meta Pixel ID","Meta Pixel ID"
+"Send hashed customer data (email, phone, name, etc.) with the pixel to improve event matching. Values are SHA-256 hashed server side.","Send hashed customer data (email, phone, name, etc.) with the pixel to improve event matching. Values are SHA-256 hashed server side."
 "Type","Type"
 "User ID tracking","User ID tracking"

--- a/composer.lock
+++ b/composer.lock
@@ -11319,27 +11319,28 @@
         },
         {
             "name": "phpstan/phpstan-strict-rules",
-            "version": "2.0.11",
+            "version": "2.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "9b000a578b85b32945b358b172c7b20e91189024"
+                "reference": "2bc5ae19ae965663b62ac907ee6342c3903ec93b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/9b000a578b85b32945b358b172c7b20e91189024",
-                "reference": "9b000a578b85b32945b358b172c7b20e91189024",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/2bc5ae19ae965663b62ac907ee6342c3903ec93b",
+                "reference": "2bc5ae19ae965663b62ac907ee6342c3903ec93b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.1.39"
+                "phpstan/phpstan": "^2.1.52"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpstan-deprecation-rules": "^2.0",
                 "phpstan/phpstan-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.6"
+                "phpunit/phpunit": "^9.6",
+                "shipmonk/name-collision-detector": "^2.1"
             },
             "type": "phpstan-extension",
             "extra": {
@@ -11364,9 +11365,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.11"
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.12"
             },
-            "time": "2026-05-02T06:54:10+00:00"
+            "time": "2026-07-19T07:24:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/tests/Frontend/Unit/GoogleAnalytics/Block/MetapixelTest.php
+++ b/tests/Frontend/Unit/GoogleAnalytics/Block/MetapixelTest.php
@@ -72,10 +72,22 @@ describe('Meta Pixel Advanced Matching', function () {
             expect($result)->toBe(['ln' => hash('sha256', 'müller')]);
         });
 
-        it('keeps only the first segment of zip codes', function () {
-            $result = $this->block->buildAdvancedMatchingData(['zp' => '90210-1234']);
+        it('truncates US ZIP+4 codes to the 5-digit base', function () {
+            $result = $this->block->buildAdvancedMatchingData(['zp' => '90210-1234', 'country' => 'US']);
 
-            expect($result)->toBe(['zp' => hash('sha256', '90210')]);
+            expect($result['zp'])->toBe(hash('sha256', '90210'));
+        });
+
+        it('keeps all digits of hyphenated non-US postal codes, dropping the separator', function () {
+            $result = $this->block->buildAdvancedMatchingData(['zp' => '123-4567', 'country' => 'JP']);
+
+            expect($result['zp'])->toBe(hash('sha256', '1234567'));
+        });
+
+        it('removes spaces from postal codes and lowercases them', function () {
+            $result = $this->block->buildAdvancedMatchingData(['zp' => 'SW1A 1AA', 'country' => 'GB']);
+
+            expect($result['zp'])->toBe(hash('sha256', 'sw1a1aa'));
         });
 
         it('lowercases the two-letter country code', function () {

--- a/tests/Frontend/Unit/GoogleAnalytics/Block/MetapixelTest.php
+++ b/tests/Frontend/Unit/GoogleAnalytics/Block/MetapixelTest.php
@@ -21,10 +21,37 @@ describe('Meta Pixel Advanced Matching', function () {
             expect($result)->toBe(['em' => hash('sha256', 'john.doe@example.com')]);
         });
 
-        it('keeps only digits in phone numbers and strips leading zeros', function () {
+        it('keeps only digits in phone numbers entered in international format', function () {
             $result = $this->block->buildAdvancedMatchingData(['ph' => '+44 (0) 7911 123-456']);
 
             expect($result)->toBe(['ph' => hash('sha256', '4407911123456')]);
+        });
+
+        it('prepends the billing country calling code to national phone numbers', function () {
+            expect($this->block->buildAdvancedMatchingData(['ph' => '(555) 123-4567', 'country' => 'US'])['ph'])
+                ->toBe(hash('sha256', '15551234567'));
+            expect($this->block->buildAdvancedMatchingData(['ph' => '07911 123456', 'country' => 'GB'])['ph'])
+                ->toBe(hash('sha256', '447911123456'));
+        });
+
+        it('keeps the Italian trunk zero when prepending the country code', function () {
+            expect($this->block->buildAdvancedMatchingData(['ph' => '06 1234567', 'country' => 'IT'])['ph'])
+                ->toBe(hash('sha256', '39061234567'));
+        });
+
+        it('treats a 00 dial-out prefix as international format', function () {
+            expect($this->block->buildAdvancedMatchingData(['ph' => '0044 7911 123456', 'country' => 'GB'])['ph'])
+                ->toBe(hash('sha256', '447911123456'));
+        });
+
+        it('sends phone digits as entered when the country is unknown', function () {
+            expect($this->block->buildAdvancedMatchingData(['ph' => '555-123-4567']))
+                ->toBe(['ph' => hash('sha256', '5551234567')]);
+        });
+
+        it('does not double the country code when it was already entered', function () {
+            expect($this->block->buildAdvancedMatchingData(['ph' => '1 555 123 4567', 'country' => 'US'])['ph'])
+                ->toBe(hash('sha256', '15551234567'));
         });
 
         it('strips punctuation and whitespace from names and cities', function () {
@@ -72,6 +99,11 @@ describe('Meta Pixel Advanced Matching', function () {
 
         it('omits invalid birthdates', function () {
             expect($this->block->buildAdvancedMatchingData(['db' => 'not a date']))->toBe([]);
+        });
+
+        it('omits legacy zero-date birthdates', function () {
+            expect($this->block->buildAdvancedMatchingData(['db' => '0000-00-00']))->toBe([]);
+            expect($this->block->buildAdvancedMatchingData(['db' => '0000-00-00 00:00:00']))->toBe([]);
         });
 
         it('hashes the external id as provided', function () {

--- a/tests/Frontend/Unit/GoogleAnalytics/Block/MetapixelTest.php
+++ b/tests/Frontend/Unit/GoogleAnalytics/Block/MetapixelTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoFrontendTestCase::class);
+
+describe('Meta Pixel Advanced Matching', function () {
+    beforeEach(function () {
+        $this->block = new Mage_GoogleAnalytics_Block_Metapixel();
+    });
+
+    describe('buildAdvancedMatchingData', function () {
+        it('normalizes and hashes email addresses', function () {
+            $result = $this->block->buildAdvancedMatchingData(['em' => ' John.Doe@Example.COM ']);
+
+            expect($result)->toBe(['em' => hash('sha256', 'john.doe@example.com')]);
+        });
+
+        it('keeps only digits in phone numbers and strips leading zeros', function () {
+            $result = $this->block->buildAdvancedMatchingData(['ph' => '+44 (0) 7911 123-456']);
+
+            expect($result)->toBe(['ph' => hash('sha256', '4407911123456')]);
+        });
+
+        it('strips punctuation and whitespace from names and cities', function () {
+            $result = $this->block->buildAdvancedMatchingData([
+                'fn' => "O'Brien",
+                'ct' => 'New York',
+            ]);
+
+            expect($result)->toBe([
+                'fn' => hash('sha256', 'obrien'),
+                'ct' => hash('sha256', 'newyork'),
+            ]);
+        });
+
+        it('preserves non-latin characters in names', function () {
+            $result = $this->block->buildAdvancedMatchingData(['ln' => 'Müller']);
+
+            expect($result)->toBe(['ln' => hash('sha256', 'müller')]);
+        });
+
+        it('keeps only the first segment of zip codes', function () {
+            $result = $this->block->buildAdvancedMatchingData(['zp' => '90210-1234']);
+
+            expect($result)->toBe(['zp' => hash('sha256', '90210')]);
+        });
+
+        it('lowercases the two-letter country code', function () {
+            $result = $this->block->buildAdvancedMatchingData(['country' => 'GB']);
+
+            expect($result)->toBe(['country' => hash('sha256', 'gb')]);
+        });
+
+        it('accepts only m or f as gender', function () {
+            expect($this->block->buildAdvancedMatchingData(['ge' => 'm']))
+                ->toBe(['ge' => hash('sha256', 'm')]);
+            expect($this->block->buildAdvancedMatchingData(['ge' => 'x']))->toBe([]);
+        });
+
+        it('formats birthdates as YYYYMMDD', function () {
+            expect($this->block->buildAdvancedMatchingData(['db' => '1985-04-12']))
+                ->toBe(['db' => hash('sha256', '19850412')]);
+            expect($this->block->buildAdvancedMatchingData(['db' => '1985-04-12 00:00:00']))
+                ->toBe(['db' => hash('sha256', '19850412')]);
+        });
+
+        it('omits invalid birthdates', function () {
+            expect($this->block->buildAdvancedMatchingData(['db' => 'not a date']))->toBe([]);
+        });
+
+        it('hashes the external id as provided', function () {
+            $result = $this->block->buildAdvancedMatchingData(['external_id' => '42']);
+
+            expect($result)->toBe(['external_id' => hash('sha256', '42')]);
+        });
+
+        it('omits empty and whitespace-only values', function () {
+            $result = $this->block->buildAdvancedMatchingData([
+                'em' => '',
+                'fn' => '   ',
+                'ln' => 'Doe',
+            ]);
+
+            expect($result)->toBe(['ln' => hash('sha256', 'doe')]);
+        });
+
+        it('returns an empty array for empty input', function () {
+            expect($this->block->buildAdvancedMatchingData([]))->toBe([]);
+        });
+
+        it('outputs only 64-character lowercase hex values', function () {
+            $result = $this->block->buildAdvancedMatchingData([
+                'em' => 'john@example.com',
+                'ph' => '+1 555 123 4567',
+                'fn' => 'John',
+                'ln' => 'Doe',
+                'ge' => 'm',
+                'db' => '1985-04-12',
+                'ct' => 'Springfield',
+                'st' => 'IL',
+                'zp' => '62701',
+                'country' => 'US',
+                'external_id' => '42',
+            ]);
+
+            expect($result)->toHaveCount(11);
+            foreach ($result as $value) {
+                expect($value)->toMatch('/^[0-9a-f]{64}$/');
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Added [Advanced Matching](https://developers.facebook.com/documentation/meta-pixel/advanced/advanced-matching/) support to the core Meta Pixel integration: customer data is normalized per the Meta spec, SHA-256 hashed **server side** (no raw PII ever appears in the page source), and passed as the third argument of `fbq('init', ...)`.
- Fixed a pre-existing bug (separate commit): the checkout success observer only set order IDs on the `google_analytics` block, so the Meta Pixel `Purchase` event never fired.

## Details

- New default-off **Advanced Matching** toggle under System → Configuration → Google API → Facebook Meta Pixel (`google/meta_pixel/advanced_matching`), only shown when the pixel is enabled.
- Supported parameters: `em`, `ph`, `fn`, `ln`, `ge`, `db`, `ct`, `st`, `zp`, `country`, `external_id` — empty/invalid values are omitted.
- Data sources, in priority order: the just-placed order on the checkout success page (covers guest checkouts and is the freshest data), then the logged-in customer with their default billing address.
- Normalization follows the Meta spec: lowercased email, digits-only phone, punctuation-stripped unicode-aware names/cities, `YYYYMMDD` birthdate, ISO-2 lowercase country, `m`/`f` gender (resolved from the attribute option label, defensively).
- Everything stays inside the existing cookie-consent guard, so nothing is computed or rendered when consent is denied.
- New `googleanalytics_metapixel_advanced_matching_data` event (transport pattern, mirroring `googleanalytics_meta_send_data_before`) lets merchants customize the already-hashed parameters.
- Meta natively accepts pre-hashed SHA-256 values, so no client-side changes are needed; Maho has no full-page cache, making per-user data in the head block safe.

## Testing

- New Pest suite `tests/Frontend/Unit/GoogleAnalytics/Block/MetapixelTest.php` covering the pure normalization/hashing builder (13 tests).
- `composer lint` clean (cs-fixer, rector, phpstan level 6); `composer test -- --testsuite=Frontend` green (152 tests).
- Manual checks: 2-arg `fbq('init')` when logged out or toggle off; hashed 64-hex params when logged in; on guest checkout success the init includes order-derived params and the Purchase event now fires; no output when cookie consent is denied.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->