### PR TITLE
Fixed admin form values silently cleared by Form::setValues()

### DIFF
--- a/app/code/core/Maho/ApiPlatform/Block/Adminhtml/Apiplatform/User/Edit/Tab/Main.php
+++ b/app/code/core/Maho/ApiPlatform/Block/Adminhtml/Apiplatform/User/Edit/Tab/Main.php
@@ -181,6 +181,9 @@ class Maho_ApiPlatform_Block_Adminhtml_Apiplatform_User_Edit_Tab_Main extends Ma
         // shows a "stored hashed" note instead of the value.
         $data = $model->getData();
         unset($data['api_key']);
+        // The checkbox is not a column of the user, so setValues() would clear
+        // its declared value and the box would post an empty string when ticked.
+        $data['regenerate_client_credentials'] = 1;
         $form->setValues($data);
         $this->setForm($form);
 

--- a/app/code/core/Maho/ApiPlatform/Block/Adminhtml/Apiplatform/User/Edit/Tab/Main.php
+++ b/app/code/core/Maho/ApiPlatform/Block/Adminhtml/Apiplatform/User/Edit/Tab/Main.php
@@ -181,8 +181,7 @@ class Maho_ApiPlatform_Block_Adminhtml_Apiplatform_User_Edit_Tab_Main extends Ma
         // shows a "stored hashed" note instead of the value.
         $data = $model->getData();
         unset($data['api_key']);
-        // The checkbox is not a column of the user, so setValues() would clear
-        // its declared value and the box would post an empty string when ticked.
+        // Not a column of the user, so seed the value setValues() would clear
         $data['regenerate_client_credentials'] = 1;
         $form->setValues($data);
         $this->setForm($form);

--- a/app/code/core/Maho/Blog/Api/BlogPostProvider.php
+++ b/app/code/core/Maho/Blog/Api/BlogPostProvider.php
@@ -79,7 +79,7 @@ final class BlogPostProvider extends CrudProvider
         $collection->addFieldToFilter('publish_date', [
             'or' => [
                 ['null' => true],
-                ['lteq' => \Mage::app()->getLocale()->formatDateForDb('now')],
+                ['lteq' => $this->publishedCutoff()],
             ],
         ]);
     }
@@ -111,7 +111,7 @@ final class BlogPostProvider extends CrudProvider
      * A future-scheduled post must not be reachable by direct id or urlKey, so
      * the single-item paths apply the same publish_date cutoff as the collection
      * (applyCollectionFilters): a null publish_date is always live, otherwise it
-     * must be at or before "now". Uses the same UTC cutoff the collection does.
+     * must be at or before the cutoff.
      */
     private function isPublished(object $post): bool
     {
@@ -120,6 +120,18 @@ final class BlogPostProvider extends CrudProvider
             return true;
         }
 
-        return $publishDate <= \Mage::app()->getLocale()->formatDateForDb('now');
+        return $publishDate <= $this->publishedCutoff();
+    }
+
+    /**
+     * publish_date is a store-local date (Maho_Blog_Model_Resource_Post::_beforeSave
+     * defaults it to today in the store's timezone), so compare it against today in
+     * that same timezone — as the frontend blocks and the sitemap observer do. A UTC
+     * cutoff would hide a post published today from every store ahead of UTC until
+     * UTC caught up.
+     */
+    private function publishedCutoff(): string
+    {
+        return \Mage::app()->getLocale()->utcToStore()->format(\Mage_Core_Model_Locale::DATE_FORMAT);
     }
 }

--- a/app/code/core/Maho/Blog/Block/Adminhtml/Category/Edit/Tab/General.php
+++ b/app/code/core/Maho/Blog/Block/Adminhtml/Category/Edit/Tab/General.php
@@ -62,11 +62,15 @@ class Maho_Blog_Block_Adminhtml_Category_Edit_Tab_General extends Mage_Adminhtml
             $renderer = $this->getStoreSwitcherRenderer();
             $field->setRenderer($renderer);
         } else {
+            $storeId = Mage::app()->getStore(true)->getId();
             $fieldset->addField('stores', 'hidden', [
                 'name' => 'stores[]',
-                'value' => Mage::app()->getStore(true)->getId(),
+                'value' => $storeId,
             ]);
-            $model->setStoreId(Mage::app()->getStore(true)->getId());
+            // Seed the element's own key: setValues() below clears whatever the
+            // data has nothing to say about, and an array value (what a loaded
+            // category carries) renders as an empty hidden input either way.
+            $model->setData('stores', $storeId);
         }
 
         $fieldset->addField('is_active', 'select', [

--- a/app/code/core/Maho/Blog/Block/Adminhtml/Category/Edit/Tab/General.php
+++ b/app/code/core/Maho/Blog/Block/Adminhtml/Category/Edit/Tab/General.php
@@ -69,8 +69,11 @@ class Maho_Blog_Block_Adminhtml_Category_Edit_Tab_General extends Mage_Adminhtml
             ]);
             // Seed the element's own key: setValues() below clears whatever the
             // data has nothing to say about, and an array value (what a loaded
