### PR TITLE
Fixed v2 API returning 500 instead of 400 for malformed JSON request bodies

### DIFF
--- a/app/code/core/Maho/ApiPlatform/symfony/EventListener/ApiExceptionListener.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/EventListener/ApiExceptionListener.php
@@ -19,6 +19,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\InsufficientAuthenticationException;
+use Symfony\Component\Serializer\Exception\NotEncodableValueException;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException as SerializerUnexpectedValueException;
 
 /**
  * API Exception Listener.
@@ -191,6 +193,35 @@ class ApiExceptionListener implements EventSubscriberInterface
 
             $headers = $statusCode === 401 ? ['WWW-Authenticate' => 'Bearer'] : [];
             return new JsonResponse($data, $statusCode, $headers);
+        }
+
+        // Request bodies the Symfony Serializer rejects while deserializing into
+        // an input DTO (API Platform's DeserializeProvider) are client errors.
+        // NotEncodableValueException = unparseable JSON; the other subclasses
+        // (NotNormalizableValueException, PartialDenormalizationException, the
+        // base class itself) = parseable JSON that doesn't fit the DTO shape.
+        // Their messages are serializer-generated and client-actionable ("The
+        // type of the "email" attribute must be ..."), safe to pass through.
+        // Processor::parseRequestBody() already maps its own JSON errors to 400;
+        // this mirrors that for the DTO path, which otherwise surfaced as 500.
+        if ($exception instanceof SerializerUnexpectedValueException) {
+            $statusCode = 400;
+            $data = [
+                'error' => 'bad_request',
+                'message' => $exception instanceof NotEncodableValueException
+                    ? 'Invalid JSON in request body'
+                    : ($exception->getMessage() ?: 'Invalid request body'),
+                'code' => $statusCode,
+            ];
+
+            if ($this->showDebug()) {
+                $data['debug'] = [
+                    'class' => $exception::class,
+                    'trace' => $exception->getTraceAsString(),
+                ];
+            }
+
+            return new JsonResponse($data, $statusCode);
         }
 
         // Mage_Core_Exception is the canonical user-facing validation/business

--- a/tests/Api/V2/Write/MalformedRequestBodyTest.php
+++ b/tests/Api/V2/Write/MalformedRequestBodyTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+/**
+ * API v2 Malformed Request Body Tests
+ *
+ * A broken request body is a client error: every body the Symfony Serializer
+ * rejects while deserializing into an input DTO must surface as 400
+ * bad_request, never 500 internal_server_error (issue #1116). Covers the
+ * DeserializeProvider path, which bypasses Processor::parseRequestBody()'s
+ * own JSON handling.
+ *
+ * @group write
+ */
+
+describe('Malformed JSON request bodies', function (): void {
+
+    it('returns 400 for syntactically invalid JSON on a public write endpoint', function (): void {
+        $response = apiPostRaw('/api/rest/v2/newsletter/subscribe', '{invalid');
+
+        expect($response['status'])->toBe(400);
+        expect($response['json']['error'])->toBe('bad_request');
+        expect($response['json']['message'])->toBe('Invalid JSON in request body');
+        expect($response['json']['code'])->toBe(400);
+    });
+
+    it('returns 400 for an empty request body', function (): void {
+        $response = apiPostRaw('/api/rest/v2/newsletter/subscribe', '');
+
+        expect($response['status'])->toBe(400);
+        expect($response['json']['error'])->toBe('bad_request');
+        expect($response['json']['message'])->toBe('Invalid JSON in request body');
+    });
+
+    it('returns 400 when a JSON value has the wrong type for the DTO', function (): void {
+        $response = apiPostRaw('/api/rest/v2/newsletter/subscribe', '{"email": {"nested": true}}');
+
+        expect($response['status'])->toBe(400);
+        expect($response['json']['error'])->toBe('bad_request');
+        expect($response['json']['message'])->not->toBe('An internal error occurred');
+        expect($response['json']['message'])->not->toBe('');
+    });
+
+    it('returns 400 for a JSON root of the wrong type', function (): void {
+        $response = apiPostRaw('/api/rest/v2/newsletter/subscribe', '"just a string"');
+
+        expect($response['status'])->toBe(400);
+        expect($response['json']['error'])->toBe('bad_request');
+        expect($response['json']['message'])->not->toBe('An internal error occurred');
+    });
+
+    it('returns 400 for malformed JSON on an authenticated write endpoint', function (): void {
+        $token = serviceToken(['cms-pages/write']);
+        $response = apiPostRaw('/api/rest/v2/cms-pages', '{invalid', $token);
+
+        expect($response['status'])->toBe(400);
+        expect($response['json']['error'])->toBe('bad_request');
+        expect($response['json']['message'])->toBe('Invalid JSON in request body');
+    });
+
+    it('still returns the domain validation error for valid JSON with an invalid value', function (): void {
+        $response = apiPost('/api/rest/v2/newsletter/subscribe', ['email' => 'not-an-email']);
+
+        expect($response['status'])->toBe(400);
+        expect($response['json']['error'])->toBe('bad_request');
+        expect($response['json']['message'])->toBe('Invalid email address');
+    });
+});

