### PR TITLE
Optimized category URL rewrite joins by matching the canonical id_path instead of a LIKE prefix scan

### DIFF
--- a/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite.php
+++ b/app/code/core/Mage/Catalog/Helper/Category/Url/Rewrite.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2024-2026 Maho <https://mahocommerce.com>
- * SPDX-FileCopyrightText: 2017-2024 The OpenMage Contributors <https://openmage.org>
+ * SPDX-FileCopyrightText: 2017-2026 The OpenMage Contributors <https://openmage.org>
  * SPDX-FileCopyrightText: 2006-2020 Magento, Inc. <https://magento.com>
  * SPDX-License-Identifier: OSL-3.0
  * @package Mage_Catalog
@@ -43,6 +43,7 @@ class Mage_Catalog_Helper_Category_Url_Rewrite extends Mage_Core_Helper_Abstract
     #[\Override]
     public function joinTableToEavCollection(Mage_Eav_Model_Entity_Collection_Abstract $collection, $storeId)
     {
+        $idPathExpr = $this->_connection->getConcatSql(["'category/'", 'e.entity_id']);
         $collection->joinTable(
             'core/url_rewrite',
             'category_id=entity_id',
@@ -50,7 +51,7 @@ class Mage_Catalog_Helper_Category_Url_Rewrite extends Mage_Core_Helper_Abstract
             '{{table}}.is_system=1 AND ' .
                 "{{table}}.store_id='{$storeId}' AND " .
                 '{{table}}.category_id IS NOT NULL AND ' .
-                "{{table}}.id_path LIKE 'category/%'",
+                "{{table}}.id_path = {$idPathExpr}",
             'left',
         );
         return $this;
@@ -65,12 +66,13 @@ class Mage_Catalog_Helper_Category_Url_Rewrite extends Mage_Core_Helper_Abstract
     #[\Override]
     public function joinTableToCollection(Mage_Catalog_Model_Resource_Category_Flat_Collection $collection, $storeId)
     {
+        $idPathExpr = $collection->getConnection()->getConcatSql(["'category/'", 'main_table.entity_id']);
         $collection->getSelect()->joinLeft(
             ['url_rewrite' => $collection->getTable('core/url_rewrite')],
             'url_rewrite.category_id = main_table.entity_id AND url_rewrite.is_system = 1 ' .
                 ' AND ' . $collection->getConnection()->quoteInto('url_rewrite.store_id = ?', $storeId) .
                 ' AND url_rewrite.category_id IS NOT NULL' .
-                ' AND ' . $collection->getConnection()->quoteInto('url_rewrite.id_path LIKE ?', 'category/%'),
+                " AND url_rewrite.id_path = {$idPathExpr}",
             ['request_path'],
         );
         return $this;
@@ -85,6 +87,7 @@ class Mage_Catalog_Helper_Category_Url_Rewrite extends Mage_Core_Helper_Abstract
     #[\Override]
     public function joinTableToSelect(\Maho\Db\Select $select, $storeId)
     {
+        $idPathExpr = $this->_connection->getConcatSql(["'category/'", 'main_table.entity_id']);
         $select->joinLeft(
             ['url_rewrite' => $this->_resource->getTableName('core/url_rewrite')],
             'url_rewrite.category_id=main_table.entity_id AND url_rewrite.is_system=1 AND ' .
@@ -93,7 +96,7 @@ class Mage_Catalog_Helper_Category_Url_Rewrite extends Mage_Core_Helper_Abstract
                     (int) $storeId,
                 ) .
                 'url_rewrite.category_id IS NOT NULL AND ' .
-                $this->_connection->prepareSqlCondition('url_rewrite.id_path', ['like' => 'category/%']),
+                "url_rewrite.id_path = {$idPathExpr}",
             ['request_path' => 'url_rewrite.request_path'],
         );
         return $this;

--- a/app/code/core/Mage/Core/Model/Resource/Url/Rewrite/Collection.php
+++ b/app/code/core/Mage/Core/Model/Resource/Url/Rewrite/Collection.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2024-2026 Maho <https://mahocommerce.com>
- * SPDX-FileCopyrightText: 2019-2024 The OpenMage Contributors <https://openmage.org>
+ * SPDX-FileCopyrightText: 2019-2026 The OpenMage Contributors <https://openmage.org>
  * SPDX-FileCopyrightText: 2006-2020 Magento, Inc. <https://magento.com>
  * SPDX-License-Identifier: OSL-3.0
  * @package Mage_Core
@@ -85,8 +85,11 @@ class Mage_Core_Model_Resource_Url_Rewrite_Collection extends Mage_Core_Model_Re
      */
     public function filterAllByCategory()
     {
+        $idPathExpr = $this->getConnection()->getConcatSql(["'category/'", 'category_id']);
         $this->getSelect()
-            ->where('id_path LIKE ?', 'category/%');
+            ->where('id_path LIKE ?', 'category/%')
+            ->where('category_id IS NOT NULL')
+            ->where("id_path = {$idPathExpr}");
         return $this;
     }
 }


### PR DESCRIPTION
## Summary

Port of OpenMage/magento-lts#5663 — many thanks to @loekvangool for the original work, the careful `ANALYZE` measurements, and the production validation behind it. 🙏

The category URL rewrite joins (EAV category collection, flat category collection, flat/sitemap selects) previously matched rewrite rows with the broad predicate `id_path LIKE 'category/%'`. Since system category rewrites always store `id_path` as exactly `category/{category_id}`, and these joins already constrain `category_id = entity_id`, the predicate can be tightened to a canonical equality:

- from `id_path LIKE 'category/%'`
- to `id_path = CONCAT('category/', entity_id)`

This lets the database resolve each join probe as a single-row lookup on the unique `(id_path, is_system, store_id)` index instead of an index range + filter. The upstream author measured the join probe dropping from cost ~80 to ~2 (~40x cheaper) on a production store with ~100k SKUs and 800 categories, with byte-for-byte identical results. These joins run on every category menu render and sitemap generation, so this is a hot path.

`filterAllByCategory()` in the URL rewrite collection gets the matching tightening (keeping the LIKE for index range use), mirroring upstream.

## Maho-specific adaptation

Instead of upstream's hard-coded `CONCAT(...)`, this uses the adapter's `getConcatSql()`, which emits `CONCAT(a, b)` on MySQL and `a || b` on PostgreSQL/SQLite, keeping the fix working across all database platforms Maho supports. Verified the generated SQL against a live install.

## Correctness / risk

On consistent data the old and new predicates select exactly the same rows. Results only diverge if `id_path` and `category_id` disagree on a rewrite row — a corrupt state where rewrites are already broken; re-saving the category / reindexing rewrites repairs it.

## Testing

- php-cs-fixer, rector, and PHPStan clean on the changed files
- Full test suites pass: Install (3), Frontend (160), Backend (2358)