### PR TITLE
Kept grid filter and pager controls out of enclosing admin forms

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Filter/Action.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Convert/Profile/Edit/Filter/Action.php
@@ -21,7 +21,7 @@ class Mage_Adminhtml_Block_System_Convert_Profile_Edit_Filter_Action extends Mag
         ];
         $value = $this->getValue();
 
-        $html  = '<select name="' . ($this->getColumn()->getName() ?: $this->getColumn()->getId()) . '" ' . $this->getColumn()->getValidateClass() . '>';
+        $html  = '<select name="' . ($this->getColumn()->getName() ?: $this->getColumn()->getId()) . '" ' . $this->getColumn()->getValidateClass() . $this->_getUnboundFormAttribute() . '>';
         foreach ($values as $k => $v) {
             $html .= '<option value="' . $k . '"' . ($value == $k ? ' selected="selected"' : '') . '>' . $v . '</option>';
         }

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -15,6 +15,14 @@
 class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
 {
     /**
+     * Never render a form with this id: grid controls point at it precisely so that they have no
+     * form owner. Grids often sit inside an edit form, where their column-named filters (name,
+     * is_active, page...) collide with its fields and overwrite them on save. Orphaning them is
+     * safe because grids serialise their own filters and pager.
+     */
+    public const UNBOUND_FORM_ID = 'maho-grid-unbound';
+
+    /**
      * Columns array
      *
      * [

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Abstract.php
@@ -64,6 +64,14 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Abstract extends Mage_Admin
     }
 
     /**
+     * Keeps this filter out of any form it is rendered inside, see Grid::UNBOUND_FORM_ID
+     */
+    protected function _getUnboundFormAttribute(): string
+    {
+        return ' form="' . Mage_Adminhtml_Block_Widget_Grid::UNBOUND_FORM_ID . '"';
+    }
+
+    /**
      * Retrieve escaped value
      *
      * @param mixed $index

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
@@ -48,16 +48,16 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Date extends Mage_Adminhtml
             . '<span class="label" aria-hidden="true" title="' . $this->quoteEscape($fromLabel) . '">&ge;</span>'
             . '<input type="date" name="' . $this->_getHtmlName() . '[from]" id="' . $htmlId . '_from"'
                 . ' aria-label="' . $this->quoteEscape($fromLabel) . '" title="' . $this->quoteEscape($fromLabel) . '"'
-                . ' value="' . $this->escapeHtml($fromValue) . '" class="input-text no-changes">'
+                . ' value="' . $this->escapeHtml($fromValue) . '" class="input-text no-changes"' . $this->_getUnboundFormAttribute() . '>'
             . '</div>';
         $html .= '<div class="range-line date">'
             . '<span class="label" aria-hidden="true" title="' . $this->quoteEscape($toLabel) . '">&le;</span>'
             . '<input type="date" name="' . $this->_getHtmlName() . '[to]" id="' . $htmlId . '_to"'
                 . ' aria-label="' . $this->quoteEscape($toLabel) . '" title="' . $this->quoteEscape($toLabel) . '"'
-                . ' value="' . $this->escapeHtml($toValue) . '" class="input-text no-changes">'
+                . ' value="' . $this->escapeHtml($toValue) . '" class="input-text no-changes"' . $this->_getUnboundFormAttribute() . '>'
             . '</div></div>';
         $html .= '<input type="hidden" name="' . $this->_getHtmlName() . '[locale]"'
-            . 'value="' . $this->getLocale()->getLocaleCode() . '">';
+            . 'value="' . $this->getLocale()->getLocaleCode() . '"' . $this->_getUnboundFormAttribute() . '>';
         return $html;
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
@@ -102,16 +102,16 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Datetime extends Mage_Admin
             . '<span class="label" aria-hidden="true" title="' . $this->quoteEscape($fromLabel) . '">&ge;</span>'
             . '<input type="' . $inputType . '" name="' . $this->_getHtmlName() . '[from]" id="' . $htmlId . '_from"'
                 . ' aria-label="' . $this->quoteEscape($fromLabel) . '" title="' . $this->quoteEscape($fromLabel) . '"'
-                . ' value="' . $this->escapeHtml($fromValue) . '" class="input-text no-changes">'
+                . ' value="' . $this->escapeHtml($fromValue) . '" class="input-text no-changes"' . $this->_getUnboundFormAttribute() . '>'
             . '</div>';
         $html .= '<div class="range-line date">'
             . '<span class="label" aria-hidden="true" title="' . $this->quoteEscape($toLabel) . '">&le;</span>'
             . '<input type="' . $inputType . '" name="' . $this->_getHtmlName() . '[to]" id="' . $htmlId . '_to"'
                 . ' aria-label="' . $this->quoteEscape($toLabel) . '" title="' . $this->quoteEscape($toLabel) . '"'
-                . ' value="' . $this->escapeHtml($toValue) . '" class="input-text no-changes">'
+                . ' value="' . $this->escapeHtml($toValue) . '" class="input-text no-changes"' . $this->_getUnboundFormAttribute() . '>'
             . '</div></div>';
         $html .= '<input type="hidden" name="' . $this->_getHtmlName() . '[locale]"'
-            . ' value="' . $this->getLocale()->getLocaleCode() . '">';
+            . ' value="' . $this->getLocale()->getLocaleCode() . '"' . $this->_getUnboundFormAttribute() . '>';
         return $html;
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Iconoptions.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Iconoptions.php
@@ -23,7 +23,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Iconoptions extends Mage_Ad
 
         $value = $this->getValue();
 
-        $html = '<select name="' . $this->_getHtmlName() . '" id="' . $this->_getHtmlId() . '" class="no-changes grid-icon-filter">';
+        $html = '<select name="' . $this->_getHtmlName() . '" id="' . $this->_getHtmlId() . '" class="no-changes grid-icon-filter"' . $this->_getUnboundFormAttribute() . '>';
         $html .= '<button type="button"><selectedcontent></selectedcontent></button>';
         foreach ($this->_getOptions() as $option) {
             if (is_array($option['value'])) {

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
@@ -24,12 +24,12 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Price extends Mage_Adminhtm
             . '<span class="label" aria-hidden="true" title="' . $this->quoteEscape($fromLabel) . '">&ge;</span>'
             . '<input type="number" name="' . $this->_getHtmlName() . '[from]" id="' . $this->_getHtmlId() . '_from"'
                 . ' aria-label="' . $this->quoteEscape($fromLabel) . '" title="' . $this->quoteEscape($fromLabel) . '"'
-                . ' value="' . $this->getEscapedValue('from') . '" class="input-text no-changes"></div>';
+                . ' value="' . $this->getEscapedValue('from') . '" class="input-text no-changes"' . $this->_getUnboundFormAttribute() . '></div>';
         $html .= '<div class="range-line">'
             . '<span class="label" aria-hidden="true" title="' . $this->quoteEscape($toLabel) . '">&le;</span>'
             . '<input type="number" name="' . $this->_getHtmlName() . '[to]" id="' . $this->_getHtmlId() . '_to"'
                 . ' aria-label="' . $this->quoteEscape($toLabel) . '" title="' . $this->quoteEscape($toLabel) . '"'
-                . ' value="' . $this->getEscapedValue('to') . '" class="input-text no-changes"></div>';
+                . ' value="' . $this->getEscapedValue('to') . '" class="input-text no-changes"' . $this->_getUnboundFormAttribute() . '></div>';
         if ($this->getDisplayCurrencySelect()) {
             $currencyLabel = Mage::helper('adminhtml')->__('Currency');
             $html .= '<div class="range-line">'
@@ -76,7 +76,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Price extends Mage_Adminhtm
         $label = $label ?: Mage::helper('adminhtml')->__('Currency');
         $html  = '';
         $html .= '<select name="' . $this->_getHtmlName() . '[currency]" id="' . $this->_getHtmlId() . '_currency"'
-            . ' aria-label="' . $this->quoteEscape($label) . '" title="' . $this->quoteEscape($label) . '">';
+            . ' aria-label="' . $this->quoteEscape($label) . '" title="' . $this->quoteEscape($label) . '"' . $this->_getUnboundFormAttribute() . '>';
         foreach ($this->_getCurrencyList() as $currency) {
             $html .= '<option value="' . $currency . '" ' . ($currency == $value ? 'selected="selected"' : '') . '>'
                 . $currency . '</option>';

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
@@ -21,12 +21,12 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Range extends Mage_Adminhtm
             . '<span class="label" aria-hidden="true" title="' . $this->quoteEscape($fromLabel) . '">&ge;</span>'
             . '<input type="number" name="' . $this->_getHtmlName() . '[from]" id="' . $this->_getHtmlId() . '_from"'
                 . ' aria-label="' . $this->quoteEscape($fromLabel) . '" title="' . $this->quoteEscape($fromLabel) . '"'
-                . ' value="' . $this->getEscapedValue('from') . '" class="input-text no-changes"></div>';
+                . ' value="' . $this->getEscapedValue('from') . '" class="input-text no-changes"' . $this->_getUnboundFormAttribute() . '></div>';
         $html .= '<div class="range-line">'
             . '<span class="label" aria-hidden="true" title="' . $this->quoteEscape($toLabel) . '">&le;</span>'
             . '<input type="number" name="' . $this->_getHtmlName() . '[to]" id="' . $this->_getHtmlId() . '_to"'
                 . ' aria-label="' . $this->quoteEscape($toLabel) . '" title="' . $this->quoteEscape($toLabel) . '"'
-                . ' value="' . $this->getEscapedValue('to') . '" class="input-text no-changes"></div>';
+                . ' value="' . $this->getEscapedValue('to') . '" class="input-text no-changes"' . $this->_getUnboundFormAttribute() . '></div>';
         $html .= '</div>';
 
         return $html;

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
@@ -53,7 +53,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Select extends Mage_Adminht
     #[\Override]
     public function getHtml()
     {
-        $html = '<select name="' . $this->_getHtmlName() . '" id="' . $this->_getHtmlId() . '" class="no-changes">';
+        $html = '<select name="' . $this->_getHtmlName() . '" id="' . $this->_getHtmlId() . '" class="no-changes"' . $this->_getUnboundFormAttribute() . '>';
         $value = $this->getValue();
         foreach ($this->_getOptions() as $option) {
             if (is_array($option['value'])) {

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Store.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Store.php
@@ -27,7 +27,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Store extends Mage_Adminhtm
         $allShow = $this->getColumn()->getStoreAll();
 
         $html  = '<select name="' . $this->escapeHtml($this->_getHtmlName()) . '" '
-               . $this->getColumn()->getValidateClass() . '>';
+               . $this->getColumn()->getValidateClass() . $this->_getUnboundFormAttribute() . '>';
         $value = $this->getColumn()->getValue();
         if ($allShow) {
             $html .= '<option value="0"' . ($value == 0 ? ' selected="selected"' : '') . '>'

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Text.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Text.php
@@ -15,6 +15,6 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Text extends Mage_Adminhtml
     #[\Override]
     public function getHtml()
     {
-        return '<div class="field-100"><input type="text" name="' . $this->_getHtmlName() . '" id="' . $this->_getHtmlId() . '" value="' . $this->getEscapedValue() . '" class="input-text no-changes"></div>';
+        return '<div class="field-100"><input type="text" name="' . $this->_getHtmlName() . '" id="' . $this->_getHtmlId() . '" value="' . $this->getEscapedValue() . '" class="input-text no-changes"' . $this->_getUnboundFormAttribute() . '></div>';
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Theme.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Theme.php
@@ -25,7 +25,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Theme extends Mage_Adminhtm
                 'label' => '',
             ]);
         }
-        return sprintf('<select name="%s" id="%s" class="no-changes">', $this->_getHtmlName(), $this->_getHtmlId())
+        return sprintf('<select name="%s" id="%s" class="no-changes"%s>', $this->_getHtmlName(), $this->_getHtmlId(), $this->_getUnboundFormAttribute())
             . $this->_drawOptions($options)
             . '</select>';
     }

--- a/app/design/adminhtml/default/default/template/widget/grid.phtml
+++ b/app/design/adminhtml/default/default/template/widget/grid.phtml
@@ -37,7 +37,7 @@ $numColumns = count($this->getColumns());
                 <span class="pager-arrow disabled" aria-label="<?= $this->quoteEscape($this->__('Go to Previous page')) ?>"><?= $this->getIconSvg('circle-arrow-left') ?></span>
             <?php endif ?>
 
-            <input type="text" name="<?= $this->getVarNamePage() ?>" value="<?= $_curPage ?>" class="input-text page" onkeypress="<?= $this->getJsObjectName() ?>.inputPage(event, '<?= $_lastPage ?>')">
+            <input type="text" name="<?= $this->getVarNamePage() ?>" value="<?= $_curPage ?>" class="input-text page" form="<?= Mage_Adminhtml_Block_Widget_Grid::UNBOUND_FORM_ID ?>" onkeypress="<?= $this->getJsObjectName() ?>.inputPage(event, '<?= $_lastPage ?>')">
 
             <?php if($_curPage < $_lastPage): ?>
                 <a href="#" title="<?= $this->quoteEscape($this->__('Next page')) ?>" aria-label="<?= $this->quoteEscape($this->__('Go to Next page')) ?>" class="pager-arrow" onclick="<?= $this->getJsObjectName() ?>.setPage('<?= ($_curPage+1) ?>');return false;"><?= $this->getIconSvg('circle-arrow-right') ?></a>
@@ -47,7 +47,7 @@ $numColumns = count($this->getColumns());
 
             <?= $this->__('of %s', $this->getCollection()->getLastPageNumber()) ?>
             <span class="separator">|</span>
-            <select name="<?= $this->getVarNameLimit() ?>" aria-label="<?= $this->quoteEscape($this->__('Items per page')) ?>" onchange="<?= $this->getJsObjectName() ?>.loadByElement(this)">
+            <select name="<?= $this->getVarNameLimit() ?>" aria-label="<?= $this->quoteEscape($this->__('Items per page')) ?>" form="<?= Mage_Adminhtml_Block_Widget_Grid::UNBOUND_FORM_ID ?>" onchange="<?= $this->getJsObjectName() ?>.loadByElement(this)">
                 <?php foreach ($this->getLimitOptions() as $pageSize): ?>
                     <option value="<?= $pageSize ?>"<?php if($this->getCollection()->getPageSize() == $pageSize): ?> selected="selected"<?php endif ?>><?= $pageSize ?></option>
                 <?php endforeach ?>
@@ -65,7 +65,7 @@ $numColumns = count($this->getColumns());
     <?php if($this->getExportTypes()): ?>
         <td class="export a-right">
             <?= $this->__('Export to:') ?>
-            <select name="<?= $this->getId() ?>_export" id="<?= $this->getId() ?>_export" style="width:8em;">
+            <select name="<?= $this->getId() ?>_export" id="<?= $this->getId() ?>_export" style="width:8em;" form="<?= Mage_Adminhtml_Block_Widget_Grid::UNBOUND_FORM_ID ?>">
             <?php foreach ($this->getExportTypes() as $_type): ?>
                 <option value="<?= $_type->getUrl() ?>"><?= $_type->getLabel() ?></option>
             <?php endforeach ?>


### PR DESCRIPTION
Follow-up to #1146, which fixed one instance of this bug by namespacing a form. This removes the whole class of bug.

## The problem

`Mage_Adminhtml_Block_Widget_Tabs` moves every tab's content into its destination element, which for an edit page is the form itself. A grid names its filters after the columns they filter, so opening a grid tab drops bare names into the form:

| Page | Grid injects into the form |
|---|---|
| Customer segments | `name`, `email`, `group`, `is_active`, `template_code`, `entity_id[from/to]`, `created_at[…]`, `page`, `limit` |
| Manage Products | `name`, `sku`, `status`, `visibility`, `set_name`, `price[from/to]`, `position` |
| Manage Categories | `name`, `sku`, `status`, `visibility`, `position` |
| Blog Categories | `is_active`, `url_key`, `title` |
| Permissions › Users | `role_name`, `assigned_user_role`, `page`, `limit` |
| Dataflow profiles | `action_code`, `performed_at[…]`, `firstname`, `lastname` |
| Feed Manager › Feeds | `status`, `started_at[…]`, `upload_status`, `errors` |

Where the form has a field of the same name, PHP keeps the last occurrence and the grid's empty filter silently overwrites the real value on save. That was the segment bug in #1146: `name` came back as `""` and the save failed with "Segment name is required", while the same collision on `is_active` flipped segments to Inactive with no error at all.

Products, Categories and Blog Categories only escape because their forms namespace their fields (`product[…]`, `general[…]`, `category[…]`) — Blog Categories has both `is_active` and `url_key` on each side, so the namespace is the only thing preventing an identical failure. Admin/API role edit escapes by prefixing its grid columns `role_user_*` instead. The remaining four dodge it purely because the names happen not to overlap today.

## The fix

Grid filter and pager controls never needed to belong to the surrounding form. A grid serialises its own controls: `varienGrid.doFilter()` builds its own `FormData` from a DOM query, the pager `page`/`limit` inputs read their value in their own handlers, and massaction submits its own form.

So they now carry `form="maho-grid-unbound"` — an id nothing ever renders. Per the HTML spec, a `form` attribute that matches no form element leaves the control with **no form owner**: it is never submitted, but stays fully functional. Applied via a shared `_getUnboundFormAttribute()` on `Grid_Column_Filter_Abstract` (so the 13 core filter renderers and any third-party subclass get it), plus the pager and export controls in `widget/grid.phtml`.

**Row controls are deliberately untouched.** Checkboxes and position inputs are collected by `serializerController` into a hidden field that *does* belong to the form, so orphaning them would break assignment grids such as role users.

Report grids are also untouched — their `report_from`/`report_to`/`report_period` controls are page-level filters that legitimately belong to their own form.

## Verification

Measured in the browser, not just reasoned about.

- **Segment edit, all three AJAX tabs open** — the form now posts only `form_key`, `segment[*]` and `rule[conditions][*]`. Every grid name is gone: 46 named controls in the DOM, 27 owned by the form. Save and Continue preserves name, status, groups and the nested condition.
- **Grid controls still work.** Product grid: filter by name returns shirts, Reset Filter restores, page size 30 yields 30 rows, next page advances the pager to 2. Segment customers grid (inside the form) filters down to "No records found" and resets correctly.
- **Fragile pages are now structurally immune.** On Permissions › Users and Role edit, every filter and pager control reports `form owner = NONE` while the form still posts exactly its own fields (including `roles[]` and `in_role_user`, which come from row controls and the serializer).
- **No regression on row controls.** Role edit's user checkbox was compared against clean `main` with a real click: identical behaviour on both. (`in_role_user` stays empty in both — pre-existing, unrelated to this change.)

`composer lint:cs-fixer` and `composer lint:phpstan` clean. Full `composer test`: 3350 passed, 2 skipped, 3 risky.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->