### PR TITLE
Replaced the relaxed `SQL_MODE` override with a pinned strict baseline on MySQL connections

### DIFF
--- a/app/code/core/Mage/Eav/Model/Resource/Helper/Mysql.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Helper/Mysql.php
@@ -103,14 +103,15 @@ class Mage_Eav_Model_Resource_Helper_Mysql extends Mage_Core_Model_Resource_Help
     /**
      * Check if database requires strict GROUP BY (all SELECT columns in GROUP BY)
      *
-     * Returns true when Maho is in developer mode, since the MySQL adapter
-     * sets SQL_MODE='ONLY_FULL_GROUP_BY' in that case.
+     * Always true: the MySQL adapter pins ONLY_FULL_GROUP_BY in its baseline
+     * SQL_MODE (issue #688 step 3), so the compliant query shape must not
+     * depend on developer mode.
      *
      * @return bool
      */
     public function requiresStrictGroupBy()
     {
-        return Mage::getIsDeveloperMode();
+        return true;
     }
 
     /**

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Category.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Category.php
@@ -410,7 +410,6 @@ class Mage_ImportExport_Model_Import_Entity_Category extends Mage_ImportExport_M
         $entityTable = Mage::getSingleton('core/resource')->getTableName('catalog_category_entity');
         $newCategoryAttributes = [];
         $isPostgres = $this->_connection instanceof \Maho\Db\Adapter\Pdo\Pgsql;
-        $isSqlite = $this->_connection instanceof \Maho\Db\Adapter\Pdo\Sqlite;
 
         foreach ($entityRows as &$row) {
             // Extract temporary data before database insert
@@ -429,13 +428,11 @@ class Mage_ImportExport_Model_Import_Entity_Category extends Mage_ImportExport_M
                         "SELECT nextval(pg_get_serial_sequence('{$entityTable}', 'entity_id'))",
                     );
                     $row['entity_id'] = $entityId;
-                } elseif ($isSqlite) {
-                    // SQLite: use placeholder path since we can't get next ID before insert
-                    // but SQLite strictly enforces NOT NULL. Will update after insert.
-                    $row['path'] = '0';
-                    $needsPathUpdate = true;
                 } else {
-                    // MySQL: let auto_increment handle it, will update path after
+                    // MySQL/SQLite: the auto-increment id is unknown before insert and
+                    // path is NOT NULL under strict mode, so insert a placeholder path
+                    // and update it after lastInsertId is available.
+                    $row['path'] = '0';
                     $needsPathUpdate = true;
                 }
             }

--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -1878,7 +1878,10 @@ class Mysql extends AbstractPdoAdapter
     #[\Override]
     public function insertForce(string $table, array $bind): int
     {
-        $this->raw_query("SET @OLD_INSERT_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO'");
+        // Add NO_AUTO_VALUE_ON_ZERO (so an explicit 0 is stored in an identity column
+        // instead of triggering auto_increment) on top of the strict baseline, rather
+        // than replacing it — the insert itself stays validated by the pinned mode.
+        $this->raw_query("SET @OLD_INSERT_SQL_MODE=@@SQL_MODE, SQL_MODE=CONCAT(@@SQL_MODE, ',NO_AUTO_VALUE_ON_ZERO')");
         $result = $this->insert($table, $bind);
         $this->raw_query("SET SQL_MODE=IFNULL(@OLD_INSERT_SQL_MODE,'')");
 
@@ -2822,7 +2825,10 @@ class Mysql extends AbstractPdoAdapter
     public function startSetup(): self
     {
         $this->raw_query('SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0');
-        $this->raw_query("SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO'");
+        // Add NO_AUTO_VALUE_ON_ZERO (data scripts may insert explicit ids, including 0)
+        // on top of the strict baseline instead of replacing it, so install/upgrade
+        // scripts run under the same strict mode as production, not a relaxed one.
+        $this->raw_query("SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE=CONCAT(@@SQL_MODE, ',NO_AUTO_VALUE_ON_ZERO')");
 
         return $this;
     }

--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -130,11 +130,19 @@ class Mysql extends AbstractPdoAdapter
     {
         // Pin a strict baseline per connection, so behavior is deterministic
         // regardless of server or provider global defaults (issue #688). The
-        // set is intentionally exactly the MySQL 8+ factory default: stricter
+        // validation flags are exactly the MySQL 8+ factory default; stricter
         // or different flags were considered and deliberately excluded, see
         // PR #1123 before changing this list. The three zero-date/division
         // flags are deprecated as standalone flags; trim them here when a
         // MySQL release drops them.
+        //
+        // NO_AUTO_VALUE_ON_ZERO is the one addition on top of the factory
+        // default: it makes an explicit 0 bound to an AUTO_INCREMENT column
+        // store 0 (instead of triggering next-value generation), matching how
+        // PostgreSQL and SQLite already behave, so insert semantics are
+        // identical across all three engines. New-row inserts omit the PK (or
+        // bind NULL) and still auto-generate as usual. Because it is now always
+        // on, startSetup()/insertForce() no longer need to toggle SQL_MODE.
         if (isset($this->_config['sql_mode'])) {
             // Escape hatch: a <sql_mode> node on the connection in local.xml
             // overrides the baseline verbatim (an empty value restores the
@@ -147,6 +155,7 @@ class Mysql extends AbstractPdoAdapter
                 'NO_ZERO_DATE',
                 'ERROR_FOR_DIVISION_BY_ZERO',
                 'NO_ENGINE_SUBSTITUTION',
+                'NO_AUTO_VALUE_ON_ZERO',
             ];
             if (!$this->isMariaDb()) {
                 // MariaDB is exempt from ONLY_FULL_GROUP_BY: its implementation lacks the
@@ -1872,20 +1881,19 @@ class Mysql extends AbstractPdoAdapter
     }
 
     /**
-     * Inserts a table row with specified data
-     * Special for Zero values to identity column
+     * Inserts a table row with specified data, storing an explicit 0 verbatim in
+     * an identity column.
+     *
+     * NO_AUTO_VALUE_ON_ZERO is now pinned permanently in the connection baseline
+     * (see _initConnection()), so a plain insert() already stores an explicit 0
+     * without triggering auto_increment — identical to the PostgreSQL and SQLite
+     * adapters. Kept as a thin wrapper for backward compatibility and to document
+     * intent at call sites.
      */
     #[\Override]
     public function insertForce(string $table, array $bind): int
     {
-        // Add NO_AUTO_VALUE_ON_ZERO (so an explicit 0 is stored in an identity column
-        // instead of triggering auto_increment) on top of the strict baseline, rather
-        // than replacing it — the insert itself stays validated by the pinned mode.
-        $this->raw_query("SET @OLD_INSERT_SQL_MODE=@@SQL_MODE, SQL_MODE=CONCAT(@@SQL_MODE, ',NO_AUTO_VALUE_ON_ZERO')");
-        $result = $this->insert($table, $bind);
-        $this->raw_query("SET SQL_MODE=IFNULL(@OLD_INSERT_SQL_MODE,'')");
-
-        return $result;
+        return $this->insert($table, $bind);
     }
 
     /**
@@ -2824,11 +2832,11 @@ class Mysql extends AbstractPdoAdapter
     #[\Override]
     public function startSetup(): self
     {
+        // SQL_MODE is left untouched: the connection baseline already pins the strict
+        // flags plus NO_AUTO_VALUE_ON_ZERO (data scripts may insert explicit ids,
+        // including 0), so install/upgrade scripts run under the same mode as
+        // production and get fully validated.
         $this->raw_query('SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0');
-        // Add NO_AUTO_VALUE_ON_ZERO (data scripts may insert explicit ids, including 0)
-        // on top of the strict baseline instead of replacing it, so install/upgrade
-        // scripts run under the same strict mode as production, not a relaxed one.
-        $this->raw_query("SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE=CONCAT(@@SQL_MODE, ',NO_AUTO_VALUE_ON_ZERO')");
 
         return $this;
     }
@@ -2839,7 +2847,6 @@ class Mysql extends AbstractPdoAdapter
     #[\Override]
     public function endSetup(): self
     {
-        $this->raw_query("SET SQL_MODE=IFNULL(@OLD_SQL_MODE,'')");
         $this->raw_query('SET FOREIGN_KEY_CHECKS=IF(@OLD_FOREIGN_KEY_CHECKS=0, 0, 1)');
 
         return $this;

--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -128,16 +128,23 @@ class Mysql extends AbstractPdoAdapter
     #[\Override]
     protected function _initConnection(): void
     {
-        /** @link http://bugs.mysql.com/bug.php?id=18551 */
-        $sqlMode = '';
-        if (\Mage::getIsDeveloperMode() && !$this->isMariaDb()) {
-            // Surface non-strict GROUP BY queries during development (issue #688).
-            // MariaDB is exempt: its ONLY_FULL_GROUP_BY lacks the functional-dependency
-            // detection of MySQL/PostgreSQL (MDEV-11588), so it would reject
-            // SQL-standard queries like SELECT t.* ... GROUP BY t.pk.
-            $sqlMode = 'ONLY_FULL_GROUP_BY';
+        // PROTOTYPE (issue #688 step 3): pin an explicit modern strict baseline (the
+        // MySQL 8+ default mode set) instead of the legacy SQL_MODE='' override, so
+        // behavior is deterministic regardless of server/provider global defaults.
+        $modes = [
+            'STRICT_TRANS_TABLES',
+            'NO_ZERO_IN_DATE',
+            'NO_ZERO_DATE',
+            'ERROR_FOR_DIVISION_BY_ZERO',
+            'NO_ENGINE_SUBSTITUTION',
+        ];
+        if (!$this->isMariaDb()) {
+            // MariaDB is exempt from ONLY_FULL_GROUP_BY: its implementation lacks the
+            // functional-dependency detection of MySQL/PostgreSQL (MDEV-11588), so it
+            // would reject SQL-standard queries like SELECT t.* ... GROUP BY t.pk.
+            array_unshift($modes, 'ONLY_FULL_GROUP_BY');
         }
-        $this->_connection->executeStatement("SET SQL_MODE='{$sqlMode}'");
+        $this->_connection->executeStatement("SET SQL_MODE='" . implode(',', $modes) . "'");
         $this->_connection->executeStatement("SET time_zone = '+00:00'");
     }
 

