### PR TITLE
Added drag-and-drop reordering and alphabetical sorting for attribute options in the admin

### DIFF
--- a/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Options/Abstract.php
+++ b/app/code/core/Mage/Eav/Block/Adminhtml/Attribute/Edit/Options/Abstract.php
@@ -104,7 +104,7 @@ abstract class Mage_Eav_Block_Adminhtml_Attribute_Edit_Options_Abstract extends 
             $values = [];
             $optionCollection = Mage::getResourceModel('eav/entity_attribute_option_collection')
                 ->setAttributeFilter($this->getAttributeObject()->getId())
-                ->setPositionOrder('desc', true)
+                ->setPositionOrder('asc', true)
                 ->load();
 
             $helper = Mage::helper('core');

--- a/app/design/adminhtml/default/default/layout/catalog.xml
+++ b/app/design/adminhtml/default/default/layout/catalog.xml
@@ -287,6 +287,9 @@ Layout handle for configurable products
     </adminhtml_catalog_product_action_attribute_edit>
 
     <adminhtml_catalog_product_attribute_edit>
+        <reference name="head">
+            <action method="addJs"><name>sortable.min.js</name></action>
+        </reference>
         <reference name="left">
             <block type="adminhtml/catalog_product_attribute_edit_tabs" name="attribute_edit_tabs"></block>
         </reference>

--- a/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
+++ b/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
@@ -64,7 +64,18 @@
                         <th><?= $this->escapeHtml($this->__('Swatch')) ?></th>
                     <?php endif ?>
                     <?php foreach ($this->getStores() as $_store): ?>
+                    <?php if ($this->getReadOnly()): ?>
                         <th><?= $this->escapeHtml($_store->getName()) ?></th>
+                    <?php else: ?>
+                        <th class="option-sort-column">
+                            <button type="button" class="option-sort-button" title="<?= $this->escapeHtml($this->__('Sort options alphabetically by this column')) ?>">
+                                <?= $this->escapeHtml($_store->getName()) ?>
+                                <span class="option-sort-icon option-sort-icon-none"><?= $this->getIconSvg('arrows-sort') ?></span>
+                                <span class="option-sort-icon option-sort-icon-asc"><?= $this->getIconSvg('sort-a-z') ?></span>
+                                <span class="option-sort-icon option-sort-icon-desc"><?= $this->getIconSvg('sort-z-a') ?></span>
+                            </button>
+                        </th>
+                    <?php endif ?>
                     <?php endforeach ?>
                         <th class="nobr a-center"><?= $this->escapeHtml($this->__('Is Default')) ?></th>
                         <th>
@@ -202,6 +213,40 @@ var attributeOption = {
             }
         });
     },