-            // category carries) renders as an empty hidden input either way.
-            $model->setData('stores', $storeId);
+            // category carries) renders as an empty hidden input either way. Keep
+            // the store the category is already assigned to, so editing doesn't
+            // narrow one saved against store 0 ("All Store Views") to the current.
+            $savedStores = $model->getStores();
+            $model->setData('stores', $savedStores !== [] ? reset($savedStores) : $storeId);
         }
 
         $fieldset->addField('is_active', 'select', [

--- a/app/code/core/Maho/Blog/Block/Adminhtml/Category/Edit/Tab/General.php
+++ b/app/code/core/Maho/Blog/Block/Adminhtml/Category/Edit/Tab/General.php
@@ -62,18 +62,19 @@ class Maho_Blog_Block_Adminhtml_Category_Edit_Tab_General extends Mage_Adminhtml
             $renderer = $this->getStoreSwitcherRenderer();
             $field->setRenderer($renderer);
         } else {
-            $storeId = Mage::app()->getStore(true)->getId();
-            $fieldset->addField('stores', 'hidden', [
-                'name' => 'stores[]',
-                'value' => $storeId,
-            ]);
-            // Seed the element's own key: setValues() below clears whatever the
-            // data has nothing to say about, and an array value (what a loaded
-            // category carries) renders as an empty hidden input either way. Keep
-            // the store the category is already assigned to, so editing doesn't
-            // narrow one saved against store 0 ("All Store Views") to the current.
-            $savedStores = $model->getStores();
-            $model->setData('stores', $savedStores !== [] ? reset($savedStores) : $storeId);
+            // One hidden input per assigned store, each seeding the key setValues() would clear
+            $savedStores = array_values((array) $model->getStores());
+            if ($savedStores === []) {
+                $savedStores = [Mage::app()->getStore(true)->getId()];
+            }
+            foreach ($savedStores as $index => $storeId) {
+                $elementId = 'stores_' . $index;
+                $fieldset->addField($elementId, 'hidden', [
+                    'name' => 'stores[]',
+                    'value' => $storeId,
+                ]);
+                $model->setData($elementId, $storeId);
+            }
         }
 
         $fieldset->addField('is_active', 'select', [

--- a/app/code/core/Maho/Blog/Block/Adminhtml/Post/Edit/Tab/Content.php
+++ b/app/code/core/Maho/Blog/Block/Adminhtml/Post/Edit/Tab/Content.php
@@ -69,18 +69,19 @@ class Maho_Blog_Block_Adminhtml_Post_Edit_Tab_Content extends Mage_Adminhtml_Blo
             $renderer = $this->getStoreSwitcherRenderer();
             $field->setRenderer($renderer);
         } else {
-            $storeId = Mage::app()->getStore(true)->getId();
-            $fieldset->addField('stores', 'hidden', [
-                'name' => 'stores[]',
-                'value' => $storeId,
-            ]);
-            // Seed the element's own key: setValues() below clears whatever the
-            // data has nothing to say about, and an array value (what a loaded
-            // post carries) renders as an empty hidden input either way. Keep the
-            // store the post is already assigned to, so editing doesn't narrow a
-            // post saved against store 0 ("All Store Views") to the current one.
-            $savedStores = $model->getStores();
-            $model->setData('stores', $savedStores !== [] ? reset($savedStores) : $storeId);
+            // One hidden input per assigned store, each seeding the key setValues() would clear
+            $savedStores = array_values((array) $model->getStores());
+            if ($savedStores === []) {
+                $savedStores = [Mage::app()->getStore(true)->getId()];
+            }
+            foreach ($savedStores as $index => $storeId) {
+                $elementId = 'stores_' . $index;
+                $fieldset->addField($elementId, 'hidden', [
+                    'name' => 'stores[]',
+                    'value' => $storeId,
+                ]);
+                $model->setData($elementId, $storeId);
+            }
         }
 
         $fieldset->addField('is_active', 'select', [

--- a/app/code/core/Maho/Blog/Block/Adminhtml/Post/Edit/Tab/Content.php
+++ b/app/code/core/Maho/Blog/Block/Adminhtml/Post/Edit/Tab/Content.php
@@ -69,11 +69,15 @@ class Maho_Blog_Block_Adminhtml_Post_Edit_Tab_Content extends Mage_Adminhtml_Blo
             $renderer = $this->getStoreSwitcherRenderer();
             $field->setRenderer($renderer);
         } else {
+            $storeId = Mage::app()->getStore(true)->getId();
             $fieldset->addField('stores', 'hidden', [
                 'name' => 'stores[]',
-                'value' => Mage::app()->getStore(true)->getId(),
+                'value' => $storeId,
             ]);
-            $model->setStoreId(Mage::app()->getStore(true)->getId());
+            // Seed the element's own key: setValues() below clears whatever the
+            // data has nothing to say about, and an array value (what a loaded
+            // post carries) renders as an empty hidden input either way.
+            $model->setData('stores', $storeId);
         }
 
         $fieldset->addField('is_active', 'select', [

--- a/app/code/core/Maho/Blog/Block/Adminhtml/Post/Edit/Tab/Content.php
+++ b/app/code/core/Maho/Blog/Block/Adminhtml/Post/Edit/Tab/Content.php
@@ -76,8 +76,11 @@ class Maho_Blog_Block_Adminhtml_Post_Edit_Tab_Content extends Mage_Adminhtml_Blo
             ]);
             // Seed the element's own key: setValues() below clears whatever the
             // data has nothing to say about, and an array value (what a loaded
-            // post carries) renders as an empty hidden input either way.
-            $model->setData('stores', $storeId);
+            // post carries) renders as an empty hidden input either way. Keep the
+            // store the post is already assigned to, so editing doesn't narrow a
+            // post saved against store 0 ("All Store Views") to the current one.
+            $savedStores = $model->getStores();
+            $model->setData('stores', $savedStores !== [] ? reset($savedStores) : $storeId);
         }
 
         $fieldset->addField('is_active', 'select', [

--- a/app/code/core/Maho/CustomerSegmentation/Block/Adminhtml/Segment/Edit/Tab/General.php
+++ b/app/code/core/Maho/CustomerSegmentation/Block/Adminhtml/Segment/Edit/Tab/General.php
@@ -67,10 +67,13 @@ class Maho_CustomerSegmentation_Block_Adminhtml_Segment_Edit_Tab_General extends
                 'values'   => Mage::getSingleton('adminhtml/system_config_source_website')->toOptionArray(),
             ]);
         } else {
+            $websiteId = (string) Mage::app()->getStore(true)->getWebsiteId();
             $fieldset->addField('website_ids', 'hidden', [
                 'name'  => 'website_ids',
-                'value' => Mage::app()->getStore(true)->getWebsiteId(),
+                'value' => $websiteId,
             ]);
+            // setValues() below nulls any element missing from the model's data
+            $model?->setWebsiteIds($websiteId);
         }
 
         $customerGroups = Mage::getResourceModel('customer/group_collection')->toOptionArray();

--- a/app/code/core/Maho/CustomerSegmentation/Block/Adminhtml/Segment/Edit/Tab/General.php
+++ b/app/code/core/Maho/CustomerSegmentation/Block/Adminhtml/Segment/Edit/Tab/General.php
@@ -72,12 +72,7 @@ class Maho_CustomerSegmentation_Block_Adminhtml_Segment_Edit_Tab_General extends
                 'name'  => 'website_ids',
                 'value' => $websiteId,
             ]);
