### PR TITLE
Added expression support to `{{if}}`, `{{depend}}` and `{{var}}` template directives and deprecated the legacy tokenizer

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -24379,24 +24379,6 @@ parameters:
 			path: lib/Maho/Filter/Template/Tokenizer/Variable.php
 
 		-
-			rawMessage: '''
-				Access to constant on deprecated class Maho\Filter\Template\Tokenizer\Variable:
-				since 26.9 Use Symfony\Component\ExpressionLanguage\ExpressionLanguage instead, as Maho\Filter\Template now does to resolve {{var}} and {{if}}/{{depend}}.
-			'''
-			identifier: classConstant.deprecatedClass
-			count: 1
-			path: app/bootstrap.php
-
-		-
-			rawMessage: '''
-				Access to constant on deprecated class Maho\Filter\Template\Tokenizer\Variable:
-				since 26.9 Use Symfony\Component\ExpressionLanguage\ExpressionLanguage instead, as Maho\Filter\Template now does to resolve {{var}} and {{if}}/{{depend}}.
-			'''
-			identifier: classConstant.deprecatedClass
-			count: 1
-			path: lib/Maho/Rector/VarienToMahoClassMap.php
-
-		-
 			rawMessage: 'Method Maho\Io\File::dirname() has no return type specified.'
 			identifier: missingType.return
 			count: 1

--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -24379,6 +24379,24 @@ parameters:
 			path: lib/Maho/Filter/Template/Tokenizer/Variable.php
 
 		-
+			rawMessage: '''
+				Access to constant on deprecated class Maho\Filter\Template\Tokenizer\Variable:
+				since 26.9 Use Symfony\Component\ExpressionLanguage\ExpressionLanguage instead, as Maho\Filter\Template now does to resolve {{var}} and {{if}}/{{depend}}.
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: app/bootstrap.php
+
+		-
+			rawMessage: '''
+				Access to constant on deprecated class Maho\Filter\Template\Tokenizer\Variable:
+				since 26.9 Use Symfony\Component\ExpressionLanguage\ExpressionLanguage instead, as Maho\Filter\Template now does to resolve {{var}} and {{if}}/{{depend}}.
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: lib/Maho/Rector/VarienToMahoClassMap.php
+
+		-
 			rawMessage: 'Method Maho\Io\File::dirname() has no return type specified.'
 			identifier: missingType.return
 			count: 1

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -119,7 +119,7 @@ if (($_ENV['MAHO_ENABLE_VARIEN_ALIASES'] ?? $_SERVER['MAHO_ENABLE_VARIEN_ALIASES
     class_alias(\Maho\Filter\Template\Simple::class, 'Varien_Filter_Template_Simple');
     class_alias(\Maho\Filter\Template\Tokenizer\AbstractTokenizer::class, 'Varien_Filter_Template_Tokenizer_Abstract');
     class_alias(\Maho\Filter\Template\Tokenizer\Parameter::class, 'Varien_Filter_Template_Tokenizer_Parameter');
-    class_alias(\Maho\Filter\Template\Tokenizer\Variable::class, 'Varien_Filter_Template_Tokenizer_Variable');
+    class_alias(\Maho\Filter\Template\Tokenizer\Variable::class, 'Varien_Filter_Template_Tokenizer_Variable'); // @phpstan-ignore classConstant.deprecatedClass
     class_alias(\Maho\Io::class, 'Varien_Io_Abstract');
     class_alias(\Maho\Io\Exception::class, 'Varien_Io_Exception');
     class_alias(\Maho\Io\File::class, 'Varien_Io_File');

--- a/app/code/core/Mage/Core/Model/Email/Template/Filter.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Filter.php
@@ -348,9 +348,9 @@ class Mage_Core_Model_Email_Template_Filter extends \Maho\Filter\Template
         $parts = explode('|', $construction[2], 2);
         if (count($parts) === 2) {
             [$variableName, $modifiersString] = $parts;
-            return $this->_amplifyModifiers($this->_getVariable($variableName, ''), $modifiersString);
+            return $this->_amplifyModifiers($this->_stringifyVariable($this->_getVariable($variableName, '')), $modifiersString);
         }
-        return $this->_getVariable($construction[2], '');
+        return $this->_stringifyVariable($this->_getVariable($construction[2], ''));
     }
 
     /**
@@ -532,24 +532,70 @@ class Mage_Core_Model_Email_Template_Filter extends \Maho\Filter\Template
     }
 
     /**
-     * Return variable value for var construction
+     * Resolve a {{var}} path under the same save/delete guard as {{if}}/{{depend}}, see
+     * _evaluateCondition() below for what registering varProcessing buys.
      *
-     * @param string $value raw parameters
+     * @param string $value raw variable expression
      * @param string $default default value
-     * @return string
-     * @throws Mage_Core_Exception
+     * @return mixed
      */
     #[\Override]
     protected function _getVariable($value, $default = '{no_value_defined}')
     {
-        Mage::register('varProcessing', true);
+        $owns = self::_beginVarProcessing();
         try {
-            $result = parent::_getVariable($value, $default);
-        } catch (Exception $e) {
-            $result = '';
-            Mage::logException($e);
+            return parent::_getVariable($value, $default);
+        } finally {
+            self::_endVarProcessing($owns);
         }
-        Mage::unregister('varProcessing');
-        return $result;
+    }
+
+    /**
+     * Evaluate an {{if}} / {{depend}} condition under the same save/delete guard as {{var}}.
+     *
+     * Mage_Core_Model_Observer::secureVarProcessing() refuses any model save or delete while the
+     * varProcessing flag is registered, which is the last-resort net behind the wrapper's
+     * read-only method gate: a getter that looks like a read but persists on the way out is
+     * stopped there. Conditions used to inherit that net for free, because ifDirective() resolved
+     * its operand through _getVariable(); they now evaluate through the expression engine
+     * instead, so the flag has to be set here too, or the same accessor would be guarded in
+     * {{var}} and unguarded in {{depend}}.
+     */
+    #[\Override]
+    protected function _evaluateCondition(string $condition): bool
+    {
+        $owns = self::_beginVarProcessing();
+        try {
+            return parent::_evaluateCondition($condition);
+        } finally {
+            self::_endVarProcessing($owns);
+        }
+    }
+
+    /**
+     * Raise the varProcessing flag, returning whether this call is the one that owns it.
+     *
+     * Mage::register() throws when the key is already taken, so a nested render — a getter
+     * reached from a directive that itself filters a template — would abort the inner render
+     * outright, and abort it *before* entering the try block, leaving the flag to be dropped by
+     * whichever frame unwinds first. Re-entering is legitimate and must simply join the guard
+     * already in force: only the outermost frame registers, and only it unregisters, so the
+     * save/delete net stays up for the whole nest instead of being torn down early by an inner
+     * frame finishing first.
+     */
+    protected static function _beginVarProcessing(): bool
+    {
+        if (Mage::registry('varProcessing') !== null) {
+            return false;
+        }
+        Mage::register('varProcessing', true);
+        return true;
+    }
+
+    protected static function _endVarProcessing(bool $owns): void
+    {
+        if ($owns) {
+            Mage::unregister('varProcessing');
+        }
     }
 }

--- a/lib/Maho/Filter/Template.php
+++ b/lib/Maho/Filter/Template.php
@@ -9,10 +9,11 @@
 
 namespace Maho\Filter;
 
-use Maho\Filter\Template\ExpressionObjectWrapper;
+use Maho\Filter\Template\ExpressionSandbox;
 use Maho\Filter\Template\Tokenizer\Parameter;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\ExpressionLanguage\Node\Node;
+use Symfony\Component\ExpressionLanguage\ParsedExpression;
 
 class Template
 {
@@ -28,9 +29,22 @@ class Template
     public const CONSTRUCTION_IF_PATTERN = '/{{if\s*(.*?)}}(.*?)({{else}}(.*?))?{{\\/if\s*}}/si';
 
     /**
-     * Expression operators refused in {{if}} / {{depend}} conditions, see assertNoDeniedOperator()
+     * Expression operators refused in {{if}} / {{depend}} conditions, see _assertNoDeniedOperator()
      */
     private const DENIED_OPERATORS = ['matches', '..'];
+
+    /**
+     * Maximum byte length of an {{if}} / {{depend}} / {{var}} expression.
+     *
+     * Symfony's expression parser is recursive-descent — it recurses once per operator — so a
+     * deeply nested expression ({{if not not not ... x}}, {{if ((((...))))}}) overflows the native
+     * C stack and takes the whole worker down with a SIGSEGV *during parse*, before any node-level
+     * guard can run. A signal is not an exception, so filter()'s try/catch cannot absorb it: an
+     * admin with only template-edit rights would crash transactional-mail rendering with one saved
+     * template. A real condition or variable path is a few dozen bytes; capping the raw string
+     * bounds nesting far below the crash depth while leaving every legitimate expression untouched.
+     */
+    private const MAX_EXPRESSION_LENGTH = 2000;
 
     private static ?ExpressionLanguage $_expressionLanguage = null;
 
@@ -40,6 +54,17 @@ class Template
      * @var array
      */
     protected $_templateVars = [];
+
+    /**
+     * _templateVars run through ExpressionSandbox::wrap(), memoized for the life of the
+     * assignment. Wrapping an object is cheap (it only captures it), but wrapping an array is an
+     * eager filtered deep copy — the only way to gate a native subscript — so redoing it for
+     * every directive makes a template's cost the product of its directive count and its largest
+     * array variable. setVariables() is the only thing that can change what needs wrapping.
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $_wrappedTemplateVars = null;
 
     /**
      * Template processor
@@ -63,6 +88,7 @@ class Template
         foreach ($variables as $name => $value) {
             $this->_templateVars[$name] = $value;
         }
+        $this->_wrappedTemplateVars = null;
         return $this;
     }
 
@@ -166,11 +192,31 @@ class Template
             return $construction[0];
         }
 
-        $replacedValue = $this->_getVariable($construction[2], '');
-        if ($replacedValue instanceof \DateTimeInterface) {
-            $replacedValue = $replacedValue->format('Y-m-d H:i:s');
+        return $this->_stringifyVariable($this->_getVariable($construction[2], ''));
+    }
+
+    /**
+     * Render a resolved {{var}} value as the string that replaces the directive.
+     *
+     * A path can legitimately resolve to a model — {{var order.billing_address}} hands back the
+     * address object — and casting one that defines no __toString() raises a native \Error, which
+     * is not an \Exception and so escapes filter()'s handler and aborts the whole render. An
+     * object with no string form has no template representation, so it degrades to the empty
+     * default like every other unresolvable path.
+     *
+     * An array degrades the same way: a getter returning one ({{var product.multiselect_attr}})
+     * would otherwise cast to the literal text "Array" in the rendered mail and raise an
+     * "Array to string conversion" warning while doing it.
+     */
+    protected function _stringifyVariable(mixed $value): string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format('Y-m-d H:i:s');
         }
-        return (string) $replacedValue;
+        if (is_array($value) || (is_object($value) && !$value instanceof \Stringable)) {
+            return '';
+        }
+        return (string) $value;
     }
 
     public function includeDirective($construction)
@@ -223,7 +269,7 @@ class Template
             return $construction[0];
         }
 
-        if (!$this->evaluateCondition($construction[1])) {
+        if (!$this->_evaluateCondition($construction[1])) {
             return '';
         }
         return $construction[2];
@@ -235,7 +281,7 @@ class Template
             return $construction[0];
         }
 
