### PR TITLE
Removed long-deprecated legacy code and formally deprecated `TYPE_TIMESTAMP`

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -139,9 +139,6 @@ defined('DS') || define('DS', DIRECTORY_SEPARATOR);
 defined('PS') || define('PS', PATH_SEPARATOR);
 defined('BP') || define('BP', Maho::getBasePath());
 
-/** @deprecated */
-defined('MAGENTO_ROOT') || define('MAGENTO_ROOT', BP);
-
 if (!empty($_SERVER['MAGE_IS_DEVELOPER_MODE']) || !empty($_ENV['MAGE_IS_DEVELOPER_MODE'])) {
     Mage::setIsDeveloperMode(true);
 

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -558,7 +558,7 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
             $this->_columns = array_merge($this->_getStaticColumns(), $this->_getEavColumns());
             foreach ($this->_columns as $fieldName => $fieldProp) {
                 $default = $fieldProp['default'];
-                if ($fieldProp['type'][0] == Maho\Db\Ddl\Table::TYPE_TIMESTAMP
+                if ($fieldProp['type'][0] == Maho\Db\Ddl\Table::TYPE_DATETIME
                     && $default === 'CURRENT_TIMESTAMP'
                 ) {
                     $default = Maho\Db\Ddl\Table::TIMESTAMP_INIT;
@@ -672,11 +672,8 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
                     $options = $column['LENGTH'];
                     $isUnsigned = null;
                     break;
-                case Maho\Db\Ddl\Table::TYPE_TIMESTAMP:
-                    $options = null;
-                    $isUnsigned = null;
-                    break;
                 case Maho\Db\Ddl\Table::TYPE_DATETIME:
+                    $options = null;
                     $isUnsigned = null;
                     break;
             }

--- a/app/code/core/Mage/Page/Block/Html/Head.php
+++ b/app/code/core/Mage/Page/Block/Html/Head.php
@@ -37,7 +37,7 @@ class Mage_Page_Block_Html_Head extends Mage_Core_Block_Template
      */
     public function addCss($name, $params = '', $referenceName = '*', $before = null)
     {
-        $this->addItem('skin_css', $name, $params, null, null, $referenceName, $before);
+        $this->addItem('skin_css', $name, $params, null, $referenceName, $before);
         return $this;
     }
 
@@ -52,7 +52,7 @@ class Mage_Page_Block_Html_Head extends Mage_Core_Block_Template
      */
     public function addJs($name, $params = '', $referenceName = '*', $before = null)
     {
-        $this->addItem('js', $name, $params, null, null, $referenceName, $before);
+        $this->addItem('js', $name, $params, null, $referenceName, $before);
         return $this;
     }
 
@@ -82,20 +82,16 @@ class Mage_Page_Block_Html_Head extends Mage_Core_Block_Template
      * @param string $type
      * @param string $name
      * @param string $params
-     * @param string $if
      * @param string $cond
      * @param string $referenceName name of the item to insert the element before. If name is not found, insert at the end, * has special meaning (before all / before all)
      * @param string|bool $before If true insert before the $referenceName instead of after
      * @return $this
      */
-    public function addItem($type, $name, $params = null, $if = null, $cond = null, $referenceName = '*', $before = false)
+    public function addItem($type, $name, $params = null, $cond = null, $referenceName = '*', $before = false)
     {
         // allow skipping of parameters in the layout XML files via empty-string
         if ($params === '') {
             $params = null;
-        }
-        if ($if === '') {
-            $if = null;
         }
         if ($cond === '') {
             $cond = null;
@@ -113,7 +109,6 @@ class Mage_Page_Block_Html_Head extends Mage_Core_Block_Template
             'type' => $type,
             'name' => $name,
             'params' => $params,
-            'if' => $if,
             'cond' => $cond,
             'should_minify' => $shouldMinify, // Flag for deferred minification
         ];
@@ -150,55 +145,43 @@ class Mage_Page_Block_Html_Head extends Mage_Core_Block_Template
     public function getCssJsHtml()
     {
         // separate items by types
-        $lines  = [];
+        $items  = [];
         foreach ($this->_data['items'] as $item) {
             if (!is_null($item['cond']) && !$this->getData($item['cond']) || !isset($item['name'])) {
                 continue;
             }
-            $if     = empty($item['if']) ? '' : $item['if'];
             $params = empty($item['params']) ? '' : $item['params'];
             switch ($item['type']) {
                 case 'js':        // js/*.js
                 case 'skin_js':   // skin/*/*.js
                 case 'js_css':    // js/*.css
                 case 'skin_css':  // skin/*/*.css
-                    $lines[$if][$item['type']][$params][$item['name']] = $item;
+                    $items[$item['type']][$params][$item['name']] = $item;
                     break;
                 default:
-                    $this->_separateOtherHtmlHeadElements($lines, $if, $item['type'], $params, $item['name'], $item);
+                    $this->_separateOtherHtmlHeadElements($items, $item['type'], $params, $item['name'], $item);
                     break;
             }
         }
 
         // prepare HTML
-        $html   = '';
-        foreach ($lines as $if => $items) {
-            if (empty($items)) {
-                continue;
-            }
-            if (!empty($if)) {
-                // @deprecated
-                continue;
-            }
+        // static and skin css
+        $html = $this->_prepareStaticAndSkinElements(
+            '<link rel="stylesheet" href="%s"%s >' . PHP_EOL,
+            empty($items['js_css']) ? [] : $items['js_css'],
+            empty($items['skin_css']) ? [] : $items['skin_css'],
+        );
 
-            // static and skin css
-            $html .= $this->_prepareStaticAndSkinElements(
-                '<link rel="stylesheet" href="%s"%s >' . PHP_EOL,
-                empty($items['js_css']) ? [] : $items['js_css'],
-                empty($items['skin_css']) ? [] : $items['skin_css'],
-            );
+        // static and skin javascripts
+        $html .= $this->_prepareStaticAndSkinElements(
+            '<script src="%s"%s></script>' . PHP_EOL,
+            empty($items['js']) ? [] : $items['js'],
+            empty($items['skin_js']) ? [] : $items['skin_js'],
+        );
 
-            // static and skin javascripts
-            $html .= $this->_prepareStaticAndSkinElements(
-                '<script src="%s"%s></script>' . PHP_EOL,
-                empty($items['js']) ? [] : $items['js'],
-                empty($items['skin_js']) ? [] : $items['skin_js'],
-            );
-
-            // other stuff
-            if (!empty($items['other'])) {
-                $html .= $this->_prepareOtherHtmlHeadElements($items['other']) . PHP_EOL;
-            }
+        // other stuff
+        if (!empty($items['other'])) {
+            $html .= $this->_prepareOtherHtmlHeadElements($items['other']) . PHP_EOL;
         }
         return $html;
     }
@@ -280,26 +263,25 @@ class Mage_Page_Block_Html_Head extends Mage_Core_Block_Template
      *
      * @see self::getCssJsHtml()
      * @param array $lines
-     * @param string $itemIf
      * @param string $itemType
      * @param string $itemParams
      * @param string $itemName
      * @param array $itemThe
      */
-    protected function _separateOtherHtmlHeadElements(&$lines, $itemIf, $itemType, $itemParams, $itemName, $itemThe)
+    protected function _separateOtherHtmlHeadElements(&$lines, $itemType, $itemParams, $itemName, $itemThe)
     {
         $params = $itemParams ? ' ' . $itemParams : '';
         $href   = $itemName;
         switch ($itemType) {
             case 'rss':
-                $lines[$itemIf]['other'][] = sprintf(
+                $lines['other'][] = sprintf(
                     '<link href="%s"%s rel="alternate" type="application/rss+xml">',
                     $href,
                     $params,
                 );
                 break;
             case 'link_rel':
-                $lines[$itemIf]['other'][] = sprintf('<link%s href="%s">', $params, $href);
+                $lines['other'][] = sprintf('<link%s href="%s">', $params, $href);
                 break;
         }
     }

--- a/app/code/core/Mage/Sales/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Setup.php
@@ -136,8 +136,6 @@ class Mage_Sales_Model_Resource_Setup extends Mage_Eav_Model_Entity_Setup
         $length = null;
         switch ($data['type']) {
             case 'timestamp':
-                $type = Maho\Db\Ddl\Table::TYPE_TIMESTAMP;
-                break;
             case 'datetime':
                 $type = Maho\Db\Ddl\Table::TYPE_DATETIME;
                 break;

--- a/app/design/adminhtml/default/default/layout/main.xml
+++ b/app/design/adminhtml/default/default/layout/main.xml
@@ -55,7 +55,7 @@ Default layout, loads most of the pages
                 <action method="addItem"><type>skin_css</type><name>menu.css</name><params>media="screen, projection"</params></action>
                 <action method="addCss"><name>print.css</name><params>media="print"</params></action>
 
-                <action method="addItem"><type>js</type><name>mage/adminhtml/rules.js</name><params/><if/><condition>can_load_rules_js</condition></action>
+                <action method="addItem"><type>js</type><name>mage/adminhtml/rules.js</name><params/><condition>can_load_rules_js</condition></action>
             </block>
 
             <block type="adminhtml/page_notices" name="global_notices" as="global_notices" template="page/notices.phtml" />
@@ -112,8 +112,8 @@ Layout for editor element
 -->
     <editor>
         <reference name="head">
-            <action method="addItem"><type>js</type><name>mage/adminhtml/wysiwyg/tiptap/setup.js</name><params>type="module"</params><if/><condition>can_load_wysiwyg</condition></action>
-            <action method="addItem"><type>js_css</type><name>mage/adminhtml/wysiwyg/tiptap/tiptap.css</name><params/><if/><condition>can_load_wysiwyg</condition></action>
+            <action method="addItem"><type>js</type><name>mage/adminhtml/wysiwyg/tiptap/setup.js</name><params>type="module"</params><condition>can_load_wysiwyg</condition></action>
+            <action method="addItem"><type>js_css</type><name>mage/adminhtml/wysiwyg/tiptap/tiptap.css</name><params/><condition>can_load_wysiwyg</condition></action>
             <action method="addJs"><script>mage/adminhtml/variables.js</script></action>
             <action method="addJs"><script>mage/adminhtml/wysiwyg/widget.js</script></action>
             <action method="addJs"><script>mage/adminhtml/uploader/instance.js</script></action>

--- a/lib/Maho/Db/Ddl/Table.php
+++ b/lib/Maho/Db/Ddl/Table.php
@@ -42,17 +42,16 @@ class Table
     public const TYPE_DATETIME         = 'datetime';
     /**
      * Value-equal alias for TYPE_DATETIME — both physically create a MySQL `datetime`
-     * column. Kept for source-compat with historical install scripts and third-party
-     * modules; new code should prefer TYPE_DATETIME for clarity. Doctrine DBAL's column
-     * model conflates TIMESTAMP and DATETIME and silently rewrites TIMESTAMP→DATETIME
-     * on diff, and Maho forces session TZ to UTC on connect (#861) which makes
-     * TIMESTAMP's TZ auto-conversion a no-op anyway. `DEFAULT CURRENT_TIMESTAMP` and
-     * `ON UPDATE CURRENT_TIMESTAMP` (the features that justified TIMESTAMP) are
-     * supported on DATETIME since MySQL 5.6 / MariaDB 10.0.
+     * column. Doctrine DBAL's column model conflates TIMESTAMP and DATETIME and
+     * silently rewrites TIMESTAMP→DATETIME on diff, and Maho forces session TZ to UTC
+     * on connect (#861) which makes TIMESTAMP's TZ auto-conversion a no-op anyway.
+     * `DEFAULT CURRENT_TIMESTAMP` and `ON UPDATE CURRENT_TIMESTAMP` (the features that
+     * justified TIMESTAMP) are supported on DATETIME since MySQL 5.6 / MariaDB 10.0.
      *
-     * Not formally @deprecated to avoid flooding PHPStan with warnings on the dozens
-     * of immutable historical install scripts that already use this constant.
+     * Kept only for third-party install scripts; to be removed together with the
+     * Varien_Db_* class aliases.
      */
+    #[\Deprecated(message: 'since 26.9 Use TYPE_DATETIME instead.')]
     public const TYPE_TIMESTAMP        = self::TYPE_DATETIME;
     public const TYPE_TEXT             = 'text';
     public const TYPE_BLOB             = 'blob'; // Used for back compatibility, when query param can't use statement options


### PR DESCRIPTION
## Summary

Removes code that has been deprecated for over a year and formally deprecates `Maho\Db\Ddl\Table::TYPE_TIMESTAMP`.

### Removed

- **`MAGENTO_ROOT` constant** (`app/bootstrap.php`): deprecated OpenMage-era alias for `BP`, unused anywhere in the codebase.
- **IE conditional-comment support in `Mage_Page_Block_Html_Head`**: the feature has been a silent no-op for years (the render path skipped every item with a non-empty `if` condition). The `$if` parameter is gone from `addItem()`, the item array no longer stores an `if` key, and `getCssJsHtml()` lost the dead grouping loop. The three adminhtml `main.xml` actions that passed an empty `<if/>` placeholder to reach `<condition>` were updated to the new argument order.

### Deprecated

- **`TYPE_TIMESTAMP`** is now formally tagged with the native `#[\Deprecated]` attribute (since 26.9). The original reason for not tagging it (PHPStan warnings on dozens of historical install scripts) no longer applies since the declarative schema migration: no sql script references it anymore. It is kept only for third-party install scripts and will be removed together with the `Varien_Db_*` class aliases.

### Cleaned up

- `Mage_Sales_Model_Resource_Setup`: merged the `'timestamp'`/`'datetime'` attribute type cases into one `TYPE_DATETIME` branch.
- `Mage_Catalog_Model_Resource_Category_Flat`: merged a switch that listed both value-equal aliases as separate cases (the `TYPE_DATETIME` branch was unreachable) and swapped the remaining `TYPE_TIMESTAMP` reference to `TYPE_DATETIME`.

Core is now completely free of `TYPE_TIMESTAMP` usage. The integration tests that deliberately pin the alias behavior were left untouched.

### Backward compatibility notes

- Third-party layout XML calling `addItem` with the old positional `<if/>` placeholder would now feed that value into `$cond`; core shipped no such usage and the feature has been a no-op for years.
- Third-party PHP code referencing `MAGENTO_ROOT` must switch to `BP`.

## Testing

- `composer lint` passes (cs-fixer, rector, phpstan).
- `composer test` passes: 3098 tests, 95235 assertions.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->