-            // setValues() below nulls any element missing from the model's data,
-            // and a loaded segment carries website_ids as an array (which renders
-            // as an empty hidden input), so normalise to the scalar the column
-            // stores. Only fall back to the current website when the segment has
-            // no scope of its own: single-store mode means one store view, not
-            // necessarily one website.
+            // Seed the key setValues() would otherwise clear, keeping the segment's own scope
             $savedWebsiteIds = $model?->getData('website_ids');
             $savedWebsiteIds = is_array($savedWebsiteIds) ? implode(',', $savedWebsiteIds) : (string) $savedWebsiteIds;
             $model?->setWebsiteIds($savedWebsiteIds !== '' ? $savedWebsiteIds : $websiteId);

--- a/app/code/core/Maho/CustomerSegmentation/Block/Adminhtml/Segment/Edit/Tab/General.php
+++ b/app/code/core/Maho/CustomerSegmentation/Block/Adminhtml/Segment/Edit/Tab/General.php
@@ -72,8 +72,15 @@ class Maho_CustomerSegmentation_Block_Adminhtml_Segment_Edit_Tab_General extends
                 'name'  => 'website_ids',
                 'value' => $websiteId,
             ]);
-            // setValues() below nulls any element missing from the model's data
-            $model?->setWebsiteIds($websiteId);
+            // setValues() below nulls any element missing from the model's data,
+            // and a loaded segment carries website_ids as an array (which renders
+            // as an empty hidden input), so normalise to the scalar the column
+            // stores. Only fall back to the current website when the segment has
+            // no scope of its own: single-store mode means one store view, not
+            // necessarily one website.
+            $savedWebsiteIds = $model?->getData('website_ids');
+            $savedWebsiteIds = is_array($savedWebsiteIds) ? implode(',', $savedWebsiteIds) : (string) $savedWebsiteIds;
+            $model?->setWebsiteIds($savedWebsiteIds !== '' ? $savedWebsiteIds : $websiteId);
         }
 
         $customerGroups = Mage::getResourceModel('customer/group_collection')->toOptionArray();

--- a/tests/Backend/Unit/Adminhtml/FormDeclaredValueTest.php
+++ b/tests/Backend/Unit/Adminhtml/FormDeclaredValueTest.php
@@ -10,42 +10,14 @@ declare(strict_types=1);
 uses(Tests\MahoBackendTestCase::class);
 
 /*
- * Source guard for a silent, recurring admin-form bug.
- *
- * Maho\Data\Form::setValues() clears every element the data array doesn't
- * mention, so a field declared as
- *
- *     $fieldset->addField('website_ids', 'hidden', ['value' => $websiteId]);
- *
- * loses that value the moment the block runs its usual
- * `$form->setValues($model->getData())` and the model has no 'website_ids' key -
- * which is exactly the case for a *new* record. The value never reaches the
- * browser, so it never comes back on POST. For a hidden field or a checkbox
- * nothing on screen hints at it: the admin sees a form that refuses to save
- * (customer segments in single-store mode rejected every new segment with
- * "select at least one website", with no field to fix) or a control that
- * silently does nothing (the API user "Regenerate Credentials" checkbox posted
- * an empty string, so `!empty($data[...])` was never true).
- *
- * The fix at each call site is to seed the same key on the model - `$model->
- * setWebsiteIds($websiteId)` next to the addField() - so setValues() restores
- * it instead of wiping it. That is what the core adminhtml blocks do
- * (Mage_Adminhtml_Block_Cms_Page_Edit_Tab_Main, ..._Promo_Quote_Edit_Tab_Main).
- *
- * The scan is deliberately narrow, to stay actionable rather than chatty:
- *   - only 'hidden' and 'checkbox' fields, where a lost value is invisible and
- *     the admin has no way to re-enter it;
- *   - only values that can't come back from the data itself (a literal empty
- *     value is a no-op; a value read off the very object whose getData() feeds
- *     setValues() comes back on its own);
- *   - anything already seeded, re-set after setValues(), or listed below.
+ * Flags hidden/checkbox fields whose declared value a later setValues() would clear.
+ * The fix is to seed the same key on the model, as Mage_Adminhtml_Block_Cms_Page_Edit_Tab_Main does.
  */
 
 /**
  * Blocks that legitimately declare a value the scan can't prove safe.
  *
- * Keyed by "<path relative to app/code>:<element id>". Add an entry only with a
- * reason that says where the value comes back from at runtime.
+ * Keyed by "<path relative to app/code>:<element id>", valued with the reason it's safe.
  *
  * @return array<string, string>
  */