+    sortByColumn: function(cellIndex, direction) {
+        let collator = new Intl.Collator('<?= $this->jsQuoteEscape(str_replace('_', '-', Mage::app()->getLocale()->getLocaleCode())) ?>', {numeric: true, sensitivity: 'base'});
+        let sign = direction === 'desc' ? -1 : 1;
+        let value = function(row) {
+            let input = row.cells[cellIndex] ? row.cells[cellIndex].querySelector('input') : null;
+            return input ? input.value : '';
+        };
+        let rows = Array.from(this.container.querySelectorAll('tr.option-row'));
+        rows.sort(function(a, b) {
+            return sign * collator.compare(value(a), value(b));
+        });
+        rows.forEach(function(row) {
+            this.container.appendChild(row);
+        }, this);
+        this.updatePositions();
+    },
+    clearSortIndicators: function() {
+        document.querySelectorAll('#attribute-options-table th.option-sort-column').forEach(function(heading) {
+            delete heading.dataset.sortDirection;
+        });
+    },
+    initColumnSort: function() {
+        let headings = document.querySelectorAll('#attribute-options-table th.option-sort-column');
+        headings.forEach(function(heading) {
+            heading.querySelector('.option-sort-button').addEventListener('click', function() {
+                let direction = heading.dataset.sortDirection === 'asc' ? 'desc' : 'asc';
+                headings.forEach(function(other) {
+                    delete other.dataset.sortDirection;
+                });
+                heading.dataset.sortDirection = direction;
+                attributeOption.sortByColumn(heading.cellIndex, direction);
+            });
+        });
+    },
     initSortable: function() {
         if (this.isReadOnly || typeof Sortable === 'undefined') {
             return;
@@ -211,7 +256,11 @@ var attributeOption = {
             draggable: 'tr.option-row',
             filter: '.no-display',
             animation: 150,
-            onUpdate: this.updatePositions.bind(this),
+            onUpdate: function() {
+                // the manual order no longer matches whatever column was last sorted on
+                this.clearSortIndicators();
+                this.updatePositions();
+            }.bind(this),
         });
     },
     updateItemsCountField: function() {
@@ -254,10 +303,12 @@ var attributeOption = {
 }
 attributeOption.bindRemoveButtons();
 attributeOption.initSortable();
+attributeOption.initColumnSort();
 let addNewOptionButton = document.getElementById('add_new_option_button');
 if (addNewOptionButton) {
     addNewOptionButton.addEventListener('click', function() {
         attributeOption.add({});
+        attributeOption.clearSortIndicators();
         attributeOption.updatePositions();
     });
 }

--- a/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
+++ b/app/design/adminhtml/default/default/template/eav/attribute/options.phtml
@@ -56,15 +56,16 @@
     </div>
     <div class="box">
         <div class="hor-scroll">
-            <table class="dynamic-grid" cellspacing="0"  cellpadding="0">
-                <tr id="attribute-options-table">
+            <table class="dynamic-grid" cellspacing="0"  cellpadding="0" id="attribute-options-table">
+                <thead>
+                    <tr>
+                        <th class="option-sort-cell"></th>
                     <?php if ($this->isConfigurableSwatchesEnabled()): ?>
                         <th><?= $this->escapeHtml($this->__('Swatch')) ?></th>
                     <?php endif ?>
                     <?php foreach ($this->getStores() as $_store): ?>
                         <th><?= $this->escapeHtml($_store->getName()) ?></th>
                     <?php endforeach ?>
-                        <th><?= $this->__('Position') ?></th>
                         <th class="nobr a-center"><?= $this->escapeHtml($this->__('Is Default')) ?></th>
                         <th>
                             <?php if (!$this->getReadOnly()):?>
@@ -72,26 +73,8 @@
                             <?php endif ?>
                         </th>
                     </tr>
-                    <tr class="no-display template" id="row-template">
-                        <?php if ($this->isConfigurableSwatchesEnabled()): ?>
-                        <td style="position:relative">
-                            <input type="hidden" disabled class="swatch-value" name="option[swatch][{{id}}]" value="{{swatch}}">
-                            <input type="color" class="input-color-html5 validate-hex-color-hash {{swatch_class}}" value="{{swatch}}">
-                            <span class="swatch-delete" data-msg-delete="<?= $this->escapeHtml($this->__('Are you sure to delete this fallback color?')) ?>"><?= $this->getIconSvg('x') ?></span>
-                        </td>
-                        <?php endif ?>
-                        <?php foreach ($this->getStores() as $_store): ?>
-                        <td><input name="option[value][{{id}}][<?= $_store->getId() ?>]" value="{{store<?= $_store->getId() ?>}}" class="input-text<?php if($_store->getId()==0): ?> required-option<?php endif ?>" type="text" <?php if ($this->getReadOnly()):?> disabled="disabled"<?php endif ?>></td>
-                        <?php endforeach ?>
-                        <td class="a-center"><input class="input-text" type="text" name="option[order][{{id}}]" value="{{sort_order}}" <?php if ($this->getReadOnly()):?> disabled="disabled"<?php endif ?>></td>
-                        <td><input class="input-radio" type="radio" name="default[]" value="{{id}}" <?php if ($this->getReadOnly()):?> disabled="disabled"<?php endif ?>></td>
-                        <td class="a-left">
-                            <input type="hidden" class="delete-flag" name="option[delete][{{id}}]" value="">
-                            <?php if (!$this->getReadOnly()):?>
-                                <?= $this->getDeleteButtonHtml() ?>
-                            <?php endif ?>
-                        </td>
-                    </tr>
+                </thead>
+                <tbody id="attribute-options-container"></tbody>
             </table>
         </div>
         <input type="hidden" id="option-count-check" value="">
@@ -104,6 +87,12 @@ var optionDefaultInputType = 'radio';
 // IE removes quotes from element.innerHTML whenever it thinks they're not needed, which breaks html.
 var templateText =
         '<tr class="option-row" title="ID: {{id}}">'+
+            '<td class="option-sort-cell">'+
+                <?php if (!$this->getReadOnly()):?>
+                    '<span class="option-sort-handle" title="<?= $this->jsQuoteEscape($this->__('Drag to reorder')) ?>"><?= $this->getIconSvg('grip-vertical') ?><\/span>'+
+                <?php endif ?>
+                '<input type="hidden" class="option-order" name="option[order][{{id}}]" value="{{sort_order}}" <?php if ($this->getReadOnly()):?> disabled="disabled"<?php endif ?>>'+
+            '<\/td>'+
         <?php if ($this->isConfigurableSwatchesEnabled()): ?>
             '<td style="position:relative">'+
                 '<input type="hidden" disabled class="swatch-value" name="option[swatch][{{id}}]" value="{{swatch}}">'+
@@ -114,7 +103,6 @@ var templateText =
 <?php foreach ($this->getStores() as $_store): ?>
             '<td><input name="option[value][{{id}}][<?= $_store->getId() ?>]" value="{{store<?= $_store->getId() ?>}}" class="input-text<?php if($_store->getId()==0): ?> required-option<?php endif ?>" type="text" <?php if ($this->getReadOnly()):?> disabled="disabled"<?php endif ?>><\/td>'+
 <?php endforeach ?>
-            '<td><input class="input-text" type="text" name="option[order][{{id}}]" value="{{sort_order}}" <?php if ($this->getReadOnly()):?> disabled="disabled"<?php endif ?>><\/td>'+
             '<td class="a-center"><input class="input-radio" type="{{intype}}" name="default[]" value="{{id}}" {{checked}} <?php if ($this->getReadOnly()):?> disabled="disabled"<?php endif ?>><\/td>'+
             '<td class="a-left" id="delete_button_container_{{id}}">'+
                 '<input type="hidden" class="delete-flag" name="option[delete][{{id}}]" value="">'+
@@ -125,7 +113,7 @@ var templateText =
         '<\/tr>';
 
 var attributeOption = {
-    table : document.getElementById('attribute-options-table'),
+    container : document.getElementById('attribute-options-container'),
     templateText : templateText,
     itemCount : 0,
     totalItems : 0,
@@ -144,7 +132,7 @@ var attributeOption = {
             data.swatch_class = 'swatch-disabled';
         }
         let newHTML = this.template.evaluate(data);
-        this.table.insertAdjacentHTML('afterend', newHTML);
+        this.container.insertAdjacentHTML('beforeend', newHTML);
         if (isNewOption && !this.isReadOnly) {
             this.enableNewOptionDeleteButton(data.id);
         }
@@ -166,6 +154,7 @@ var attributeOption = {
             element.classList.add('no-display', 'template');
             this.totalItems--;
             this.updateItemsCountField();
+            this.updatePositions();
         }
     },
     swatch : function(event){
@@ -200,6 +189,30 @@ var attributeOption = {
                 elementSwatchOption.classList.add('swatch-disabled');
             }
         }
+    },
+    updatePositions: function() {
+        let position = 0;
+        this.container.querySelectorAll('tr.option-row').forEach(function(row) {
+            if (row.classList.contains('no-display')) {
+                return;
+            }
+            let orderInput = row.querySelector('.option-order');
+            if (orderInput) {
+                orderInput.value = position++;
+            }
+        });
+    },
+    initSortable: function() {
+        if (this.isReadOnly || typeof Sortable === 'undefined') {
+            return;
+        }
+        new Sortable(this.container, {
+            handle: '.option-sort-handle',
+            draggable: 'tr.option-row',
+            filter: '.no-display',
+            animation: 150,
+            onUpdate: this.updatePositions.bind(this),
+        });
     },
     updateItemsCountField: function() {
         let optionCountCheck = document.getElementById('option-count-check');
@@ -239,14 +252,14 @@ var attributeOption = {
         });
     }
 }
