### PR TITLE
Disabled global-scope attribute fields when editing on a store view scope

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2024-2026 Maho <https://mahocommerce.com>
- * SPDX-FileCopyrightText: 2019-2024 The OpenMage Contributors <https://openmage.org>
+ * SPDX-FileCopyrightText: 2019-2026 The OpenMage Contributors <https://openmage.org>
  * SPDX-FileCopyrightText: 2006-2020 Magento, Inc. <https://magento.com>
  * SPDX-License-Identifier: OSL-3.0
  * @package Mage_Adminhtml
@@ -95,6 +95,21 @@ class Mage_Adminhtml_Block_Catalog_Form_Renderer_Fieldset_Element extends Mage_A
     }
 
     /**
+     * Check whether a global-scope attribute is being edited on a specific store view,
+     * where it cannot legitimately be overridden (global attributes have no per-store value)
+     */
+    public function isGlobalAttributeEditedInStoreScope(): bool
+    {
+        $attribute = $this->getAttribute();
+        if ($attribute === null || !$attribute->isScopeGlobal()) {
+            return false;
+        }
+
+        $dataObject = $this->getDataObject();
+        return $dataObject !== null && (bool) $dataObject->getStoreId();
+    }
+
+    /**
      * Disable field in default value using case
      *
      * @return $this
@@ -102,6 +117,9 @@ class Mage_Adminhtml_Block_Catalog_Form_Renderer_Fieldset_Element extends Mage_A
     public function checkFieldDisable()
     {
         if ($this->canDisplayUseDefault() && $this->usedDefault()) {
+            $this->getElement()->setDisabled(true);
+        }
+        if ($this->isGlobalAttributeEditedInStoreScope()) {
             $this->getElement()->setDisabled(true);
         }
         return $this;

--- a/tests/Backend/Unit/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/ElementTest.php
+++ b/tests/Backend/Unit/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/ElementTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Mage_Catalog_Model_Resource_Eav_Attribute as CatalogAttribute;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Build the element graph the block reads through:
+ * block->getElement()->getEntityAttribute() and ->getForm()->getDataObject().
+ */
+function makeFieldsetElementBlock(int $isGlobal, int $storeId): Mage_Adminhtml_Block_Catalog_Form_Renderer_Fieldset_Element
+{
+    $attribute = Mage::getModel('catalog/resource_eav_attribute');
+    $attribute->setData('is_global', $isGlobal);
+
+    $dataObject = Mage::getModel('catalog/product');
+    $dataObject->setStoreId($storeId);
+
+    $form = new Maho\DataObject(['data_object' => $dataObject]);
+    $element = new Maho\DataObject(['entity_attribute' => $attribute, 'form' => $form]);
+
+    /** @var Mage_Adminhtml_Block_Catalog_Form_Renderer_Fieldset_Element $block */
+    $block = Mage::app()->getLayout()->createBlock('adminhtml/catalog_form_renderer_fieldset_element');
+
+    // _element is a protected property with no public setter (it is normally
+    // assigned inside render()); inject the stub graph directly.
+    $property = new ReflectionProperty(Mage_Adminhtml_Block_Widget_Form_Renderer_Fieldset_Element::class, '_element');
+    $property->setValue($block, $element);
+
+    return $block;
+}
+
+describe('Mage_Adminhtml_Block_Catalog_Form_Renderer_Fieldset_Element::isGlobalAttributeEditedInStoreScope', function () {
+    it('is true for a global attribute edited on a store view scope', function () {
+        $block = makeFieldsetElementBlock(CatalogAttribute::SCOPE_GLOBAL, 1);
+
+        expect($block->isGlobalAttributeEditedInStoreScope())->toBeTrue();
+    });
+
+    it('is false for a global attribute edited on the default scope', function () {
+        $block = makeFieldsetElementBlock(CatalogAttribute::SCOPE_GLOBAL, 0);
+
+        expect($block->isGlobalAttributeEditedInStoreScope())->toBeFalse();
+    });
+
+    it('is false for a website scoped attribute on a store view scope', function () {
+        $block = makeFieldsetElementBlock(CatalogAttribute::SCOPE_WEBSITE, 1);
+
+        expect($block->isGlobalAttributeEditedInStoreScope())->toBeFalse();
+    });
+
+    it('is false for a store scoped attribute on a store view scope', function () {
+        $block = makeFieldsetElementBlock(CatalogAttribute::SCOPE_STORE, 1);
+
+        expect($block->isGlobalAttributeEditedInStoreScope())->toBeFalse();
+    });
+});


### PR DESCRIPTION
## What

When editing a product/category in a **store view** scope, fields for **global-scope** EAV attributes were left editable. Because a global attribute stores a single value at the default (store 0) scope and has no per-store representation, saving from a store view could write an orphan store-scoped row for that attribute — data the loader never reads, corrupting attribute data.

This disables the field whenever a global-scope attribute is rendered on a non-default store scope, so global attributes can only be edited at the **Default / All Store Views** scope. It mirrors the existing greyed-out "Use Default" handling that already protects non-global attributes.

## How

`Mage_Adminhtml_Block_Catalog_Form_Renderer_Fieldset_Element::checkFieldDisable()` now also disables the element when a new `isGlobalAttributeOnStoreScope()` check is true (global attribute + non-zero store id).

## Tests

Added `tests/Backend/Unit/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/ElementTest.php` covering the four scope/scope-context combinations (global on store view → disabled; global on default → editable; website/store scoped → unaffected).

## Credit

Ported from OpenMage — thanks to the original work in OpenMage/magento-lts#5699. 🙏