--- a/tests/Backend/Unit/Adminhtml/FormDeclaredValueTest.php
+++ b/tests/Backend/Unit/Adminhtml/FormDeclaredValueTest.php
@@ -1,0 +1,411 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/*
+ * Source guard for a silent, recurring admin-form bug.
+ *
+ * Maho\Data\Form::setValues() clears every element the data array doesn't
+ * mention, so a field declared as
+ *
+ *     $fieldset->addField('website_ids', 'hidden', ['value' => $websiteId]);
+ *
+ * loses that value the moment the block runs its usual
+ * `$form->setValues($model->getData())` and the model has no 'website_ids' key -
+ * which is exactly the case for a *new* record. The value never reaches the
+ * browser, so it never comes back on POST. For a hidden field or a checkbox
+ * nothing on screen hints at it: the admin sees a form that refuses to save
+ * (customer segments in single-store mode rejected every new segment with
+ * "select at least one website", with no field to fix) or a control that
+ * silently does nothing (the API user "Regenerate Credentials" checkbox posted
+ * an empty string, so `!empty($data[...])` was never true).
+ *
+ * The fix at each call site is to seed the same key on the model - `$model->
+ * setWebsiteIds($websiteId)` next to the addField() - so setValues() restores
+ * it instead of wiping it. That is what the core adminhtml blocks do
+ * (Mage_Adminhtml_Block_Cms_Page_Edit_Tab_Main, ..._Promo_Quote_Edit_Tab_Main).
+ *
+ * The scan is deliberately narrow, to stay actionable rather than chatty:
+ *   - only 'hidden' and 'checkbox' fields, where a lost value is invisible and
+ *     the admin has no way to re-enter it;
+ *   - only values that can't come back from the data itself (a literal empty
+ *     value is a no-op; a value read off the very object whose getData() feeds
+ *     setValues() comes back on its own);
+ *   - anything already seeded, re-set after setValues(), or listed below.
+ */
+
+/**
+ * Blocks that legitimately declare a value the scan can't prove safe.
+ *
+ * Keyed by "<path relative to app/code>:<element id>". Add an entry only with a
+ * reason that says where the value comes back from at runtime.
+ *
+ * @return array<string, string>
+ */
+function declaredValueAllowlist(): array
+{
+    return [
+        'core/Mage/Adminhtml/Block/System/Email/Template/Edit/Form.php:variables' =>
+            'setValues() only runs for session form data, which is the POST - and the POST carries this hidden field back.',
+        'core/Mage/Payment/Block/Adminhtml/Payment/Restriction/Edit/Form.php:type' =>
+            'setValues() is skipped entirely while the registry model is empty (new restriction); once populated, type is a column of it.',
+        'core/Maho/CustomerSegmentation/Block/Adminhtml/Segment/Sequence/Edit/Form.php:segment_id' =>
+            'editSequenceAction() seeds segment_id on the sequence model before rendering, so getData() carries it.',
+    ];
+}
+
+/**
+ * Every "<file>:<id>" the scan flags, with the details needed for the message.
+ *
+ * @return array<int, array{file: string, id: string, type: string, line: int, expr: string}>
+ */
+function declaredValueFindings(): array
+{
+    $findings = [];
+    foreach (declaredValueBlockFiles() as $file) {
+        foreach (declaredValueScanFile($file) as $finding) {
+            $findings[] = $finding;
+        }
+    }
+    return $findings;
+}
+
+/**
+ * @return array<int, string>
+ */
+function declaredValueBlockFiles(): array
+{
+    $files = [];
+    $dir = new RecursiveDirectoryIterator(Mage::getBaseDir() . '/app/code');
+    foreach (new RecursiveIteratorIterator($dir) as $file) {
+        /** @var SplFileInfo $file */
+        if (!$file->isFile() || $file->getExtension() !== 'php') {
+            continue;
+        }
+        if (!str_contains($file->getPathname(), '/Block/')) {
+            continue;
+        }
+        $files[] = $file->getPathname();
+    }
+    sort($files);
+    return $files;
+}
+
+/**
+ * @return array<int, array{file: string, id: string, type: string, line: int, expr: string}>
+ */
+function declaredValueScanFile(string $file): array
+{
+    $source = (string) file_get_contents($file);
+    if (!str_contains($source, 'addField') || !str_contains($source, 'setValues(')) {
+        return [];
+    }
+
+    $relative = str_replace(Mage::getBaseDir() . '/app/code/', '', $file);
+    $tokens = token_get_all($source);
+    $declarations = [];
+    $setValuesLines = [];
+
+    foreach ($tokens as $index => $token) {
+        if (!is_array($token) || $token[0] !== T_STRING) {
+            continue;
+        }
+        if ($token[1] === 'setValues') {
+            $setValuesLines[] = $token[2];
+            continue;
+        }
+        if ($token[1] !== 'addField') {
+            continue;
+        }
+        $call = declaredValueParseAddField($tokens, $index);
+        if ($call === null) {
+            continue;
+        }
+        $declarations[] = $call + ['file' => $relative];
+    }
+
+    if ($declarations === [] || $setValuesLines === []) {
+        return [];
+    }
+
+    $sources = declaredValueSetValuesSources($source);
+    $findings = [];
+    foreach ($declarations as $declaration) {
+        // A value declared after the last setValues() call is never touched by it.
+        if (!array_filter($setValuesLines, fn(int $line): bool => $line > $declaration['line'])) {
+            continue;
+        }
+        // Only fields whose value the admin can neither see nor retype.
+        if (!in_array($declaration['type'], ['hidden', 'checkbox'], true)) {
+            continue;
+        }
+        // Clearing an already-empty value is a no-op.
+        if (in_array($declaration['expr'], ['', "''", '""', 'null'], true)) {
+            continue;
+        }
+        // A value read off the object whose data feeds setValues() comes back on its own.
+        foreach ($sources as $variable) {
+            if (str_contains($declaration['expr'], '$' . $variable . '->')) {
+                continue 2;
+            }
+        }
+        if (declaredValueIsSeeded($source, $declaration['id'])) {
+            continue;
+        }
+        $findings[] = $declaration;
+    }
+
+    return $findings;
+}
+
+/**
+ * Parse `addField('<id>', '<type>', [...])` starting at the addField token.
+ *
+ * @param array<int, array{0: int, 1: string, 2: int}|string> $tokens
+ * @return array{id: string, type: string, line: int, expr: string}|null
+ */
+function declaredValueParseAddField(array $tokens, int $index): ?array
+{
+    $count = count($tokens);
+    $line = is_array($tokens[$index]) ? $tokens[$index][2] : 0;
+
+    $cursor = $index + 1;
+    while ($cursor < $count && is_array($tokens[$cursor]) && in_array($tokens[$cursor][0], [T_WHITESPACE, T_COMMENT], true)) {
+        $cursor++;
+    }
+    if (($tokens[$cursor] ?? null) !== '(') {
+        return null;
+    }
+
+    // Split the call into top-level arguments.
+    $arguments = [];
+    $current = [];
+    $depth = 0;
+    for (; $cursor < $count; $cursor++) {
+        $token = $tokens[$cursor];
+        $text = is_array($token) ? $token[1] : $token;
+        if (in_array($text, ['(', '[', '{'], true)) {
+            $depth++;
+            if ($depth === 1) {
+                continue;
+            }
+        } elseif (in_array($text, [')', ']', '}'], true)) {
+            $depth--;
+            if ($depth === 0) {
+                $arguments[] = $current;
+                break;
+            }
+        }
+        if ($depth === 1 && $text === ',') {
+            $arguments[] = $current;
+            $current = [];
+            continue;
+        }
+        $current[] = $token;
+    }
+    if (count($arguments) < 3) {
+        return null;
+    }
+
+    $id = declaredValueStringLiteral($arguments[0]);
+    $type = declaredValueStringLiteral($arguments[1]);
+    if ($id === null || $type === null) {
+        return null;
+    }
+
+    $expr = declaredValueConfigValue($arguments[2]);
+    if ($expr === null) {
+        return null;
+    }
+
+    return ['id' => $id, 'type' => $type, 'line' => $line, 'expr' => $expr];
+}
+
+/**
+ * @param array<int, array{0: int, 1: string, 2: int}|string> $argument
+ */
+function declaredValueStringLiteral(array $argument): ?string
+{
+    foreach ($argument as $token) {
+        if (is_array($token) && $token[0] === T_WHITESPACE) {
+            continue;
+        }
+        if (is_array($token) && $token[0] === T_CONSTANT_ENCAPSED_STRING) {
+            return trim($token[1], "'\"");
+        }
+        return null;
+    }
+    return null;
+}
+
+/**
+ * Source text of the top-level 'value' entry of a field config array, if any.
+ *
+ * @param array<int, array{0: int, 1: string, 2: int}|string> $argument
+ */
+function declaredValueConfigValue(array $argument): ?string
+{
+    $depth = 0;
+    $collecting = false;
+    $expr = '';
+
+    for ($i = 0, $count = count($argument); $i < $count; $i++) {
+        $token = $argument[$i];
+        $text = is_array($token) ? $token[1] : $token;
+
+        if (in_array($text, ['[', '(', '{'], true)) {
+            $depth++;
+            if ($collecting) {
+                $expr .= $text;
+            }
+            continue;
+        }
+        if (in_array($text, [']', ')', '}'], true)) {
+            $depth--;
+            if ($collecting && $depth >= 1) {
+                $expr .= $text;
+                continue;
+            }
+            if ($collecting) {
+                return trim($expr);
+            }
+            continue;
+        }
+        if ($collecting) {
+            if ($depth === 1 && $text === ',') {
+                return trim($expr);
+            }
+            $expr .= $text;
+            continue;
+        }
+        if ($depth === 1 && is_array($token) && $token[0] === T_CONSTANT_ENCAPSED_STRING && trim($token[1], "'\"") === 'value') {
+            for ($j = $i + 1; $j < $count; $j++) {
+                $next = $argument[$j];
+                if (is_array($next) && $next[0] === T_WHITESPACE) {
+                    continue;
+                }
+                if (is_array($next) && $next[0] === T_DOUBLE_ARROW) {
+                    $collecting = true;
+                    $i = $j;
+                }
+                break;
+            }
+        }
+    }
+
+    return $collecting ? trim($expr) : null;
+}
+
+/**
+ * Variables whose data ends up in setValues(): `setValues($model->getData())`,
+ * plus one hop through `$data = $model->getData(); ... setValues($data)`.
+ *
+ * @return array<int, string>
+ */
+function declaredValueSetValuesSources(string $source): array
+{
+    preg_match_all('/->setValues\(\s*\$(\w+)/', $source, $direct);
+    $variables = $direct[1];
+
+    foreach ($direct[1] as $variable) {
+        preg_match_all('/\$' . preg_quote($variable, '/') . '\s*=\s*\$(\w+)->getData\(/', $source, $indirect);
+        foreach ($indirect[1] as $origin) {
+            $variables[] = $origin;
+        }
+    }
+
+    return array_values(array_unique($variables));
+}
+
+/**
+ * Whether the block puts the same key back where setValues() will find it, or
+ * re-applies it to the element afterwards.
+ */
+function declaredValueIsSeeded(string $source, string $id): bool
+{
+    $studly = str_replace(' ', '', ucwords(str_replace('_', ' ', $id)));
+    $quoted = preg_quote($id, '/');
+
+    $patterns = [
+        '/->set' . preg_quote($studly, '/') . '\s*\(/',        // $model->setWebsiteIds(...)
+        "/->setData\(\s*'{$quoted}'/",                          // $model->setData('website_ids', ...)
+        "/getElement\(\s*'{$quoted}'\s*\)/",                    // $form->getElement('website_ids')->setValue(...)
+        "/\['{$quoted}'\]\s*=/",                                // $data['website_ids'] = ...
+        "/'{$quoted}'\s*=>/",                                   // 'website_ids' => ... in a data array
+    ];
+
+    foreach ($patterns as $pattern) {
+        if (preg_match($pattern, $source)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+it('never lets Form::setValues() wipe a hidden or checkbox value the block declared', function () {
+    $allowlist = declaredValueAllowlist();
+    $offenders = [];
+
+    foreach (declaredValueFindings() as $finding) {
+        $key = $finding['file'] . ':' . $finding['id'];
+        if (isset($allowlist[$key])) {
+            continue;
+        }
+        $offenders[] = sprintf(
+            "%s:%d\n    field '%s' (%s) declares value: %s\n    -> seed the same key on the model next to addField(), e.g. \$model->set%s(...), "
+            . "or re-apply it after setValues() via \$form->getElement('%s')->setValue(...).",
+            $finding['file'],
+            $finding['line'],
+            $finding['id'],
+            $finding['type'],
+            $finding['expr'],
+            str_replace(' ', '', ucwords(str_replace('_', ' ', $finding['id']))),
+            $finding['id'],
+        );
+    }
+
+    expect($offenders)->toBe([], "Form::setValues() will clear these declared values before the form renders:\n\n"
+        . implode("\n\n", $offenders)
+        . "\n\nIf the value does come back at runtime, add the case to declaredValueAllowlist() with the reason.\n");
+});
+
+it('recognises a declared value that setValues() would wipe', function () {
+    // The analyzer itself, exercised on the shape it exists to catch.
+    $file = sys_get_temp_dir() . '/maho_declared_value_' . getmypid() . '.php';
+    file_put_contents($file, <<<'PHP'
+        <?php
+        class Some_Block
+        {
+            protected function _prepareForm()
+            {
+                $fieldset->addField('website_ids', 'hidden', [
+                    'name'  => 'website_ids',
+                    'value' => Mage::app()->getStore(true)->getWebsiteId(),
+                ]);
+                $fieldset->addField('is_active', 'select', [
+                    'name'   => 'is_active',
+                    'values' => [['value' => 1, 'label' => 'Active']],
+                ]);
+                $form->setValues($model->getData());
+            }
+        }
+        PHP);
+
+    try {
+        $findings = declaredValueScanFile($file);
+    } finally {
+        unlink($file);
+    }
+
+    expect($findings)->toHaveCount(1);
+    expect($findings[0]['id'])->toBe('website_ids');
+    expect($findings[0]['type'])->toBe('hidden');
+});

--- a/tests/Backend/Unit/Adminhtml/SingleStoreScopeSeedTest.php
+++ b/tests/Backend/Unit/Adminhtml/SingleStoreScopeSeedTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/*
+ * In single-store mode the admin forms below replace their scope selector with a
+ * hidden field carrying the current scope. Two things have to hold for that to be
+ * safe, and both were broken:
+ *
+ *  1. the value has to survive `$form->setValues($model->getData())`, which nulls
+ *     every element the data doesn't mention - so a *new* record posted an empty
+ *     scope (segments rejected with "select at least one website", blog records
+ *     landed on store 0);
+ *  2. it must not overwrite the scope an *existing* record was saved with. Single
+ *     store mode means one store *view*, not one website, and a blog record may
+ *     legitimately sit on store 0 ("All Store Views").
+ */
+
+/**
+ * Force isSingleStoreMode() on, whatever the test install's store count is.
+ * `_isSingleStore` is protected with no public setter for `true`.
+ */
+function withSingleStoreMode(callable $fn): mixed
+{
+    $property = new ReflectionProperty(Mage_Core_Model_App::class, '_isSingleStore');
+    $original = $property->getValue(Mage::app());
+    $property->setValue(Mage::app(), true);
+
+    try {
+        return $fn();
+    } finally {
+        $property->setValue(Mage::app(), $original);
+    }
+}
+
+/**
+ * Build the tab's form from the registered model, and hand it back.
+ *
+ * Instantiated directly rather than through the layout: createBlock() runs
+ * _prepareLayout(), and the post tab's reaches for the 'head' block that only
+ * the real edit page provides. _prepareForm() is the subject here.
+ *
+ * @param class-string<Mage_Adminhtml_Block_Widget_Form> $blockClass
+ */
+function prepareScopeForm(string $blockClass, string $registryKey, Maho\DataObject $model): Maho\Data\Form
+{
+    Mage::unregister($registryKey);
+    Mage::register($registryKey, $model);
+
+    try {
+        $block = new $blockClass();
+        (new ReflectionMethod($block, '_prepareForm'))->invoke($block);
+        return $block->getForm();
+    } finally {
+        Mage::unregister($registryKey);
+    }
+}
+
+function currentWebsiteId(): string
+{
+    return (string) Mage::app()->getStore(true)->getWebsiteId();
+}
+
+function currentStoreId(): string
+{
+    return (string) Mage::app()->getStore(true)->getId();
+}
+
+describe('customer segment website scope in single-store mode', function () {
+    it('gives a new segment the current website', function () {
+        $segment = Mage::getModel('customersegmentation/segment');
+
+        // Resolve the expectation inside the same context: getStore(true) answers
+        // with the current store only while single-store mode is on.
+        [$form, $websiteId] = withSingleStoreMode(fn() => [
+            prepareScopeForm(
+                Maho_CustomerSegmentation_Block_Adminhtml_Segment_Edit_Tab_General::class,
+                'current_customer_segment',
+                $segment,
+            ),
+            currentWebsiteId(),
+        ]);
+
+        // Empty here is the original bug: the field posts nothing and the save
+        // fails with "Please select at least one website", with no field to fix.
+        expect((string) $form->getElement('website_ids')->getValue())->toBe($websiteId);
+    });
+
+    it('keeps an existing segment on the website it was saved with', function () {
+        $segment = Mage::getModel('customersegmentation/segment');
+        // _afterLoad() hands the form an array; 7 is deliberately not the current
+        // website - a website with no store view still counts as single-store.
+        $segment->setId(123)->setData('website_ids', ['7']);
+
+        $form = withSingleStoreMode(fn() => prepareScopeForm(
+            Maho_CustomerSegmentation_Block_Adminhtml_Segment_Edit_Tab_General::class,
+            'current_customer_segment',
+            $segment,
+        ));
+
+        expect($form->getElement('website_ids')->getValue())->toBe('7');
+    });
+});
+
+describe('blog store scope in single-store mode', function () {
+    it('gives a new post the current store view', function () {
+        $post = Mage::getModel('blog/post');
+
+        [$form, $storeId] = withSingleStoreMode(fn() => [
+            prepareScopeForm(
+                Maho_Blog_Block_Adminhtml_Post_Edit_Tab_Content::class,
+                'blog_post',
+                $post,
+            ),
+            currentStoreId(),
+        ]);
+
+        expect((string) $form->getElement('stores')->getValue())->toBe($storeId);
+    });
+
+    it('keeps an existing post on store 0 ("All Store Views")', function () {
+        $post = Mage::getModel('blog/post');
+        $post->setId(456)->setData('stores', [0]);
+
+        $form = withSingleStoreMode(fn() => prepareScopeForm(
+            Maho_Blog_Block_Adminhtml_Post_Edit_Tab_Content::class,
+            'blog_post',
+            $post,
+        ));
+
+        expect((string) $form->getElement('stores')->getValue())->toBe('0');
+    });
+
+    it('keeps an existing category on store 0 ("All Store Views")', function () {
+        $category = Mage::getModel('blog/category');
+        $category->setId(789)->setData('stores', [0]);
+
+        $form = withSingleStoreMode(fn() => prepareScopeForm(
+            Maho_Blog_Block_Adminhtml_Category_Edit_Tab_General::class,
+            'blog_category',
+            $category,
+        ));
+
+        expect((string) $form->getElement('stores')->getValue())->toBe('0');
+    });
+});

--- a/tests/Backend/Unit/Adminhtml/SingleStoreScopeSeedTest.php
+++ b/tests/Backend/Unit/Adminhtml/SingleStoreScopeSeedTest.php
@@ -10,22 +10,12 @@ declare(strict_types=1);
 uses(Tests\MahoBackendTestCase::class);
 
 /*
- * In single-store mode the admin forms below replace their scope selector with a
- * hidden field carrying the current scope. Two things have to hold for that to be
- * safe, and both were broken:
- *
- *  1. the value has to survive `$form->setValues($model->getData())`, which nulls
- *     every element the data doesn't mention - so a *new* record posted an empty
- *     scope (segments rejected with "select at least one website", blog records
- *     landed on store 0);
- *  2. it must not overwrite the scope an *existing* record was saved with. Single
- *     store mode means one store *view*, not one website, and a blog record may
- *     legitimately sit on store 0 ("All Store Views").
+ * In single-store mode these forms swap their scope selector for a hidden field.
+ * That value must survive setValues(), and must not overwrite an existing record's own scope.
  */
 
 /**
- * Force isSingleStoreMode() on, whatever the test install's store count is.
- * `_isSingleStore` is protected with no public setter for `true`.
+ * Force isSingleStoreMode() on: `_isSingleStore` is protected with no public setter for `true`.
  */
 function withSingleStoreMode(callable $fn): mixed
 {
@@ -77,8 +67,7 @@ describe('customer segment website scope in single-store mode', function () {
     it('gives a new segment the current website', function () {
         $segment = Mage::getModel('customersegmentation/segment');
 
-        // Resolve the expectation inside the same context: getStore(true) answers
-        // with the current store only while single-store mode is on.
+        // getStore(true) only answers with the current store while single-store mode is on
         [$form, $websiteId] = withSingleStoreMode(fn() => [
             prepareScopeForm(
                 Maho_CustomerSegmentation_Block_Adminhtml_Segment_Edit_Tab_General::class,
@@ -88,15 +77,13 @@ describe('customer segment website scope in single-store mode', function () {
             currentWebsiteId(),
         ]);
 
-        // Empty here is the original bug: the field posts nothing and the save
-        // fails with "Please select at least one website", with no field to fix.
+        // Empty here is the original bug: nothing posts and the save fails
         expect((string) $form->getElement('website_ids')->getValue())->toBe($websiteId);
     });
 
     it('keeps an existing segment on the website it was saved with', function () {
         $segment = Mage::getModel('customersegmentation/segment');
-        // _afterLoad() hands the form an array; 7 is deliberately not the current
-        // website - a website with no store view still counts as single-store.
+        // _afterLoad() hands the form an array; 7 is deliberately not the current website
         $segment->setId(123)->setData('website_ids', ['7']);
 
         $form = withSingleStoreMode(fn() => prepareScopeForm(
@@ -122,7 +109,7 @@ describe('blog store scope in single-store mode', function () {
             currentStoreId(),
         ]);
 
-        expect((string) $form->getElement('stores')->getValue())->toBe($storeId);
+        expect((string) $form->getElement('stores_0')->getValue())->toBe($storeId);
     });
 
     it('keeps an existing post on store 0 ("All Store Views")', function () {
@@ -135,7 +122,32 @@ describe('blog store scope in single-store mode', function () {
             $post,
         ));
 
-        expect((string) $form->getElement('stores')->getValue())->toBe('0');
+        expect((string) $form->getElement('stores_0')->getValue())->toBe('0');
+    });
+
+    it('keeps every store an existing post is assigned to', function () {
+        // Dropping any assigned store makes _saveStoreRelations() DELETE its row
+        $post = Mage::getModel('blog/post');
+        $post->setId(456)->setData('stores', [0, 1]);
+
+        $form = withSingleStoreMode(fn() => prepareScopeForm(
+            Maho_Blog_Block_Adminhtml_Post_Edit_Tab_Content::class,
+            'blog_post',
+            $post,
+        ));
+
+        $posted = [];
+        foreach ($form->getElements() as $fieldset) {
+            foreach ($fieldset->getElements() as $element) {
+                if ($element->getName() === 'stores[]') {
+                    $posted[] = (string) $element->getValue();
+                }
+            }
+        }
+
+        expect($posted)->toBe(['0', '1']);
+        // Seeding must not overwrite 'stores': getStores() returns [] for a non-array value
+        expect($post->getStores())->toBe([0, 1]);
     });
 
     it('keeps an existing category on store 0 ("All Store Views")', function () {
@@ -148,6 +160,6 @@ describe('blog store scope in single-store mode', function () {
             $category,
         ));
 
-        expect((string) $form->getElement('stores')->getValue())->toBe('0');
+        expect((string) $form->getElement('stores_0')->getValue())->toBe('0');
     });
 });

--- a/tests/Backend/Unit/Blog/Api/BlogPostProviderTest.php
+++ b/tests/Backend/Unit/Blog/Api/BlogPostProviderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Maho\Blog\Api\BlogPostProvider;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/*
+ * publish_date is a store-local date, so the API's "is it live yet" cutoff has to be
+ * store-local too. A UTC cutoff hid a post published today from every store ahead of
+ * UTC until UTC caught up - for a store on Europe/London that is every post created
+ * between 23:00 and 00:00 UTC in summer.
+ */
+
+/**
+ * Run $fn with the current store's timezone overridden.
+ */
+function withBlogStoreTimezone(string $timezone, callable $fn): mixed
+{
+    $store = Mage::app()->getStore();
+    $original = $store->getConfig(Mage_Core_Model_Locale::XML_PATH_DEFAULT_TIMEZONE);
+    $store->setConfig(Mage_Core_Model_Locale::XML_PATH_DEFAULT_TIMEZONE, $timezone);
+
+    try {
+        return $fn();
+    } finally {
+        $store->setConfig(Mage_Core_Model_Locale::XML_PATH_DEFAULT_TIMEZONE, $original);
+    }
+}
+
+function blogStoreToday(): string
+{
+    return Mage::app()->getLocale()->utcToStore()->format(Mage_Core_Model_Locale::DATE_FORMAT);
+}
+
+/**
+ * @param 'publishedCutoff'|'isPublished' $method
+ */
+function callBlogPostProvider(string $method, mixed ...$args): mixed
+{
+    return (new ReflectionMethod(BlogPostProvider::class, $method))
+        ->invoke(new BlogPostProvider(), ...$args);
+}
+
+describe('blog post publish cutoff', function () {
+    // UTC+14: its date runs ahead of UTC's for most of the day, which is what broke
+    it('cuts off on today in the store timezone, not on UTC now', function () {
+        [$cutoff, $today] = withBlogStoreTimezone('Pacific/Kiritimati', fn() => [
+            callBlogPostProvider('publishedCutoff'),
+            blogStoreToday(),
+        ]);
+
+        expect($cutoff)->toBe($today);
+    });
+
+    it('treats a post published today in the store timezone as live', function () {
+        $published = withBlogStoreTimezone('Pacific/Kiritimati', function () {
+            $post = Mage::getModel('blog/post')->setData('publish_date', blogStoreToday());
+            return callBlogPostProvider('isPublished', $post);
+        });
+
+        expect($published)->toBeTrue();
+    });
+
+    it('keeps a future-dated post out of reach', function () {
+        $published = withBlogStoreTimezone('Pacific/Kiritimati', function () {
+            $tomorrow = Mage::app()->getLocale()->utcToStore()
+                ->modify('+1 day')
+                ->format(Mage_Core_Model_Locale::DATE_FORMAT);
+            $post = Mage::getModel('blog/post')->setData('publish_date', $tomorrow);
+            return callBlogPostProvider('isPublished', $post);
+        });
+
+        expect($published)->toBeFalse();
+    });
+
+    it('treats a post with no publish date as live', function () {
+        expect(callBlogPostProvider('isPublished', Mage::getModel('blog/post')))->toBeTrue();
+    });
+});


### PR DESCRIPTION
`Maho\Data\Form::setValues()` clears every element the data array doesn't mention, so a field declared as

```php
$fieldset->addField('website_ids', 'hidden', ['value' => $websiteId]);
```

loses that value as soon as the block runs its usual `$form->setValues($model->getData())` and the model has no such key — the case for every *new* record. The value never reaches the browser, so it never comes back on POST, and for a hidden field or a checkbox nothing on screen hints at it. Three admin forms shipped this, each silent in its own way.

### Customer segments

In single-store mode the "Assign to Website" multiselect is replaced by a hidden `website_ids` field pre-filled with the current website — which `setValues()` then wiped. Saving a new segment failed with *"Please select at least one website."* and no visible field to fix it. Editing an existing segment failed the same way: `_afterLoad()` restores `website_ids` as an *array*, an array value renders as an empty hidden input, and `loadPost()` writes the empty POST value straight back over the loaded one.

The value stays a scalar string: `_beforeSave()` only implodes arrays, and the column holds a comma-separated list read back with `FIND_IN_SET`.

### API Platform user

The "Regenerate Credentials" checkbox is not a column of the user, so it rendered `value=""`. Ticking it posted an empty string, `!empty($data['regenerate_client_credentials'])` never fired, and regenerating client credentials silently did nothing.

### Blog post / category

The single-store branch seeded `setStoreId()`, a key no element uses, so the hidden `stores` field posted empty and the record was saved against store 0 instead of the store view. A loaded record renders empty too, since an array value yields an empty hidden input.

### Keeping a record's saved scope

Seeding the current scope *unconditionally* would trade one silent overwrite for another. Single-store mode means one store **view**, not one website — `isSingleStoreMode()` counts `core_store` rows, and a website with no store view adds none — so a segment scoped to such a website would be reassigned to the current one. A blog post or category saved against store 0, "All Store Views", which `Maho_Blog_Model_Resource_Post::getLoadByUrlKeySelect()` reads as every store, would be narrowed to the current store view on edit.

So the seed only fills a gap: an existing record keeps the scope it was saved with, and a loaded array value is normalised to the scalar the hidden input renders.

`tests/Backend/Unit/Adminhtml/SingleStoreScopeSeedTest.php` covers both halves per entity — a new record gets the current scope, an existing one keeps its own. Written red-first: with the seed reverted the three preservation cases fail (`7 → 1`, `0 → 3`, `0 → 3`) while the new-record cases pass.

### The guard

Each fix is one call site, so `tests/Backend/Unit/Adminhtml/FormDeclaredValueTest.php` catches the next one at test time. It tokenizes the admin blocks, flags `addField()` calls that declare a value in a form that later calls `setValues()`, and spells out the fix in the failure message (seed the same key on the model, as `Mage_Adminhtml_Block_Cms_Page_Edit_Tab_Main` does).

It is deliberately narrow, so it stays actionable rather than chatty:

- only `hidden` and `checkbox` fields, where a lost value is invisible and the admin cannot re-enter it;
- only values that can't come back on their own — an already-empty value is a no-op, and a value read off the object whose `getData()` feeds `setValues()` returns with it;
- anything the block seeds back, re-applies after `setValues()`, or that is allowlisted.

That takes 18 raw pattern matches down to the 4 real ones. Three allowlist entries remain, each carrying the reason it is safe at runtime. A second test exercises the analyzer itself on the shape it exists to catch.

`composer lint` clean; Backend suite passes.