--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -128,23 +128,31 @@ class Mysql extends AbstractPdoAdapter
     #[\Override]
     protected function _initConnection(): void
     {
-        // PROTOTYPE (issue #688 step 3): pin an explicit modern strict baseline (the
-        // MySQL 8+ default mode set) instead of the legacy SQL_MODE='' override, so
-        // behavior is deterministic regardless of server/provider global defaults.
-        $modes = [
-            'STRICT_TRANS_TABLES',
-            'NO_ZERO_IN_DATE',
-            'NO_ZERO_DATE',
-            'ERROR_FOR_DIVISION_BY_ZERO',
-            'NO_ENGINE_SUBSTITUTION',
-        ];
-        if (!$this->isMariaDb()) {
-            // MariaDB is exempt from ONLY_FULL_GROUP_BY: its implementation lacks the
-            // functional-dependency detection of MySQL/PostgreSQL (MDEV-11588), so it
-            // would reject SQL-standard queries like SELECT t.* ... GROUP BY t.pk.
-            array_unshift($modes, 'ONLY_FULL_GROUP_BY');
+        // Pin an explicit modern strict baseline (the MySQL 8+ default mode set)
+        // per connection, so behavior is deterministic regardless of server or
+        // provider global defaults (issue #688).
+        if (isset($this->_config['sql_mode'])) {
+            // Escape hatch: a <sql_mode> node on the connection in local.xml
+            // overrides the baseline verbatim (an empty value restores the
+            // legacy fully-relaxed behavior).
+            $sqlMode = (string) $this->_config['sql_mode'];
+        } else {
+            $modes = [
+                'STRICT_TRANS_TABLES',
+                'NO_ZERO_IN_DATE',
+                'NO_ZERO_DATE',
+                'ERROR_FOR_DIVISION_BY_ZERO',
+                'NO_ENGINE_SUBSTITUTION',
+            ];
+            if (!$this->isMariaDb()) {
+                // MariaDB is exempt from ONLY_FULL_GROUP_BY: its implementation lacks the
+                // functional-dependency detection of MySQL/PostgreSQL (MDEV-11588), so it
+                // would reject SQL-standard queries like SELECT t.* ... GROUP BY t.pk.
+                array_unshift($modes, 'ONLY_FULL_GROUP_BY');
+            }
+            $sqlMode = implode(',', $modes);
         }
-        $this->_connection->executeStatement("SET SQL_MODE='" . implode(',', $modes) . "'");
+        $this->_connection->executeStatement('SET SQL_MODE=' . $this->_connection->quote($sqlMode));
         $this->_connection->executeStatement("SET time_zone = '+00:00'");
     }
 

--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -128,23 +128,13 @@ class Mysql extends AbstractPdoAdapter
     #[\Override]
     protected function _initConnection(): void
     {
-        // Pin an explicit strict baseline per connection, so behavior is
-        // deterministic regardless of server or provider global defaults
-        // (issue #688). The set is intentionally the MySQL 8+ factory default,
-        // the most battle-tested combination there is. Flags beyond it were
-        // considered and excluded on purpose:
-        // - STRICT_ALL_TABLES: an error midway through a multi-row write on a
-        //   non-transactional table leaves partial data with no rollback,
-        //   which is why MySQL keeps it out of its defaults too
-        // - ANSI_QUOTES/PIPES_AS_CONCAT/REAL_AS_FLOAT change SQL parsing and
-        //   would break MySQL-idiom queries (double-quoted string literals)
-        // - NO_BACKSLASH_ESCAPES would desync server escaping from what PDO
-        //   quoting produces
-        // - NO_AUTO_VALUE_ON_ZERO is needed only for explicit id=0 inserts and
-        //   is applied scoped to setup scripts by startSetup()
-        // NO_ZERO_DATE, NO_ZERO_IN_DATE and ERROR_FOR_DIVISION_BY_ZERO are
-        // deprecated as standalone flags (slated to fold into strict mode);
-        // trim them here when a MySQL release drops them.
+        // Pin a strict baseline per connection, so behavior is deterministic
+        // regardless of server or provider global defaults (issue #688). The
+        // set is intentionally exactly the MySQL 8+ factory default: stricter
+        // or different flags were considered and deliberately excluded, see
+        // PR #1123 before changing this list. The three zero-date/division
+        // flags are deprecated as standalone flags; trim them here when a
+        // MySQL release drops them.
         if (isset($this->_config['sql_mode'])) {
             // Escape hatch: a <sql_mode> node on the connection in local.xml
             // overrides the baseline verbatim (an empty value restores the

--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -128,9 +128,23 @@ class Mysql extends AbstractPdoAdapter
     #[\Override]
     protected function _initConnection(): void
     {
-        // Pin an explicit modern strict baseline (the MySQL 8+ default mode set)
-        // per connection, so behavior is deterministic regardless of server or
-        // provider global defaults (issue #688).
+        // Pin an explicit strict baseline per connection, so behavior is
+        // deterministic regardless of server or provider global defaults
+        // (issue #688). The set is intentionally the MySQL 8+ factory default,
+        // the most battle-tested combination there is. Flags beyond it were
+        // considered and excluded on purpose:
+        // - STRICT_ALL_TABLES: an error midway through a multi-row write on a
+        //   non-transactional table leaves partial data with no rollback,
+        //   which is why MySQL keeps it out of its defaults too
+        // - ANSI_QUOTES/PIPES_AS_CONCAT/REAL_AS_FLOAT change SQL parsing and
+        //   would break MySQL-idiom queries (double-quoted string literals)
+        // - NO_BACKSLASH_ESCAPES would desync server escaping from what PDO
+        //   quoting produces
+        // - NO_AUTO_VALUE_ON_ZERO is needed only for explicit id=0 inserts and
+        //   is applied scoped to setup scripts by startSetup()
+        // NO_ZERO_DATE, NO_ZERO_IN_DATE and ERROR_FOR_DIVISION_BY_ZERO are
+        // deprecated as standalone flags (slated to fold into strict mode);
+        // trim them here when a MySQL release drops them.
         if (isset($this->_config['sql_mode'])) {
             // Escape hatch: a <sql_mode> node on the connection in local.xml
             // overrides the baseline verbatim (an empty value restores the

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -13,6 +13,7 @@ use Mage;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
@@ -711,6 +712,17 @@ class HealthCheck extends BaseMahoCommand
     }
 
     #[\Override]
+    protected function configure(): void
+    {
+        $this->addOption(
+            'check-zero-dates',
+            null,
+            InputOption::VALUE_NONE,
+            'Also scan every date column for stored zero-date values (full table scans, slow on large stores)',
+        );
+    }
+
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $hasErrors = false;
@@ -894,7 +906,7 @@ class HealthCheck extends BaseMahoCommand
         $this->checkOrphanedResources($input, $output, Mage::getResourceModel('admin/rules'), 'admin');
         $this->checkOrphanedResources($input, $output, Mage::getResourceModel('api/rules'), 'API');
 
-        $this->checkZeroDates($output);
+        $this->checkZeroDates($output, (bool) $input->getOption('check-zero-dates'));
 
         if ($hasErrors) {
             return Command::FAILURE;
@@ -908,8 +920,12 @@ class HealthCheck extends BaseMahoCommand
      * baseline (NO_ZERO_DATE): stored '0000-00-00' values make any later UPDATE
      * of those rows fail, and zero-date column defaults make INSERTs omitting
      * the column fail. Typically found on stores migrated from Magento/OpenMage.
+     *
+     * The DEFAULT check is a single indexed information_schema query and always
+     * runs. The stored-value scan is a full table scan per date column (slow on
+     * large stores), so it runs only when explicitly requested via $scanValues.
      */
-    private function checkZeroDates(OutputInterface $output): void
+    private function checkZeroDates(OutputInterface $output, bool $scanValues): void
     {
         $output->write('Checking for legacy zero dates... ');
 
@@ -920,10 +936,13 @@ class HealthCheck extends BaseMahoCommand
         }
 
         $badDefaults = \MahoCLI\Helper\ZeroDateScanner::findZeroDateDefaults($adapter);
-        $badValues = \MahoCLI\Helper\ZeroDateScanner::findZeroDateValues($adapter);
+        $badValues = $scanValues ? \MahoCLI\Helper\ZeroDateScanner::findZeroDateValues($adapter) : [];
 
         if (empty($badDefaults) && empty($badValues)) {
             $output->writeln('<info>OK</info>');
+            if (!$scanValues) {
+                $output->writeln('(DEFAULTs only; add --check-zero-dates to also scan stored values, slow on large stores)');
+            }
             return;
         }
 

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -894,11 +894,81 @@ class HealthCheck extends BaseMahoCommand
         $this->checkOrphanedResources($input, $output, Mage::getResourceModel('admin/rules'), 'admin');
         $this->checkOrphanedResources($input, $output, Mage::getResourceModel('api/rules'), 'API');
 
+        $this->checkZeroDates($output);
+
         if ($hasErrors) {
             return Command::FAILURE;
         }
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Detect legacy zero dates that are incompatible with the strict SQL_MODE
+     * baseline (NO_ZERO_DATE): stored '0000-00-00' values make any later UPDATE
+     * of those rows fail, and zero-date column defaults make INSERTs omitting
+     * the column fail. Typically found on stores migrated from Magento/OpenMage.
+     */
+    private function checkZeroDates(OutputInterface $output): void
+    {
+        $output->write('Checking for legacy zero dates... ');
+
+        $adapter = \Mage::getSingleton('core/resource')->getConnection('core_read');
+        if (!($adapter instanceof \Maho\Db\Adapter\Pdo\Mysql)) {
+            $output->writeln('<info>OK (MySQL/MariaDB only check)</info>');
+            return;
+        }
+
+        $dbName = (string) $adapter->fetchOne('SELECT DATABASE()');
+
+        $badDefaults = $adapter->fetchAll(
+            'SELECT TABLE_NAME, COLUMN_NAME FROM information_schema.COLUMNS'
+            . ' WHERE TABLE_SCHEMA = ? AND COLUMN_DEFAULT LIKE ?',
+            [$dbName, '0000-00-00%'],
+        );
+
+        $dateColumns = $adapter->fetchAll(
+            'SELECT TABLE_NAME, COLUMN_NAME, DATA_TYPE FROM information_schema.COLUMNS'
+            . " WHERE TABLE_SCHEMA = ? AND DATA_TYPE IN ('date', 'datetime', 'timestamp')",
+            [$dbName],
+        );
+        $columnsWithZeroDates = [];
+        foreach ($dateColumns as $column) {
+            $zero = $column['DATA_TYPE'] === 'date' ? '0000-00-00' : '0000-00-00 00:00:00';
+            $found = $adapter->fetchOne(sprintf(
+                'SELECT 1 FROM %s WHERE %s = %s LIMIT 1',
+                $adapter->quoteIdentifier($column['TABLE_NAME']),
+                $adapter->quoteIdentifier($column['COLUMN_NAME']),
+                $adapter->quote($zero),
+            ));
+            if ($found) {
+                $columnsWithZeroDates[] = $column['TABLE_NAME'] . '.' . $column['COLUMN_NAME'];
+            }
+        }
+
+        if (empty($badDefaults) && empty($columnsWithZeroDates)) {
+            $output->writeln('<info>OK</info>');
+            return;
+        }
+
+        $output->writeln('');
+        $output->writeln('<comment>Warning: Found legacy zero dates, which strict SQL_MODE (NO_ZERO_DATE) rejects:</comment>');
+        if (!empty($badDefaults)) {
+            $output->writeln('Columns with a zero-date DEFAULT (INSERTs omitting the column will fail):');
+            foreach ($badDefaults as $column) {
+                $output->writeln('- ' . $column['TABLE_NAME'] . '.' . $column['COLUMN_NAME']);
+            }
+        }
+        if (!empty($columnsWithZeroDates)) {
+            $output->writeln('Columns containing zero-date values (UPDATEs rewriting those rows will fail):');
+            foreach ($columnsWithZeroDates as $column) {
+                $output->writeln('- ' . $column);
+            }
+        }
+        $output->writeln('Update the values to NULL (or a real date) and change the column defaults.');
+        $output->writeln('To temporarily restore the old behavior, set <sql_mode></sql_mode> on the');
+        $output->writeln('connection in app/etc/local.xml while you clean up.');
+        $output->writeln('');
     }
 
     private function checkOrphanedResources(

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -919,34 +919,10 @@ class HealthCheck extends BaseMahoCommand
             return;
         }
 
-        $dbName = (string) $adapter->fetchOne('SELECT DATABASE()');
+        $badDefaults = \MahoCLI\Helper\ZeroDateScanner::findZeroDateDefaults($adapter);
+        $badValues = \MahoCLI\Helper\ZeroDateScanner::findZeroDateValues($adapter);
 
-        $badDefaults = $adapter->fetchAll(
-            'SELECT TABLE_NAME, COLUMN_NAME FROM information_schema.COLUMNS'
-            . ' WHERE TABLE_SCHEMA = ? AND COLUMN_DEFAULT LIKE ?',
-            [$dbName, '0000-00-00%'],
-        );
-
-        $dateColumns = $adapter->fetchAll(
-            'SELECT TABLE_NAME, COLUMN_NAME, DATA_TYPE FROM information_schema.COLUMNS'
-            . " WHERE TABLE_SCHEMA = ? AND DATA_TYPE IN ('date', 'datetime', 'timestamp')",
-            [$dbName],
-        );
-        $columnsWithZeroDates = [];
-        foreach ($dateColumns as $column) {
-            $zero = $column['DATA_TYPE'] === 'date' ? '0000-00-00' : '0000-00-00 00:00:00';
-            $found = $adapter->fetchOne(sprintf(
-                'SELECT 1 FROM %s WHERE %s = %s LIMIT 1',
-                $adapter->quoteIdentifier($column['TABLE_NAME']),
-                $adapter->quoteIdentifier($column['COLUMN_NAME']),
-                $adapter->quote($zero),
-            ));
-            if ($found) {
-                $columnsWithZeroDates[] = $column['TABLE_NAME'] . '.' . $column['COLUMN_NAME'];
-            }
-        }
-
-        if (empty($badDefaults) && empty($columnsWithZeroDates)) {
+        if (empty($badDefaults) && empty($badValues)) {
             $output->writeln('<info>OK</info>');
             return;
         }
@@ -955,17 +931,17 @@ class HealthCheck extends BaseMahoCommand
         $output->writeln('<comment>Warning: Found legacy zero dates, which strict SQL_MODE (NO_ZERO_DATE) rejects:</comment>');
         if (!empty($badDefaults)) {
             $output->writeln('Columns with a zero-date DEFAULT (INSERTs omitting the column will fail):');
-            foreach ($badDefaults as $column) {
-                $output->writeln('- ' . $column['TABLE_NAME'] . '.' . $column['COLUMN_NAME']);
+            foreach ($badDefaults as $finding) {
+                $output->writeln('- ' . $finding['table'] . '.' . $finding['column']);
             }
         }
-        if (!empty($columnsWithZeroDates)) {
+        if (!empty($badValues)) {
             $output->writeln('Columns containing zero-date values (UPDATEs rewriting those rows will fail):');
-            foreach ($columnsWithZeroDates as $column) {
-                $output->writeln('- ' . $column);
+            foreach ($badValues as $finding) {
+                $output->writeln(sprintf('- %s.%s (%d row(s))', $finding['table'], $finding['column'], $finding['rows']));
             }
         }
-        $output->writeln('Update the values to NULL (or a real date) and change the column defaults.');
+        $output->writeln('Run: ./maho legacy:fix-zero-dates');
         $output->writeln('To temporarily restore the old behavior, set <sql_mode></sql_mode> on the');
         $output->writeln('connection in app/etc/local.xml while you clean up.');
         $output->writeln('');

--- a/lib/MahoCLI/Commands/LegacyFixZeroDates.php
+++ b/lib/MahoCLI/Commands/LegacyFixZeroDates.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package MahoCLI
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Commands;
+
+use Mage;
+use MahoCLI\Helper\ZeroDateScanner;
+use Maho\Db\Adapter\Pdo\Mysql;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'legacy:fix-zero-dates',
+    description: 'Fix legacy zero dates that strict SQL_MODE rejects (dry run by default, apply with --force)',
+)]
+class LegacyFixZeroDates extends BaseMahoCommand
+{
+    #[\Override]
+    protected function configure(): void
+    {
+        $this->addOption('force', null, InputOption::VALUE_NONE, 'Apply the fixes instead of only reporting them');
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->initMaho();
+
+        $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+        if (!($adapter instanceof Mysql)) {
+            $output->writeln('<info>Nothing to do: zero dates only exist on MySQL/MariaDB.</info>');
+            return Command::SUCCESS;
+        }
+
+        $apply = (bool) $input->getOption('force');
+        $defaults = ZeroDateScanner::findZeroDateDefaults($adapter);
+        $values = ZeroDateScanner::findZeroDateValues($adapter);
+
+        if (empty($defaults) && empty($values)) {
+            $output->writeln('<info>No zero dates found, nothing to fix.</info>');
+            return Command::SUCCESS;
+        }
+
+        if (!$apply) {
+            $output->writeln('<comment>Dry run: re-run with --force to apply the changes below.</comment>');
+            $output->writeln('');
+        }
+
+        $manual = [];
+
+        foreach ($values as $finding) {
+            $target = "{$finding['table']}.{$finding['column']}";
+            if (!$finding['nullable']) {
+                $manual[] = "$target holds {$finding['rows']} zero-date row(s) but is NOT NULL";
+                continue;
+            }
+            if ($apply) {
+                $updated = $adapter->update(
+                    $finding['table'],
+                    [$finding['column'] => null],
+                    ZeroDateScanner::zeroDatePredicate($adapter, $finding['column']),
+                );
+                $output->writeln("Set $updated zero-date row(s) to NULL in $target");
+            } else {
+                $output->writeln("Would set {$finding['rows']} zero-date row(s) to NULL in $target");
+            }
+        }
+
+        foreach ($defaults as $finding) {
+            $target = "{$finding['table']}.{$finding['column']}";
+            if (!$finding['nullable']) {
+                $manual[] = "$target has a zero-date DEFAULT but is NOT NULL";
+                continue;
+            }
+            if ($apply) {
+                $adapter->query(sprintf(
+                    'ALTER TABLE %s ALTER COLUMN %s SET DEFAULT NULL',
+                    $adapter->quoteIdentifier($finding['table']),
+                    $adapter->quoteIdentifier($finding['column']),
+                ));
+                $output->writeln("Changed DEFAULT to NULL on $target");
+            } else {
+                $output->writeln("Would change DEFAULT to NULL on $target");
+            }
+        }
+
+        if (!empty($manual)) {
+            $output->writeln('');
+            $output->writeln('<comment>Manual attention needed (a NULL fix would violate the column definition):</comment>');
+            foreach ($manual as $line) {
+                $output->writeln('- ' . $line);
+            }
+            $output->writeln('Decide per column: make it nullable, or set a meaningful real date.');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/lib/MahoCLI/Commands/LegacyFixZeroDates.php
+++ b/lib/MahoCLI/Commands/LegacyFixZeroDates.php
@@ -29,6 +29,23 @@ class LegacyFixZeroDates extends BaseMahoCommand
     protected function configure(): void
     {
         $this->addOption('force', null, InputOption::VALUE_NONE, 'Apply the fixes instead of only reporting them');
+        $this->setHelp(<<<'HELP'
+            Scans every date/datetime/timestamp column for legacy '0000-00-00' values and
+            zero-date column DEFAULTs, typically left behind by stores migrated from
+            Magento/OpenMage. Strict SQL_MODE (NO_ZERO_DATE) rejects rewriting such rows
+            and inserting via such defaults.
+
+            What it changes, per finding:
+            - nullable column with zero-date rows: sets those rows to NULL
+              (in Magento 1 semantics a zero date always meant "no value")
+            - nullable column with a zero-date DEFAULT: changes it to DEFAULT NULL
+              (metadata-only, instant even on huge tables)
+            - NOT NULL columns: never touched; listed for a per-column decision
+              (make the column nullable, or backfill a meaningful real date)
+
+            Without --force nothing is written: the command prints exactly what it
+            would change, with per-column row counts. Re-run with --force to apply.
+            HELP);
     }
 
     #[\Override]

--- a/lib/MahoCLI/Commands/LegacyFixZeroDates.php
+++ b/lib/MahoCLI/Commands/LegacyFixZeroDates.php
@@ -105,6 +105,7 @@ class LegacyFixZeroDates extends BaseMahoCommand
                     $adapter->quoteIdentifier($finding['table']),
                     $adapter->quoteIdentifier($finding['column']),
                 ));
+                $adapter->resetDdlCache($finding['table']);
                 $output->writeln("Changed DEFAULT to NULL on $target");
             } else {
                 $output->writeln("Would change DEFAULT to NULL on $target");

--- a/lib/MahoCLI/Helper/ZeroDateScanner.php
+++ b/lib/MahoCLI/Helper/ZeroDateScanner.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Scans MySQL/MariaDB schemas for legacy zero dates that strict SQL_MODE rejects.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package MahoCLI
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Helper;
+
+use Maho\Db\Adapter\Pdo\Mysql;
+
+class ZeroDateScanner
+{
+    /**
+     * Columns whose DEFAULT is a zero date: any INSERT omitting the column fails
+     * under NO_ZERO_DATE.
+     *
+     * @return list<array{table: string, column: string, nullable: bool}>
+     */
+    public static function findZeroDateDefaults(Mysql $adapter): array
+    {
+        $rows = $adapter->fetchAll(
+            'SELECT TABLE_NAME, COLUMN_NAME, IS_NULLABLE FROM information_schema.COLUMNS'
+            . ' WHERE TABLE_SCHEMA = ? AND COLUMN_DEFAULT LIKE ?',
+            [self::databaseName($adapter), '0000-00-00%'],
+        );
+
+        $findings = [];
+        foreach ($rows as $row) {
+            $findings[] = [
+                'table' => $row['TABLE_NAME'],
+                'column' => $row['COLUMN_NAME'],
+                'nullable' => $row['IS_NULLABLE'] === 'YES',
+            ];
+        }
+        return $findings;
+    }
+
+    /**
+     * Columns containing stored zero-date values: any UPDATE rewriting such a row
+     * fails under NO_ZERO_DATE. Includes the per-column row count.
+     *
+     * @return list<array{table: string, column: string, nullable: bool, rows: int}>
+     */
+    public static function findZeroDateValues(Mysql $adapter): array
+    {
+        $columns = $adapter->fetchAll(
+            'SELECT TABLE_NAME, COLUMN_NAME, IS_NULLABLE FROM information_schema.COLUMNS'
+            . " WHERE TABLE_SCHEMA = ? AND DATA_TYPE IN ('date', 'datetime', 'timestamp')",
+            [self::databaseName($adapter)],
+        );
+
+        $findings = [];
+        foreach ($columns as $column) {
+            $rows = (int) $adapter->fetchOne(sprintf(
+                'SELECT COUNT(*) FROM %s WHERE %s',
+                $adapter->quoteIdentifier($column['TABLE_NAME']),
+                self::zeroDatePredicate($adapter, $column['COLUMN_NAME']),
+            ));
+            if ($rows > 0) {
+                $findings[] = [
+                    'table' => $column['TABLE_NAME'],
+                    'column' => $column['COLUMN_NAME'],
+                    'nullable' => $column['IS_NULLABLE'] === 'YES',
+                    'rows' => $rows,
+                ];
+            }
+        }
+        return $findings;
+    }
+
+    /**
+     * WHERE fragment matching zero dates (including partial ones like
+     * '0000-00-00 10:30:00'). Compares as CHAR: under strict SQL_MODE,
+     * comparing a date column to a zero-date literal is itself an error.
+     */
+    public static function zeroDatePredicate(Mysql $adapter, string $column): string
+    {
+        return sprintf(
+            "CAST(%s AS CHAR) LIKE '0000-00-00%%'",
+            $adapter->quoteIdentifier($column),
+        );
+    }
+
+    private static function databaseName(Mysql $adapter): string
+    {
+        return (string) $adapter->fetchOne('SELECT DATABASE()');
+    }
+}

--- a/lib/MahoCLI/Helper/ZeroDateScanner.php
+++ b/lib/MahoCLI/Helper/ZeroDateScanner.php
@@ -24,10 +24,15 @@ class ZeroDateScanner
      */
     public static function findZeroDateDefaults(Mysql $adapter): array
     {
+        // Restrict to date/datetime/timestamp columns: a non-date column whose text
+        // default merely starts with '0000-00-00' is not a zero-date default and must
+        // not be "fixed". MariaDB quotes literal defaults in information_schema (e.g.
+        // '0000-00-00'), MySQL returns them bare (0000-00-00), so match both forms.
         $rows = $adapter->fetchAll(
             'SELECT TABLE_NAME, COLUMN_NAME, IS_NULLABLE FROM information_schema.COLUMNS'
-            . ' WHERE TABLE_SCHEMA = ? AND COLUMN_DEFAULT LIKE ?',
-            [self::databaseName($adapter), '0000-00-00%'],
+            . " WHERE TABLE_SCHEMA = ? AND DATA_TYPE IN ('date', 'datetime', 'timestamp')"
+            . ' AND (COLUMN_DEFAULT LIKE ? OR COLUMN_DEFAULT LIKE ?)',
+            [self::databaseName($adapter), '0000-00-00%', "'0000-00-00%"],
         );
 
         $findings = [];

--- a/maho
+++ b/maho
@@ -74,6 +74,7 @@ $application->addCommand(new \MahoCLI\Commands\LegacyRenameMysql4Classes());
 $application->addCommand(new \MahoCLI\Commands\LegacyMigrateObservers());
 $application->addCommand(new \MahoCLI\Commands\LegacyMigrateCron());
 $application->addCommand(new \MahoCLI\Commands\LegacyMigrateRoutes());
+$application->addCommand(new \MahoCLI\Commands\LegacyFixZeroDates());
 
 $application->addCommand(new \MahoCLI\Commands\Serve());
 $application->addCommand(new \MahoCLI\Commands\Shell());

--- a/tests/Backend/Integration/Db/Adapter/CustomQueryMethodsTest.php
+++ b/tests/Backend/Integration/Db/Adapter/CustomQueryMethodsTest.php
@@ -27,8 +27,7 @@ beforeEach(function () {
         ], 'ID')
         ->addColumn('name', \Maho\Db\Ddl\Table::TYPE_TEXT, 100, [], 'Name')
         ->addColumn('value', \Maho\Db\Ddl\Table::TYPE_INTEGER, null, [], 'Value')
-        ->addColumn('status', \Maho\Db\Ddl\Table::TYPE_SMALLINT, null, ['default' => 1], 'Status')
-        ->setOption('type', 'TEMPORARY');
+        ->addColumn('status', \Maho\Db\Ddl\Table::TYPE_SMALLINT, null, ['default' => 1], 'Status');
     $this->adapter->createTable($sourceTable);
 
     $targetTable = $this->adapter->newTable($this->tempTableTarget)
@@ -44,14 +43,18 @@ beforeEach(function () {
             $this->adapter->getIndexName($this->tempTableTarget, ['name'], AdapterInterface::INDEX_TYPE_UNIQUE),
             ['name'],
             ['type' => AdapterInterface::INDEX_TYPE_UNIQUE],
-        )
-        ->setOption('type', 'TEMPORARY');
+        );
     $this->adapter->createTable($targetTable);
 
     // Insert test data
     $this->adapter->insert($this->tempTableSource, ['name' => 'test1', 'value' => 100]);
     $this->adapter->insert($this->tempTableSource, ['name' => 'test2', 'value' => 200]);
     $this->adapter->insert($this->tempTableSource, ['name' => 'test3', 'value' => 300]);
+});
+
+afterEach(function () {
+    $this->adapter->dropTable($this->tempTableSource);
+    $this->adapter->dropTable($this->tempTableTarget);
 });
 
 describe('insertFromSelect', function () {

--- a/tests/Backend/Integration/Db/Adapter/DdlOperationsTest.php
+++ b/tests/Backend/Integration/Db/Adapter/DdlOperationsTest.php
@@ -951,19 +951,18 @@ describe('DDL Operations - Table Management', function () {
     it('creates temporary table', function () {
         $table = $this->adapter->newTable($this->testTableName)
             ->addColumn('id', Table::TYPE_INTEGER, null, ['nullable' => false, 'primary' => true])
-            ->addColumn('data', Table::TYPE_TEXT, 255, [])
-            ->setOption('type', 'TEMPORARY');
+            ->addColumn('data', Table::TYPE_TEXT, 255, []);
 
-        $this->adapter->createTable($table);
+        $this->adapter->createTemporaryTable($table);
 
-        // Temporary tables exist for the current connection
-        expect($this->adapter->isTableExists($this->testTableName))->toBeTrue();
-
-        // Can insert data
+        // Temporary tables are connection-local and invisible to SHOW TABLES /
+        // information_schema, so assert through actual reads and writes instead.
         $this->adapter->insert($this->testTableName, ['id' => 1, 'data' => 'test']);
 
         $result = $this->adapter->fetchOne("SELECT data FROM {$this->testTableName} WHERE id = 1");
         expect($result)->toBe('test');
+
+        $this->adapter->dropTemporaryTable($this->testTableName);
     });
 });
 

--- a/tests/Backend/Integration/Db/Adapter/MysqlStrictModeTest.php
+++ b/tests/Backend/Integration/Db/Adapter/MysqlStrictModeTest.php
@@ -61,6 +61,9 @@ it('pins the strict baseline SQL_MODE on connection init', function () {
     expect($sqlMode)->toContain('NO_ZERO_IN_DATE');
     expect($sqlMode)->toContain('ERROR_FOR_DIVISION_BY_ZERO');
     expect($sqlMode)->toContain('NO_ENGINE_SUBSTITUTION');
+    // Added on top of the MySQL factory default so an explicit 0 is stored in an
+    // identity column (matching PostgreSQL/SQLite) instead of triggering auto_increment.
+    expect($sqlMode)->toContain('NO_AUTO_VALUE_ON_ZERO');
 });
 
 it('includes ONLY_FULL_GROUP_BY in the baseline on genuine MySQL', function () {
@@ -148,25 +151,26 @@ it('preserves the strict baseline across startSetup and endSetup', function () {
     expect(fetchSqlMode($adapter))->toBe($modeBefore);
 });
 
-it('keeps the strict baseline active during setup, only adding NO_AUTO_VALUE_ON_ZERO', function () {
+it('keeps the strict baseline active during setup without touching SQL_MODE', function () {
     $adapter = createFreshMysqlAdapter();
+    $modeBefore = fetchSqlMode($adapter);
     $adapter->startSetup();
     // Setup scripts must run under the same strict mode as production, so a bad
     // write in an install/upgrade script is caught instead of silently truncated.
+    // The baseline already carries NO_AUTO_VALUE_ON_ZERO, so setup leaves SQL_MODE alone.
     $modeDuring = fetchSqlMode($adapter);
     $adapter->endSetup();
 
+    expect($modeDuring)->toBe($modeBefore);
     expect($modeDuring)->toContain('STRICT_TRANS_TABLES');
     expect($modeDuring)->toContain('NO_ZERO_DATE');
     expect($modeDuring)->toContain('NO_AUTO_VALUE_ON_ZERO');
 });
 
-it('preserves the live SQL_MODE in insertForce so the bulk-import path still works', function () {
+it('stores an explicit 0 in an identity column via both insert and insertForce', function () {
     $adapter = createFreshMysqlAdapter();
-    $modeBefore = fetchSqlMode($adapter);
-    expect($modeBefore)->toContain('STRICT_TRANS_TABLES');
 
-    $tempTable = 'test_insertforce_' . uniqid();
+    $tempTable = 'test_zero_identity_' . uniqid();
     $table = $adapter->newTable($tempTable)
         ->addColumn('id', \Maho\Db\Ddl\Table::TYPE_INTEGER, null, [
             'identity' => true,
@@ -176,10 +180,23 @@ it('preserves the live SQL_MODE in insertForce so the bulk-import path still wor
         ->addColumn('val', \Maho\Db\Ddl\Table::TYPE_VARCHAR, 50, [], 'Val');
     $adapter->createTable($table);
 
-    $adapter->insertForce($tempTable, ['id' => 0, 'val' => 'test']);
+    try {
+        // Permanent NO_AUTO_VALUE_ON_ZERO: an explicit 0 is stored verbatim rather
+        // than triggering auto_increment, identical to the PostgreSQL/SQLite adapters.
+        $adapter->insert($tempTable, ['id' => 0, 'val' => 'via-insert']);
+        expect((int) $adapter->fetchOne("SELECT id FROM {$tempTable} WHERE val = 'via-insert'"))->toBe(0);
 
-    // SQL_MODE should be restored to the strict baseline after insertForce
-    expect(fetchSqlMode($adapter))->toBe($modeBefore);
+        // insertForce is now a thin wrapper over insert and behaves identically.
+        $adapter->insertForce($tempTable, ['id' => 5, 'val' => 'via-force']);
+        expect((int) $adapter->fetchOne("SELECT id FROM {$tempTable} WHERE val = 'via-force'"))->toBe(5);
 
-    $adapter->dropTable($tempTable);
+        // A new row still auto-generates when the PK is omitted.
+        $adapter->insert($tempTable, ['val' => 'auto']);
+        expect((int) $adapter->fetchOne("SELECT id FROM {$tempTable} WHERE val = 'auto'"))->toBeGreaterThan(0);
+
+        // The baseline is unchanged by the inserts.
+        expect(fetchSqlMode($adapter))->toContain('NO_AUTO_VALUE_ON_ZERO');
+    } finally {
+        $adapter->dropTable($tempTable);
+    }
 });

--- a/tests/Backend/Integration/Db/Adapter/MysqlStrictModeTest.php
+++ b/tests/Backend/Integration/Db/Adapter/MysqlStrictModeTest.php
@@ -148,6 +148,19 @@ it('preserves the strict baseline across startSetup and endSetup', function () {
     expect(fetchSqlMode($adapter))->toBe($modeBefore);
 });
 
+it('keeps the strict baseline active during setup, only adding NO_AUTO_VALUE_ON_ZERO', function () {
+    $adapter = createFreshMysqlAdapter();
+    $adapter->startSetup();
+    // Setup scripts must run under the same strict mode as production, so a bad
+    // write in an install/upgrade script is caught instead of silently truncated.
+    $modeDuring = fetchSqlMode($adapter);
+    $adapter->endSetup();
+
+    expect($modeDuring)->toContain('STRICT_TRANS_TABLES');
+    expect($modeDuring)->toContain('NO_ZERO_DATE');
+    expect($modeDuring)->toContain('NO_AUTO_VALUE_ON_ZERO');
+});
+
 it('preserves the live SQL_MODE in insertForce so the bulk-import path still works', function () {
     $adapter = createFreshMysqlAdapter();
     $modeBefore = fetchSqlMode($adapter);

--- a/tests/Backend/Integration/Db/Adapter/MysqlStrictModeTest.php
+++ b/tests/Backend/Integration/Db/Adapter/MysqlStrictModeTest.php
@@ -14,7 +14,7 @@ uses(Tests\MahoBackendTestCase::class);
 
 /**
  * Helper: create a fresh MySQL adapter instance using the same connection params from local.xml.
- * Bypasses the singleton cache so _initConnection() re-runs with the current developer mode setting.
+ * Bypasses the singleton cache so _initConnection() re-runs.
  */
 function createFreshMysqlAdapter(): Mysql
 {
@@ -34,8 +34,9 @@ function fetchSqlMode(Mysql $adapter): string
 }
 
 /**
- * Helper: whether the live server is MariaDB. MariaDB is exempt from the developer-mode
- * ONLY_FULL_GROUP_BY toggle because it lacks functional-dependency detection (MDEV-11588).
+ * Helper: whether the live server is MariaDB. MariaDB is exempt from ONLY_FULL_GROUP_BY
+ * because it lacks functional-dependency detection (MDEV-11588), but it still gets the
+ * rest of the strict baseline.
  */
 function isMariaDbServer(Mysql $adapter): bool
 {
@@ -52,97 +53,94 @@ beforeEach(function () {
     }
 });
 
-it('sets SQL_MODE to ONLY_FULL_GROUP_BY on MySQL connection init when developer mode is on', function () {
-    Mage::setIsDeveloperMode(true);
+it('pins the strict baseline SQL_MODE on connection init', function () {
     $adapter = createFreshMysqlAdapter();
-    if (isMariaDbServer($adapter)) {
-        $this->markTestSkipped('Genuine-MySQL-only test: MariaDB is exempt from strict mode.');
-    }
     $sqlMode = fetchSqlMode($adapter);
-    expect($sqlMode)->toContain('ONLY_FULL_GROUP_BY');
+    expect($sqlMode)->toContain('STRICT_TRANS_TABLES');
+    expect($sqlMode)->toContain('NO_ZERO_DATE');
+    expect($sqlMode)->toContain('NO_ZERO_IN_DATE');
+    expect($sqlMode)->toContain('ERROR_FOR_DIVISION_BY_ZERO');
+    expect($sqlMode)->toContain('NO_ENGINE_SUBSTITUTION');
 });
 
-it('keeps SQL_MODE empty on MariaDB even when developer mode is on', function () {
-    Mage::setIsDeveloperMode(true);
+it('includes ONLY_FULL_GROUP_BY in the baseline on genuine MySQL', function () {
+    $adapter = createFreshMysqlAdapter();
+    if (isMariaDbServer($adapter)) {
+        $this->markTestSkipped('Genuine-MySQL-only test: MariaDB is exempt from ONLY_FULL_GROUP_BY.');
+    }
+    expect(fetchSqlMode($adapter))->toContain('ONLY_FULL_GROUP_BY');
+});
+
+it('exempts MariaDB from ONLY_FULL_GROUP_BY but keeps the rest of the strict baseline', function () {
     $adapter = createFreshMysqlAdapter();
     if (!isMariaDbServer($adapter)) {
         $this->markTestSkipped('MariaDB-only test.');
     }
-    expect(fetchSqlMode($adapter))->toBe('');
-});
-
-it('sets SQL_MODE to an empty string on MySQL connection init when developer mode is off', function () {
-    Mage::setIsDeveloperMode(false);
-    $adapter = createFreshMysqlAdapter();
     $sqlMode = fetchSqlMode($adapter);
     expect($sqlMode)->not->toContain('ONLY_FULL_GROUP_BY');
-    expect($sqlMode)->toBe('');
+    expect($sqlMode)->toContain('STRICT_TRANS_TABLES');
 });
 
-it('raises an SQL error on a GROUP BY query missing aggregates when developer mode is on', function () {
-    Mage::setIsDeveloperMode(true);
+it('pins the same SQL_MODE baseline regardless of developer mode', function () {
+    $modes = [];
+    foreach ([true, false] as $devMode) {
+        Mage::setIsDeveloperMode($devMode);
+        $adapter = createFreshMysqlAdapter();
+        $modes[] = fetchSqlMode($adapter);
+    }
+    expect($modes[0])->toBe($modes[1]);
+});
+
+it('raises an SQL error on a GROUP BY query missing aggregates even with developer mode off', function () {
+    Mage::setIsDeveloperMode(false);
     $adapter = createFreshMysqlAdapter();
     if (isMariaDbServer($adapter)) {
-        $this->markTestSkipped('Genuine-MySQL-only test: MariaDB is exempt from strict mode.');
+        $this->markTestSkipped('Genuine-MySQL-only test: MariaDB is exempt from ONLY_FULL_GROUP_BY.');
     }
-    // core_config_data has scope_id and path columns; selecting path without grouping or aggregating it
-    // violates ONLY_FULL_GROUP_BY
+    // core_config_data has scope and path columns; selecting path without grouping or
+    // aggregating it violates ONLY_FULL_GROUP_BY
     expect(fn() => $adapter->fetchAll(
         'SELECT scope, path FROM core_config_data GROUP BY scope',
     ))->toThrow(\Exception::class);
 });
 
-it('does not raise an SQL error on the same non-strict GROUP BY query when developer mode is off', function () {
-    Mage::setIsDeveloperMode(false);
+it('rejects writes that would be silently truncated under the legacy relaxed mode', function () {
     $adapter = createFreshMysqlAdapter();
-    $results = $adapter->fetchAll(
-        'SELECT scope, path FROM core_config_data GROUP BY scope',
-    );
-    expect($results)->toBeArray();
+    $tempTable = 'test_strict_' . uniqid();
+    $table = $adapter->newTable($tempTable)
+        ->addColumn('id', \Maho\Db\Ddl\Table::TYPE_INTEGER, null, [
+            'identity' => true,
+            'nullable' => false,
+            'primary' => true,
+        ], 'ID')
+        ->addColumn('val', \Maho\Db\Ddl\Table::TYPE_VARCHAR, 5, [], 'Val');
+    $adapter->createTable($table);
+
+    expect(fn() => $adapter->insert($tempTable, ['val' => 'longer than five']))
+        ->toThrow(\Exception::class);
+
+    $adapter->dropTable($tempTable);
 });
 
-it('keeps the SET time_zone statement working alongside the SQL_MODE toggle', function () {
-    foreach ([true, false] as $devMode) {
-        Mage::setIsDeveloperMode($devMode);
-        $adapter = createFreshMysqlAdapter();
-        $tz = $adapter->fetchOne('SELECT @@time_zone');
-        expect($tz)->toBe('+00:00');
-    }
+it('keeps the SET time_zone statement working alongside the SQL_MODE baseline', function () {
+    $adapter = createFreshMysqlAdapter();
+    $tz = $adapter->fetchOne('SELECT @@time_zone');
+    expect($tz)->toBe('+00:00');
 });
 
-it('preserves ONLY_FULL_GROUP_BY across startSetup and endSetup when developer mode is on', function () {
-    Mage::setIsDeveloperMode(true);
+it('preserves the strict baseline across startSetup and endSetup', function () {
     $adapter = createFreshMysqlAdapter();
-    if (isMariaDbServer($adapter)) {
-        $this->markTestSkipped('Genuine-MySQL-only test: MariaDB is exempt from strict mode.');
-    }
-    $adapter->startSetup();
-    $adapter->endSetup();
-    $sqlMode = fetchSqlMode($adapter);
-    expect($sqlMode)->toContain('ONLY_FULL_GROUP_BY');
-});
-
-it('preserves the empty SQL_MODE across startSetup and endSetup when developer mode is off', function () {
-    Mage::setIsDeveloperMode(false);
-    $adapter = createFreshMysqlAdapter();
-    $adapter->startSetup();
-    $adapter->endSetup();
-    $sqlMode = fetchSqlMode($adapter);
-    expect($sqlMode)->toBe('');
-});
-
-it('preserves the live SQL_MODE in insertForce so the bulk-import path still works in dev mode', function () {
-    Mage::setIsDeveloperMode(true);
-    $adapter = createFreshMysqlAdapter();
-    if (isMariaDbServer($adapter)) {
-        $this->markTestSkipped('Genuine-MySQL-only test: MariaDB is exempt from strict mode.');
-    }
-
-    // SQL_MODE before
     $modeBefore = fetchSqlMode($adapter);
-    expect($modeBefore)->toContain('ONLY_FULL_GROUP_BY');
+    $adapter->startSetup();
+    $adapter->endSetup();
+    expect(fetchSqlMode($adapter))->toBe($modeBefore);
+});
 
-    // Create a temp table and call insertForce
+it('preserves the live SQL_MODE in insertForce so the bulk-import path still works', function () {
+    $adapter = createFreshMysqlAdapter();
+    $modeBefore = fetchSqlMode($adapter);
+    expect($modeBefore)->toContain('STRICT_TRANS_TABLES');
+
     $tempTable = 'test_insertforce_' . uniqid();
     $table = $adapter->newTable($tempTable)
         ->addColumn('id', \Maho\Db\Ddl\Table::TYPE_INTEGER, null, [
@@ -150,13 +148,13 @@ it('preserves the live SQL_MODE in insertForce so the bulk-import path still wor
             'nullable' => false,
             'primary' => true,
         ], 'ID')
-        ->addColumn('val', \Maho\Db\Ddl\Table::TYPE_VARCHAR, 50, [], 'Val')
-        ->setOption('type', 'TEMPORARY');
+        ->addColumn('val', \Maho\Db\Ddl\Table::TYPE_VARCHAR, 50, [], 'Val');
     $adapter->createTable($table);
 
     $adapter->insertForce($tempTable, ['id' => 0, 'val' => 'test']);
 
-    // SQL_MODE should be restored to ONLY_FULL_GROUP_BY after insertForce
-    $modeAfter = fetchSqlMode($adapter);
-    expect($modeAfter)->toContain('ONLY_FULL_GROUP_BY');
+    // SQL_MODE should be restored to the strict baseline after insertForce
+    expect(fetchSqlMode($adapter))->toBe($modeBefore);
+
+    $adapter->dropTable($tempTable);
 });

--- a/tests/Backend/Integration/Db/Adapter/MysqlStrictModeTest.php
+++ b/tests/Backend/Integration/Db/Adapter/MysqlStrictModeTest.php
@@ -81,6 +81,18 @@ it('exempts MariaDB from ONLY_FULL_GROUP_BY but keeps the rest of the strict bas
     expect($sqlMode)->toContain('STRICT_TRANS_TABLES');
 });
 
+it('honors the sql_mode escape hatch from the connection config', function () {
+    $resource = Mage::getSingleton('core/resource');
+    $config = $resource->getConnection('core_write')->getConfig();
+    $config['sql_mode'] = '';
+    $adapter = new Mysql($config);
+    expect(fetchSqlMode($adapter))->toBe('');
+
+    $config['sql_mode'] = 'STRICT_TRANS_TABLES';
+    $adapter = new Mysql($config);
+    expect(fetchSqlMode($adapter))->toBe('STRICT_TRANS_TABLES');
+});
+
 it('pins the same SQL_MODE baseline regardless of developer mode', function () {
     $modes = [];
     foreach ([true, false] as $devMode) {

--- a/tests/Backend/Integration/Db/Adapter/ZeroDateScannerTest.php
+++ b/tests/Backend/Integration/Db/Adapter/ZeroDateScannerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+use MahoCLI\Helper\ZeroDateScanner;
+use Maho\Db\Adapter\Pdo\Mysql;
+
+uses(Tests\MahoBackendTestCase::class);
+
+beforeEach(function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    if (!($adapter instanceof Mysql)) {
+        $this->markTestSkipped('MySQL-only test: zero dates only exist on MySQL/MariaDB.');
+    }
+});
+
+it('detects legacy zero-date values and defaults, and rescans clean after the NULL fix', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    $table = 'zero_date_scanner_probe';
+    $modeBefore = (string) $adapter->fetchOne('SELECT @@SESSION.sql_mode');
+
+    try {
+        // Seed legacy data the way it actually got there: under the relaxed mode
+        $adapter->query("SET SESSION sql_mode=''");
+        $adapter->query(
+            "CREATE TABLE {$table} ("
+            . ' id INT PRIMARY KEY,'
+            . ' d DATE NULL,'
+            . ' dt DATETIME NULL,'
+            . " d_def DATE NULL DEFAULT '0000-00-00',"
+            . ' locked DATE NOT NULL'
+            . ')',
+        );
+        $adapter->query("INSERT INTO {$table} VALUES (1, '0000-00-00', '0000-00-00 00:00:00', NULL, '0000-00-00')");
+        $adapter->query('SET SESSION sql_mode = ' . $adapter->quote($modeBefore));
+
+        $values = array_values(array_filter(
+            ZeroDateScanner::findZeroDateValues($adapter),
+            fn(array $f) => $f['table'] === $table,
+        ));
+        $byColumn = array_column($values, null, 'column');
+        expect(array_keys($byColumn))->toEqualCanonicalizing(['d', 'dt', 'locked']);
+        expect($byColumn['d']['nullable'])->toBeTrue();
+        expect($byColumn['d']['rows'])->toBe(1);
+        expect($byColumn['locked']['nullable'])->toBeFalse();
+
+        $defaults = array_values(array_filter(
+            ZeroDateScanner::findZeroDateDefaults($adapter),
+            fn(array $f) => $f['table'] === $table,
+        ));
+        expect(array_column($defaults, 'column'))->toBe(['d_def']);
+
+        // The fix the legacy:fix-zero-dates command applies for nullable columns
+        foreach (['d', 'dt'] as $column) {
+            $adapter->update(
+                $table,
+                [$column => null],
+                ZeroDateScanner::zeroDatePredicate($adapter, $column),
+            );
+        }
+        $adapter->query("ALTER TABLE {$table} ALTER COLUMN d_def SET DEFAULT NULL");
+
+        $remainingValues = array_values(array_filter(
+            ZeroDateScanner::findZeroDateValues($adapter),
+            fn(array $f) => $f['table'] === $table,
+        ));
+        // Only the NOT NULL column is left, flagged for manual attention
+        expect(array_column($remainingValues, 'column'))->toBe(['locked']);
+        $remainingDefaults = array_filter(
+            ZeroDateScanner::findZeroDateDefaults($adapter),
+            fn(array $f) => $f['table'] === $table,
+        );
+        expect($remainingDefaults)->toBeEmpty();
+    } finally {
+        $adapter->query("DROP TABLE IF EXISTS {$table}");
+        $adapter->query('SET SESSION sql_mode = ' . $adapter->quote($modeBefore));
+    }
+});

--- a/tests/Backend/Integration/Eav/StrictGroupByTest.php
+++ b/tests/Backend/Integration/Eav/StrictGroupByTest.php
@@ -297,30 +297,20 @@ it('loads the catalog product attribute collection with stacked filters (advance
     expect($collection->getSize())->toBe(count($collection->getItems()));
 });
 
-it('reports strict GROUP BY as required when developer mode is on', function () {
-    Mage::setIsDeveloperMode(true);
-    $helper = Mage::getResourceHelper('eav');
-    $adapter = Mage::getSingleton('core/resource')->getConnection('core_read');
+it('reports strict GROUP BY as required independently of developer mode', function () {
+    foreach ([true, false] as $devMode) {
+        Mage::setIsDeveloperMode($devMode);
+        $helper = Mage::getResourceHelper('eav');
+        $adapter = Mage::getSingleton('core/resource')->getConnection('core_read');
 
-    if ($adapter instanceof \Maho\Db\Adapter\Pdo\Sqlite) {
-        // SQLite never enforces strict GROUP BY, regardless of developer mode.
-        expect($helper->requiresStrictGroupBy())->toBeFalse();
-    } else {
-        // MySQL (ONLY_FULL_GROUP_BY in developer mode) and PostgreSQL (always).
-        expect($helper->requiresStrictGroupBy())->toBeTrue();
-    }
-});
-
-it('reports strict GROUP BY as not required when developer mode is off', function () {
-    Mage::setIsDeveloperMode(false);
-    $helper = Mage::getResourceHelper('eav');
-    $adapter = Mage::getSingleton('core/resource')->getConnection('core_read');
-
-    if ($adapter instanceof \Maho\Db\Adapter\Pdo\Pgsql) {
-        // PostgreSQL enforces strict GROUP BY natively, independent of dev mode.
-        expect($helper->requiresStrictGroupBy())->toBeTrue();
-    } else {
-        // MySQL only enables ONLY_FULL_GROUP_BY in developer mode; SQLite never.
-        expect($helper->requiresStrictGroupBy())->toBeFalse();
+        if ($adapter instanceof \Maho\Db\Adapter\Pdo\Sqlite) {
+            // SQLite never enforces strict GROUP BY.
+            expect($helper->requiresStrictGroupBy())->toBeFalse();
+        } else {
+            // MySQL pins ONLY_FULL_GROUP_BY in its connection baseline and
+            // PostgreSQL enforces strict grouping natively - both regardless
+            // of developer mode, so the compliant query shape is the only shape.
+            expect($helper->requiresStrictGroupBy())->toBeTrue();
+        }
     }
 });


### PR DESCRIPTION
Ref #688 (step 3, the final one)

## What this does

Removes the legacy `SET SQL_MODE=''` override and pins an explicit modern strict baseline on every MySQL connection:

```
ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,
ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_AUTO_VALUE_ON_ZERO
```

The first six flags are the MySQL 8+ default mode set. `NO_AUTO_VALUE_ON_ZERO` is added on top of it (see "Insert semantics" below). Pinning the whole set per connection (instead of inheriting the server's global mode) keeps behavior deterministic on every host: a self-managed MySQL, a managed cluster (DigitalOcean and friends enforce strict modes globally and hand out no SUPER privilege), or a provider with exotic global flags all behave identically.

- **MariaDB** gets the same baseline minus `ONLY_FULL_GROUP_BY` (MDEV-11588: no functional-dependency detection, so it would reject SQL-standard queries like `SELECT t.* ... GROUP BY t.pk`).
- **Developer mode no longer matters**: the same mode runs in dev, CI, and production, so dev now tests exactly what production executes. The EAV helper's `requiresStrictGroupBy()` is unconditional for the same reason: the compliant query shape must not depend on the runtime flag.
- **What each flag buys**: `STRICT_TRANS_TABLES` turns silent truncation/clamping of bad values into hard errors (no more silently corrupted data); `NO_ZERO_DATE`/`NO_ZERO_IN_DATE` reject `'0000-00-00'`; `ONLY_FULL_GROUP_BY` rejects non-deterministic grouping.

### Insert semantics (`NO_AUTO_VALUE_ON_ZERO`)

MySQL was the only adapter that turned an explicit `id = 0` bound to an `AUTO_INCREMENT` column into a freshly-generated value; PostgreSQL and SQLite store the `0` verbatim (their `insertForce()` is already a plain `insert()`). Pinning `NO_AUTO_VALUE_ON_ZERO` makes MySQL match them, so there is **one insert contract across all three engines**: omit the PK or bind `NULL` for a new row, an explicit value is honored. New-entity saves omit the PK (or bind `NULL`) and still auto-generate as before. Consequences:

- `Mysql::insertForce()` collapses to a thin `insert()` wrapper (kept for BC and call-site intent), identical to the Pgsql/Sqlite adapters.
- `startSetup()`/`endSetup()` no longer toggle `SQL_MODE` — the baseline already carries the flag, so install/upgrade/data scripts run under the **full strict baseline** and finally get validated, instead of the relaxed `SQL_MODE='NO_AUTO_VALUE_ON_ZERO'` they used to run under.

## Fallout fixed along the way

- **Category importer**: inserted rows without `path` (NOT NULL) and relied on the silent implicit default; it now inserts a placeholder and updates it after `lastInsertId()`, same as the existing SQLite path.
- **Temp-table test fixtures**: four call sites used `setOption('type', 'TEMPORARY')`, which never created temporary tables. Relaxed MySQL silently substituted InnoDB, and `NO_ENGINE_SUBSTITUTION` turns that into an error. Fixtures now create regular tables with cleanup (matching what they actually exercised), and the DDL temporary-table test uses the real `createTemporaryTable()` API.
- **Strict-mode tests** rewritten for the pinned baseline, including a new test proving oversized writes are rejected instead of silently truncated.

## Operational safety for existing stores

- **`./maho health-check`** now detects legacy zero dates (stored values and column defaults), typically found on stores migrated from Magento/OpenMage. Under `NO_ZERO_DATE`, an UPDATE touching such a row, or an INSERT relying on such a default, fails.
- **`./maho legacy:fix-zero-dates`** (new command, dry run by default, `--force` to apply) sets zero-date rows to NULL and changes zero-date defaults to `DEFAULT NULL` on nullable columns; NOT NULL columns are listed for manual attention. Detection is shared with health-check via `MahoCLI\Helper\ZeroDateScanner`, and compares as `CAST(col AS CHAR) LIKE '0000-00-00%'` because under strict mode even comparing a date column to a zero-date literal is an error.
- **Escape hatch**: a `<sql_mode>` node on the connection in `app/etc/local.xml` overrides the baseline verbatim; an empty value restores the legacy fully-relaxed behavior. Intended as a temporary exit while cleaning up, not a configuration choice.

### How the zero-date fix works

For each nullable column holding zero-date rows, one UPDATE per column:

```sql
UPDATE some_table SET some_col = NULL
WHERE CAST(some_col AS CHAR) LIKE '0000-00-00%'
```

- Writing NULL is legal under `NO_ZERO_DATE` (strict mode forbids writing zero dates, and this removes them), and MySQL only validates the columns an UPDATE actually sets, so rows are fixable even when the table has other quirks.
- The WHERE compares as CHAR because the naive `WHERE some_col = '0000-00-00'` is itself rejected under strict mode: MySQL refuses to parse a zero-date literal in a comparison (error 1525). The string comparison sidesteps date parsing and also catches partially-zero values like `0000-00-00 10:30:00`.

For each nullable column with a zero-date DEFAULT, a metadata-only DDL statement (instant even on huge tables):

```sql
ALTER TABLE some_table ALTER COLUMN some_col SET DEFAULT NULL
```

NULL is the right replacement because `'0000-00-00'` in Magento 1 semantics always meant "no value"; NULL is the honest representation, matches what PostgreSQL installs already have (zero dates cannot exist there), and date logic handles it correctly (`IS NULL`, aggregates skipping it, formatters showing blank).

NOT NULL columns are deliberately not auto-fixed: NULL would violate the column definition and there is no correct date a tool could invent, so they are listed for a per-column decision (make it nullable, or backfill a meaningful real date).

## Tests

Full Backend suite green under the strict baseline with developer mode off (production conditions): MySQL 9.7 (2479 passed), PostgreSQL 18 (2464 passed), SQLite (2401 passed), plus the Install suite including full sample-data import and reindexing. New tests cover the pinned baseline, the MariaDB exemption, the escape hatch, mode preservation across `startSetup()`/`endSetup()`/`insertForce()`, truncation rejection, and the zero-date scanner (seeded authentically under a relaxed session, detected and fixed under the strict connection).

MariaDB is the one engine not verified locally; the CI matrix covers it.

## Documentation

The [Database Layer](https://mahocommerce.com/developer/database-layer/) page has been updated (maho-home) to describe the pinned baseline, the flag-by-flag rationale, the legacy-store upgrade workflow, and the escape hatch.

## Why exactly this flag set

The validation flags are the MySQL 8.0/8.4/9.x factory default, the most battle-tested combination there is, so a Maho connection validates data exactly like stock modern MySQL and pinning them costs nothing on fresh installs. `NO_AUTO_VALUE_ON_ZERO` is the one deliberate addition on top (cross-engine insert parity, see "Insert semantics" above). Stricter or different flags were considered and excluded deliberately:

- **`STRICT_ALL_TABLES`**: the only debatable exclusion. It extends strictness to non-transactional engines, but an error midway through a multi-row write there leaves partial data with no rollback, which is exactly why MySQL keeps it out of its own defaults. Would become a no-op anyway once the schema is verified 100% InnoDB.
- **The `ANSI` group** (`ANSI_QUOTES`, `PIPES_AS_CONCAT`, `REAL_AS_FLOAT`): changes how SQL is parsed rather than how data is validated; `ANSI_QUOTES` would turn double-quoted string literals into identifier references and break MySQL-idiom SQL across the codebase.
- **`NO_BACKSLASH_ESCAPES`**: would desynchronize the server's escaping rules from what PDO quoting produces, a correctness/security mismatch rather than a strictness upgrade.
- **`TRADITIONAL`**: shorthand bundle including `STRICT_ALL_TABLES`, same reasoning.

(`NO_AUTO_VALUE_ON_ZERO` is *not* excluded — it is deliberately included, see "Insert semantics" above. It is the only non-factory-default flag in the baseline.)

Forward-looking notes: MySQL has deprecated `NO_ZERO_DATE`, `NO_ZERO_IN_DATE` and `ERROR_FOR_DIVISION_BY_ZERO` as standalone flags (slated to fold into strict mode); when a MySQL release drops them the adapter list needs a one-line trim, on our schedule rather than the server's. For MariaDB the baseline (minus `ONLY_FULL_GROUP_BY`) is slightly stricter than MariaDB's own default, which lacks the zero-date flags; that is intentional, the goal is identical behavior across MySQL, MariaDB and PostgreSQL, not faithfulness to each engine's factory settings.

---

## 📝 Release notes (action required for existing stores)

> **Include this in the 26.9 release notes.** The strict SQL_MODE baseline is a
> breaking change for stores that carry legacy zero dates (`0000-00-00`) — almost
> always stores migrated from Magento 1 / OpenMage. **Nothing in the upgrade runs
> automatically**: neither `health-check` nor the zero-date migration is triggered
> by the version bump, so an affected store will start throwing runtime errors
> after upgrading (any `UPDATE` touching a zero-date row, or any `INSERT` relying
> on a zero-date column default, fails under `NO_ZERO_DATE`).

**After upgrading to 26.9, run:**

1. **Detect** — `./maho health-check --check-zero-dates`
   The `--check-zero-dates` flag is required to scan stored values; a bare
   `health-check` only reports zero-date column *defaults* (the value scan is a
   full table scan and is opt-in). Fresh installs and PostgreSQL are unaffected
   and will report clean.
2. **Preview the fix** — `./maho legacy:fix-zero-dates` (dry run, writes nothing)
3. **Apply** — `./maho legacy:fix-zero-dates --force`
   Nullable columns: zero-date rows → `NULL`, zero-date defaults → `DEFAULT NULL`.
   `NOT NULL` columns are **not** auto-fixed — they are listed for a manual
   per-column decision (make the column nullable, or backfill a real date).

**Temporary escape hatch:** set an empty `<sql_mode></sql_mode>` node on the
connection in `app/etc/local.xml` to restore the old fully-relaxed behavior while
you clean up. Intended as a short-lived exit, not a permanent setting.

**For extension authors — insert semantics change (MySQL):** `NO_AUTO_VALUE_ON_ZERO`
is now always on. Binding an explicit `0` to an `AUTO_INCREMENT` primary key now
stores `0` instead of generating a new id. This only affects code that inserted a
literal `0` to get a fresh row — a pattern that was already non-portable (it stored
`0` on PostgreSQL/SQLite). Insert a new row the portable way: omit the primary key
or bind `NULL`.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->