### PR TITLE
Fixed customer segment save blanking the name and status after opening a grid tab

### DIFF
--- a/app/code/core/Maho/CustomerSegmentation/Block/Adminhtml/Segment/Edit/Tab/EmailAutomation.php
+++ b/app/code/core/Maho/CustomerSegmentation/Block/Adminhtml/Segment/Edit/Tab/EmailAutomation.php
@@ -24,7 +24,7 @@ class Maho_CustomerSegmentation_Block_Adminhtml_Segment_Edit_Tab_EmailAutomation
         $fieldset->addField('auto_email_active', 'select', [
             'label'  => Mage::helper('customersegmentation')->__('Enable Email Automation'),
             'title'  => Mage::helper('customersegmentation')->__('Enable Email Automation'),
-            'name'   => 'auto_email_active',
+            'name'   => 'segment[auto_email_active]',
             'values' => [
                 ['value' => 0, 'label' => Mage::helper('customersegmentation')->__('No')],
                 ['value' => 1, 'label' => Mage::helper('customersegmentation')->__('Yes')],
@@ -35,7 +35,7 @@ class Maho_CustomerSegmentation_Block_Adminhtml_Segment_Edit_Tab_EmailAutomation
         $fieldset->addField('allow_overlapping_sequences', 'select', [
             'label'  => Mage::helper('customersegmentation')->__('Allow Overlapping Sequences'),
             'title'  => Mage::helper('customersegmentation')->__('Allow Overlapping Sequences'),
-            'name'   => 'allow_overlapping_sequences',
+            'name'   => 'segment[allow_overlapping_sequences]',
             'values' => [
                 ['value' => 0, 'label' => Mage::helper('customersegmentation')->__('No')],
                 ['value' => 1, 'label' => Mage::helper('customersegmentation')->__('Yes')],

--- a/app/code/core/Maho/CustomerSegmentation/Block/Adminhtml/Segment/Edit/Tab/General.php
+++ b/app/code/core/Maho/CustomerSegmentation/Block/Adminhtml/Segment/Edit/Tab/General.php
@@ -23,19 +23,19 @@ class Maho_CustomerSegmentation_Block_Adminhtml_Segment_Edit_Tab_General extends
 
         if ($model && $model->getId()) {
             $fieldset->addField('segment_id', 'hidden', [
-                'name' => 'segment_id',
+                'name' => 'segment[segment_id]',
             ]);
         }
 
         $fieldset->addField('name', 'text', [
-            'name'     => 'name',
+            'name'     => 'segment[name]',
             'label'    => Mage::helper('customersegmentation')->__('Segment Name'),
             'title'    => Mage::helper('customersegmentation')->__('Segment Name'),
             'required' => true,
         ]);
 
         $fieldset->addField('description', 'textarea', [
-            'name'  => 'description',
+            'name'  => 'segment[description]',
             'label' => Mage::helper('customersegmentation')->__('Description'),
             'title' => Mage::helper('customersegmentation')->__('Description'),
         ]);
@@ -43,7 +43,7 @@ class Maho_CustomerSegmentation_Block_Adminhtml_Segment_Edit_Tab_General extends
         $fieldset->addField('is_active', 'select', [
             'label'  => Mage::helper('customersegmentation')->__('Status'),
             'title'  => Mage::helper('customersegmentation')->__('Status'),
-            'name'   => 'is_active',
+            'name'   => 'segment[is_active]',
             'values' => [
                 ['value' => 1, 'label' => Mage::helper('customersegmentation')->__('Active')],
                 ['value' => 0, 'label' => Mage::helper('customersegmentation')->__('Inactive')],
@@ -53,14 +53,14 @@ class Maho_CustomerSegmentation_Block_Adminhtml_Segment_Edit_Tab_General extends
         $fieldset->addField('refresh_mode', 'select', [
             'label'  => Mage::helper('customersegmentation')->__('Refresh Mode'),
             'title'  => Mage::helper('customersegmentation')->__('Refresh Mode'),
-            'name'   => 'refresh_mode',
+            'name'   => 'segment[refresh_mode]',
             'values' => Mage::getModel('customersegmentation/segment')->getRefreshModeOptions(),
             'note'   => Mage::helper('customersegmentation')->__('Automatic: Refreshed daily via cron. Manual: Must be refreshed manually.'),
         ]);
 
         if (!Mage::app()->isSingleStoreMode()) {
             $fieldset->addField('website_ids', 'multiselect', [
-                'name'     => 'website_ids',
+                'name'     => 'segment[website_ids]',
                 'label'    => Mage::helper('customersegmentation')->__('Assign to Website'),
                 'title'    => Mage::helper('customersegmentation')->__('Assign to Website'),
                 'required' => true,
@@ -69,7 +69,7 @@ class Maho_CustomerSegmentation_Block_Adminhtml_Segment_Edit_Tab_General extends
         } else {
             $websiteId = (string) Mage::app()->getStore(true)->getWebsiteId();
             $fieldset->addField('website_ids', 'hidden', [
-                'name'  => 'website_ids',
+                'name'  => 'segment[website_ids]',
                 'value' => $websiteId,
             ]);
             // Seed the key setValues() would otherwise clear, keeping the segment's own scope
@@ -82,7 +82,7 @@ class Maho_CustomerSegmentation_Block_Adminhtml_Segment_Edit_Tab_General extends
         array_unshift($customerGroups, ['value' => '', 'label' => Mage::helper('customersegmentation')->__('-- Please Select --')]);
 
         $fieldset->addField('customer_group_ids', 'multiselect', [
-            'name'   => 'customer_group_ids',
+            'name'   => 'segment[customer_group_ids]',
             'label'  => Mage::helper('customersegmentation')->__('Customer Groups'),
             'title'  => Mage::helper('customersegmentation')->__('Customer Groups'),
             'values' => $customerGroups,

--- a/app/code/core/Maho/CustomerSegmentation/controllers/Adminhtml/CustomerSegmentation_IndexController.php
+++ b/app/code/core/Maho/CustomerSegmentation/controllers/Adminhtml/CustomerSegmentation_IndexController.php
@@ -76,7 +76,9 @@ class Maho_CustomerSegmentation_Adminhtml_CustomerSegmentation_IndexController e
 
         $data = Mage::getSingleton('adminhtml/session')->getFormData(true);
         if (!empty($data)) {
-            $segment->setData($data);
+            // loadPost() (not setData()) so the submitted conditions tree is rebuilt instead of
+            // being left as a raw array, which would render the Conditions tab as if it were empty
+            $segment->loadPost($data);
         }
 
         Mage::register('current_customer_segment', $segment);
@@ -94,7 +96,11 @@ class Maho_CustomerSegmentation_Adminhtml_CustomerSegmentation_IndexController e
     #[Maho\Config\Route('/admin/customersegmentation_index/save')]
     public function saveAction(): void
     {
-        if ($data = $this->getRequest()->getPost()) {
+        if ($post = $this->getRequest()->getPost()) {
+            // The segment's own fields live under the "segment" key: the tabs are rendered inside
+            // the edit form, so unprefixed names would be overwritten by the filter and pager
+            // inputs of the grids loaded into the Customers and E-mails on Enter/Exit tabs.
+            $data = $post['segment'] ?? [];
             $segment = Mage::getModel('customersegmentation/segment');
             $segmentId = $this->getRequest()->getParam('id');
 
@@ -111,10 +117,9 @@ class Maho_CustomerSegmentation_Adminhtml_CustomerSegmentation_IndexController e
 
             try {
                 // Process conditions
-                if (isset($data['rule']['conditions'])) {
-                    $data['conditions'] = $data['rule']['conditions'];
+                if (isset($post['rule']['conditions'])) {
+                    $data['conditions'] = $post['rule']['conditions'];
                 }
-                unset($data['rule']);
 
                 $segment->loadPost($data);
                 $segment->save();


### PR DESCRIPTION
## Problem

Saving a customer segment intermittently failed with **"Segment name is required."**, clearing the name and the conditions logic while keeping the selected customer groups.

It isn't random — it happens whenever one of the AJAX tabs has been opened before saving.

`Segment/Edit/Tabs.php` sets `destElementId` to `edit_form`, so every tab's content lives inside the segment `<form>`, including the grids loaded by the **Customers** and **E-mails on Enter/Exit** tabs. Those grids render a filter row and pager whose inputs use bare column names, and the segment form used bare field names too. PHP keeps the last occurrence of a repeated key, so the grid's empty filter won:

```js
new FormData(edit_form).getAll('name')  →  ["Test", ""]
```

| Tab opened | Names injected into `edit_form` |
|---|---|
| Customers | **`name`**, `email`, `group`, `entity_id[from/to]`, `created_at[...]`, `page`, `limit` |
| E-mails on Enter / Exit | **`is_active`**, `template_code`, `template_subject`, `step_number[...]`, `page`, `limit` |

So there was a second, silent variant of the same bug: opening either E-mails tab and saving blanked `is_active` and flipped the segment to **Inactive**, with no error message at all.

## Fix

Prefixed the segment's own fields with `segment[...]`, the same way core namespaces `product[...]` and `account[...]`. The grid inputs now land in a separate namespace and are ignored on save. Field *ids* are unchanged, so `$form->setValues()` (which keys off the element id) still works.

Also swapped `setData()` for `loadPost()` when re-rendering after a failed save, so the submitted conditions tree is rebuilt instead of being left as a raw array — that's why the Conditions tab came back empty after the error.

## Verification

Manually, against the admin:

- With all three AJAX tabs open, changed the status and the conditions aggregator, then Save and Continue Edit → saved correctly, name, status, groups and conditions all preserved. The stray `name` / `is_active` grid inputs are still posted, but now ignored.
- Added a nested condition (Customer Group == General) and saved → persisted and re-rendered correctly.
- Deliberately cleared the name and saved → correct error, and the conditions logic (`all` / FALSE) survived the redisplay instead of resetting.
- Created a new segment from scratch → saved fine.

`composer lint:cs-fixer` and `composer lint:phpstan` clean; 400 Backend tests pass.

## Note, not addressed here

A brand-new segment renders Status preselected to **Inactive** — `is_active` has no default, so `setValues()` sets null and the select loose-matches option `0`. Pre-existing and separate from this bug, so left alone.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->