-let rowTemplate = document.getElementById('row-template');
-if (rowTemplate) {
-    rowTemplate.remove();
-}
 attributeOption.bindRemoveButtons();
+attributeOption.initSortable();
 let addNewOptionButton = document.getElementById('add_new_option_button');
 if (addNewOptionButton) {
-    addNewOptionButton.addEventListener('click', attributeOption.add.bind(attributeOption));
+    addNewOptionButton.addEventListener('click', function() {
+        attributeOption.add({});
+        attributeOption.updatePositions();
+    });
 }
 Validation.addAllThese([
     ['required-option', '<?= $this->jsQuoteEscape($this->__('Failed')) ?>', function(v) {
@@ -259,5 +272,6 @@ Validation.addAllThese([
 <?php foreach ($this->getOptionValues() as $_value): ?>
     attributeOption.add(<?= $_value->toJson() ?>);
 <?php endforeach ?>
+attributeOption.updatePositions();
 //]]>
 </script>

--- a/app/locale/en_US/Mage_Adminhtml.csv
+++ b/app/locale/en_US/Mage_Adminhtml.csv
@@ -919,6 +919,7 @@
 "SOAP / XML-RPC (legacy)","SOAP / XML-RPC (legacy)"
 "Some items in this order have different invoice and shipment types. You can create shipment only after the invoice is created.","Some items in this order have different invoice and shipment types. You can create shipment only after the invoice is created."
 "Some of the ordered items do not exist in the catalog anymore and will be removed if you try to edit the order.","Some of the ordered items do not exist in the catalog anymore and will be removed if you try to edit the order."
+"Sort options alphabetically by this column","Sort options alphabetically by this column"
 "Special Price:","Special Price:"
 "Specific Countries","Specific Countries"
 "Specified","Specified"

--- a/app/locale/en_US/Mage_Adminhtml.csv
+++ b/app/locale/en_US/Mage_Adminhtml.csv
@@ -327,6 +327,7 @@
 "Download","Download"
 "Downloads","Downloads"
 "Do you really want to KILL parallel process and start new indexing process?","Do you really want to KILL parallel process and start new indexing process?"
+"Drag to reorder","Drag to reorder"
 "Drop-down","Drop-down"
 "Edit","Edit"
 "Edit Block","Edit Block"

--- a/public/skin/adminhtml/default/default/form.css
+++ b/public/skin/adminhtml/default/default/form.css
@@ -223,6 +223,40 @@ select[multiple], select[size] {
 #attribute-options-table tr.sortable-ghost {
   opacity: .4; }
 
+#attribute-options-table thead th {
+  white-space: nowrap; }
+
+#attribute-options-table th.option-sort-column {
+  padding: 0; }
+  #attribute-options-table .option-sort-button {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--maho-space-1);
+    background: none;
+    border: 0;
+    border-radius: 0;
+    padding: var(--maho-space-1) var(--maho-space-2);
+    color: inherit;
+    font: inherit;
+    line-height: inherit;
+    cursor: pointer; }
+  #attribute-options-table .option-sort-button:hover {
+    background: none;
+    color: var(--maho-accent); }
+  #attribute-options-table .option-sort-icon {
+    display: none;
+    color: var(--maho-ink-muted); }
+  #attribute-options-table .option-sort-icon svg {
+    width: 14px;
+    height: 14px;
+    display: block; }
+  #attribute-options-table .option-sort-column:not([data-sort-direction]) .option-sort-icon-none,
+  #attribute-options-table .option-sort-column[data-sort-direction="asc"] .option-sort-icon-asc,
+  #attribute-options-table .option-sort-column[data-sort-direction="desc"] .option-sort-icon-desc {
+    display: block; }
+  #attribute-options-table .option-sort-column[data-sort-direction] .option-sort-icon {
+    color: var(--maho-accent); }
+
 td:has(input.swatch-option) {
   display: flex;
   gap: var(--maho-space-1); }