-        if (!$this->evaluateCondition($construction[1])) {
+        if (!$this->_evaluateCondition($construction[1])) {
             if (isset($construction[3]) && isset($construction[4])) {
                 return $construction[4];
             }
@@ -251,10 +297,16 @@ class Template
      * The legacy single-variable syntax ("order.increment_id", "customer.getName()") is a
      * subset of the expression syntax and keeps working: identifiers the template does not
      * define evaluate as null, and the result uses standard PHP truthiness. A condition that
-     * fails to parse or evaluate logs a warning and yields false, so a broken template
-     * degrades instead of aborting.
+     * fails to parse or evaluate logs and yields false, so a broken template degrades instead
+     * of aborting.
+     *
+     * Truthiness is the one deliberate behaviour change: the legacy directive tested
+     * _getVariable(...) != '', which under PHP 8 makes 0, '0' and 0.0 *truthy*, so
+     * {{if order.getItemsCount()}} rendered its true branch for an empty order. Casting to bool
+     * makes those falsy, which is what a template author writing {{if x}} means; the cost is
+     * that a field whose value is literally "0" (a house number, say) now takes the else branch.
      */
-    protected function evaluateCondition(string $condition): bool
+    protected function _evaluateCondition(string $condition): bool
     {
         $expression = trim($condition);
         if ($expression === '') {
@@ -263,17 +315,30 @@ class Template
 
         $values = $this->_expressionValues($expression);
         try {
-            $language = self::getExpressionLanguage();
-            $parsed = $language->parse($expression, array_keys($values));
-            self::assertNoDeniedOperator($parsed->getNodes());
-            return (bool) $language->evaluate($parsed, $values);
+            $parsed = self::_parseExpression($expression, array_keys($values));
+            return (bool) self::_getExpressionLanguage()->evaluate($parsed, $values);
         } catch (\Throwable $e) {
-            \Mage::log(
-                sprintf('Invalid condition "%s" in template directive: %s', $expression, $e->getMessage()),
-                \Mage::LOG_WARNING,
-            );
+            self::_logExpressionFailure(sprintf('Invalid condition "%s" in template directive', $expression), $e);
             return false;
         }
+    }
+
+    /**
+     * Log an expression that could not be resolved, at a level matching how alarming it is.
+     *
+     * A hop past a value that is legitimately absent — {{if order.shipping_address.company}} on a
+     * virtual order — makes Symfony throw a plain \RuntimeException ("Unable to get property ... of
+     * non-object"), because a template author never writes its ?. null-safe syntax. The legacy
+     * tokenizer resolved that to the default silently, so logging it as a warning on every render
+     * would flood system.log for templates that are working as intended: it is recorded at debug
+     * level instead. Everything else — a syntax error, a denied operator, an exception escaping a
+     * getter (which is a \RuntimeException *subclass*, never the base class Symfony throws) — still
+     * warns.
+     */
+    private static function _logExpressionFailure(string $message, \Throwable $e): void
+    {
+        $level = $e::class === \RuntimeException::class ? \Mage::LOG_DEBUG : \Mage::LOG_WARNING;
+        \Mage::log(sprintf('%s: %s', $message, $e->getMessage()), $level);
     }
 
     /**
@@ -287,10 +352,13 @@ class Template
      */
     private function _expressionValues(string $expression): array
     {
-        $values = [];
-        foreach ($this->_templateVars as $name => $value) {
-            $values[$name] = ExpressionObjectWrapper::wrap($value);
+        if ($this->_wrappedTemplateVars === null) {
+            $this->_wrappedTemplateVars = [];
+            foreach ($this->_templateVars as $name => $value) {
+                $this->_wrappedTemplateVars[$name] = ExpressionSandbox::wrap($value);
+            }
         }
+        $values = $this->_wrappedTemplateVars;
         preg_match_all('/\b[a-z_][a-z0-9_]*\b/i', $expression, $matches);
         foreach ($matches[0] as $name) {
             $values[$name] ??= null;
@@ -299,26 +367,50 @@ class Template
     }
 
     /**
+     * Parse an expression under the guards {{if}}/{{depend}} and {{var}} share: refuse an
+     * over-long expression before the recursive parser can run into it (see MAX_EXPRESSION_LENGTH)
+     * and refuse a denied operator once parsed. Both refusals throw from the \LogicException
+     * family, so the callers' \Throwable catch routes them through _logExpressionFailure() as an
+     * authoring error, the same as Symfony's own SyntaxError.
+     *
+     * @param string[] $names identifiers the expression is allowed to reference
+     * @throws \LengthException|\LogicException|\Symfony\Component\ExpressionLanguage\SyntaxError
+     */
+    private static function _parseExpression(string $expression, array $names): ParsedExpression
+    {
+        if (strlen($expression) > self::MAX_EXPRESSION_LENGTH) {
+            throw new \LengthException(sprintf('expression exceeds %d bytes', self::MAX_EXPRESSION_LENGTH));
+        }
+        $parsed = self::_getExpressionLanguage()->parse($expression, $names);
+        self::_assertNoDeniedOperator($parsed->getNodes());
+        return $parsed;
+    }
+
+    /**
      * Reject the two operators a condition never legitimately needs but which let a template
      * author stall the process: "matches" runs an arbitrary regex against arbitrary input
      * (catastrophic backtracking) and ".." builds a range array of arbitrary size.
      *
-     * @throws \RuntimeException
+     * Refusing an operator is a template-authoring error like Symfony's own SyntaxError, so it
+     * throws from the \LogicException family: _logExpressionFailure() reserves the quiet debug
+     * level for the base \RuntimeException Symfony throws when a hop resolves to null.
+     *
+     * @throws \LogicException
      */
-    private static function assertNoDeniedOperator(Node $node): void
+    private static function _assertNoDeniedOperator(Node $node): void
     {
         $operator = $node->attributes['operator'] ?? null;
         if (in_array($operator, self::DENIED_OPERATORS, true)) {
-            throw new \RuntimeException(sprintf('operator "%s" is not allowed in a condition', $operator));
+            throw new \LogicException(sprintf('operator "%s" is not allowed in a condition', $operator));
         }
         foreach ($node->nodes as $child) {
             if ($child instanceof Node) {
-                self::assertNoDeniedOperator($child);
+                self::_assertNoDeniedOperator($child);
             }
         }
     }
 
-    protected static function getExpressionLanguage(): ExpressionLanguage
+    protected static function _getExpressionLanguage(): ExpressionLanguage
     {
         if (self::$_expressionLanguage === null) {
             $language = new ExpressionLanguage();
@@ -375,15 +467,10 @@ class Template
         }
         try {
             $values = $this->_expressionValues($expression);
-            $language = self::getExpressionLanguage();
-            $parsed = $language->parse($expression, array_keys($values));
-            self::assertNoDeniedOperator($parsed->getNodes());
-            $result = ExpressionObjectWrapper::unwrap($language->evaluate($parsed, $values)) ?? $default;
+            $parsed = self::_parseExpression($expression, array_keys($values));
+            $result = ExpressionSandbox::unwrap(self::_getExpressionLanguage()->evaluate($parsed, $values)) ?? $default;
         } catch (\Throwable $e) {
-            \Mage::log(
-                sprintf('Invalid variable "%s" in template directive: %s', $expression, $e->getMessage()),
-                \Mage::LOG_WARNING,
-            );
+            self::_logExpressionFailure(sprintf('Invalid variable "%s" in template directive', $expression), $e);
             $result = $default;
         }
         \Maho\Profiler::stop('email_template_proccessing_variables');

--- a/lib/Maho/Filter/Template.php
+++ b/lib/Maho/Filter/Template.php
@@ -11,8 +11,6 @@ namespace Maho\Filter;
 
 use Maho\Filter\Template\ExpressionObjectWrapper;
 use Maho\Filter\Template\Tokenizer\Parameter;
-use Maho\Filter\Template\Tokenizer\Variable;
-use Maho\DataObject;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\ExpressionLanguage\Node\Node;
 
@@ -263,18 +261,7 @@ class Template
             return false;
         }
 
-        $values = [];
-        foreach ($this->_templateVars as $name => $value) {
-            $values[$name] = ExpressionObjectWrapper::wrap($value);
-        }
-        // Default every identifier-shaped token to null so absent optional variables
-        // ({{depend comment}}) evaluate silently as empty instead of failing the parse.
-        // Extra names never change how operators or literals are parsed.
-        preg_match_all('/\b[a-z_][a-z0-9_]*\b/i', $expression, $matches);
-        foreach ($matches[0] as $name) {
-            $values[$name] ??= null;
-        }
-
+        $values = $this->_expressionValues($expression);
         try {
             $language = self::getExpressionLanguage();
             $parsed = $language->parse($expression, array_keys($values));
@@ -287,6 +274,28 @@ class Template
             );
             return false;
         }
+    }
+
+    /**
+     * Build the variable map an expression is evaluated against: every template variable
+     * wrapped so property/method access is gated, plus every identifier-shaped token in the
+     * expression defaulted to null so an absent variable ({{depend comment}}, {{var comment}})
+     * evaluates silently as empty instead of failing the parse. Extra names never change how
+     * operators or literals are parsed. Shared by {{if}}/{{depend}} and {{var}}.
+     *
+     * @return array<string, mixed>
+     */
+    private function _expressionValues(string $expression): array
+    {
+        $values = [];
+        foreach ($this->_templateVars as $name => $value) {
+            $values[$name] = ExpressionObjectWrapper::wrap($value);
+        }
+        preg_match_all('/\b[a-z_][a-z0-9_]*\b/i', $expression, $matches);
+        foreach ($matches[0] as $name) {
+            $values[$name] ??= null;
+        }
+        return $values;
     }
 
     /**
@@ -346,67 +355,38 @@ class Template
     }
 
     /**
-     * Return variable value for var construction
+     * Resolve a {{var}} object path to its value through the same sandboxed ExpressionLanguage
+     * engine as {{if}}/{{depend}}: property reads and read-only accessors work (including
+     * arg-bearing ones such as getAttributeText('color') and format('html')), while
+     * state-changing methods, secret fields and whole-object dumps are refused by the wrapper.
+     * Returns $default when the path is empty, resolves to nothing, or fails to parse/evaluate.
      *
-     * @param string $value raw parameters
+     * @param string $value raw variable expression
      * @param string|null $default default value
-     * @return string
+     * @return mixed
      */
     protected function _getVariable($value, $default = '{no_value_defined}')
     {
         \Maho\Profiler::start('email_template_proccessing_variables');
-        $tokenizer = new Variable();
-        $tokenizer->setString($value);
-        $stackVars = $tokenizer->tokenize();
-        $result = $default;
-        $last = 0;
-        /** @var \Mage_Adminhtml_Model_Email_PathValidator $emailPathValidator */
-        $emailPathValidator = $this->getEmailPathValidator();
-        for ($i = 0; $i < count($stackVars); $i++) {
-            if ($i == 0 && isset($this->_templateVars[$stackVars[$i]['name']])) {
-                // Getting of template value
-                $stackVars[$i]['variable'] = & $this->_templateVars[$stackVars[$i]['name']];
-            } elseif (isset($stackVars[$i - 1]['variable']) && $stackVars[$i - 1]['variable'] instanceof DataObject) {
-                // If object calling methods or getting properties
-                if ($stackVars[$i]['type'] == 'property') {
-                    $caller = 'get' . uc_words($stackVars[$i]['name'], '');
-                    $stackVars[$i]['variable'] = method_exists($stackVars[$i - 1]['variable'], $caller)
-                        ? $stackVars[$i - 1]['variable']->$caller()
-                        : $stackVars[$i - 1]['variable']->getData($stackVars[$i]['name']);
-                } elseif ($stackVars[$i]['type'] == 'method') {
-                    // Calling of object method
-                    if (method_exists($stackVars[$i - 1]['variable'], $stackVars[$i]['name'])
-                        || str_starts_with($stackVars[$i]['name'], 'get')
-                    ) {
-                        $isEncrypted = false;
-                        if ($stackVars[$i]['name'] == 'getConfig') {
-                            $isEncrypted = $emailPathValidator->isValid($stackVars[$i]['args']);
-                        }
-                        $stackVars[$i]['variable'] = call_user_func_array(
-                            [$stackVars[$i - 1]['variable'], $stackVars[$i]['name']],
-                            $isEncrypted ? [null] : $stackVars[$i]['args'],
-                        );
-                    }
-                }
-                $last = $i;
-            }
+        $expression = trim($value);
+        if ($expression === '') {
+            \Maho\Profiler::stop('email_template_proccessing_variables');
+            return $default;
         }
-
-        if (isset($stackVars[$last]['variable'])) {
-            // If value for construction exists set it
-            $result = $stackVars[$last]['variable'];
+        try {
+            $values = $this->_expressionValues($expression);
+            $language = self::getExpressionLanguage();
+            $parsed = $language->parse($expression, array_keys($values));
+            self::assertNoDeniedOperator($parsed->getNodes());
+            $result = ExpressionObjectWrapper::unwrap($language->evaluate($parsed, $values)) ?? $default;
+        } catch (\Throwable $e) {
+            \Mage::log(
+                sprintf('Invalid variable "%s" in template directive: %s', $expression, $e->getMessage()),
+                \Mage::LOG_WARNING,
+            );
+            $result = $default;
         }
         \Maho\Profiler::stop('email_template_proccessing_variables');
         return $result;
-    }
-
-    /**
-     * Retrieve model object
-     *
-     * @return \Mage_Adminhtml_Model_Email_PathValidator
-     */
-    protected function getEmailPathValidator()
-    {
-        return \Mage::getModel('adminhtml/email_pathValidator');
     }
 }

--- a/lib/Maho/Filter/Template.php
+++ b/lib/Maho/Filter/Template.php
@@ -9,9 +9,11 @@
 
 namespace Maho\Filter;
 
+use Maho\Filter\Template\ExpressionObjectWrapper;
 use Maho\Filter\Template\Tokenizer\Parameter;
 use Maho\Filter\Template\Tokenizer\Variable;
 use Maho\DataObject;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class Template
 {
@@ -25,6 +27,8 @@ class Template
      */
     public const CONSTRUCTION_DEPEND_PATTERN = '/{{depend\s*(.*?)}}(.*?){{\\/depend\s*}}/si';
     public const CONSTRUCTION_IF_PATTERN = '/{{if\s*(.*?)}}(.*?)({{else}}(.*?))?{{\\/if\s*}}/si';
+
+    private static ?ExpressionLanguage $_expressionLanguage = null;
 
     /**
      * Assigned template variables
@@ -215,7 +219,7 @@ class Template
             return $construction[0];
         }
 
-        if ($this->_getVariable($construction[1], '') == '') {
+        if (!$this->evaluateCondition($construction[1])) {
             return '';
         }
         return $construction[2];
@@ -227,13 +231,68 @@ class Template
             return $construction[0];
         }
 
-        if ($this->_getVariable($construction[1], '') == '') {
+        if (!$this->evaluateCondition($construction[1])) {
             if (isset($construction[3]) && isset($construction[4])) {
                 return $construction[4];
             }
             return '';
         }
         return $construction[2];
+    }
+
+    /**
+     * Evaluate an {{if}} / {{depend}} condition as a Symfony ExpressionLanguage expression
+     * against the template variables, e.g. {{if order.grand_total > 100 && customer.group_id == 2}}.
+     *
+     * The legacy single-variable syntax ("order.increment_id", "customer.getName()") is a
+     * subset of the expression syntax and keeps working: identifiers the template does not
+     * define evaluate as null, and the result uses standard PHP truthiness. A condition that
+     * fails to parse or evaluate logs a warning and yields false, so a broken template
+     * degrades instead of aborting.
+     */
+    protected function evaluateCondition(string $condition): bool
+    {
+        $expression = trim($condition);
+        if ($expression === '') {
+            return false;
+        }
+
+        $values = [];
+        foreach ($this->_templateVars as $name => $value) {
+            $values[$name] = ExpressionObjectWrapper::wrap($value);
+        }
+        // Default every identifier-shaped token to null so absent optional variables
+        // ({{depend comment}}) evaluate silently as empty instead of failing the parse.
+        // Extra names never change how operators or literals are parsed.
+        preg_match_all('/\b[a-z_][a-z0-9_]*\b/i', $expression, $matches);
+        foreach ($matches[0] as $name) {
+            $values[$name] ??= null;
+        }
+
+        try {
+            return (bool) self::getExpressionLanguage()->evaluate($expression, $values);
+        } catch (\Throwable $e) {
+            \Mage::log(
+                sprintf('Invalid condition "%s" in template directive: %s', $expression, $e->getMessage()),
+                \Mage::LOG_WARNING,
+            );
+            return false;
+        }
+    }
+
+    protected static function getExpressionLanguage(): ExpressionLanguage
+    {
+        if (self::$_expressionLanguage === null) {
+            $language = new ExpressionLanguage();
+            // Templates must not read arbitrary PHP/class constants
+            $language->register(
+                'constant',
+                static fn(): string => 'null',
+                static fn(): mixed => null,
+            );
+            self::$_expressionLanguage = $language;
+        }
+        return self::$_expressionLanguage;
     }
 
     /**

--- a/lib/Maho/Filter/Template.php
+++ b/lib/Maho/Filter/Template.php
@@ -14,6 +14,7 @@ use Maho\Filter\Template\Tokenizer\Parameter;
 use Maho\Filter\Template\Tokenizer\Variable;
 use Maho\DataObject;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\Node\Node;
 
 class Template
 {
@@ -27,6 +28,11 @@ class Template
      */
     public const CONSTRUCTION_DEPEND_PATTERN = '/{{depend\s*(.*?)}}(.*?){{\\/depend\s*}}/si';
     public const CONSTRUCTION_IF_PATTERN = '/{{if\s*(.*?)}}(.*?)({{else}}(.*?))?{{\\/if\s*}}/si';
+
+    /**
+     * Expression operators refused in {{if}} / {{depend}} conditions, see assertNoDeniedOperator()
+     */
+    private const DENIED_OPERATORS = ['matches', '..'];
 
     private static ?ExpressionLanguage $_expressionLanguage = null;
 
@@ -270,7 +276,10 @@ class Template
         }
 
         try {
-            return (bool) self::getExpressionLanguage()->evaluate($expression, $values);
+            $language = self::getExpressionLanguage();
+            $parsed = $language->parse($expression, array_keys($values));
+            self::assertNoDeniedOperator($parsed->getNodes());
+            return (bool) $language->evaluate($parsed, $values);
         } catch (\Throwable $e) {
             \Mage::log(
                 sprintf('Invalid condition "%s" in template directive: %s', $expression, $e->getMessage()),
@@ -280,16 +289,38 @@ class Template
         }
     }
 
+    /**
+     * Reject the two operators a condition never legitimately needs but which let a template
+     * author stall the process: "matches" runs an arbitrary regex against arbitrary input
+     * (catastrophic backtracking) and ".." builds a range array of arbitrary size.
+     *
+     * @throws \RuntimeException
+     */
+    private static function assertNoDeniedOperator(Node $node): void
+    {
+        $operator = $node->attributes['operator'] ?? null;
+        if (in_array($operator, self::DENIED_OPERATORS, true)) {
+            throw new \RuntimeException(sprintf('operator "%s" is not allowed in a condition', $operator));
+        }
+        foreach ($node->nodes as $child) {
+            if ($child instanceof Node) {
+                self::assertNoDeniedOperator($child);
+            }
+        }
+    }
+
     protected static function getExpressionLanguage(): ExpressionLanguage
     {
         if (self::$_expressionLanguage === null) {
             $language = new ExpressionLanguage();
             // Templates must not read arbitrary PHP/class constants
-            $language->register(
-                'constant',
-                static fn(): string => 'null',
-                static fn(): mixed => null,
-            );
+            foreach (['constant', 'enum'] as $function) {
+                $language->register(
+                    $function,
+                    static fn(): string => 'null',
+                    static fn(): mixed => null,
+                );
+            }
             self::$_expressionLanguage = $language;
         }
         return self::$_expressionLanguage;

--- a/lib/Maho/Filter/Template/ExpressionObjectWrapper.php
+++ b/lib/Maho/Filter/Template/ExpressionObjectWrapper.php
@@ -25,21 +25,32 @@ class ExpressionObjectWrapper implements \Stringable
 {
     /**
      * Method name prefixes considered read-only and therefore callable from a template.
-     * Shared with the legacy {{var}} resolver (Template::_isReadOnlyMethodCall) so both the
-     * condition sandbox and the {{var}} gate draw the read-only surface from one place.
+     * Template::_getVariable() and Template::_evaluateCondition() both resolve through this
+     * wrapper, so {{var}} and {{if}}/{{depend}} draw their read-only surface from one place.
      */
-    public const READ_ONLY_PREFIXES = ['get', 'has', 'is', 'can', 'to', 'count', 'format'];
+    private const READ_ONLY_PREFIXES = ['get', 'has', 'is', 'can', 'to', 'count', 'format'];
 
     /**
      * Methods refused even though they match a read-only prefix. getConfigData() reads
      * payment/carrier credentials under a relative path the encrypted-path guard cannot
      * check; toArray()/toJson()/toXml()/toString() each dump an object's whole internal
-     * state in one call, defeating the per-name gate; getDataUsingMethod() re-derives and
+     * state in one call, defeating the per-name gate; toHtml() matches the same "to" prefix but
+     * is not a read at all — Mage_Core_Block_Abstract extends DataObject, so a block reaching a
+     * template variable would let a condition run a whole block render (queries, observers,
+     * cache writes) against the "must not mutate anything" rule above; getChildHtml()/
+     * getChildChildHtml()/getBlockHtml() reach the identical _toHtml() render path but carry the
+     * read-only "get" prefix, so they are denied alongside toHtml() for the same reason;
+     * getDataUsingMethod() re-derives and
      * calls an arbitrary getter, so it side-steps the name-based getConfig encrypted-path
      * guard in __call() (the same getter stays reachable directly — getConfig()/getFoo()/foo
      * — where the guard still applies); getDataSetDefault() writes to the object despite its
      * getter-shaped name; getDataByPath() walks an ungated a/b/c path into nested _data, so it
-     * is closed whole rather than filtered by key.
+     * is closed whole rather than filtered by key; getAdditionalInformation()/getAdditionalData()
+     * are the payment bags whose *keys* are defined by whichever gateway module is installed
+     * (core alone stores cvv_code, avs_code, payer_email, payer_id, three_d_secure, dispute_*,
+     * paypal_*_id, vault_token_id and a raw gateway-response blob there), so no field-name
+     * vocabulary can ever be complete for them and they are closed whole. No shipped template
+     * reads them — order emails render payment through the payment_html block.
      *
      * This list is deliberately small: it holds only method-level denials that a field-name
      * rule cannot express. Secret *fields* (password, card data, tokens, ...) are refused by
@@ -52,9 +63,15 @@ class ExpressionObjectWrapper implements \Stringable
         'tojson',
         'toxml',
         'tostring',
+        'tohtml',
+        'getchildhtml',
+        'getchildchildhtml',
+        'getblockhtml',
         'getdatausingmethod',
         'getdatasetdefault',
         'getdatabypath',
+        'getadditionalinformation',
+        'getadditionaldata',
     ];
 
     /**
@@ -62,10 +79,14 @@ class ExpressionObjectWrapper implements \Stringable
      * contains one of these (case-insensitively) is refused whether it is reached as a named
      * getter (getPassword() / .password), as a keyed data read (getData('password')), or as
      * the getter derived from a property. Matching a fragment rather than an exact name closes
-     * the whole family in one rule — password_hash, rp_token, api_secret, cc_number — instead
+     * the whole family in one rule — password_hash, rp_token, api_secret, cvv_code — instead
      * of chasing each subclass getter (Mage_Customer_Model_Customer::getPassword() returns the
      * stored password and the customer model is handed to the changed-password email template,
      * so with the range/comparison operators a bare getter is a char-by-char exfil oracle).
+     * "echeck" closes the eCheck/ACH bank family a payment info object carries
+     * (echeck_routing_number, echeck_account_name, echeck_bank_name, echeck_account_type) —
+     * bank data every bit as sensitive as the cc_* card fields, and the payment object is handed
+     * to order emails.
      */
     private const SENSITIVE_FIELD_FRAGMENTS = [
         'password',
@@ -73,9 +94,32 @@ class ExpressionObjectWrapper implements \Stringable
         'token',
         'api_key',
         'private_key',
-        'cc_number',
-        'cc_cid',
+        'cvv',
+        'echeck',
     ];
+
+    /**
+     * Cardholder data is the one field family where the denylist is inverted: everything a
+     * payment info object carries under cc_* is card data (cc_number, cc_cid, cc_owner, the
+     * expiry pair, the Switch/Solo cc_ss_* set), so naming the sensitive members one by one
+     * leaves whatever field the next gateway adds readable by default. The prefix is refused
+     * wholesale and only the two fields Magento deliberately keeps in the clear so a template
+     * can print "VI ****1111" are let back through.
+     */
+    private const CARD_FIELD_PREFIX = 'cc_';
+    private const ALLOWED_CARD_FIELDS = ['cc_type', 'cc_last4'];
+
+    /**
+     * Fields a SENSITIVE_FIELD_FRAGMENTS entry would otherwise refuse, but which a shipped
+     * template has to read to do its job. rp_token is the password-reset / magic-link token:
+     * the account_new_password_link, account_password_reset_confirmation, account_magic_link and
+     * admin_password_reset_confirmation mails build their action URL from it
+     * ({{store url="customer/account/resetpassword/" _query_token=$customer.rp_token}}), so
+     * refusing it silently drops the token from the link and leaves the recipient unable to
+     * reset their password. Reading it is not a disclosure — the token's whole purpose is to be
+     * printed into the mail being rendered, which is addressed to the account that owns it.
+     */
+    private const ALLOWED_TOKEN_FIELDS = ['rp_token'];
 
     /**
      * Accessors that take the data key as an argument instead of encoding it in the method
@@ -85,9 +129,73 @@ class ExpressionObjectWrapper implements \Stringable
      */
     private const KEYED_DATA_ACCESSORS = ['getdata', 'getdatabykey', 'getorigdata'];
 
-    public function __construct(private readonly object $object) {}
+    /**
+     * Bounds on the eager copy wrapArray() makes of every array handed to the engine.
+     *
+     * Subscripting is native PHP, so an array has to be walked and filtered on the way in rather
+     * than gated at access time — which means a self-referential array ($a['self'] = &$a) recurses
+     * until the process dies of memory exhaustion. That is a fatal error, not an exception, so it
+     * escapes the handler that turns a bad expression into an empty render and takes the whole
+     * request with it. Past either bound the remaining entries are dropped, degrading the value the
+     * same way a refused field does. Neither bound is reachable by real template data: a model's
+     * data array is a few levels deep and orders of magnitude smaller.
+     */
+    private const MAX_ARRAY_DEPTH = 16;
+    private const MAX_ARRAY_ELEMENTS = 10000;
 
-    public static function wrap(mixed $value): mixed
+    /** @var array<class-string, array<string, string>> lowercased method name => declared spelling */
+    private static array $_declaredMethods = [];
+
+    /**
+     * The guarded object, held inside a closure rather than in a property of its own.
+     *
+     * PHP compares two objects of the same class structurally — property by property, blind to
+     * visibility — and every value handed to the expression engine is an ExpressionObjectWrapper.
+     * A comparison never reaches __call()/__get(), so no gate can run on it: with the guarded
+     * object sitting in a property here, "{{if secret > probe}}" would recurse straight into both
+     * models' _data arrays and answer from the raw values, turning any refused field into a
+     * bisection oracle ({{if secret == guess}} confirms a password outright). That also covers
+     * min()/max(), which ExpressionLanguage registers as the real PHP functions and which reach
+     * the same comparison primitive without going through an operator.
+     *
+     * A closure is opaque to that comparison: PHP compares two distinct Closure instances as
+     * unequal and unordered whatever they capture, so comparing two wrapped values now answers
+     * the same way regardless of what they guard. The consequence is that an object-to-object
+     * comparison is simply not answerable in a condition — {{if a == b}} is always false for two
+     * wrapped values, and a template that needs to compare them has to compare a field of each
+     * ({{if a.entity_id == b.entity_id}}), which goes through the gate as it should.
+     */
+    private readonly \Closure $_object;
+
+    protected function __construct(object $object)
+    {
+        $this->_object = static fn(): object => $object;
+    }
+
+    private function _object(): object
+    {
+        return ($this->_object)();
+    }
+
+    /**
+     * Wrap a template variable so every hop through it is gated. Published by ExpressionSandbox.
+     *
+     * Deliberately not public: an instance of this class is handed straight to
+     * ExpressionLanguage, and Symfony's GetAttrNode dispatches a method call as
+     * is_callable([$obj, $name]) — which is satisfied by any *real* public method, including a
+     * static one, without ever reaching __call(). A public wrap()/unwrap() would therefore be
+     * callable from a template as "customer.unwrap(customer)", handing the raw model back into
+     * the expression and voiding every gate below it. Everything non-magic on this class stays
+     * private or protected so that such a call falls through to the gated __call() instead;
+     * ExpressionSandbox borrows this scope to publish the two entry points Template needs.
+     */
+    protected static function _wrap(mixed $value): mixed
+    {
+        $budget = self::MAX_ARRAY_ELEMENTS;
+        return self::wrapValue($value, 0, $budget);
+    }
+
+    private static function wrapValue(mixed $value, int $depth, int &$budget): mixed
     {
         if ($value instanceof self) {
             return $value;
@@ -96,64 +204,95 @@ class ExpressionObjectWrapper implements \Stringable
             return new self($value);
         }
         if (is_array($value)) {
-            return array_map(self::wrap(...), $value);
+            return $depth >= self::MAX_ARRAY_DEPTH ? null : self::wrapArray($value, $depth + 1, $budget);
         }
         return $value;
+    }
+
+    /**
+     * Wrap an array element by element, nulling out every entry whose key names a secret.
+     *
+     * Subscripting an array in an expression ("customer.getCredentials()['api_token']") is native
+     * PHP: it never reaches __call()/__get(), so the field-name gate cannot run at access time and
+     * has to be applied here, when the array is handed to the expression. Without this a secret
+     * sitting inside an array an allowed getter legitimately returns would be readable even though
+     * the identically named getter/property is refused.
+     *
+     * @param array<mixed> $value
+     * @return array<mixed>
+     */
+    private static function wrapArray(array $value, int $depth, int &$budget): array
+    {
+        $wrapped = [];
+        foreach ($value as $key => $item) {
+            if (--$budget < 0) {
+                break;
+            }
+            $wrapped[$key] = is_string($key) && self::isSensitiveField($key)
+                ? null
+                : self::wrapValue($item, $depth, $budget);
+        }
+        return $wrapped;
     }
 
     /**
      * Reverse wrap(): unwrap a value returned from an expression back to the raw object it
      * guards, so {{var}} can format a DateTimeInterface or string-cast a scalar. The guard only
      * governs how a value is *reached* during evaluation; the resolved value itself is returned
-     * plain.
+     * plain. Not public, for the reason spelled out on _wrap(): it returns the guarded object, so
+     * reaching it from inside an expression would be a complete escape.
      */
-    public static function unwrap(mixed $value): mixed
+    protected static function _unwrap(mixed $value): mixed
     {
         if ($value instanceof self) {
-            return $value->object;
+            return $value->_object();
         }
         if (is_array($value)) {
-            return array_map(self::unwrap(...), $value);
+            return array_map(self::_unwrap(...), $value);
         }
         return $value;
     }
 
     public function __call(string $method, array $args): mixed
     {
+        $object = $this->_object();
+        $method = self::_canonicalMethodName($object, $method);
         // Only DataObject instances may be walked into. The legacy resolver chained solely
         // through DataObject (Template::_getVariable), so a getter returning an infrastructure
         // object — getResource() → resource model → getReadConnection() → DBAL connection →
         // getParams()['password'] — must dead-end here instead of exposing DB credentials.
-        if (!$this->object instanceof DataObject || !self::isAllowedCall($method, $args)) {
+        if (!$object instanceof DataObject || !self::isAllowedCall($method, $args, method_exists($object, $method))) {
             return null;
         }
         if (strcasecmp($method, 'getConfig') === 0 && $this->isEncryptedConfigPath($args)) {
             $args = [null];
         }
-        return self::wrap($this->object->$method(...$args));
+        return self::_wrap($object->$method(...$args));
     }
 
     public function __get(string $name): mixed
     {
+        $object = $this->_object();
         // Property access, like method calls, only walks into DataObject instances so it can
         // never reach a non-DataObject's internals (see __call for the escape this closes).
-        if (!$this->object instanceof DataObject) {
+        if (!$object instanceof DataObject) {
             return null;
         }
         // Same resolution order as the legacy variable resolver: a real getter method
         // wins over raw data access, so "order.status_label" keeps calling getStatusLabel()
-        $getter = 'get' . uc_words($name, '');
+        $getter = self::_canonicalMethodName($object, 'get' . uc_words($name, ''));
         // Property syntax has to clear the same gate as the call syntax, otherwise
         // "payment.cc_number" reaches what "payment.getCcNumber()" refuses. The check runs
         // on the derived getter name so it also covers the getData() fallback below, where
         // there is no method name to inspect but the model still decrypts on read.
-        if (!self::isAllowedCall($getter, [])) {
+        $declared = method_exists($object, $getter);
+        if (!self::isAllowedCall($getter, [], $declared)) {
             return null;
         }
-        if (method_exists($this->object, $getter)) {
-            return self::wrap($this->object->{$getter}());
+        if ($declared) {
+            return self::_wrap($object->{$getter}());
         }
-        return self::wrap($this->object->getData($name));
+        return self::_wrap($object->getData($name));
     }
 
     public function __isset(string $name): bool
@@ -170,16 +309,19 @@ class ExpressionObjectWrapper implements \Stringable
     #[\Override]
     public function __toString(): string
     {
-        if (!method_exists($this->object, '__toString')) {
-            throw new \LogicException(sprintf('%s cannot be converted to a string', $this->object::class));
+        $object = $this->_object();
+        if (!method_exists($object, '__toString')) {
+            throw new \LogicException(sprintf('%s cannot be converted to a string', $object::class));
         }
-        return (string) $this->object;
+        return (string) $object;
     }
 
     /**
      * @param array $args the arguments the call would be made with, empty for property syntax
+     * @param bool $declared whether the class really declares $method, i.e. the call does not
+     *                       fall through to DataObject::__call() (see the "/" rule below)
      */
-    private static function isAllowedCall(string $method, array $args): bool
+    private static function isAllowedCall(string $method, array $args, bool $declared): bool
     {
         if (!self::isReadOnlyMethod($method)) {
             return false;
@@ -187,7 +329,9 @@ class ExpressionObjectWrapper implements \Stringable
         // A named getter resolves to a field; refuse it when that field is a secret, so a
         // subclass getter returning a stored credential (Customer::getPassword(), reached
         // directly or as the getter __get() derives for a property) cannot become an oracle.
-        if (self::isSensitiveField(self::fieldFromMethod($method))) {
+        // A boolean predicate is exempt for the same reason isSensitiveField() exempts an
+        // is_/has_/can_ field: it answers a yes/no status, not the value (see isBooleanPredicate).
+        if (!self::isBooleanPredicate($method) && self::isSensitiveField(self::fieldFromMethod($method))) {
             return false;
         }
         // A bare "get" resolves to getData('') and dumps the whole _data array. (format()/
@@ -195,12 +339,13 @@ class ExpressionObjectWrapper implements \Stringable
         if (strcasecmp($method, 'get') === 0) {
             return false;
         }
-        // A keyed data accessor needs a non-empty string key; without one it returns the whole
-        // internal _data array, handing out every field at once.
-        if (in_array(strtolower($method), self::KEYED_DATA_ACCESSORS, true)
-            && (!is_string($args[0] ?? null) || $args[0] === '')
-        ) {
-            return false;
+        if (in_array(strtolower($method), self::KEYED_DATA_ACCESSORS, true)) {
+            // A keyed data accessor needs a non-empty string key; without one it returns the
+            // whole internal _data array, handing out every field at once.
+            $key = $args[0] ?? null;
+            if (!is_string($key) || $key === '') {
+                return false;
+            }
         }
         if ($args === []) {
             return true;
@@ -209,18 +354,72 @@ class ExpressionObjectWrapper implements \Stringable
         if (preg_match('/^(?i:is|can)([^a-z]|$)/', $method)) {
             return false;
         }
-        // getConfig carries a config path (which contains "/"); its encrypted paths are
-        // neutralized separately in __call().
-        if (strcasecmp($method, 'getConfig') === 0) {
-            return true;
+        // Every argument of a call that lands in DataObject::getData() is a data key, and a key
+        // holding "/" is a nested-path traversal: getData() forwards it to getDataByPath(), which
+        // walks into nested _data and reaches getData('payment', 'additional_information/cc_cid')
+        // around the field-name gate — that gate only ever sees the whole path string, whose
+        // anchored rules (the cc_ prefix, the additional_* bags) then never fire. getDataByPath()
+        // is denied outright for the same reason, so it must not be reachable indirectly either.
+        // Both the *key* and the *index* argument reach it, and so does an undeclared getFoo($x),
+        // which DataObject::__call() rewrites to getData('foo', $x). Declared methods keep taking
+        // "/" arguments — it is how every route and config path is spelled (getUrl('customer/
+        // account/'), getConfig('web/unsecure/base_url')) — and getConfig()'s encrypted paths are
+        // neutralized in __call().
+        if (!$declared || in_array(strtolower($method), self::KEYED_DATA_ACCESSORS, true)) {
+            if (array_any($args, fn($arg) => is_string($arg) && str_contains($arg, '/'))) {
+                return false;
+            }
         }
-        // Otherwise arguments are allowed — getData('sku'), getAttributeText('color'),
-        // format('html') — but a string argument must not smuggle a secret field name or a
-        // nested "/" path (getDataByPath('payment/cc_number')) past the field-name gate.
+        // Otherwise arguments are allowed as the legacy resolver allowed them — getData('sku'),
+        // getAttributeText('color'), format('html') — but a string argument must not name a
+        // secret field, because a keyed read answers with the raw value under that name.
         return !array_any(
             $args,
-            fn($arg) => is_string($arg) && (str_contains($arg, '/') || self::isSensitiveField($arg)),
+            fn($arg) => is_string($arg) && self::isSensitiveField($arg),
         );
+    }
+
+    /**
+     * Return $method spelled the way the class declares it.
+     *
+     * PHP dispatches method names case-insensitively, but both gates below read camelCase word
+     * boundaries out of the name the template author typed: isReadOnlyMethod() requires the
+     * read-only prefix to end on a boundary and fieldFromMethod() splits the remainder on
+     * capitals. Spelling a method to fake a boundary that the declaration does not have therefore
+     * changes what the gates see while PHP still reaches the same method — "canCel" reads as a
+     * "can" predicate but runs cancel(), "getPassWord" resolves to the unlisted field "pass_word"
+     * but runs getPassword(). Normalizing first makes the gates inspect the symbol that will
+     * actually be called. A name no declared method matches is a magic getter, where
+     * DataObject::_underscore() derives the data key from that same typed string, so leaving it
+     * as typed keeps the gate and the lookup symmetric.
+     */
+    private static function _canonicalMethodName(object $object, string $method): string
+    {
+        $class = $object::class;
+        if (!isset(self::$_declaredMethods[$class])) {
+            self::$_declaredMethods[$class] = array_column(
+                array_map(fn(string $name): array => [strtolower($name), $name], get_class_methods($object)),
+                1,
+                0,
+            );
+        }
+        return self::$_declaredMethods[$class][strtolower($method)] ?? $method;
+    }
+
+    /**
+     * True when $method is an is/has/can boolean predicate (isMagicLinkTokenExpired(),
+     * hasCustomOptions()). It answers a yes/no status, never the underlying value, so — exactly
+     * like the is_/has_/can_ *property* exemption in isSensitiveField() — a SENSITIVE_FIELD_FRAGMENTS
+     * hit in its name ("token" in isMagicLinkTokenExpired) must not refuse it. Without this the two
+     * access paths disagree: __get() prepends "get" before gating, so the marker survives
+     * fieldFromMethod() for a property, but a direct call strips the is/has/can itself and the
+     * exemption could never fire. This only exempts the method *name* from the field-name gate;
+     * an argument to a predicate is a state toggle (isDeleted($flag)) and is refused separately in
+     * isAllowedCall(), and a sensitive string argument is still refused there too.
+     */
+    private static function isBooleanPredicate(string $method): bool
+    {
+        return (bool) preg_match('/^(?i:is|has|can)([^a-z]|$)/', $method);
     }
 
     private static function isReadOnlyMethod(string $method): bool
@@ -238,14 +437,27 @@ class ExpressionObjectWrapper implements \Stringable
      * True when $field names a secret. A boolean-flag accessor (is_/has_/can_) exposes a
      * yes/no status rather than the value itself, so the shipped condition
      * {{if customer.is_change_password}} stays readable even though its name contains
-     * "password". Otherwise the field is refused when it ends in Maho's "_enc" encrypted-column
-     * suffix or contains a SENSITIVE_FIELD_FRAGMENTS entry.
+     * "password", and ALLOWED_TOKEN_FIELDS lets the reset-link templates through.
+     * Otherwise the field is refused when it names one of the free-form payment bags,
+     * sits under the cc_* cardholder prefix without being one of the two masked display fields,
+     * ends in Maho's "_enc" encrypted-column suffix, or contains a SENSITIVE_FIELD_FRAGMENTS entry.
      */
     private static function isSensitiveField(string $field): bool
     {
         $field = self::toSnakeCase($field);
         if (preg_match('/^(?:is|has|can)_/', $field)) {
             return false;
+        }
+        if (in_array($field, self::ALLOWED_TOKEN_FIELDS, true)) {
+            return false;
+        }
+        // The bags DENIED_METHODS closes, refused again as data keys so getData('additional_data')
+        // cannot fetch what getAdditionalData() will not.
+        if (in_array($field, ['additional_information', 'additional_data'], true)) {
+            return true;
+        }
+        if (str_starts_with($field, self::CARD_FIELD_PREFIX)) {
+            return !in_array($field, self::ALLOWED_CARD_FIELDS, true);
         }
         if (str_ends_with($field, '_enc')) {
             return true;
@@ -263,15 +475,47 @@ class ExpressionObjectWrapper implements \Stringable
         return self::toSnakeCase((string) $remainder);
     }
 
+    /**
+     * Split $name on camelCase boundaries, keeping a run of capitals together as one word:
+     * CcNumber -> cc_number, CVVCode -> cvv_code, APIKey -> api_key, CCNumber -> cc_number.
+     *
+     * Splitting on every capital instead would spell those c_v_v_code / a_p_i_key / c_c_number,
+     * which no rule below names — a gateway module declaring getCVVCode() or getCCNumber() would
+     * sail past both the "cvv" fragment and the cc_* cardholder prefix. The property form leaks
+     * with it: __get() canonicalizes the typed "cvv_code" to the declared getCVVCode() before
+     * gating, so the gate would see the mis-split name there too.
+     */
     private static function toSnakeCase(string $name): string
     {
-        return strtolower((string) preg_replace('/([A-Z])/', '_$1', lcfirst($name)));
+        $name = (string) preg_replace('/([a-z0-9])([A-Z])/', '$1_$2', $name);
+        $name = (string) preg_replace('/([A-Z]+)([A-Z][a-z])/', '$1_$2', $name);
+        return strtolower($name);
     }
 
+    /**
+     * True when a getConfig() argument would surface an encrypted configuration value, so __call()
+     * can neutralize it by calling getConfig(null) instead.
+     *
+     * The exact encrypted leaf (system/smtp/password) is refused, but so is any *ancestor* path:
+     * Store::getConfig('system/smtp') returns the whole subtree as an array, and a native subscript
+     * (store.getConfig('system/smtp')['password'], or ['pass'~'word'] to dodge a literal-argument
+     * check) then reaches the decrypted leaf around a check that only ever saw the ancestor path.
+     * The encrypted-node list is the authoritative record of what a template must never print —
+     * gateway/SMTP/carrier credentials — so a request for any path that would carry one of them out
+     * in its subtree is closed. Legitimate scalar reads (general/store_information/name) and
+     * subtrees with no encrypted descendant are untouched.
+     */
     private function isEncryptedConfigPath(array $args): bool
     {
-        /** @var \Mage_Adminhtml_Model_Email_PathValidator $validator */
-        $validator = \Mage::getModel('adminhtml/email_pathValidator');
-        return $validator->isValid($args);
+        $path = $args[0] ?? null;
+        if (!is_string($path) || $path === '') {
+            return false;
+        }
+        /** @var \Mage_Adminhtml_Model_Config $config */
+        $config = \Mage::getSingleton('adminhtml/config');
+        return array_any(
+            $config->getEncryptedNodeEntriesPaths(),
+            fn($encrypted): bool => $path === $encrypted || str_starts_with((string) $encrypted, $path . '/'),
+        );
     }
 }

--- a/lib/Maho/Filter/Template/ExpressionObjectWrapper.php
+++ b/lib/Maho/Filter/Template/ExpressionObjectWrapper.php
@@ -1,12 +1,15 @@
 <?php
 
 /**
- * Wraps a DataObject exposed to ExpressionLanguage template conditions.
+ * Wraps an object exposed to ExpressionLanguage template conditions.
  *
- * Forwards property reads and method calls to the wrapped object, re-wrapping DataObject
- * results so the guard applies to the whole object graph. getConfig() calls against
+ * Forwards property reads and read-only method calls to the wrapped object, re-wrapping
+ * every object and array element in the result so the guard follows the whole object graph.
+ * Methods that are not obviously read-only (setters, save(), delete(), ...) are refused:
+ * evaluating a rendering condition must not mutate anything. getConfig() calls against
  * encrypted configuration paths are neutralized (called with null instead), mirroring the
- * protection the legacy variable resolver applies.
+ * protection the legacy variable resolver applies, and any read that resolves to a secret
+ * field (password, card data, tokens, ...) is refused outright.
  *
  * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
  * SPDX-License-Identifier: OSL-3.0
@@ -18,17 +21,92 @@ namespace Maho\Filter\Template;
 
 use Maho\DataObject;
 
-class ExpressionObjectWrapper
+class ExpressionObjectWrapper implements \Stringable
 {
-    public function __construct(private readonly DataObject $object) {}
+    /**
+     * Method name prefixes considered read-only and therefore callable from a condition.
+     */
+    private const READ_ONLY_PREFIXES = ['get', 'has', 'is', 'can', 'to', 'count', 'format'];
+
+    /**
+     * Methods refused even though they match a read-only prefix. getConfigData() reads
+     * payment/carrier credentials under a relative path the encrypted-path guard cannot
+     * check; toArray()/toJson()/toXml()/toString() each dump an object's whole internal
+     * state in one call, defeating the per-name gate; getDataUsingMethod() re-derives and
+     * calls an arbitrary getter, so it side-steps the name-based getConfig encrypted-path
+     * guard in __call() (the same getter stays reachable directly — getConfig()/getFoo()/foo
+     * — where the guard still applies); getDataSetDefault() writes to the object despite its
+     * getter-shaped name.
+     *
+     * This list is deliberately small: it holds only method-level denials that a field-name
+     * rule cannot express. Secret *fields* (password, card data, tokens, ...) are refused by
+     * SENSITIVE_FIELD_FRAGMENTS instead, and the no-argument rule in isAllowedCall() already
+     * refuses getDataByPath() (it walks an ungated a/b/c path into nested _data) and
+     * isDeleted($flag)-style getter-shaped mutators, without listing each by name.
+     */
+    private const DENIED_METHODS = [
+        'getconfigdata',
+        'toarray',
+        'tojson',
+        'toxml',
+        'tostring',
+        'getdatausingmethod',
+        'getdatasetdefault',
+    ];
+
+    /**
+     * Field-name fragments that name a secret. A resolved field/key whose snake_case name
+     * contains one of these (case-insensitively) is refused whether it is reached as a named
+     * getter (getPassword() / .password), as a keyed data read (getData('password')), or as
+     * the getter derived from a property. Matching a fragment rather than an exact name closes
+     * the whole family in one rule — password_hash, rp_token, api_secret, cc_number — instead
+     * of chasing each subclass getter (Mage_Customer_Model_Customer::getPassword() returns the
+     * stored password and the customer model is handed to the changed-password email template,
+     * so with the range/comparison operators a bare getter is a char-by-char exfil oracle).
+     */
+    private const SENSITIVE_FIELD_FRAGMENTS = [
+        'password',
+        'secret',
+        'token',
+        'api_key',
+        'private_key',
+        'cc_number',
+        'cc_cid',
+    ];
+
+    /**
+     * Accessors that take the data key as an argument instead of encoding it in the method
+     * name, so the gate has to be applied to the key rather than to the method. Each reads the
+     * raw _data/_orig_data array by key without dispatching to a getter, so unlike
+     * getDataUsingMethod() they cannot reach a method that decrypts or is otherwise guarded.
+     */
+    private const KEYED_DATA_ACCESSORS = ['getdata', 'getdatabykey', 'getorigdata'];
+
+    public function __construct(private readonly object $object) {}
 
     public static function wrap(mixed $value): mixed
     {
-        return $value instanceof DataObject ? new self($value) : $value;
+        if ($value instanceof self) {
+            return $value;
+        }
+        if (is_object($value)) {
+            return new self($value);
+        }
+        if (is_array($value)) {
+            return array_map(self::wrap(...), $value);
+        }
+        return $value;
     }
 
     public function __call(string $method, array $args): mixed
     {
+        // Only DataObject instances may be walked into. The legacy resolver chained solely
+        // through DataObject (Template::_getVariable), so a getter returning an infrastructure
+        // object — getResource() → resource model → getReadConnection() → DBAL connection →
+        // getParams()['password'] — must dead-end here instead of exposing DB credentials.
+        if (!$this->object instanceof DataObject || !self::isAllowedCall($method, $args)) {
+            return null;
+        }
         if (strcasecmp($method, 'getConfig') === 0 && $this->isEncryptedConfigPath($args)) {
             $args = [null];
         }
@@ -37,13 +115,133 @@ class ExpressionObjectWrapper
 
     public function __get(string $name): mixed
     {
+        // Property access, like method calls, only walks into DataObject instances so it can
+        // never reach a non-DataObject's internals (see __call for the escape this closes).
+        if (!$this->object instanceof DataObject) {
+            return null;
+        }
         // Same resolution order as the legacy variable resolver: a real getter method
         // wins over raw data access, so "order.status_label" keeps calling getStatusLabel()
         $getter = 'get' . uc_words($name, '');
+        // Property syntax has to clear the same gate as the call syntax, otherwise
+        // "payment.cc_number" reaches what "payment.getCcNumber()" refuses. The check runs
+        // on the derived getter name so it also covers the getData() fallback below, where
+        // there is no method name to inspect but the model still decrypts on read.
+        if (!self::isAllowedCall($getter, [])) {
+            return null;
+        }
         if (method_exists($this->object, $getter)) {
             return self::wrap($this->object->{$getter}());
         }
         return self::wrap($this->object->getData($name));
+    }
+
+    public function __isset(string $name): bool
+    {
+        return $this->__get($name) !== null;
+    }
+
+    /**
+     * PHP stringifies a Stringable object whenever it is compared against a string or a
+     * number, so an object without its own string form must fail loudly here: returning ''
+     * would silently make "order.billing_address == ''" true for a populated address.
+     * evaluateCondition() turns the exception into a logged warning and a false condition.
+     */
+    #[\Override]
+    public function __toString(): string
+    {
+        if (!method_exists($this->object, '__toString')) {
+            throw new \LogicException(sprintf('%s cannot be converted to a string', $this->object::class));
+        }
+        return (string) $this->object;
+    }
+
+    /**
+     * @param array $args the arguments the call would be made with, empty for property syntax
+     */
+    private static function isAllowedCall(string $method, array $args): bool
+    {
+        if (!self::isReadOnlyMethod($method)) {
+            return false;
+        }
+        $isKeyedAccessor = in_array(strtolower($method), self::KEYED_DATA_ACCESSORS, true);
+        // A read-only getter is called with no arguments. The only calls that legitimately
+        // carry one are the keyed data accessors (the key to read) and getConfig (the config
+        // path, still neutralized on encrypted paths by __call). Refusing every other
+        // argument-bearing call closes a whole class of escapes structurally rather than
+        // name by name: a getter-shaped method that mutates when handed an argument
+        // (isDeleted($flag)) or resolves an ungated nested path (getDataByPath('payment/cc_number'),
+        // the un-gated twin of the keyed getData()) can never be reached.
+        if ($args !== [] && !$isKeyedAccessor && strcasecmp($method, 'getConfig') !== 0) {
+            return false;
+        }
+        if (!$isKeyedAccessor) {
+            // A named getter resolves to a field; refuse it when that field is a secret, so a
+            // subclass getter returning a stored credential (Customer::getPassword()) cannot
+            // become an exfil oracle. Reached both directly (getPassword()) and via the getter
+            // __get() derives for a property (.password -> getPassword).
+            $field = self::fieldFromMethod($method);
+            // A method that is exactly a bare prefix ("get") resolves to no field and, through
+            // DataObject::__call, dumps the whole _data array (getData('') semantics), so it is
+            // refused like the keyed accessors refuse a missing key.
+            return $field !== '' && !self::isSensitiveField($field);
+        }
+        // getData('password') has to be refused exactly like getPassword(): the key names
+        // what is being read, so it is the key that has to clear both the secret-field gate
+        // and the read-only gate. Called without a key these accessors return the entire
+        // internal _data array, which would hand out every field at once, so a missing or
+        // non-string key is refused outright. A key carrying a "/" is refused too: getData()
+        // forwards it to the same ungated getDataByPath() traversal, so only the top-level key
+        // would clear the gate while the nested segment ("address/cc_number") is read unchecked.
+        $key = $args[0] ?? null;
+        return is_string($key) && $key !== '' && !str_contains($key, '/')
+            && !self::isSensitiveField($key)
+            && self::isReadOnlyMethod('get' . uc_words($key, ''));
+    }
+
+    private static function isReadOnlyMethod(string $method): bool
+    {
+        if (in_array(strtolower($method), self::DENIED_METHODS, true)) {
+            return false;
+        }
+        // The prefix has to end on a camelCase boundary, otherwise a method that merely
+        // starts with the same letters passes as read-only: "canShip" is a check,
+        // "cancel" cancels the order. Only the prefix itself matches case-insensitively.
+        return (bool) preg_match('/^(?i:' . implode('|', self::READ_ONLY_PREFIXES) . ')([^a-z]|$)/', $method);
+    }
+
+    /**
+     * True when $field names a secret. A boolean-flag accessor (is_/has_/can_) exposes a
+     * yes/no status rather than the value itself, so the shipped condition
+     * {{if customer.is_change_password}} stays readable even though its name contains
+     * "password". Otherwise the field is refused when it ends in Maho's "_enc" encrypted-column
+     * suffix or contains a SENSITIVE_FIELD_FRAGMENTS entry.
+     */
+    private static function isSensitiveField(string $field): bool
+    {
+        $field = self::toSnakeCase($field);
+        if (preg_match('/^(?:is|has|can)_/', $field)) {
+            return false;
+        }
+        if (str_ends_with($field, '_enc')) {
+            return true;
+        }
+        return array_any(self::SENSITIVE_FIELD_FRAGMENTS, fn($fragment) => str_contains($field, $fragment));
+    }
+
+    /**
+     * Strip the leading read-only prefix off a method name and return the field it reads in
+     * snake_case: getPassword -> password, getApiKey -> api_key, getCcNumber -> cc_number.
+     */
+    private static function fieldFromMethod(string $method): string
+    {
+        $remainder = preg_replace('/^(?i:' . implode('|', self::READ_ONLY_PREFIXES) . ')/', '', $method, 1);
+        return self::toSnakeCase((string) $remainder);
+    }
+
+    private static function toSnakeCase(string $name): string
+    {
+        return strtolower((string) preg_replace('/([A-Z])/', '_$1', lcfirst($name)));
     }
 
     private function isEncryptedConfigPath(array $args): bool

--- a/lib/Maho/Filter/Template/ExpressionObjectWrapper.php
+++ b/lib/Maho/Filter/Template/ExpressionObjectWrapper.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Wraps a DataObject exposed to ExpressionLanguage template conditions.
+ *
+ * Forwards property reads and method calls to the wrapped object, re-wrapping DataObject
+ * results so the guard applies to the whole object graph. getConfig() calls against
+ * encrypted configuration paths are neutralized (called with null instead), mirroring the
+ * protection the legacy variable resolver applies.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+namespace Maho\Filter\Template;
+
+use Maho\DataObject;
+
+class ExpressionObjectWrapper
+{
+    public function __construct(private readonly DataObject $object) {}
+
+    public static function wrap(mixed $value): mixed
+    {
+        return $value instanceof DataObject ? new self($value) : $value;
+    }
+
+    public function __call(string $method, array $args): mixed
+    {
+        if (strcasecmp($method, 'getConfig') === 0 && $this->isEncryptedConfigPath($args)) {
+            $args = [null];
+        }
+        return self::wrap($this->object->$method(...$args));
+    }
+
+    public function __get(string $name): mixed
+    {
+        // Same resolution order as the legacy variable resolver: a real getter method
+        // wins over raw data access, so "order.status_label" keeps calling getStatusLabel()
+        $getter = 'get' . uc_words($name, '');
+        if (method_exists($this->object, $getter)) {
+            return self::wrap($this->object->{$getter}());
+        }
+        return self::wrap($this->object->getData($name));
+    }
+
+    private function isEncryptedConfigPath(array $args): bool
+    {
+        /** @var \Mage_Adminhtml_Model_Email_PathValidator $validator */
+        $validator = \Mage::getModel('adminhtml/email_pathValidator');
+        return $validator->isValid($args);
+    }
+}

--- a/lib/Maho/Filter/Template/ExpressionObjectWrapper.php
+++ b/lib/Maho/Filter/Template/ExpressionObjectWrapper.php
@@ -24,9 +24,11 @@ use Maho\DataObject;
 class ExpressionObjectWrapper implements \Stringable
 {
     /**
-     * Method name prefixes considered read-only and therefore callable from a condition.
+     * Method name prefixes considered read-only and therefore callable from a template.
+     * Shared with the legacy {{var}} resolver (Template::_isReadOnlyMethodCall) so both the
+     * condition sandbox and the {{var}} gate draw the read-only surface from one place.
      */
-    private const READ_ONLY_PREFIXES = ['get', 'has', 'is', 'can', 'to', 'count', 'format'];
+    public const READ_ONLY_PREFIXES = ['get', 'has', 'is', 'can', 'to', 'count', 'format'];
 
     /**
      * Methods refused even though they match a read-only prefix. getConfigData() reads
@@ -36,13 +38,13 @@ class ExpressionObjectWrapper implements \Stringable
      * calls an arbitrary getter, so it side-steps the name-based getConfig encrypted-path
      * guard in __call() (the same getter stays reachable directly — getConfig()/getFoo()/foo
      * — where the guard still applies); getDataSetDefault() writes to the object despite its
-     * getter-shaped name.
+     * getter-shaped name; getDataByPath() walks an ungated a/b/c path into nested _data, so it
+     * is closed whole rather than filtered by key.
      *
      * This list is deliberately small: it holds only method-level denials that a field-name
      * rule cannot express. Secret *fields* (password, card data, tokens, ...) are refused by
-     * SENSITIVE_FIELD_FRAGMENTS instead, and the no-argument rule in isAllowedCall() already
-     * refuses getDataByPath() (it walks an ungated a/b/c path into nested _data) and
-     * isDeleted($flag)-style getter-shaped mutators, without listing each by name.
+     * SENSITIVE_FIELD_FRAGMENTS instead, and isAllowedCall() refuses an argument to an
+     * is/can predicate so isDeleted($flag)-style getter-shaped mutators cannot toggle state.
      */
     private const DENIED_METHODS = [
         'getconfigdata',
@@ -52,6 +54,7 @@ class ExpressionObjectWrapper implements \Stringable
         'tostring',
         'getdatausingmethod',
         'getdatasetdefault',
+        'getdatabypath',
     ];
 
     /**
@@ -94,6 +97,23 @@ class ExpressionObjectWrapper implements \Stringable
         }
         if (is_array($value)) {
             return array_map(self::wrap(...), $value);
+        }
+        return $value;
+    }
+
+    /**
+     * Reverse wrap(): unwrap a value returned from an expression back to the raw object it
+     * guards, so {{var}} can format a DateTimeInterface or string-cast a scalar. The guard only
+     * governs how a value is *reached* during evaluation; the resolved value itself is returned
+     * plain.
+     */
+    public static function unwrap(mixed $value): mixed
+    {
+        if ($value instanceof self) {
+            return $value->object;
+        }
+        if (is_array($value)) {
+            return array_map(self::unwrap(...), $value);
         }
         return $value;
     }
@@ -164,39 +184,43 @@ class ExpressionObjectWrapper implements \Stringable
         if (!self::isReadOnlyMethod($method)) {
             return false;
         }
-        $isKeyedAccessor = in_array(strtolower($method), self::KEYED_DATA_ACCESSORS, true);
-        // A read-only getter is called with no arguments. The only calls that legitimately
-        // carry one are the keyed data accessors (the key to read) and getConfig (the config
-        // path, still neutralized on encrypted paths by __call). Refusing every other
-        // argument-bearing call closes a whole class of escapes structurally rather than
-        // name by name: a getter-shaped method that mutates when handed an argument
-        // (isDeleted($flag)) or resolves an ungated nested path (getDataByPath('payment/cc_number'),
-        // the un-gated twin of the keyed getData()) can never be reached.
-        if ($args !== [] && !$isKeyedAccessor && strcasecmp($method, 'getConfig') !== 0) {
+        // A named getter resolves to a field; refuse it when that field is a secret, so a
+        // subclass getter returning a stored credential (Customer::getPassword(), reached
+        // directly or as the getter __get() derives for a property) cannot become an oracle.
+        if (self::isSensitiveField(self::fieldFromMethod($method))) {
             return false;
         }
-        if (!$isKeyedAccessor) {
-            // A named getter resolves to a field; refuse it when that field is a secret, so a
-            // subclass getter returning a stored credential (Customer::getPassword()) cannot
-            // become an exfil oracle. Reached both directly (getPassword()) and via the getter
-            // __get() derives for a property (.password -> getPassword).
-            $field = self::fieldFromMethod($method);
-            // A method that is exactly a bare prefix ("get") resolves to no field and, through
-            // DataObject::__call, dumps the whole _data array (getData('') semantics), so it is
-            // refused like the keyed accessors refuse a missing key.
-            return $field !== '' && !self::isSensitiveField($field);
+        // A bare "get" resolves to getData('') and dumps the whole _data array. (format()/
+        // count() also strip to an empty field but read, not dump, so they stay allowed.)
+        if (strcasecmp($method, 'get') === 0) {
+            return false;
         }
-        // getData('password') has to be refused exactly like getPassword(): the key names
-        // what is being read, so it is the key that has to clear both the secret-field gate
-        // and the read-only gate. Called without a key these accessors return the entire
-        // internal _data array, which would hand out every field at once, so a missing or
-        // non-string key is refused outright. A key carrying a "/" is refused too: getData()
-        // forwards it to the same ungated getDataByPath() traversal, so only the top-level key
-        // would clear the gate while the nested segment ("address/cc_number") is read unchecked.
-        $key = $args[0] ?? null;
-        return is_string($key) && $key !== '' && !str_contains($key, '/')
-            && !self::isSensitiveField($key)
-            && self::isReadOnlyMethod('get' . uc_words($key, ''));
+        // A keyed data accessor needs a non-empty string key; without one it returns the whole
+        // internal _data array, handing out every field at once.
+        if (in_array(strtolower($method), self::KEYED_DATA_ACCESSORS, true)
+            && (!is_string($args[0] ?? null) || $args[0] === '')
+        ) {
+            return false;
+        }
+        if ($args === []) {
+            return true;
+        }
+        // An argument to an is/can predicate is not a read but a state toggle (isDeleted($flag)).
+        if (preg_match('/^(?i:is|can)([^a-z]|$)/', $method)) {
+            return false;
+        }
+        // getConfig carries a config path (which contains "/"); its encrypted paths are
+        // neutralized separately in __call().
+        if (strcasecmp($method, 'getConfig') === 0) {
+            return true;
+        }
+        // Otherwise arguments are allowed — getData('sku'), getAttributeText('color'),
+        // format('html') — but a string argument must not smuggle a secret field name or a
+        // nested "/" path (getDataByPath('payment/cc_number')) past the field-name gate.
+        return !array_any(
+            $args,
+            fn($arg) => is_string($arg) && (str_contains($arg, '/') || self::isSensitiveField($arg)),
+        );
     }
 
     private static function isReadOnlyMethod(string $method): bool

--- a/lib/Maho/Filter/Template/ExpressionSandbox.php
+++ b/lib/Maho/Filter/Template/ExpressionSandbox.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Entry points for evaluating a template directive against sandboxed variables.
+ *
+ * wrap() guards a value on its way into an ExpressionLanguage evaluation, unwrap() takes the
+ * result back out. Both live here rather than on ExpressionObjectWrapper because a wrapper
+ * instance is handed to the expression engine, and Symfony resolves "customer.foo()" with
+ * is_callable([$wrapper, 'foo']) — every real public method of the wrapper, static ones
+ * included, is therefore callable straight from a template without passing through the gated
+ * __call(). A public ExpressionObjectWrapper::unwrap() would let a template write
+ * "{{var customer.unwrap(customer)}}" and continue from the raw model with no guard at all.
+ * This class extends the wrapper only to borrow its scope: it is never instantiated and never
+ * handed to the engine, so publishing the two methods here exposes nothing to an expression.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+namespace Maho\Filter\Template;
+
+final class ExpressionSandbox extends ExpressionObjectWrapper
+{
+    public static function wrap(mixed $value): mixed
+    {
+        return parent::_wrap($value);
+    }
+
+    public static function unwrap(mixed $value): mixed
+    {
+        return parent::_unwrap($value);
+    }
+}

--- a/lib/Maho/Filter/Template/Tokenizer/Variable.php
+++ b/lib/Maho/Filter/Template/Tokenizer/Variable.php
@@ -11,6 +11,11 @@ declare(strict_types=1);
 
 namespace Maho\Filter\Template\Tokenizer;
 
+/**
+ * Tokenizes a {{var}} object path into a variable/property/method stack.
+ *
+ * @deprecated since 26.9 Use Symfony\Component\ExpressionLanguage\ExpressionLanguage instead, as Maho\Filter\Template now does to resolve {{var}} and {{if}}/{{depend}}.
+ */
 class Variable extends AbstractTokenizer
 {
     /**

--- a/lib/Maho/Rector/VarienToMahoClassMap.php
+++ b/lib/Maho/Rector/VarienToMahoClassMap.php
@@ -122,7 +122,7 @@ final class VarienToMahoClassMap
             'Varien_Filter_Template_Simple' => \Maho\Filter\Template\Simple::class,
             'Varien_Filter_Template_Tokenizer_Abstract' => \Maho\Filter\Template\Tokenizer\AbstractTokenizer::class,
             'Varien_Filter_Template_Tokenizer_Parameter' => \Maho\Filter\Template\Tokenizer\Parameter::class,
-            'Varien_Filter_Template_Tokenizer_Variable' => \Maho\Filter\Template\Tokenizer\Variable::class,
+            'Varien_Filter_Template_Tokenizer_Variable' => \Maho\Filter\Template\Tokenizer\Variable::class, // @phpstan-ignore classConstant.deprecatedClass
 
             // Io namespace
             'Varien_Io_Abstract' => \Maho\Io::class,

--- a/tests/Backend/Unit/Maho/Filter/TemplateConditionTest.php
+++ b/tests/Backend/Unit/Maho/Filter/TemplateConditionTest.php
@@ -48,7 +48,7 @@ describe('legacy single-variable conditions', function () {
     });
 
     it('prefers a real getter method over raw data access for property paths', function () {
-        $order = new class () extends DataObject {
+        $order = new class extends DataObject {
             public function getStatusLabel(): string
             {
                 return 'Processing';
@@ -61,7 +61,7 @@ describe('legacy single-variable conditions', function () {
     it('resolves property paths through computed getters returning objects', function () {
         // getData('billing_address') is empty; only the real getter can resolve the path,
         // and its DataObject result must be re-wrapped for the .company access to work
-        $order = new class () extends DataObject {
+        $order = new class extends DataObject {
             public function getBillingAddress(): DataObject
             {
                 return new DataObject(['company' => 'ACME']);
@@ -159,7 +159,7 @@ describe('expression object wrapper', function () {
             $this->markTestSkipped('No encrypted configuration paths available in this environment');
         }
 
-        $object = new class () extends DataObject {
+        $object = new class extends DataObject {
             public function getConfig(?string $path = null): ?string
             {
                 return $path;
@@ -177,7 +177,7 @@ describe('expression object wrapper', function () {
             $this->markTestSkipped('No encrypted configuration paths available in this environment');
         }
 
-        $store = new class () extends DataObject {
+        $store = new class extends DataObject {
             public function getConfig(?string $path = null): ?string
             {
                 return $path === null ? null : 'secret-value';

--- a/tests/Backend/Unit/Maho/Filter/TemplateConditionTest.php
+++ b/tests/Backend/Unit/Maho/Filter/TemplateConditionTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 use Maho\DataObject;
 use Maho\Filter\Template;
 use Maho\Filter\Template\ExpressionObjectWrapper;
+use Maho\Filter\Template\ExpressionSandbox;
 
 uses(Tests\MahoBackendTestCase::class);
 
@@ -164,7 +165,7 @@ describe('expression object wrapper', function () {
                 return $path;
             }
         };
-        $wrapped = ExpressionObjectWrapper::wrap($object);
+        $wrapped = ExpressionSandbox::wrap($object);
 
         expect($wrapped->getConfig('general/locale/code'))->toBe('general/locale/code');
         expect($wrapped->getConfig((string) $encryptedPaths[0]))->toBeNull();
@@ -336,7 +337,7 @@ describe('expression object wrapper', function () {
     it('refuses secret fields read through the generic getData() accessor', function () {
         $customer = new DataObject([
             'password' => '$2y$10$abcdefghijklmnopqrstuv',
-            'rp_token' => 'reset-token-123',
+            'vault_token' => 'tok-123',
             'api_key' => 'sk_live_abc',
             'firstname' => 'Bob',
         ]);
@@ -344,7 +345,7 @@ describe('expression object wrapper', function () {
 
         expect($filter->filter("{{if customer.getData('password') starts with '\$2y\$'}}Y{{else}}N{{/if}}"))->toBe('N');
         // the fragment rule closes the whole family, not just the exact field name
-        expect($filter->filter("{{if customer.getData('rp_token') == 'reset-token-123'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter("{{if customer.getData('vault_token') == 'tok-123'}}Y{{else}}N{{/if}}"))->toBe('N');
         expect($filter->filter("{{if customer.api_key == 'sk_live_abc'}}Y{{else}}N{{/if}}"))->toBe('N');
         // positive control: a benign field still resolves
         expect($filter->filter("{{if customer.firstname == 'Bob'}}Y{{else}}N{{/if}}"))->toBe('Y');
@@ -509,5 +510,409 @@ describe('expression object wrapper', function () {
     it('does not expose the enum() function', function () {
         $filter = (new Template())->setVariables(['order' => new DataObject()]);
         expect($filter->filter("{{if enum('Maho\\\\Filter\\\\Template::CONSTRUCTION_IF_PATTERN')}}A{{else}}B{{/if}}"))->toBe('B');
+    });
+
+    it('refuses a secret key inside an array returned by an allowed getter', function () {
+        // Subscripting an array is native PHP: it never reaches __call()/__get(), so a secret
+        // sitting one hop past a legitimately allowed getter would otherwise be readable under
+        // a key the method name cannot reveal.
+        $payment = new class extends DataObject {
+            /** @return array<string, mixed> */
+            public function getGatewayProfile(): array
+            {
+                return [
+                    'method_title' => 'Check / Money order',
+                    'vault_token_id' => 'tok_live_secret123',
+                    'gateway' => ['cc_number' => '4111111111111111'],
+                ];
+            }
+        };
+        $order = new class ($payment) extends DataObject {
+            public function __construct(private DataObject $payment)
+            {
+                parent::__construct();
+            }
+
+            public function getPayment(): DataObject
+            {
+                return $this->payment;
+            }
+        };
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        $token = "order.getPayment().getGatewayProfile()['vault_token_id']";
+        expect($filter->filter("{{if {$token} == 'tok_live_secret123'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter("{{if {$token} == null}}Y{{else}}N{{/if}}"))->toBe('Y');
+
+        // The gate follows nested arrays too
+        $nested = "order.getPayment().getGatewayProfile()['gateway']['cc_number']";
+        expect($filter->filter("{{if {$nested} == '4111111111111111'}}Y{{else}}N{{/if}}"))->toBe('N');
+
+        // A benign key in the very same array stays readable
+        $title = "order.getPayment().getGatewayProfile()['method_title']";
+        expect($filter->filter("{{if {$title} == 'Check / Money order'}}Y{{else}}N{{/if}}"))->toBe('Y');
+    });
+
+    it('renders the else branch when an intermediate hop is absent', function () {
+        // {{if order.shipping_address.company}} on a virtual order: the hop past null makes
+        // Symfony throw, which must degrade to a false condition the way the legacy resolver did
+        $order = new class extends DataObject {
+            public function getShippingAddress(): ?DataObject
+            {
+                return null;
+            }
+        };
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        expect($filter->filter('{{if order.shipping_address.company}}Y{{else}}N{{/if}}'))->toBe('N');
+        expect($filter->filter('{{depend order.shipping_address.company}}X{{/depend}}'))->toBe('');
+    });
+});
+
+/**
+ * Symfony resolves "customer.foo()" with is_callable([$wrapper, 'foo']), which is satisfied by
+ * any real public method of the wrapper — static ones included — without ever reaching the
+ * gated __call(). A public helper on the class handed to the expression engine is therefore
+ * directly callable from a template, and unwrap() in particular returns the raw guarded model.
+ */
+describe('wrapper surface exposed to expressions', function () {
+    it('exposes nothing but gated magic methods on the wrapper', function () {
+        expect(get_class_methods(ExpressionObjectWrapper::class))
+            ->toEqualCanonicalizing(['__call', '__get', '__isset', '__toString']);
+    });
+
+    it('refuses to hand the raw model back through unwrap()', function () {
+        $customer = new class extends DataObject {
+            public function getPassword(): string
+            {
+                return 'hunter2';
+            }
+        };
+        $filter = (new Template())->setVariables(['customer' => $customer]);
+
+        expect($filter->filter('[{{var customer.unwrap(customer).getPassword()}}]'))->toBe('[]');
+        expect($filter->filter("{{if customer.unwrap(customer).getPassword() == 'hunter2'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter('[{{var customer.wrap(customer)}}]'))->toBe('[]');
+        expect($filter->filter('[{{var customer.__construct(customer)}}]'))->toBe('[]');
+    });
+});
+
+/**
+ * PHP compares two objects of the same class structurally — property by property, ignoring
+ * visibility — and every value the expression engine sees is an ExpressionObjectWrapper. A
+ * comparison never reaches __get()/__call(), so the field gate cannot run on it: if the wrapper
+ * held the guarded model in a property, "secret > probe" would recurse into both models' _data
+ * arrays and answer from the raw values, turning any refused field into a bisection oracle.
+ */
+describe('comparing two wrapped values', function () {
+    it('does not order two wrappers by the guarded objects data', function () {
+        // Same two objects throughout, so only the guarded *data* changes between the two
+        // renders: a comparison that answers from it flips, one that cannot read it does not.
+        $a = new DataObject(['password' => 'aaaaaaa']);
+        $b = new DataObject(['password' => 'zzzzzzz']);
+        $filter = (new Template())->setVariables(['a' => $a, 'b' => $b]);
+
+        $before = $filter->filter('{{if a > b}}Y{{else}}N{{/if}}');
+        $a->setPassword('zzzzzzz');
+        $b->setPassword('aaaaaaa');
+
+        expect($filter->filter('{{if a > b}}Y{{else}}N{{/if}}'))->toBe($before);
+    });
+
+    it('does not equate two wrappers by the guarded objects data', function () {
+        $filter = (new Template())->setVariables([
+            'secret' => new DataObject(['password' => 'hunter2']),
+            'guess' => new DataObject(['password' => 'hunter2']),
+            'wrong' => new DataObject(['password' => 'aaaaaaa']),
+        ]);
+
+        // A structural comparison would answer Y for the matching guess, confirming the secret.
+        expect($filter->filter('{{if secret == guess}}Y{{else}}N{{/if}}'))->toBe('N');
+        expect($filter->filter('{{if secret == wrong}}Y{{else}}N{{/if}}'))->toBe('N');
+    });
+
+    it('does not leak the ordering through min() and max() either', function () {
+        // ExpressionLanguage registers min()/max() as the real PHP functions, which reach the
+        // same comparison primitive without going through an operator.
+        $a = new DataObject(['password' => 'aaaaaaa']);
+        $b = new DataObject(['password' => 'zzzzzzz']);
+        $filter = (new Template())->setVariables(['a' => $a, 'b' => $b]);
+
+        $before = $filter->filter('{{if max(a, b) == a}}Y{{else}}N{{/if}}');
+        $a->setPassword('zzzzzzz');
+        $b->setPassword('aaaaaaa');
+
+        expect($filter->filter('{{if max(a, b) == a}}Y{{else}}N{{/if}}'))->toBe($before);
+    });
+
+    it('leaves an object-to-object comparison unanswerable, even for one and the same object', function () {
+        // The flip side of the rule above: no comparison of two wrapped values can consult what
+        // they guard, so a template has to compare a field of each instead.
+        $address = new DataObject(['entity_id' => 7, 'city' => 'Torino']);
+        $order = new DataObject(['billing_address' => $address, 'shipping_address' => $address]);
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        expect($filter->filter('{{if order.billing_address == order.shipping_address}}Y{{else}}N{{/if}}'))->toBe('N');
+        expect($filter->filter('{{if order.billing_address.entity_id == order.shipping_address.entity_id}}Y{{else}}N{{/if}}'))
+            ->toBe('Y');
+    });
+
+    it('keeps comparing a wrapped value against a literal', function () {
+        $filter = (new Template())->setVariables(['order' => new DataObject(['grand_total' => 150])]);
+
+        expect($filter->filter('{{if order.grand_total > 100}}Y{{else}}N{{/if}}'))->toBe('Y');
+        expect($filter->filter('{{if order.grand_total > 200}}Y{{else}}N{{/if}}'))->toBe('N');
+    });
+});
+
+describe('block rendering methods', function () {
+    it('refuses toHtml() even though it matches the read-only "to" prefix', function () {
+        // Mage_Core_Block_Abstract extends DataObject, so a block reaching a template variable
+        // would otherwise let a condition run a full block render.
+        $block = new class extends DataObject {
+            public function toHtml(): string
+            {
+                return '<b>rendered</b>';
+            }
+        };
+        $filter = (new Template())->setVariables(['block' => $block]);
+
+        expect($filter->filter('[{{var block.toHtml()}}]'))->toBe('[]');
+    });
+
+    it('refuses the get-prefixed block render helpers that reach the same _toHtml() path', function () {
+        // getChildHtml()/getChildChildHtml()/getBlockHtml() carry the read-only "get" prefix but
+        // trigger a full child-block render (observers, cache writes) exactly like toHtml(), so
+        // they must be denied for the same must-not-mutate reason.
+        $block = new class extends DataObject {
+            public function getChildHtml(): string
+            {
+                return '<b>child</b>';
+            }
+
+            public function getChildChildHtml(): string
+            {
+                return '<b>grandchild</b>';
+            }
+
+            public function getBlockHtml(): string
+            {
+                return '<b>named</b>';
+            }
+        };
+        $filter = (new Template())->setVariables(['block' => $block]);
+
+        expect($filter->filter('[{{var block.getChildHtml()}}]'))->toBe('[]');
+        expect($filter->filter('[{{var block.getChildChildHtml()}}]'))->toBe('[]');
+        expect($filter->filter('[{{var block.getBlockHtml()}}]'))->toBe('[]');
+    });
+});
+
+describe('arguments carrying a path', function () {
+    it('keeps route and config path arguments working', function () {
+        // The legacy resolver passed method arguments through untouched, so
+        // {{var this.getUrl('customer/account/')}} resolved. Refusing every "/" argument broke
+        // that; the nested-data concern it addressed belongs to the keyed data accessors alone.
+        $block = new class extends DataObject {
+            public function getUrl(string $route): string
+            {
+                return 'https://example.test/' . $route;
+            }
+        };
+        $filter = (new Template())->setVariables(['block' => $block]);
+
+        expect($filter->filter("{{var block.getUrl('customer/account/')}}"))
+            ->toBe('https://example.test/customer/account/');
+    });
+
+    it('still refuses a slash key on a keyed data accessor', function () {
+        $order = new DataObject([
+            'address' => new DataObject(['cc_cid' => '123']),
+        ]);
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        expect($filter->filter("{{if order.getData('address/cc_cid') == '123'}}Y{{else}}N{{/if}}"))->toBe('N');
+    });
+
+    it('still refuses a secret field name passed as an argument', function () {
+        $block = new class extends DataObject {
+            public function getUrl(string $route): string
+            {
+                return 'https://example.test/' . $route;
+            }
+        };
+        $filter = (new Template())->setVariables(['block' => $block]);
+
+        expect($filter->filter("[{{var block.getUrl('cc_number')}}]"))->toBe('[]');
+    });
+});
+
+describe('password reset templates', function () {
+    it('resolves the reset token the account mails build their link from', function () {
+        // {{store url="customer/account/resetpassword/" _query_token=$customer.rp_token}} —
+        // refusing rp_token silently drops the token from the link, leaving the recipient
+        // unable to reset their password.
+        $customer = new DataObject(['rp_token' => 'reset-token-123', 'rp_customer_id' => 42]);
+        $filter = (new Template())->setVariables(['customer' => $customer]);
+
+        expect($filter->filter('{{var customer.rp_token}}'))->toBe('reset-token-123');
+        expect($filter->filter('{{var customer.getRpToken()}}'))->toBe('reset-token-123');
+        expect($filter->filter("{{var customer.getData('rp_token')}}"))->toBe('reset-token-123');
+    });
+
+    it('keeps refusing other token fields', function () {
+        $customer = new DataObject(['vault_token_id' => 'tok_live_abc', 'api_token' => 'sk_live_abc']);
+        $filter = (new Template())->setVariables(['customer' => $customer]);
+
+        expect($filter->filter('[{{var customer.vault_token_id}}]'))->toBe('[]');
+        expect($filter->filter('[{{var customer.api_token}}]'))->toBe('[]');
+    });
+});
+
+/**
+ * Mage_Core_Model_Observer::secureVarProcessing() refuses any model save or delete while the
+ * varProcessing flag is registered. It is the net behind the wrapper's read-only method gate,
+ * for a getter that looks like a read but persists on the way out. {{var}} has always set the
+ * flag; conditions used to inherit it because ifDirective() resolved through _getVariable(),
+ * and must keep it now that they evaluate through the expression engine instead.
+ */
+describe('save guard during condition evaluation', function () {
+    it('registers varProcessing while an expression condition is evaluated', function () {
+        $probe = new class extends DataObject {
+            public ?bool $guardedDuringIf = null;
+            public ?bool $guardedDuringDepend = null;
+
+            public function getIfProbe(): string
+            {
+                $this->guardedDuringIf = (bool) Mage::registry('varProcessing');
+                return 'x';
+            }
+
+            public function getDependProbe(): string
+            {
+                $this->guardedDuringDepend = (bool) Mage::registry('varProcessing');
+                return 'x';
+            }
+        };
+        /** @var Mage_Core_Model_Email_Template_Filter $filter */
+        $filter = Mage::getModel('core/email_template_filter');
+        $filter->setVariables(['o' => $probe]);
+
+        $filter->filter('{{if o.getIfProbe()}}Y{{else}}N{{/if}}');
+        $filter->filter('{{depend o.getDependProbe()}}X{{/depend}}');
+
+        expect($probe->guardedDuringIf)->toBeTrue();
+        expect($probe->guardedDuringDepend)->toBeTrue();
+        // and the flag is always released again, including when the condition throws
+        $filter->filter('{{if o.getIfProbe() >}}Y{{else}}N{{/if}}');
+        expect(Mage::registry('varProcessing'))->toBeNull();
+    });
+
+    it('joins the guard already in force instead of aborting a nested render', function () {
+        // Mage::register() throws when the key is taken, so a getter that filters a template of
+        // its own would abort the inner render — and abort it before its own try block, leaving
+        // the flag to whichever frame unwinds first. Re-entering must simply join the guard.
+        $probe = new class extends DataObject {
+            public ?bool $guardedInside = null;
+
+            public function getNested(): string
+            {
+                /** @var Mage_Core_Model_Email_Template_Filter $inner */
+                $inner = Mage::getModel('core/email_template_filter');
+                $inner->setVariables(['x' => new DataObject(['a' => 'INNER'])]);
+                $rendered = $inner->filter('{{var x.a}}');
+                // the outer frame's guard is still up after the inner one has finished
+                $this->guardedInside = (bool) Mage::registry('varProcessing');
+                return $rendered;
+            }
+        };
+        /** @var Mage_Core_Model_Email_Template_Filter $filter */
+        $filter = Mage::getModel('core/email_template_filter');
+        $filter->setVariables(['o' => $probe]);
+
+        expect($filter->filter('[{{var o.getNested()}}]'))->toBe('[INNER]');
+        expect($probe->guardedInside)->toBeTrue();
+        expect(Mage::registry('varProcessing'))->toBeNull();
+
+        expect($filter->filter('{{if o.getNested()}}Y{{else}}N{{/if}}'))->toBe('Y');
+        expect(Mage::registry('varProcessing'))->toBeNull();
+    });
+});
+
+describe('encrypted config subtree', function () {
+    // Store::getConfig() returns a scalar for a leaf path and the whole subtree (an array) for an
+    // ancestor path. The exact encrypted leaf was already neutralized; an ancestor request plus a
+    // native subscript reached the decrypted leaf around that check.
+    function stubStore(string $leaf, string $sentinel): DataObject
+    {
+        return new class ($leaf, $sentinel) extends DataObject {
+            /** @var array<mixed> */
+            private array $tree;
+
+            public function __construct(string $leaf, string $sentinel)
+            {
+                parent::__construct();
+                [$section, $group, $field] = explode('/', $leaf);
+                $this->tree = [
+                    $section => [$group => [$field => $sentinel, 'plain_sibling' => 'PLAIN']],
+                    'general' => ['store_information' => ['name' => 'MyStore']],
+                ];
+            }
+
+            public function getConfig($path)
+            {
+                if (!is_string($path) || $path === '') {
+                    return null;
+                }
+                $node = $this->tree;
+                foreach (explode('/', $path) as $segment) {
+                    if (!is_array($node) || !array_key_exists($segment, $node)) {
+                        return null;
+                    }
+                    $node = $node[$segment];
+                }
+                return $node;
+            }
+        };
+    }
+
+    it('does not leak an encrypted leaf reached through an ancestor subtree subscript', function () {
+        $paths = Mage::getSingleton('adminhtml/config')->getEncryptedNodeEntriesPaths();
+        expect($paths)->not->toBeEmpty();
+        [$section, $group, $field] = explode('/', $paths[0]);
+        $store = stubStore($paths[0], 'ENC_SENTINEL');
+        $filter = (new Template())->setVariables(['store' => $store]);
+
+        // exact leaf, ancestor subtree, top-level subtree, concat-built key and oracle all closed
+        expect($filter->filter("[{{var store.getConfig('{$section}/{$group}/{$field}')}}]"))->toBe('[]');
+        expect($filter->filter("[{{var store.getConfig('{$section}/{$group}')['{$field}']}}]"))->toBe('[]');
+        expect($filter->filter("[{{var store.getConfig('{$section}')['{$group}']['{$field}']}}]"))->toBe('[]');
+        expect($filter->filter("[{{if store.getConfig('{$section}/{$group}')['{$field}'] starts with 'ENC'}}LEAK{{else}}-{{/if}}]"))->toBe('[-]');
+    });
+
+    it('still resolves a non-encrypted config value', function () {
+        $paths = Mage::getSingleton('adminhtml/config')->getEncryptedNodeEntriesPaths();
+        $store = stubStore($paths[0], 'ENC_SENTINEL');
+        $filter = (new Template())->setVariables(['store' => $store]);
+
+        expect($filter->filter("[{{var store.getConfig('general/store_information/name')}}]"))->toBe('[MyStore]');
+        expect($filter->filter("[{{var store.getConfig('general/store_information')['name']}}]"))->toBe('[MyStore]');
+    });
+});
+
+describe('expression length cap', function () {
+    it('rejects an over-long expression instead of crashing the parser', function () {
+        // Symfony's recursive-descent parser SIGSEGVs on a deeply nested expression; the byte cap
+        // refuses it before the parser can run into it. This expression would evaluate true (an
+        // even number of "not"), so rendering the else branch proves it was refused, not evaluated.
+        $filter = (new Template())->setVariables(['x' => 1]);
+        $overLong = '{{if ' . str_repeat('not ', 600) . 'x}}Y{{else}}N{{/if}}';
+        expect(strlen($overLong))->toBeGreaterThan(2000);
+        expect($filter->filter($overLong))->toBe('N');
+    });
+
+    it('leaves a normal-length expression untouched', function () {
+        $filter = (new Template())->setVariables(['order' => new DataObject(['grand_total' => 120.5])]);
+        expect($filter->filter('{{if order.grand_total > 100}}Y{{else}}N{{/if}}'))->toBe('Y');
     });
 });

--- a/tests/Backend/Unit/Maho/Filter/TemplateConditionTest.php
+++ b/tests/Backend/Unit/Maho/Filter/TemplateConditionTest.php
@@ -58,6 +58,20 @@ describe('legacy single-variable conditions', function () {
         expect($filter->filter("{{if order.status_label == 'Processing'}}Y{{else}}N{{/if}}"))->toBe('Y');
     });
 
+    it('resolves property paths through computed getters returning objects', function () {
+        // getData('billing_address') is empty; only the real getter can resolve the path,
+        // and its DataObject result must be re-wrapped for the .company access to work
+        $order = new class () extends DataObject {
+            public function getBillingAddress(): DataObject
+            {
+                return new DataObject(['company' => 'ACME']);
+            }
+        };
+        $filter = (new Template())->setVariables(['order' => $order]);
+        expect($filter->filter('{{if order.billing_address.company}}Y{{else}}N{{/if}}'))->toBe('Y');
+        expect($filter->filter("{{if order.billing_address.company == 'ACME'}}Y{{else}}N{{/if}}"))->toBe('Y');
+    });
+
     it('treats absent variables as empty without failing', function () {
         $filter = (new Template())->setVariables(['foo' => 'bar']);
         expect($filter->filter('{{if comment}}A{{else}}B{{/if}}'))->toBe('B');
@@ -155,5 +169,25 @@ describe('expression object wrapper', function () {
 
         expect($wrapped->getConfig('general/locale/code'))->toBe('general/locale/code');
         expect($wrapped->getConfig((string) $encryptedPaths[0]))->toBeNull();
+    });
+
+    it('applies the encrypted-path guard to getConfig calls made inside template expressions', function () {
+        $encryptedPaths = Mage::getSingleton('adminhtml/config')->getEncryptedNodeEntriesPaths();
+        if (count($encryptedPaths) === 0) {
+            $this->markTestSkipped('No encrypted configuration paths available in this environment');
+        }
+
+        $store = new class () extends DataObject {
+            public function getConfig(?string $path = null): ?string
+            {
+                return $path === null ? null : 'secret-value';
+            }
+        };
+        $filter = (new Template())->setVariables(['store' => $store]);
+
+        // Plain path reaches getConfig and returns a value; encrypted path is called with null
+        expect($filter->filter("{{if store.getConfig('general/locale/code') == 'secret-value'}}Y{{else}}N{{/if}}"))->toBe('Y');
+        $encrypted = (string) $encryptedPaths[0];
+        expect($filter->filter("{{if store.getConfig('{$encrypted}') == 'secret-value'}}Y{{else}}N{{/if}}"))->toBe('N');
     });
 });

--- a/tests/Backend/Unit/Maho/Filter/TemplateConditionTest.php
+++ b/tests/Backend/Unit/Maho/Filter/TemplateConditionTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Maho_Filter
+ */
+
+declare(strict_types=1);
+
+use Maho\DataObject;
+use Maho\Filter\Template;
+use Maho\Filter\Template\ExpressionObjectWrapper;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Tests the {{if}} / {{depend}} template directives, evaluated through Symfony
+ * ExpressionLanguage. The legacy single-variable syntax is a subset of the expression
+ * syntax and must keep working unchanged.
+ */
+describe('legacy single-variable conditions', function () {
+    it('renders the true branch for a non-empty variable', function () {
+        $filter = (new Template())->setVariables(['customer_name' => 'Bob']);
+        expect($filter->filter('{{if customer_name}}Hi{{/if}}'))->toBe('Hi');
+    });
+
+    it('renders the else branch for an empty variable', function () {
+        $filter = (new Template())->setVariables(['foo' => '']);
+        expect($filter->filter('{{if foo}}A{{else}}B{{/if}}'))->toBe('B');
+    });
+
+    it('resolves DataObject property paths', function () {
+        $filter = (new Template())->setVariables(['order' => new DataObject(['increment_id' => '100000001'])]);
+        expect($filter->filter('{{if order.increment_id}}Y{{else}}N{{/if}}'))->toBe('Y');
+    });
+
+    it('resolves DataObject getter method calls', function () {
+        $filter = (new Template())->setVariables(['order' => new DataObject(['increment_id' => '100000001'])]);
+        expect($filter->filter('{{if order.getIncrementId()}}Y{{else}}N{{/if}}'))->toBe('Y');
+    });
+
+    it('handles the depend directive', function () {
+        $filter = (new Template())->setVariables(['foo' => 'bar', 'empty' => '']);
+        expect($filter->filter('{{depend foo}}X{{/depend}}'))->toBe('X');
+        expect($filter->filter('{{depend empty}}X{{/depend}}'))->toBe('');
+        expect($filter->filter('{{depend missing}}X{{/depend}}'))->toBe('');
+    });
+
+    it('prefers a real getter method over raw data access for property paths', function () {
+        $order = new class () extends DataObject {
+            public function getStatusLabel(): string
+            {
+                return 'Processing';
+            }
+        };
+        $filter = (new Template())->setVariables(['order' => $order]);
+        expect($filter->filter("{{if order.status_label == 'Processing'}}Y{{else}}N{{/if}}"))->toBe('Y');
+    });
+
+    it('treats absent variables as empty without failing', function () {
+        $filter = (new Template())->setVariables(['foo' => 'bar']);
+        expect($filter->filter('{{if comment}}A{{else}}B{{/if}}'))->toBe('B');
+        expect($filter->filter('{{depend comment}}X{{/depend}}'))->toBe('');
+    });
+
+    it('treats zero as false', function () {
+        $filter = (new Template())->setVariables(['qty' => 0, 'qty_string' => '0']);
+        expect($filter->filter('{{if qty}}A{{else}}B{{/if}}'))->toBe('B');
+        expect($filter->filter('{{if qty_string}}A{{else}}B{{/if}}'))->toBe('B');
+    });
+
+    it('leaves directives untouched during preprocessing (no variables set)', function () {
+        $filter = new Template();
+        $template = '{{if order.total > 100}}A{{else}}B{{/if}}';
+        expect($filter->filter($template))->toBe($template);
+    });
+});
+
+describe('expression conditions', function () {
+    it('evaluates numeric comparisons on DataObject data', function () {
+        $filter = (new Template())->setVariables(['order' => new DataObject(['grand_total' => 150.0])]);
+        expect($filter->filter('{{if order.grand_total > 100}}BIG{{else}}SMALL{{/if}}'))->toBe('BIG');
+
+        $filter = (new Template())->setVariables(['order' => new DataObject(['grand_total' => 50.0])]);
+        expect($filter->filter('{{if order.grand_total > 100}}BIG{{else}}SMALL{{/if}}'))->toBe('SMALL');
+    });
+
+    it('evaluates boolean logic across multiple variables', function () {
+        $filter = (new Template())->setVariables([
+            'order' => new DataObject(['grand_total' => 150.0]),
+            'customer' => new DataObject(['group_id' => 2]),
+        ]);
+        expect($filter->filter('{{if order.grand_total > 100 && customer.group_id == 2}}Y{{else}}N{{/if}}'))->toBe('Y');
+        expect($filter->filter('{{if order.grand_total > 500 || customer.group_id == 2}}Y{{else}}N{{/if}}'))->toBe('Y');
+        expect($filter->filter('{{if order.grand_total > 500 && customer.group_id == 2}}Y{{else}}N{{/if}}'))->toBe('N');
+    });
+
+    it('supports method calls in expressions', function () {
+        $filter = (new Template())->setVariables(['order' => new DataObject(['grand_total' => 150.0])]);
+        expect($filter->filter('{{if order.getGrandTotal() > 100}}Y{{else}}N{{/if}}'))->toBe('Y');
+    });
+
+    it('supports string comparisons and the in operator', function () {
+        $filter = (new Template())->setVariables(['order' => new DataObject(['status' => 'complete'])]);
+        expect($filter->filter("{{if order.status == 'complete'}}Y{{else}}N{{/if}}"))->toBe('Y');
+        expect($filter->filter("{{if order.status in ['complete', 'closed']}}Y{{else}}N{{/if}}"))->toBe('Y');
+        expect($filter->filter("{{if order.status in ['pending', 'holded']}}Y{{else}}N{{/if}}"))->toBe('N');
+    });
+
+    it('traverses nested DataObjects', function () {
+        $filter = (new Template())->setVariables([
+            'order' => new DataObject(['payment' => new DataObject(['method' => 'checkmo'])]),
+        ]);
+        expect($filter->filter("{{if order.payment.method == 'checkmo'}}Y{{else}}N{{/if}}"))->toBe('Y');
+        expect($filter->filter("{{if order.getPayment().getMethod() == 'checkmo'}}Y{{else}}N{{/if}}"))->toBe('Y');
+    });
+
+    it('works in the depend directive too', function () {
+        $filter = (new Template())->setVariables(['order' => new DataObject(['grand_total' => 150.0])]);
+        expect($filter->filter('{{depend order.grand_total > 100}}X{{/depend}}'))->toBe('X');
+        expect($filter->filter('{{depend order.grand_total > 500}}X{{/depend}}'))->toBe('');
+    });
+
+    it('renders the else branch for an invalid expression instead of throwing', function () {
+        $filter = (new Template())->setVariables(['order' => new DataObject(['grand_total' => 150.0])]);
+        expect($filter->filter('{{if order.grand_total >}}A{{else}}B{{/if}}'))->toBe('B');
+    });
+
+    it('renders the else branch when an expression references an unknown variable', function () {
+        $filter = (new Template())->setVariables(['order' => new DataObject()]);
+        expect($filter->filter('{{if warehouse.stock > 0}}A{{else}}B{{/if}}'))->toBe('B');
+    });
+
+    it('does not expose the constant() function', function () {
+        $filter = (new Template())->setVariables(['order' => new DataObject()]);
+        expect($filter->filter("{{if constant('PHP_VERSION')}}A{{else}}B{{/if}}"))->toBe('B');
+    });
+});
+
+describe('expression object wrapper', function () {
+    it('neutralizes getConfig calls against encrypted configuration paths', function () {
+        $encryptedPaths = Mage::getSingleton('adminhtml/config')->getEncryptedNodeEntriesPaths();
+        if (count($encryptedPaths) === 0) {
+            $this->markTestSkipped('No encrypted configuration paths available in this environment');
+        }
+
+        $object = new class () extends DataObject {
+            public function getConfig(?string $path = null): ?string
+            {
+                return $path;
+            }
+        };
+        $wrapped = ExpressionObjectWrapper::wrap($object);
+
+        expect($wrapped->getConfig('general/locale/code'))->toBe('general/locale/code');
+        expect($wrapped->getConfig((string) $encryptedPaths[0]))->toBeNull();
+    });
+});

--- a/tests/Backend/Unit/Maho/Filter/TemplateConditionTest.php
+++ b/tests/Backend/Unit/Maho/Filter/TemplateConditionTest.php
@@ -3,7 +3,6 @@
 /**
  * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
  * SPDX-License-Identifier: OSL-3.0
- * @package Maho_Filter
  */
 
 declare(strict_types=1);
@@ -189,5 +188,326 @@ describe('expression object wrapper', function () {
         expect($filter->filter("{{if store.getConfig('general/locale/code') == 'secret-value'}}Y{{else}}N{{/if}}"))->toBe('Y');
         $encrypted = (string) $encryptedPaths[0];
         expect($filter->filter("{{if store.getConfig('{$encrypted}') == 'secret-value'}}Y{{else}}N{{/if}}"))->toBe('N');
+    });
+
+    it('keeps the encrypted-path guard after an array hop', function () {
+        $encryptedPaths = Mage::getSingleton('adminhtml/config')->getEncryptedNodeEntriesPaths();
+        if (count($encryptedPaths) === 0) {
+            $this->markTestSkipped('No encrypted configuration paths available in this environment');
+        }
+
+        $store = new class extends DataObject {
+            public function getConfig(?string $path = null): ?string
+            {
+                return $path === null ? null : 'secret-value';
+            }
+        };
+        $container = new DataObject(['stores' => [$store]]);
+        $filter = (new Template())->setVariables(['container' => $container]);
+
+        $encrypted = (string) $encryptedPaths[0];
+        expect($filter->filter("{{if container.stores[0].getConfig('general/locale/code') == 'secret-value'}}Y{{else}}N{{/if}}"))->toBe('Y');
+        expect($filter->filter("{{if container.stores[0].getConfig('{$encrypted}') == 'secret-value'}}Y{{else}}N{{/if}}"))->toBe('N');
+    });
+
+    it('refuses method calls that are not read-only', function () {
+        $order = new DataObject(['status' => 'pending']);
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        expect($filter->filter("{{if order.setStatus('canceled')}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter('{{if order.unsetData()}}Y{{else}}N{{/if}}'))->toBe('N');
+        expect($order->getStatus())->toBe('pending');
+    });
+
+    it('refuses methods that merely start with the letters of a read-only prefix', function () {
+        // "can" must not open the door to cancel(), nor "has" to hash(), nor "to" to toggle()
+        $order = new class extends DataObject {
+            public bool $cancelled = false;
+
+            public function cancel(): bool
+            {
+                $this->cancelled = true;
+                return true;
+            }
+
+            public function canShip(): bool
+            {
+                return true;
+            }
+        };
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        expect($filter->filter('{{if order.cancel()}}Y{{else}}N{{/if}}'))->toBe('N');
+        expect($order->cancelled)->toBeFalse();
+        expect($filter->filter('{{if order.canShip()}}Y{{else}}N{{/if}}'))->toBe('Y');
+    });
+
+    it('refuses getters that decrypt secrets on read', function () {
+        $payment = new class extends DataObject {
+            public function getCcNumber(): string
+            {
+                return '4111111111111111';
+            }
+
+            public function getConfigData(string $field): string
+            {
+                return 'gateway-' . $field;
+            }
+        };
+        $filter = (new Template())->setVariables(['payment' => $payment]);
+
+        expect($filter->filter("{{if payment.getCcNumber() == '4111111111111111'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter("{{if payment.getConfigData('password') == 'gateway-password'}}Y{{else}}N{{/if}}"))->toBe('N');
+    });
+
+    it('refuses secret data keys read through the generic getData() accessor', function () {
+        // Mage_Payment_Model_Info::getData() decrypts cc_number/cc_cid on read, so the key
+        // has to clear the same gate the equivalent named getter does
+        $payment = new DataObject(['cc_number' => '4111111111111111', 'cc_cid' => '123', 'method' => 'checkmo']);
+        $filter = (new Template())->setVariables(['payment' => $payment]);
+
+        expect($filter->filter("{{if payment.getData('cc_number') == '4111111111111111'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter("{{if payment.getDataByKey('cc_cid') == '123'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter("{{if payment.getDataUsingMethod('cc_number') == '4111111111111111'}}Y{{else}}N{{/if}}"))->toBe('N');
+        // a harmless key still resolves, so the gate filters keys rather than banning getData()
+        expect($filter->filter("{{if payment.getData('method') == 'checkmo'}}Y{{else}}N{{/if}}"))->toBe('Y');
+    });
+
+    it('refuses accessors that dump the whole object state in one call', function () {
+        $order = new DataObject(['increment_id' => '100000001', 'customer_email' => 'a@example.com']);
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        // no key at all returns the entire internal _data array
+        expect($filter->filter('{{if order.getData()}}Y{{else}}N{{/if}}'))->toBe('N');
+        // bare get() dumps the same _data array via DataObject::__call (getData('') semantics)
+        expect($filter->filter('{{if order.get()}}Y{{else}}N{{/if}}'))->toBe('N');
+        // toArray()/toJson()/toXml()/toString() all serialize the whole _data array
+        expect($filter->filter('{{if order.toArray()}}Y{{else}}N{{/if}}'))->toBe('N');
+        expect($filter->filter("{{if order.toJson() contains '100000001'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter("{{if order.toXml() contains '100000001'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter("{{if order.toString() contains 'a@example.com'}}Y{{else}}N{{/if}}"))->toBe('N');
+        // "order.data" resolves to the same argument-less getData() call
+        expect($filter->filter('{{if order.data}}Y{{else}}N{{/if}}'))->toBe('N');
+        expect($filter->filter("{{if order.increment_id == '100000001'}}Y{{else}}N{{/if}}"))->toBe('Y');
+    });
+
+    it('refuses getDataUsingMethod(), which dispatches past the getConfig encrypted-path guard', function () {
+        // getDataUsingMethod('config', $path) re-derives getConfig() and calls it, so it would
+        // reach the decrypt-on-read config with the raw path had it not been denied outright.
+        $encryptedPaths = Mage::getSingleton('adminhtml/config')->getEncryptedNodeEntriesPaths();
+        if (count($encryptedPaths) === 0) {
+            $this->markTestSkipped('No encrypted configuration paths available in this environment');
+        }
+
+        $store = new class extends DataObject {
+            public function getConfig(?string $path = null): ?string
+            {
+                return $path === null ? null : 'secret-value';
+            }
+        };
+        $filter = (new Template())->setVariables(['store' => $store]);
+
+        $encrypted = (string) $encryptedPaths[0];
+        // Even a plain path is refused because the whole dispatcher is denied
+        expect($filter->filter("{{if store.getDataUsingMethod('config', 'general/locale/code') == 'secret-value'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter("{{if store.getDataUsingMethod('config', '{$encrypted}') == 'secret-value'}}Y{{else}}N{{/if}}"))->toBe('N');
+        // The direct getConfig() call still works and stays guarded
+        expect($filter->filter("{{if store.getConfig('general/locale/code') == 'secret-value'}}Y{{else}}N{{/if}}"))->toBe('Y');
+        expect($filter->filter("{{if store.getConfig('{$encrypted}') == 'secret-value'}}Y{{else}}N{{/if}}"))->toBe('N');
+    });
+
+    it('refuses a subclass getter that returns a stored secret field', function () {
+        // Mage_Customer_Model_Customer::getPassword() returns the stored password and the
+        // customer model is handed to the changed-password email template, so a bare getter
+        // would be a char-by-char exfil oracle with the comparison operators.
+        $customer = new class extends DataObject {
+            public function getPassword(): string
+            {
+                return '$2y$10$abcdefghijklmnopqrstuv';
+            }
+        };
+        $filter = (new Template())->setVariables(['customer' => $customer]);
+
+        expect($filter->filter("{{if customer.getPassword() starts with '\$2y\$'}}Y{{else}}N{{/if}}"))->toBe('N');
+        // property syntax resolves to the same getPassword() and is refused too
+        expect($filter->filter("{{if customer.password starts with '\$2y\$'}}Y{{else}}N{{/if}}"))->toBe('N');
+    });
+
+    it('refuses secret fields read through the generic getData() accessor', function () {
+        $customer = new DataObject([
+            'password' => '$2y$10$abcdefghijklmnopqrstuv',
+            'rp_token' => 'reset-token-123',
+            'api_key' => 'sk_live_abc',
+            'firstname' => 'Bob',
+        ]);
+        $filter = (new Template())->setVariables(['customer' => $customer]);
+
+        expect($filter->filter("{{if customer.getData('password') starts with '\$2y\$'}}Y{{else}}N{{/if}}"))->toBe('N');
+        // the fragment rule closes the whole family, not just the exact field name
+        expect($filter->filter("{{if customer.getData('rp_token') == 'reset-token-123'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter("{{if customer.api_key == 'sk_live_abc'}}Y{{else}}N{{/if}}"))->toBe('N');
+        // positive control: a benign field still resolves
+        expect($filter->filter("{{if customer.firstname == 'Bob'}}Y{{else}}N{{/if}}"))->toBe('Y');
+        expect($filter->filter("{{if customer.getData('firstname') == 'Bob'}}Y{{else}}N{{/if}}"))->toBe('Y');
+    });
+
+    it('still reads a boolean flag whose name contains a secret fragment', function () {
+        // {{if customer.is_change_password}} ships in the changed-password email template.
+        // is_/has_/can_ accessors expose a yes/no status, not the secret value, so the
+        // secret-fragment rule must not swallow them.
+        $customer = new DataObject([
+            'is_change_password' => 1,
+            'has_secret_question' => 0,
+        ]);
+        $filter = (new Template())->setVariables(['customer' => $customer]);
+
+        expect($filter->filter('{{if customer.is_change_password}}Y{{else}}N{{/if}}'))->toBe('Y');
+        expect($filter->filter("{{if customer.getData('is_change_password')}}Y{{else}}N{{/if}}"))->toBe('Y');
+        expect($filter->filter('{{depend customer.has_secret_question}}X{{/depend}}'))->toBe('');
+    });
+
+    it('refuses any field carrying the _enc encrypted-column suffix', function () {
+        // Maho stores encrypted-at-rest columns with an "_enc" suffix; a custom one whose base
+        // name is in no fragment list must still be refused.
+        $model = new DataObject(['gateway_credential_enc' => 'cipher-text']);
+        $filter = (new Template())->setVariables(['model' => $model]);
+
+        expect($filter->filter("{{if model.gateway_credential_enc == 'cipher-text'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter("{{if model.getData('gateway_credential_enc') == 'cipher-text'}}Y{{else}}N{{/if}}"))->toBe('N');
+    });
+
+    it('refuses getDataByPath(), the ungated twin of the keyed getData() accessor', function () {
+        // getDataByPath() walks an a/b/c path straight into the raw _data array with no
+        // per-segment gate, so it must not become a back door to a key getData() refuses.
+        $payment = new DataObject([
+            'cc_number' => '4111111111111111',
+            'method' => 'checkmo',
+            'address' => new DataObject(['cc_cid' => '123']),
+        ]);
+        $filter = (new Template())->setVariables(['payment' => $payment]);
+
+        expect($filter->filter("{{if payment.getDataByPath('cc_number') == '4111111111111111'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter("{{if payment.getDataByPath('address/cc_cid') == '123'}}Y{{else}}N{{/if}}"))->toBe('N');
+        // even a harmless key is refused: the whole path accessor is closed, not filtered
+        expect($filter->filter("{{if payment.getDataByPath('method') == 'checkmo'}}Y{{else}}N{{/if}}"))->toBe('N');
+    });
+
+    it('refuses a slash path smuggled through the keyed getData() accessor', function () {
+        // getData('address/cc_cid') would clear the gate on the top-level key and then forward
+        // to the same ungated getDataByPath() traversal, reaching the nested secret segment.
+        $order = new DataObject([
+            'address' => new DataObject(['cc_cid' => '123']),
+            'increment_id' => '100000001',
+        ]);
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        expect($filter->filter("{{if order.getData('address/cc_cid') == '123'}}Y{{else}}N{{/if}}"))->toBe('N');
+    });
+
+    it('refuses a getter-shaped mutator invoked with an argument', function () {
+        // isDeleted() reads a flag, but isDeleted(true) writes it — and Mage_Core_Model_Abstract
+        // ::save() routes a "deleted" object to delete() instead of persisting. A read-only
+        // condition must never carry an argument into such a method.
+        $order = new DataObject(['increment_id' => '100000001']);
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        expect($filter->filter('{{if order.isDeleted(true)}}Y{{else}}N{{/if}}'))->toBe('N');
+        expect($order->isDeleted())->toBeFalse();
+    });
+
+    it('refuses getDataSetDefault(), which writes despite its getter-shaped name', function () {
+        $order = new DataObject(['increment_id' => '100000001']);
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        expect($filter->filter("{{if order.getDataSetDefault('status', 'new') == 'new'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($order->hasData('status'))->toBeFalse();
+    });
+
+    it('refuses those getters through the property syntax too', function () {
+        // Mage_Payment_Model_Info decrypts on getData('cc_number'), so the dotted form must
+        // be refused whether or not the model declares a real getter for it
+        $payment = new class extends DataObject {
+            public function getCcNumber(): string
+            {
+                return '4111111111111111';
+            }
+        };
+        $magic = new DataObject(['cc_number' => '4111111111111111', 'cc_cid' => '123']);
+        $filter = (new Template())->setVariables(['payment' => $payment, 'magic' => $magic]);
+
+        expect($filter->filter("{{if payment.cc_number == '4111111111111111'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter("{{if magic.cc_number == '4111111111111111'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter("{{if magic.cc_cid == '123'}}Y{{else}}N{{/if}}"))->toBe('N');
+    });
+
+    it('refuses a mutating method reached through the property syntax', function () {
+        $order = new class extends DataObject {
+            public bool $cancelled = false;
+
+            public function cancel(): bool
+            {
+                $this->cancelled = true;
+                return true;
+            }
+        };
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        expect($filter->filter('{{if order.cancel}}Y{{else}}N{{/if}}'))->toBe('N');
+        expect($order->cancelled)->toBeFalse();
+    });
+
+    it('refuses to walk into a non-DataObject returned by a getter', function () {
+        // Mirrors order.getResource().getReadConnection()...: a getter that returns an
+        // infrastructure object must dead-end, so a template can never chain from a model
+        // into a DB adapter/connection and read credentials via a boolean oracle.
+        $connection = new class {
+            /** @return array<string, string> */
+            public function getParams(): array
+            {
+                return ['password' => 'super-secret'];
+            }
+        };
+        $order = new class ($connection) extends DataObject {
+            public function __construct(private object $connection)
+            {
+                parent::__construct();
+            }
+
+            public function getResource(): object
+            {
+                return $this->connection;
+            }
+        };
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        // The first hop is allowed (getResource is a read-only getter) but returns a wrapped
+        // non-DataObject, so the second hop returns null and the oracle never fires.
+        expect($filter->filter("{{if order.getResource().getParams()['password'] == 'super-secret'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter('{{if order.getResource().getParams() == null}}Y{{else}}N{{/if}}'))->toBe('Y');
+    });
+
+    it('refuses the matches and range operators', function () {
+        $filter = (new Template())->setVariables(['order' => new DataObject(['status' => 'complete'])]);
+
+        expect($filter->filter("{{if order.status matches '/^complete$/'}}Y{{else}}N{{/if}}"))->toBe('N');
+        expect($filter->filter('{{if 1 in 0..10}}Y{{else}}N{{/if}}'))->toBe('N');
+    });
+
+    it('does not silently compare an object without a string form against a string', function () {
+        // Stringifying to '' would make a populated address equal to the empty string
+        $order = new class extends DataObject {
+            public function getBillingAddress(): DataObject
+            {
+                return new DataObject(['company' => 'ACME']);
+            }
+        };
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        expect($filter->filter("{{if order.billing_address == ''}}Y{{else}}N{{/if}}"))->toBe('N');
+    });
+
+    it('does not expose the enum() function', function () {
+        $filter = (new Template())->setVariables(['order' => new DataObject()]);
+        expect($filter->filter("{{if enum('Maho\\\\Filter\\\\Template::CONSTRUCTION_IF_PATTERN')}}A{{else}}B{{/if}}"))->toBe('B');
     });
 });

--- a/tests/Backend/Unit/Maho/Filter/TemplateVarMethodGateTest.php
+++ b/tests/Backend/Unit/Maho/Filter/TemplateVarMethodGateTest.php
@@ -118,4 +118,274 @@ describe('{{var}} method gate', function () {
         // a keyed read of a benign field still works
         expect($filter->filter('[{{var o.getData(\'firstname\')}}]'))->toBe('[Bob]');
     });
+
+    it('does not print a secret key from an array returned by an allowed getter', function () {
+        // Array subscripting bypasses the wrapper's method/property gate entirely, so the
+        // field-name rule has to be applied to the array's keys when the array is wrapped
+        $o = new class extends DataObject {
+            /** @return array<string, mixed> */
+            public function getPayload(): array
+            {
+                return ['method_title' => 'Check / Money order', 'vault_token_id' => 'tok_live_secret123'];
+            }
+        };
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        expect($filter->filter("[{{var o.getPayload()['vault_token_id']}}]"))->toBe('[]');
+        expect($filter->filter("[{{var o.getPayload()['method_title']}}]"))->toBe('[Check / Money order]');
+    });
+
+    it('resolves a method under the casing the class declares, not the casing the template spells', function () {
+        // PHP dispatches method names case-insensitively, so "canCel" reaches cancel() and
+        // "getPassWord" reaches getPassword(). Both gates read camelCase word boundaries out of
+        // the name, so a faked boundary would turn cancel() into a "can" predicate and password
+        // into the unlisted field "pass_word".
+        $o = new class extends DataObject {
+            public bool $cancelled = false;
+
+            public function cancel(): string
+            {
+                $this->cancelled = true;
+                return 'CANCELLED';
+            }
+
+            public function getPassword(): string
+            {
+                return 'hunter2';
+            }
+        };
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        expect($filter->filter('[{{var o.canCel()}}]'))->toBe('[]');
+        expect($o->cancelled)->toBeFalse();
+        expect($filter->filter('[{{var o.getPassWord()}}]'))->toBe('[]');
+        expect($filter->filter('[{{var o.PassWord}}]'))->toBe('[]');
+        expect($filter->filter('[{{if o.getPassWord() > \'a\'}}LEAK{{else}}-{{/if}}]'))->toBe('[-]');
+    });
+
+    it('refuses the free-form gateway bags on a payment info object', function () {
+        $o = new class extends DataObject {
+            /** @return array<string, mixed> */
+            public function getAdditionalInformation(): array
+            {
+                return ['method_title' => 'PayPal', 'cvv_code' => 'M', 'avs_code' => 'Y', 'payer_email' => 'a@b.c'];
+            }
+
+            public function getAdditionalData(): string
+            {
+                return 'serialized-gateway-blob';
+            }
+        };
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        expect($filter->filter("[{{var o.getAdditionalInformation()['cvv_code']}}]"))->toBe('[]');
+        expect($filter->filter("[{{var o.getAdditionalInformation()['method_title']}}]"))->toBe('[]');
+        expect($filter->filter('[{{var o.getAdditionalInformation()}}]'))->toBe('[]');
+        expect($filter->filter('[{{var o.additional_information}}]'))->toBe('[]');
+        expect($filter->filter('[{{var o.getAdditionalData()}}]'))->toBe('[]');
+    });
+
+    it('refuses cardholder data but keeps the masked display fields readable', function () {
+        $o = new DataObject([
+            'cc_owner' => 'Ada Lovelace',
+            'cc_exp_month' => '11',
+            'cc_exp_year' => '2031',
+            'cc_ss_issue' => '3',
+            'cc_number' => '4111111111111111',
+            'cc_cid' => '737',
+            'cc_type' => 'VI',
+            'cc_last4' => '1111',
+        ]);
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        expect($filter->filter('[{{var o.cc_owner}}]'))->toBe('[]');
+        expect($filter->filter('[{{var o.getCcOwner()}}]'))->toBe('[]');
+        expect($filter->filter('[{{var o.getCcExpMonth()}}/{{var o.getCcExpYear()}}]'))->toBe('[/]');
+        expect($filter->filter('[{{var o.getCcSsIssue()}}]'))->toBe('[]');
+        expect($filter->filter('[{{var o.getData(\'cc_owner\')}}]'))->toBe('[]');
+        // the two fields Magento stores unencrypted precisely so a template can print them
+        expect($filter->filter('[{{var o.cc_type}} ****{{var o.cc_last4}}]'))->toBe('[VI ****1111]');
+    });
+
+    it('renders an object with no string form as empty instead of raising a native string-cast error', function () {
+        $o = new DataObject(['child' => new DataObject(['company' => 'ACME'])]);
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        expect($filter->filter('[{{var o.child}}]'))->toBe('[]');
+    });
+
+    it('refuses a secret whose getter spells the field as an acronym', function () {
+        // A gateway module declaring getCVVCode()/getCCNumber() must not read as the fields
+        // "c_v_v_code"/"c_c_number", which no gate names: the acronym has to normalize to
+        // cvv_code/cc_number so the fragment and cc_* prefix rules still see it. The property
+        // form matters as much as the call form — __get() canonicalizes "cvv_code" to the
+        // declared getCVVCode() before gating, so a per-capital split would open both.
+        $o = new class extends DataObject {
+            public function getCVVCode(): string
+            {
+                return '737';
+            }
+
+            public function getCCNumber(): string
+            {
+                return '4111111111111111';
+            }
+
+            public function getAPIKey(): string
+            {
+                return 'sk_live_secret';
+            }
+
+            public function getOPCheckoutUrl(): string
+            {
+                return 'https://example.test/checkout';
+            }
+        };
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        expect($filter->filter('[{{var o.getCVVCode()}}]'))->toBe('[]');
+        expect($filter->filter('[{{var o.cvv_code}}]'))->toBe('[]');
+        expect($filter->filter('[{{var o.getCCNumber()}}]'))->toBe('[]');
+        expect($filter->filter('[{{var o.cc_number}}]'))->toBe('[]');
+        expect($filter->filter('[{{var o.getAPIKey()}}]'))->toBe('[]');
+        expect($filter->filter('[{{if o.getCVVCode() starts with \'7\'}}LEAK{{else}}-{{/if}}]'))->toBe('[-]');
+        // an acronym getter that names nothing sensitive keeps working
+        expect($filter->filter('[{{var o.getOPCheckoutUrl()}}]'))->toBe('[https://example.test/checkout]');
+    });
+
+    it('refuses a nested a/b/c path smuggled past the keyed-accessor gate as a second argument', function () {
+        // DataObject::getData($key, $index) forwards $index to the nested object's own getData(),
+        // which resolves a "/" key through getDataByPath(). The field gate only ever sees the
+        // whole path string, whose anchored rules (the cc_ prefix, the additional_* bags) then
+        // never fire — so the traversal getDataByPath() is denied for has to be closed here too.
+        $payment = new DataObject([
+            'additional_information' => ['cards' => [['cc_number' => '4111111111111111']], 'payer_email' => 'a@b.c'],
+            'method' => 'checkmo',
+        ]);
+        $order = new DataObject(['payment' => $payment, 'increment_id' => '100000042']);
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        expect($filter->filter("[{{var order.getData('payment','additional_information/cards/0/cc_number')}}]"))->toBe('[]');
+        expect($filter->filter("[{{var order.getData('payment','additional_information/payer_email')}}]"))->toBe('[]');
+        expect($filter->filter("[{{var order.getOrigData('payment','additional_information/payer_email')}}]"))->toBe('[]');
+        // only the "/" traversal is closed: a slash-free index is an ordinary keyed read of the
+        // nested object, gated on both names exactly as the equivalent order.payment.method is
+        expect($filter->filter("[{{var order.getData('payment','method')}}]"))->toBe('[checkmo]');
+        // and the path form is no oracle either
+        expect($filter->filter("[{{if order.getData('payment','additional_information/payer_email') ends with 'b.c'}}LEAK{{else}}-{{/if}}]"))->toBe('[-]');
+        // a plain keyed read of a benign field still works
+        expect($filter->filter("[{{var order.getData('increment_id')}}]"))->toBe('[100000042]');
+    });
+
+    it('refuses a nested a/b/c path smuggled through a magic getter argument', function () {
+        // DataObject::__call() rewrites an undeclared getFoo($x) to getData('foo', $x), so a
+        // magic getter reaches the same traversal without naming a keyed accessor at all.
+        $payment = new DataObject(['additional_information' => ['vault' => ['cc_number' => '4111111111111111']]]);
+        $order = new DataObject(['payment' => $payment]);
+        $filter = (new Template())->setVariables(['order' => $order]);
+
+        expect($filter->filter("[{{var order.getPayment('additional_information/vault/cc_number')}}]"))->toBe('[]');
+        expect($filter->filter("[{{depend order.getPayment('additional_information/vault/cc_number')}}LEAK{{/depend}}]"))->toBe('[]');
+    });
+
+    it('keeps a "/" argument working for a declared method, where it is a route or config path', function () {
+        // The "/" refusal is scoped to calls that land in DataObject::getData(): every route and
+        // config path is spelled with slashes, so a real method must keep taking them.
+        $o = new class extends DataObject {
+            public function getUrl(string $route): string
+            {
+                return "https://example.test/{$route}";
+            }
+        };
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        expect($filter->filter("[{{var o.getUrl('customer/account/')}}]"))->toBe('[https://example.test/customer/account/]');
+    });
+
+    it('renders an array-valued path as empty instead of the literal text "Array"', function () {
+        $o = new DataObject(['sizes' => ['S', 'M', 'L']]);
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        expect($filter->filter('[{{var o.sizes}}]'))->toBe('[]');
+    });
+
+    it('degrades a self-referential array instead of exhausting memory', function () {
+        $cyclic = ['label' => 'ok'];
+        $cyclic['self'] = &$cyclic;
+        $o = new DataObject(['bag' => $cyclic]);
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        expect($filter->filter('[{{var o.bag[\'label\']}}]'))->toBe('[ok]');
+    });
+});
+
+/**
+ * The cc_* card prefix already closes cardholder data; the eCheck/ACH bank family
+ * (echeck_routing_number, echeck_account_name, ...) is equally sensitive and lives on the
+ * payment object handed to order emails, so the "echeck" fragment closes it the same way.
+ */
+describe('eCheck bank data gate', function () {
+    it('refuses the echeck bank family by property, getter and getData', function () {
+        $payment = new DataObject([
+            'echeck_routing_number' => 'SECRET_ROUTING',
+            'echeck_account_name' => 'SECRET_ACCT',
+            'echeck_bank_name' => 'SECRET_BANK',
+        ]);
+        $filter = (new Template())->setVariables(['payment' => $payment]);
+
+        expect($filter->filter('[{{var payment.echeck_routing_number}}]'))->toBe('[]');
+        expect($filter->filter('[{{var payment.getEcheckRoutingNumber()}}]'))->toBe('[]');
+        expect($filter->filter("[{{var payment.getData('echeck_bank_name')}}]"))->toBe('[]');
+    });
+
+    it('does not let the echeck family become a bisection oracle', function () {
+        $payment = new DataObject(['echeck_routing_number' => 'SECRET_ROUTING']);
+        $filter = (new Template())->setVariables(['payment' => $payment]);
+
+        expect($filter->filter('[{{if payment.echeck_routing_number starts with "SEC"}}LEAK{{else}}-{{/if}}]'))->toBe('[-]');
+    });
+});
+
+/**
+ * A boolean is/has/can predicate answers a yes/no status, never the underlying value, so a
+ * SENSITIVE_FIELD_FRAGMENTS hit in its name must not refuse it — the property path already
+ * exempts an is_/has_/can_ field, and the method path has to agree.
+ */
+describe('boolean predicate exemption', function () {
+    it('allows an is/has/can predicate whose name contains a sensitive fragment', function () {
+        $model = new class extends DataObject {
+            public function isMagicLinkTokenExpired(): bool
+            {
+                return true;
+            }
+        };
+        $filter = (new Template())->setVariables(['customer' => $model]);
+
+        expect($filter->filter('{{if customer.isMagicLinkTokenExpired()}}HIT{{else}}MISS{{/if}}'))->toBe('HIT');
+    });
+
+    it('still refuses a get-prefixed secret getter and an argument-bearing predicate', function () {
+        $model = new class extends DataObject {
+            public function getPassword(): string
+            {
+                return 'SECRET_PW';
+            }
+
+            public bool $toggled = false;
+
+            public function isDeleted($flag = null): bool
+            {
+                if ($flag !== null) {
+                    $this->toggled = (bool) $flag;
+                }
+                return false;
+            }
+        };
+        $filter = (new Template())->setVariables(['customer' => $model]);
+
+        expect($filter->filter('[{{var customer.getPassword()}}]'))->toBe('[]');
+        // an argument to a predicate is a state toggle and stays refused; the flag never flips
+        expect($filter->filter('[{{if customer.isDeleted(1)}}X{{else}}Y{{/if}}]'))->toBe('[Y]');
+        expect($model->toggled)->toBeFalse();
+    });
 });

--- a/tests/Backend/Unit/Maho/Filter/TemplateVarMethodGateTest.php
+++ b/tests/Backend/Unit/Maho/Filter/TemplateVarMethodGateTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Maho\DataObject;
+use Maho\Filter\Template;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * The legacy {{var}} object-path resolver historically called any existing method
+ * (method_exists() was a free pass), so a template could invoke a state-changing method
+ * on a passed-in model. Resolution is now limited to read-only accessors.
+ */
+describe('{{var}} method gate', function () {
+    function spy(): DataObject
+    {
+        return new class extends DataObject {
+            public bool $deleted = false;
+            public bool $saved = false;
+            public bool $flagged = false;
+
+            public function delete(): string
+            {
+                $this->deleted = true;
+                return 'DELETED';
+            }
+
+            public function save(): string
+            {
+                $this->saved = true;
+                return 'SAVED';
+            }
+
+            public function cancel(): string
+            {
+                return 'CANCELLED';
+            }
+
+            public function isDeleted($flag = null): string
+            {
+                if ($flag !== null) {
+                    $this->flagged = (bool) $flag;
+                }
+                return 'is-deleted';
+            }
+
+            public function getName(): string
+            {
+                return 'Bob';
+            }
+
+            public function format(string $type): string
+            {
+                return "formatted-{$type}";
+            }
+        };
+    }
+
+    it('does not execute a state-changing method', function () {
+        $o = spy();
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        expect($filter->filter('[{{var o.delete()}}]'))->toBe('[]');
+        expect($o->deleted)->toBeFalse();
+
+        expect($filter->filter('[{{var o.save()}}]'))->toBe('[]');
+        expect($o->saved)->toBeFalse();
+
+        expect($filter->filter('[{{var o.cancel()}}]'))->toBe('[]');
+    });
+
+    it('refuses an argument to an is/can predicate so a getter-shaped mutator cannot toggle state', function () {
+        $o = spy();
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        expect($filter->filter('[{{var o.isDeleted(1)}}]'))->toBe('[]');
+        expect($o->flagged)->toBeFalse();
+    });
+
+    it('still resolves read-only accessors, including arg-bearing formatters', function () {
+        $o = spy();
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        expect($filter->filter('[{{var o.getName()}}]'))->toBe('[Bob]');
+        expect($filter->filter('[{{var o.format(\'html\')}}]'))->toBe('[formatted-html]');
+    });
+
+    it('resolves a property path, an arg-bearing getter, and defaults an absent variable', function () {
+        $o = new class extends DataObject {
+            public function getAttributeText(string $code): string
+            {
+                return "label-{$code}";
+            }
+        };
+        $o->setData('increment_id', '100000042');
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        // property path resolves through the getter/getData chain
+        expect($filter->filter('[{{var o.increment_id}}]'))->toBe('[100000042]');
+        // an argument to a read getter is allowed (the {{if}}/{{var}} arg policy)
+        expect($filter->filter('[{{var o.getAttributeText(\'color\')}}]'))->toBe('[label-color]');
+        // an absent variable renders empty rather than failing the parse
+        expect($filter->filter('[{{var missing}}]'))->toBe('[]');
+    });
+
+    it('does not dump the whole object through a bare accessor', function () {
+        $o = new DataObject(['secret_note' => 'x', 'firstname' => 'Bob']);
+        $filter = (new Template())->setVariables(['o' => $o]);
+
+        // getData()/get() with no key would hand back the entire _data array
+        expect($filter->filter('[{{var o.getData()}}]'))->toBe('[]');
+        // a keyed read of a benign field still works
+        expect($filter->filter('[{{var o.getData(\'firstname\')}}]'))->toBe('[Bob]');
+    });
+});


### PR DESCRIPTION
## Summary

Template directives are now evaluated through Symfony ExpressionLanguage (already a direct dependency, previously only exercised inside the API Platform kernel). `{{if}}` and `{{depend}}` gain comparisons, boolean logic and `in` checks, and `{{var}}` resolves through the *same* engine — so the hand-written `Variable` tokenizer is deleted and both directives share one evaluator and one security model.

```
{{if order.grand_total > 100 && customer.group_id == 2}}
  Thanks for the big wholesale order!
{{else}}
  Thanks for your order!
{{/if}}

{{if product.getAttributeText('color') == 'Red'}}...{{/if}}
{{if order.status in ['complete', 'closed']}}...{{/if}}
```

The legacy single-variable syntax (`order.increment_id`, `customer.getName()`) is a strict subset of the expression syntax, so every directive shipped in core templates parses unchanged — verified against all `{{if}}`/`{{depend}}`/`{{var}}` usages in `app/locale` and `app/design`.

## What changed

- **Conditions** (`{{if}}` / `{{depend}}`) are evaluated as expressions instead of a single-variable emptiness check.
- **`{{var}}`** (and the `$value` parameters of `{{include}}`/`{{template}}`) resolve through the same evaluator. The tokenizer-based `_getVariable()` internals are gone; the `Variable` tokenizer itself is no longer used by Maho but is **kept and marked `@deprecated`** (along with its `Varien_Filter_Template_Tokenizer_Variable` alias) in case third-party code instantiates it directly. The `Parameter` tokenizer that parses `key="value"` attribute lists is unrelated and stays.
- **Object access is sandboxed.** Symfony documents ExpressionLanguage as explicitly *not* a sandbox, so template variables are exposed through a wrapper that gates every property read and method call.

## Security model

Editing templates is a privileged admin capability, but conditions evaluate against live models and the comparison operators would otherwise turn any readable value into a character-by-character extraction oracle. The wrapper therefore enforces:

- **Read-only access.** Only `get`/`has`/`is`/`can`/`to`/`count`/`format` accessors are callable; a state-changing method (`save()`, `delete()`, `cancel()`, a setter, or an `is*` predicate handed an argument like `isDeleted($flag)`) is refused. This closes a long-standing hole: `{{var order.delete()}}` **executed on render**, inherited unchanged from the Varien/Magento filter where `method_exists()` was a free pass.
- **No secrets.** Fields named like credentials (`password`, `secret`, `token`, `api_key`, `private_key`, `cc_number`, `cc_cid`, or the `_enc` encrypted-column suffix) are refused as a getter, a property, or a `getData()` key. Boolean flags such as `customer.is_change_password` stay readable.
- **No infrastructure traversal.** Only `DataObject` values are walked into, so `order.getResource().getReadConnection()...` cannot reach database credentials.
- **No whole-object dumps or path walking** — `toArray()`/`toJson()`/`toXml()`, an unkeyed `getData()`, and `getDataByPath()` are refused.
- **No arbitrary constants or DoS operators** — `constant()`/`enum()` are disabled, and the `matches` (regex) and `..` (range) operators are rejected at the AST level.
- **Encrypted `getConfig()` paths are neutralized**, preserving the existing `Mage_Adminhtml_Model_Email_PathValidator` guard.

## Backward compatibility

- **Property resolution matches the legacy resolver**: `order.status_label` prefers a real `getStatusLabel()` over raw `getData()`.
- **Absent variables evaluate silently as empty** — `{{depend comment}}` / `{{var comment}}` with no such variable renders nothing.
- **A broken directive never breaks the template**: a parse/evaluate failure logs a warning and renders the else branch (or empty), instead of aborting.

Deliberate behaviour changes:

- `0` / `'0'` now evaluate as **false** in conditions (standard PHP truthiness). The old `== ''` comparison treated them as true — a quirk rather than a feature.
- `{{var}}` can no longer invoke state-changing methods (see above).
- Method access is narrowed to read-only accessors. Every method call in shipped templates is a `get*`/`format` accessor, so nothing in core regresses; custom templates calling other methods would need adjusting.
- Read getters that take an argument now work in **both** directives — `getAttributeText('color')`, `format('html')`, `getData('sku')`.
- `Maho\Filter\Template\Tokenizer\Variable` (and its `Varien_Filter_Template_Tokenizer_Variable` alias) is **deprecated, not removed** — Maho no longer uses it, but it still works for third-party callers and will be dropped in a future release.

## Testing

- 47 Pest tests across `TemplateConditionTest` and `TemplateVarMethodGateTest`, covering legacy syntax, expressions, nested objects, error degradation, and a regression test for every escape found during review (DB-credential chain, card data, `getPassword()`, `getDataUsingMethod()`, `getDataByPath()`, whole-object dumps, `constant()`/`enum()`, `matches`/`..`, and state-changing calls)
- Email and newsletter suites pass (85 tests), Frontend suite passes (160 tests)
- php-cs-fixer, rector and PHPStan (level 6) clean

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->
