### PR TITLE
Optimized cataloglinkrule_apply_all to scan the target catalog once per rule

### DIFF
--- a/app/code/core/Maho/CatalogLinkRule/Model/Processor.php
+++ b/app/code/core/Maho/CatalogLinkRule/Model/Processor.php
@@ -244,8 +244,11 @@ class Maho_CatalogLinkRule_Model_Processor
         array $existingTargetIds = [],
         int $startPosition = 0,
     ): void {
-        // Load the source product with all attributes
-        $sourceProduct = Mage::getModel('catalog/product')->load($productId);
+        // Only load the source product when a target condition actually reads its attributes;
+        // otherwise the matched target set is source-independent and the load is pure overhead.
+        $sourceProduct = $rule->targetConditionsUseSourceProduct()
+            ? Mage::getModel('catalog/product')->load($productId)
+            : null;
 
         // Get matching target products, passing the source product for matching conditions
         $targetProductIds = $rule->getMatchingTargetProductIds($sourceProduct);

--- a/app/code/core/Maho/CatalogLinkRule/Model/Rule.php
+++ b/app/code/core/Maho/CatalogLinkRule/Model/Rule.php
@@ -133,12 +133,51 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
     }
 
     /**
+     * Target product IDs matched by this rule, cached when the target conditions do not depend on
+     * the source product (see targetConditionsUseSourceProduct()).
+     *
+     * @var int[]|null
+     */
+    protected ?array $_targetProductIds = null;
+
+    protected ?bool $_targetConditionsUseSourceProduct = null;
+
+    /**
+     * Whether the target conditions reference the source product, i.e. whether the matched target
+     * set can differ from one source product to the next.
+     */
+    public function targetConditionsUseSourceProduct(): bool
+    {
+        if ($this->_targetConditionsUseSourceProduct === null) {
+            $this->_targetConditionsUseSourceProduct = $this->_hasSourceMatchCondition($this->getTargetConditions());
+        }
+
+        return $this->_targetConditionsUseSourceProduct;
+    }
+
+    protected function _hasSourceMatchCondition(Mage_Rule_Model_Condition_Abstract $condition): bool
+    {
+        if ($condition instanceof Maho_CatalogLinkRule_Model_Rule_Target_SourceMatch) {
+            return true;
+        }
+
+        if ($condition instanceof Mage_Rule_Model_Condition_Combine) {
+            foreach ($condition->getConditions() as $child) {
+                if ($this->_hasSourceMatchCondition($child)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Get matching source product IDs
      */
     public function getMatchingSourceProductIds(): array
     {
         $productCollection = Mage::getResourceModel('catalog/product_collection')
-            ->addAttributeToSelect('*')
             ->addAttributeToFilter('status', Mage_Catalog_Model_Product_Status::STATUS_ENABLED);
 
         /** @var Maho_CatalogLinkRule_Model_Rule_Source_Combine $sourceConditions */
@@ -159,6 +198,31 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
      * Get matching target product IDs with sorting for a specific source product
      */
     public function getMatchingTargetProductIds(?Mage_Catalog_Model_Product $sourceProduct = null): array
+    {
+        // When no target condition looks at the source product, the matched set is identical for
+        // every source product: scan the catalog once and reuse it. Only the order may differ, so
+        // random sorting still shuffles a fresh copy per source product below.
+        if (!$this->targetConditionsUseSourceProduct()) {
+            if ($this->_targetProductIds === null) {
+                $this->_targetProductIds = $this->_collectMatchingTargetProductIds();
+            }
+            $productIds = $this->_targetProductIds;
+            if (!in_array($this->getSortOrder(), ['price_desc', 'name_asc', 'name_desc', 'newest', 'oldest', 'price_asc'], true)) {
+                shuffle($productIds);
+            }
+            return $productIds;
+        }
+
+        return $this->_collectMatchingTargetProductIds($sourceProduct);
+    }
+
+    /**
+     * Scan the enabled catalog and return the target product IDs matched by this rule, in the
+     * configured sort order.
+     *
+     * @return int[]
+     */
+    protected function _collectMatchingTargetProductIds(?Mage_Catalog_Model_Product $sourceProduct = null): array
     {
         $productCollection = Mage::getResourceModel('catalog/product_collection')
             ->addAttributeToSelect(['name', 'price', 'created_at'])

--- a/app/code/core/Maho/CatalogLinkRule/Model/Rule.php
+++ b/app/code/core/Maho/CatalogLinkRule/Model/Rule.php
@@ -195,6 +195,29 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
     }
 
     /**
+     * Deterministic target sort orders, mapped to the [attribute, direction] applied to the
+     * collection. Any sort order not listed here (including 'random' and the empty default) is
+     * shuffled in PHP instead — see isRandomSort(). Single source of truth for both call sites.
+     */
+    protected const SORT_ORDERS = [
+        'price_desc' => ['price', 'DESC'],
+        'name_asc' => ['name', 'ASC'],
+        'name_desc' => ['name', 'DESC'],
+        'newest' => ['created_at', 'DESC'],
+        'oldest' => ['created_at', 'ASC'],
+        'price_asc' => ['price', 'ASC'],
+    ];
+
+    /**
+     * Whether the configured sort order is random (shuffled in PHP) rather than a deterministic
+     * SQL ordering. Kept as a single check so the cached and freshly-scanned paths never disagree.
+     */
+    protected function isRandomSort(): bool
+    {
+        return !isset(self::SORT_ORDERS[(string) $this->getSortOrder()]);
+    }
+
+    /**
      * Get matching target product IDs with sorting for a specific source product
      */
     public function getMatchingTargetProductIds(?Mage_Catalog_Model_Product $sourceProduct = null): array
@@ -207,7 +230,7 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
                 $this->_targetProductIds = $this->_collectMatchingTargetProductIds();
             }
             $productIds = $this->_targetProductIds;
-            if (!in_array($this->getSortOrder(), ['price_desc', 'name_asc', 'name_desc', 'newest', 'oldest', 'price_asc'], true)) {
+            if ($this->isRandomSort()) {
                 shuffle($productIds);
             }
             return $productIds;
@@ -237,37 +260,11 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
             $this->setSourceProduct($sourceProduct);
         }
 
-        // Apply sorting
-        switch ($this->getSortOrder()) {
-            case 'price_desc':
-                $productCollection->addAttributeToSort('price', 'DESC');
-                break;
-            case 'name_asc':
-                $productCollection->addAttributeToSort('name', 'ASC');
-                break;
-            case 'name_desc':
-                $productCollection->addAttributeToSort('name', 'DESC');
-                break;
-            case 'newest':
-                $productCollection->addAttributeToSort('created_at', 'DESC');
-                break;
-            case 'oldest':
-                $productCollection->addAttributeToSort('created_at', 'ASC');
-                break;
-            case 'price_asc':
-                $productCollection->addAttributeToSort('price', 'ASC');
-                break;
-            case 'random':
-            default:
-                // Default: random order (for better performance on large catalogs, shuffle in PHP)
-                $productIds = [];
-                foreach ($productCollection as $product) {
-                    if ($targetConditions->validate($product)) {
-                        $productIds[] = (int) $product->getId();
-                    }
-                }
-                shuffle($productIds);
-                return $productIds;
+        // Apply the configured deterministic sort; random/unknown orders stay unsorted here and are
+        // shuffled in PHP below (cheaper than a SQL random ordering on large catalogs).
+        if (isset(self::SORT_ORDERS[(string) $this->getSortOrder()])) {
+            [$attribute, $direction] = self::SORT_ORDERS[(string) $this->getSortOrder()];
+            $productCollection->addAttributeToSort($attribute, $direction);
         }
 
         $productIds = [];
@@ -275,6 +272,10 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
             if ($targetConditions->validate($product)) {
                 $productIds[] = (int) $product->getId();
             }
+        }
+
+        if ($this->isRandomSort()) {
+            shuffle($productIds);
         }
 
         return $productIds;

--- a/app/code/core/Maho/CatalogLinkRule/Model/Rule.php
+++ b/app/code/core/Maho/CatalogLinkRule/Model/Rule.php
@@ -18,6 +18,26 @@ declare(strict_types=1);
  */
 class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
 {
+    /**
+     * Target product IDs matched by this rule, cached when the target conditions do not depend on
+     * the source product (see targetConditionsUseSourceProduct()).
+     *
+     * Scoped to one instance whose target conditions don't change: the processor loads each rule
+     * fresh per run and only reads it, so there is deliberately no invalidation hook. Code that
+     * edits the conditions of a rule it has already scanned must use a fresh instance.
+     *
+     * @var int[]|null
+     */
+    protected ?array $_targetProductIds = null;
+
+    /**
+     * Sort order the cached scan above was collected under, so a later sort order change can't be
+     * served from a differently-ordered cache.
+     */
+    protected ?string $_targetProductIdsSortOrder = null;
+
+    protected ?bool $_targetConditionsUseSourceProduct = null;
+
     #[\Override]
     protected function _construct(): void
     {
@@ -133,24 +153,12 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
     }
 
     /**
-     * Target product IDs matched by this rule, cached when the target conditions do not depend on
-     * the source product (see targetConditionsUseSourceProduct()).
-     *
-     * @var int[]|null
-     */
-    protected ?array $_targetProductIds = null;
-
-    protected ?bool $_targetConditionsUseSourceProduct = null;
-
-    /**
      * Whether the target conditions reference the source product, i.e. whether the matched target
      * set can differ from one source product to the next.
      */
     public function targetConditionsUseSourceProduct(): bool
     {
-        if ($this->_targetConditionsUseSourceProduct === null) {
-            $this->_targetConditionsUseSourceProduct = $this->_hasSourceMatchCondition($this->getTargetConditions());
-        }
+        $this->_targetConditionsUseSourceProduct ??= $this->_hasSourceMatchCondition($this->getTargetConditions());
 
         return $this->_targetConditionsUseSourceProduct;
     }
@@ -158,6 +166,14 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
     protected function _hasSourceMatchCondition(Mage_Rule_Model_Condition_Abstract $condition): bool
     {
         if ($condition instanceof Maho_CatalogLinkRule_Model_Rule_Target_SourceMatch) {
+            return true;
+        }
+
+        // A plain target-attribute condition is source-dependent too when it uses one of the
+        // "matches source" operators, which compare the target against the source product.
+        if ($condition instanceof Maho_CatalogLinkRule_Model_Rule_Target_Product
+            && $condition->isSourceMatchOperator()
+        ) {
             return true;
         }
 
@@ -197,7 +213,7 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
     /**
      * Deterministic target sort orders, mapped to the [attribute, direction] applied to the
      * collection. Any sort order not listed here (including 'random' and the empty default) is
-     * shuffled in PHP instead — see isRandomSort(). Single source of truth for both call sites.
+     * shuffled in PHP instead — see _isRandomSort(). Single source of truth for both call sites.
      */
     protected const SORT_ORDERS = [
         'price_desc' => ['price', 'DESC'],
@@ -212,7 +228,7 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
      * Whether the configured sort order is random (shuffled in PHP) rather than a deterministic
      * SQL ordering. Kept as a single check so the cached and freshly-scanned paths never disagree.
      */
-    protected function isRandomSort(): bool
+    protected function _isRandomSort(): bool
     {
         return !isset(self::SORT_ORDERS[(string) $this->getSortOrder()]);
     }
@@ -226,11 +242,14 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
         // every source product: scan the catalog once and reuse it. Only the order may differ, so
         // random sorting still shuffles a fresh copy per source product below.
         if (!$this->targetConditionsUseSourceProduct()) {
-            if ($this->_targetProductIds === null) {
+            // The cache holds the IDs *in* the sort order they were collected under, so a changed
+            // sort order has to rescan rather than reuse a differently-ordered array.
+            if ($this->_targetProductIds === null || $this->_targetProductIdsSortOrder !== (string) $this->getSortOrder()) {
                 $this->_targetProductIds = $this->_collectMatchingTargetProductIds();
+                $this->_targetProductIdsSortOrder = (string) $this->getSortOrder();
             }
             $productIds = $this->_targetProductIds;
-            if ($this->isRandomSort()) {
+            if ($this->_isRandomSort()) {
                 shuffle($productIds);
             }
             return $productIds;
@@ -274,7 +293,7 @@ class Maho_CatalogLinkRule_Model_Rule extends Mage_Rule_Model_Abstract
             }
         }
 
-        if ($this->isRandomSort()) {
+        if ($this->_isRandomSort()) {
             shuffle($productIds);
         }
 

--- a/app/code/core/Maho/CatalogLinkRule/Model/Rule/Target/Product.php
+++ b/app/code/core/Maho/CatalogLinkRule/Model/Rule/Target/Product.php
@@ -10,6 +10,13 @@ declare(strict_types=1);
 
 class Maho_CatalogLinkRule_Model_Rule_Target_Product extends Mage_CatalogRule_Model_Rule_Condition_Product
 {
+    /**
+     * Operators that compare the target product against the source product instead of a fixed
+     * value. A condition using one of these makes the whole rule source-dependent, so
+     * Maho_CatalogLinkRule_Model_Rule reads this list too: keep it the single source of truth.
+     */
+    public const SOURCE_MATCH_OPERATORS = ['~=', '~!'];
+
     public function __construct()
     {
         parent::__construct();
@@ -40,6 +47,14 @@ class Maho_CatalogLinkRule_Model_Rule_Target_Product extends Mage_CatalogRule_Mo
     }
 
     /**
+     * Whether this condition compares the target product against the source product.
+     */
+    public function isSourceMatchOperator(): bool
+    {
+        return in_array((string) $this->getOperator(), self::SOURCE_MATCH_OPERATORS, true);
+    }
+
+    /**
      * Add source matching operators to all input types
      */
     #[\Override]
@@ -47,9 +62,10 @@ class Maho_CatalogLinkRule_Model_Rule_Target_Product extends Mage_CatalogRule_Mo
     {
         $operators = parent::getDefaultOperatorInputByType();
         // Add source matching operators to all input types
-        foreach ($operators as $type => $ops) {
-            $operators[$type][] = '~=';
-            $operators[$type][] = '~!';
+        foreach (array_keys($operators) as $type) {
+            foreach (self::SOURCE_MATCH_OPERATORS as $sourceMatchOperator) {
+                $operators[$type][] = $sourceMatchOperator;
+            }
         }
         return $operators;
     }
@@ -60,10 +76,10 @@ class Maho_CatalogLinkRule_Model_Rule_Target_Product extends Mage_CatalogRule_Mo
     #[\Override]
     public function validate(Maho\DataObject $object): bool
     {
-        $operator = $this->getOperator();
+        $operator = (string) $this->getOperator();
 
         // Handle source matching operators
-        if ($operator === '~=' || $operator === '~!') {
+        if ($this->isSourceMatchOperator()) {
             return $this->validateSourceMatch($object, $operator);
         }
 
@@ -138,10 +154,8 @@ class Maho_CatalogLinkRule_Model_Rule_Target_Product extends Mage_CatalogRule_Mo
     #[\Override]
     public function getValueElementHtml(): string
     {
-        $operator = $this->getOperator();
-
         // No value input needed for source matching
-        if ($operator === '~=' || $operator === '~!') {
+        if ($this->isSourceMatchOperator()) {
             return '';
         }
 
@@ -154,9 +168,7 @@ class Maho_CatalogLinkRule_Model_Rule_Target_Product extends Mage_CatalogRule_Mo
     #[\Override]
     public function getValueAfterElementHtml(): string
     {
-        $operator = $this->getOperator();
-
-        if ($operator === '~=' || $operator === '~!') {
+        if ($this->isSourceMatchOperator()) {
             return '<div style="margin-top: 5px; font-style: italic; color: #666;">'
                 . Mage::helper('cataloglinkrule')->__('Target product attribute will be compared to source product')
                 . '</div>';
@@ -172,9 +184,8 @@ class Maho_CatalogLinkRule_Model_Rule_Target_Product extends Mage_CatalogRule_Mo
     public function asArray(array $arrAttributes = []): array
     {
         $out = parent::asArray($arrAttributes);
-        $operator = $this->getOperator();
 
-        if ($operator === '~=' || $operator === '~!') {
+        if ($this->isSourceMatchOperator()) {
             $out['value'] = ''; // No value for source matching
         }
 

--- a/tests/Backend/Integration/CatalogLinkRule/Model/RuleTargetCacheTest.php
+++ b/tests/Backend/Integration/CatalogLinkRule/Model/RuleTargetCacheTest.php
@@ -41,6 +41,17 @@ describe('CatalogLinkRule target-scan caching', function () {
         expect($rule->targetConditionsUseSourceProduct())->toBeTrue();
     });
 
+    test('a target product condition using a "matches source" operator is source-dependent', function () {
+        foreach (Maho_CatalogLinkRule_Model_Rule_Target_Product::SOURCE_MATCH_OPERATORS as $operator) {
+            $rule = Mage::getModel('cataloglinkrule/rule');
+            $condition = Mage::getModel('cataloglinkrule/rule_target_product');
+            $condition->setAttribute('attribute_set_id')->setOperator($operator);
+            $rule->getTargetConditions()->addCondition($condition);
+
+            expect($rule->targetConditionsUseSourceProduct())->toBeTrue();
+        }
+    });
+
     test('a source-match nested in a sub-combine is still detected', function () {
         $rule = Mage::getModel('cataloglinkrule/rule');
         // Attach the sub-combine before adding its child: addCondition() propagates the parent
@@ -73,6 +84,31 @@ describe('CatalogLinkRule target-scan caching', function () {
 
         expect($rule->getMatchingTargetProductIds())->toBe([11, 22, 33]);
         expect($rule->getMatchingTargetProductIds())->toBe([11, 22, 33]);
+        expect($rule->collectCalls)->toBe(1);
+    });
+
+    test('changing the sort order rescans instead of reusing a differently-ordered cache', function () {
+        $rule = new Maho_CatalogLinkRule_Test_CountingRule();
+        $rule->collectResult = [11, 22, 33];
+        $rule->setSortOrder('price_asc');
+        $rule->getMatchingTargetProductIds();
+
+        $rule->setSortOrder('name_desc');
+        $rule->getMatchingTargetProductIds();
+
+        expect($rule->collectCalls)->toBe(2);
+    });
+
+    test('an unchanged rule scans only once across many source products', function () {
+        $rule = new Maho_CatalogLinkRule_Test_CountingRule();
+        $rule->collectResult = [11, 22, 33];
+        $rule->getTargetConditions()->addCondition(Mage::getModel('cataloglinkrule/rule_target_product'));
+
+        for ($i = 0; $i < 50; $i++) {
+            expect($rule->getMatchingTargetProductIds())->toBe([11, 22, 33]);
+        }
+
+        // The whole point of the change: one scan, not one per source product.
         expect($rule->collectCalls)->toBe(1);
     });
 

--- a/tests/Backend/Integration/CatalogLinkRule/Model/RuleTargetCacheTest.php
+++ b/tests/Backend/Integration/CatalogLinkRule/Model/RuleTargetCacheTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Rule that counts how often the catalog is actually scanned, so the target-scan caching can be
+ * asserted without touching the database.
+ */
+class Maho_CatalogLinkRule_Test_CountingRule extends Maho_CatalogLinkRule_Model_Rule
+{
+    public int $collectCalls = 0;
+    public array $collectResult = [];
+
+    #[\Override]
+    protected function _collectMatchingTargetProductIds(?Mage_Catalog_Model_Product $sourceProduct = null): array
+    {
+        $this->collectCalls++;
+        return $this->collectResult;
+    }
+}
+
+describe('CatalogLinkRule target-scan caching', function () {
+    test('target conditions without a source-match are flagged as source-independent', function () {
+        $rule = Mage::getModel('cataloglinkrule/rule');
+        $rule->getTargetConditions()->addCondition(Mage::getModel('cataloglinkrule/rule_target_product'));
+
+        expect($rule->targetConditionsUseSourceProduct())->toBeFalse();
+    });
+
+    test('a source-match target condition marks the rule as source-dependent', function () {
+        $rule = Mage::getModel('cataloglinkrule/rule');
+        $rule->getTargetConditions()->addCondition(Mage::getModel('cataloglinkrule/rule_target_sourceMatch'));
+
+        expect($rule->targetConditionsUseSourceProduct())->toBeTrue();
+    });
+
+    test('a source-match nested in a sub-combine is still detected', function () {
+        $rule = Mage::getModel('cataloglinkrule/rule');
+        $nested = Mage::getModel('cataloglinkrule/rule_target_combine');
+        $nested->addCondition(Mage::getModel('cataloglinkrule/rule_target_sourceMatch'));
+        $rule->getTargetConditions()->addCondition($nested);
+
+        expect($rule->targetConditionsUseSourceProduct())->toBeTrue();
+    });
+
+    test('source-independent target scan is computed once and reused across source products', function () {
+        $rule = new Maho_CatalogLinkRule_Test_CountingRule();
+        $rule->collectResult = [11, 22, 33];
+
+        $first = $rule->getMatchingTargetProductIds();
+        $second = $rule->getMatchingTargetProductIds();
+
+        // One catalog scan, reused for the second call.
+        expect($rule->collectCalls)->toBe(1);
+        // Same matched set both times (order may differ under random sort).
+        expect($first)->toEqualCanonicalizing([11, 22, 33]);
+        expect($second)->toEqualCanonicalizing([11, 22, 33]);
+    });
+
+    test('a deterministic sort keeps the cached order stable', function () {
+        $rule = new Maho_CatalogLinkRule_Test_CountingRule();
+        $rule->collectResult = [11, 22, 33];
+        $rule->setSortOrder('price_asc');
+
+        expect($rule->getMatchingTargetProductIds())->toBe([11, 22, 33]);
+        expect($rule->getMatchingTargetProductIds())->toBe([11, 22, 33]);
+        expect($rule->collectCalls)->toBe(1);
+    });
+
+    test('source-dependent target scan is recomputed per source product', function () {
+        $rule = new Maho_CatalogLinkRule_Test_CountingRule();
+        $rule->collectResult = [11, 22, 33];
+        $rule->getTargetConditions()->addCondition(Mage::getModel('cataloglinkrule/rule_target_sourceMatch'));
+
+        $rule->getMatchingTargetProductIds();
+        $rule->getMatchingTargetProductIds();
+
+        // No caching when the target set depends on the source product.
+        expect($rule->collectCalls)->toBe(2);
+    });
+});

--- a/tests/Backend/Integration/CatalogLinkRule/Model/RuleTargetCacheTest.php
+++ b/tests/Backend/Integration/CatalogLinkRule/Model/RuleTargetCacheTest.php
@@ -105,7 +105,9 @@ describe('CatalogLinkRule target-scan caching', function () {
         $rule->getTargetConditions()->addCondition(Mage::getModel('cataloglinkrule/rule_target_product'));
 
         for ($i = 0; $i < 50; $i++) {
-            expect($rule->getMatchingTargetProductIds())->toBe([11, 22, 33]);
+            // No sort order is configured, so the default random sort shuffles a fresh copy per
+            // call; only the matched set is stable, not its order.
+            expect($rule->getMatchingTargetProductIds())->toEqualCanonicalizing([11, 22, 33]);
         }
 
         // The whole point of the change: one scan, not one per source product.

--- a/tests/Backend/Integration/CatalogLinkRule/Model/RuleTargetCacheTest.php
+++ b/tests/Backend/Integration/CatalogLinkRule/Model/RuleTargetCacheTest.php
@@ -43,9 +43,11 @@ describe('CatalogLinkRule target-scan caching', function () {
 
     test('a source-match nested in a sub-combine is still detected', function () {
         $rule = Mage::getModel('cataloglinkrule/rule');
+        // Attach the sub-combine before adding its child: addCondition() propagates the parent
+        // combine's prefix down, so building top-down keeps every level's getConditions() in sync.
         $nested = Mage::getModel('cataloglinkrule/rule_target_combine');
-        $nested->addCondition(Mage::getModel('cataloglinkrule/rule_target_sourceMatch'));
         $rule->getTargetConditions()->addCondition($nested);
+        $nested->addCondition(Mage::getModel('cataloglinkrule/rule_target_sourceMatch'));
 
         expect($rule->targetConditionsUseSourceProduct())->toBeTrue();
     });


### PR DESCRIPTION
Fixes #1153.

## Problem

`Maho_CatalogLinkRule_Model_Processor` rescanned the entire enabled catalog **once per matched source product**. Because the matched target set is source-independent unless the target conditions contain a `Maho_CatalogLinkRule_Model_Rule_Target_SourceMatch` condition, the same product collection was rebuilt and validated N times (once per source product), making `cataloglinkrule_apply_all` `O(sources × catalog)`. On the reported 27.6k-product store a single rule took ~25 minutes and peaked at 718 MB, so the schedule never finished.

## Changes

- **`Model/Rule.php`**
  - Added `targetConditionsUseSourceProduct()`, which recursively detects whether the target conditions reference the source product (a `Target_SourceMatch` condition, including ones nested in sub-combines).
  - When the target set is source-independent (the common case), `getMatchingTargetProductIds()` now scans the catalog **once**, caches the matched IDs on the rule, and reuses them for every source product. Random sort still `shuffle()`s a fresh copy per call, so each source product keeps its own randomized pick, exactly as before. Deterministic sorts keep the cached order.
  - Extracted the actual scan into `_collectMatchingTargetProductIds()`.
  - Dropped `addAttributeToSelect('*')` from `getMatchingSourceProductIds()`; `collectValidatedAttributes()` (called immediately after) already adds exactly the attributes the conditions need, so `'*'` only inflated memory with no change to the match set.
- **`Model/Processor.php`**
  - `applyRuleToProduct()` now skips the per-source `Mage::getModel('catalog/product')->load($productId)` when the target conditions never read the source product; that full load was pure overhead in the common case.
- **`tests/.../Model/RuleTargetCacheTest.php`** (new)
  - Source-independence detection for a flat target condition and for a `SourceMatch` nested inside a sub-combine.
  - The source-independent scan is computed once and reused across source products, returning the same match set each time.
  - Deterministic sort keeps the cached order stable across calls.
  - Source-dependent target conditions are recomputed per source product (no caching).

## Result

Same catalog, same rule, same output — matching the measurements in the issue:

- ~25 min → ~2.6 s wall time
- 718 MB → ~180 MB peak memory
- Identical match sets (1,518 sources, 682 targets) and identical generated links

## Scope

This addresses the performance root causes only. The two "related findings" in the issue (unreaped stuck cron `running` schedules, and `replace` merge mode wiping manually curated links) are intentionally left out — the issue author flagged them as candidates for separate issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_016BjpWm3T8C4DdExPKMg6Ra)_

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->