--- a/public/skin/adminhtml/default/default/form.css
+++ b/public/skin/adminhtml/default/default/form.css
@@ -206,6 +206,23 @@ select[multiple], select[size] {
   padding: var(--maho-space-3) var(--maho-space-3) var(--maho-space-4);
   font-size: var(--maho-text-2xl); }
 
+#attribute-options-table th.option-sort-cell, #attribute-options-table td.option-sort-cell {
+  width: 20px;
+  padding-right: var(--maho-space-1); }
+#attribute-options-table .option-sort-handle {
+  display: block;
+  width: 16px;
+  height: 16px;
+  color: var(--maho-ink-muted);
+  cursor: grab; }
+  #attribute-options-table .option-sort-handle svg {
+    width: 16px;
+    height: 16px; }
+  #attribute-options-table .option-sort-handle:active {
+    cursor: grabbing; }
+#attribute-options-table tr.sortable-ghost {
+  opacity: .4; }
+
 td:has(input.swatch-option) {
   display: flex;
   gap: var(--maho-space-1); }


### PR DESCRIPTION
Closes #1143

Reordering the options of a dropdown/multiselect attribute meant hand-editing a number in every row. This replaces the free-text Position input in Catalog > Attributes > Manage Options with a drag handle, and adds alphabetical sorting on any store view column. Both derive `sort_order` from the row order.

