### PR TITLE
Fixed FeedManager platform default mappings losing their transformers and use_parent

### DIFF
--- a/app/code/core/Maho/FeedManager/Model/Mapper.php
+++ b/app/code/core/Maho/FeedManager/Model/Mapper.php
@@ -123,11 +123,16 @@ class Maho_FeedManager_Model_Mapper
             $defaults = $this->_platform->getDefaultMappings();
             foreach ($defaults as $feedAttr => $config) {
                 if (!isset($this->_mappings[$feedAttr])) {
+                    $transformers = $config['transformers'] ?? [];
+                    if (is_string($transformers)) {
+                        $transformers = Maho_FeedManager_Model_Transformer::parseChainString($transformers);
+                    }
                     $this->_mappings[$feedAttr] = [
                         'source_type' => $config['source_type'],
                         'source_value' => $config['source_value'],
-                        'transformers' => [],
+                        'transformers' => $transformers,
                         'conditions' => [],
+                        'use_parent' => (string) ($config['use_parent'] ?? ''),
                     ];
                 }
             }

--- a/tests/Backend/Unit/FeedManager/Model/MapperTest.php
+++ b/tests/Backend/Unit/FeedManager/Model/MapperTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('Mapper default mappings', function () {
+    function getMapperMappings(Maho_FeedManager_Model_Feed $feed): array
+    {
+        $mapper = new Maho_FeedManager_Model_Mapper($feed);
+        $property = new ReflectionProperty(Maho_FeedManager_Model_Mapper::class, '_mappings');
+        return $property->getValue($mapper);
+    }
+
+    beforeEach(function () {
+        $this->feed = Mage::getModel('feedmanager/feed');
+        $this->feed->setPlatform('google');
+        $this->feed->setStoreId(1);
+    });
+
+    test('platform defaults keep their transformer chains', function () {
+        $mappings = getMapperMappings($this->feed);
+
+        // Google default: availability maps is_in_stock 1/0 -> in_stock/out_of_stock
+        expect($mappings)->toHaveKey('availability');
+        expect($mappings['availability']['transformers'])->not->toBeEmpty();
+        expect($mappings['availability']['transformers'][0]['transformer'])->toBe('conditional');
+        expect($mappings['availability']['transformers'][0]['options']['true_value'])->toBe('in_stock');
+    });
+
+    test('platform defaults keep their use_parent mode', function () {
+        $mappings = getMapperMappings($this->feed);
+
+        // Google defaults: variant children link to the parent product page
+        // and fall back to the parent image when they have none of their own
+        expect($mappings['link']['use_parent'])->toBe('always');
+        expect($mappings['image_link']['use_parent'])->toBe('if_empty');
+    });
+
+    test('db mappings are not overridden by platform defaults', function () {
+        $this->feed->save();
+        Mage::getModel('feedmanager/attributeMapping')
+            ->setFeedId((int) $this->feed->getId())
+            ->setPlatformAttribute('availability')
+            ->setSourceType('static')
+            ->setSourceValue('in_stock')
+            ->save();
+
+        $mappings = getMapperMappings($this->feed);
+
+        expect($mappings['availability']['source_type'])->toBe('static');
+        expect($mappings['availability']['source_value'])->toBe('in_stock');
+        expect($mappings['availability']['transformers'])->toBeEmpty();
+    });
+});

--- a/tests/Backend/Unit/FeedManager/Model/MapperTest.php
+++ b/tests/Backend/Unit/FeedManager/Model/MapperTest.php
@@ -43,6 +43,8 @@ describe('Mapper default mappings', function () {
     });
 
     test('db mappings are not overridden by platform defaults', function () {
+        $this->feed->setName('Mapper Test Feed');
+        $this->feed->setFilename('mapper-test-feed');
         $this->feed->save();
         Mage::getModel('feedmanager/attributeMapping')
             ->setFeedId((int) $this->feed->getId())


### PR DESCRIPTION
Fixes #1113.

`Mapper::_loadMappings()` applied the platform adapter's default mappings with a hard-coded `'transformers' => []` and never copied `use_parent`, so on the writer/DB-mappings path (the path a feed created with platform defaults uses):

- Google's default `availability` emitted raw `1`/`0` instead of `in_stock`/`out_of_stock` (items disapproved by Google)
- `link` lost `use_parent: always` — variant children linked to their own not-visible/redirecting URLs instead of the parent page
- `image_link`/`description`/`brand` lost `use_parent: if_empty`, so variant children inheriting them from the parent emitted nothing
- `item_group_id` got each child's own value, grouping nothing
- `identifier_exists`, `sale_price_effective_date` etc. lost their conditional/date transformers

The fix parses string transformer chains with `parseChainString()` (exactly like the XML-structure builder path already does) and forwards `use_parent`, which `_getSourceValue()` already reads.

Includes a regression test (`MapperTest`) covering the transformer chain, the `use_parent` modes, and that explicit DB mappings still take precedence over defaults. Full FeedManager unit suite passes (488 tests), phpstan and cs-fixer clean. Verified on a real ~23k-product catalogue: children now emit parent-fallback description/image, parent links, correct `in_stock` availability and parent-sku `item_group_id`.