--- a/tests/Helpers/ApiV2Helper.php
+++ b/tests/Helpers/ApiV2Helper.php
@@ -294,6 +294,18 @@ class ApiV2Helper
     }
 
     /**
+     * HTTP POST with a raw, unencoded body — for sending deliberately malformed
+     * JSON or other non-array payloads that post() would json_encode.
+     *
+     * @param array<string, string> $extraHeaders
+     * @return array{status: int, json: array, raw: string, headers: array}
+     */
+    public static function postRaw(string $path, string $body, ?string $token = null, array $extraHeaders = []): array
+    {
+        return self::request('POST', $path, $body, $token, $extraHeaders);
+    }
+
+    /**
      * HTTP PUT request
      *
      * @param array<string, string> $extraHeaders
@@ -809,7 +821,7 @@ class ApiV2Helper
      * @param array<string, string> $extraHeaders
      * @return array{status: int, json: array, raw: string, headers: array}
      */
-    private static function request(string $method, string $path, ?array $data = null, ?string $token = null, array $extraHeaders = []): array
+    private static function request(string $method, string $path, array|string|null $data = null, ?string $token = null, array $extraHeaders = []): array
     {
         $url = self::getBaseUrl() . $path;
 
@@ -843,7 +855,7 @@ class ApiV2Helper
         ];
 
         if ($data !== null) {
-            $options['http']['content'] = json_encode($data);
+            $options['http']['content'] = is_array($data) ? json_encode($data) : $data;
         }
 
         $requestUrl = $url;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -59,6 +59,11 @@ function apiPost(string $path, array $data, ?string $token = null, array $extraH
     return ApiV2Helper::post($path, $data, $token, $extraHeaders);
 }
 
+function apiPostRaw(string $path, string $body, ?string $token = null, array $extraHeaders = []): array
+{
+    return ApiV2Helper::postRaw($path, $body, $token, $extraHeaders);
+}
+
 function apiPut(string $path, array $data, ?string $token = null, array $extraHeaders = []): array
 {
     return ApiV2Helper::put($path, $data, $token, $extraHeaders);


### PR DESCRIPTION
Fixes #1116

## Problem

Sending a body the Symfony Serializer can't deserialize to any v2 endpoint with an input DTO returned `500 internal_server_error` instead of a client error. API Platform's `DeserializeProvider` parses the body before `Processor::parseRequestBody()` (which already maps its own JSON errors to 400), and the serializer's exceptions matched none of the branches in `ApiExceptionListener::createErrorResponse()`, so they fell through to the generic 500 handler.

Reproduction showed the problem was broader than syntax errors — all of these returned 500:

| Body | Exception |
|---|---|
| `{invalid` | `NotEncodableValueException` |
| empty body | `NotEncodableValueException` |
| `{"email": {"nested": true}}` | `NotNormalizableValueException` |
| `"just a string"` | `UnexpectedValueException` |

## Fix

Added a branch to `ApiExceptionListener` mapping the serializer's `UnexpectedValueException` family (which includes `NotEncodableValueException`, `NotNormalizableValueException` and `PartialDenormalizationException`) to `400 bad_request`, matching stock API Platform behavior:

- Unparseable JSON → `{"error": "bad_request", "message": "Invalid JSON in request body", "code": 400}`, mirroring `parseRequestBody()`
- Shape/type mismatches pass through the serializer's client-actionable message (e.g. `The type of the "email" attribute must be "null|string", "array" given.`)

Since these no longer hit the generic branch, unauthenticated clients can no longer generate `Mage::logException()` noise on demand with broken payloads.

## Tests

Developed TDD: `tests/Api/V2/Write/MalformedRequestBodyTest.php` (5 failing cases before the fix, plus a control asserting valid-JSON domain validation still returns its own 400) covering a public endpoint (newsletter subscribe) and an authenticated one (cms-pages). Added a raw-body `apiPostRaw()` helper since the existing `apiPost()` JSON-encodes an array and can't send malformed bodies.

- Full Api suite: 572 passed (1920 assertions)
- phpstan / php-cs-fixer / rector clean

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->