No schema or save-path change: `sort_order` already exists and the controller already consumes `option[order][...]`. SortableJS is already vendored and already used for the same shape of problem in the configurable-attributes block, so no new dependency either.

### Drag-and-drop reordering

- `eav/attribute/options.phtml`: the table becomes a proper `thead`/`tbody`, so option rows are siblings inside a container SortableJS can own (previously rows were injected as siblings of the header row). Rows now append to the tbody instead of being inserted after the header.
- The Position column is gone. `option[order][{{id}}]` survives as a hidden input, rewritten from the row index on drag, add and delete, so positions stay dense and consistent even for rows the user never touched. Keeping both a drag handle and an editable number would let the two disagree.
- Rows flagged for deletion (hidden with `no-display`, not removed from the DOM) are skipped when renumbering and are not draggable.
- New options are appended at the end rather than inserted at the top, which is what drag ordering implies. To match, `getOptionValues()` now loads options in ascending position order: the old `desc` order existed only because `insertAdjacentHTML('afterend')` reversed the rows on the way in.
- No sortable when the attribute is read only, same as the configurable-attributes block. The init is also guarded on `Sortable` being present, so a third-party block subclassing `Mage_Eav_Block_Adminhtml_Attribute_Edit_Options_Abstract` on a page without `sortable.min.js` degrades to a static list instead of erroring.
- `sortable.min.js` added to the `adminhtml_catalog_product_attribute_edit` head, which had no `head` reference at all (the global include in `main.xml` lives inside the `editor` handle, which this page does not pull in).
- Dropped the `#row-template` row: it duplicated the JS row template and was removed from the DOM on load anyway, so keeping the two in sync bought nothing.

### Alphabetical sorting

- Every store view column header is a sort toggle: click once for A to Z, click again for Z to A. Sorting rewrites the same hidden `option[order][...]` inputs the drag handle writes, so it is a real reorder that persists on save, not a view-only sort.
- Sorting on any store view column, not just Admin, since a shop may well want the order that reads correctly in its own language. The comparison uses `Intl.Collator` in the admin locale with `numeric: true`, so "Size 2" sorts before "Size 10" and accented labels land where the locale expects.
- The header shows a neutral icon when the column is not the sorted one, and the A-Z or Z-A icon in the accent color when it is. The indicator is cleared as soon as the order stops matching it, that is on drag and on adding a new option, so it cannot claim an order that is no longer there.
- Headers stay plain text when the attribute is read only, matching the drag handle.
- Header cells no longer wrap, the Add Option button was breaking across two lines.

### Testing

Verified on the color attribute (19 options): initial load numbers rows 0..n densely, dragging a row to the top renumbers everything, adding appends with the next index, deleting renumbers around the deleted row and leaves its delete flag intact. Sorting Z to A and saving wrote the reversed positions to `eav_attribute_option`, and the reloaded page showed the same order. Sorting with a row flagged for deletion keeps the flag and skips the row when renumbering. Backend suite passes (2513 passed, 2 skipped), phpstan and cs-fixer clean.

Bulk-adding options by pasting a list is a cheap follow-up but stays a separate change, as noted in the issue.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->
