### PR TITLE
Review follow-ups for the stuck-cron reaper: clearer admin comment and cron:unlock tests

### DIFF
--- a/app/code/core/Mage/Cron/etc/system.xml
+++ b/app/code/core/Mage/Cron/etc/system.xml
@@ -47,7 +47,7 @@ SPDX-License-Identifier: AFL-3.0
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <validate>required-entry validate-digits validate-zero-or-greater</validate>
-                            <comment>Stale jobs whose worker died (OOM, timeout, SIGKILL) are flipped from "running" to "error" after this many minutes. Set to 0 to disable.</comment>
+                            <comment>Stale jobs whose worker died (OOM, timeout, SIGKILL) are flipped from "running" to "error" after this many minutes. Keep this above the runtime of your slowest job, as any job still running past this threshold is marked as an error. Set to 0 to disable.</comment>
                         </max_running_time>
                         <history_cleanup_every translate="label">
                             <label>History Cleanup Every</label>

--- a/app/locale/en_US/Mage_Cron.csv
+++ b/app/locale/en_US/Mage_Cron.csv
@@ -62,7 +62,7 @@
 "Schedule","Schedule"
 "Schedule Ahead for","Schedule Ahead for"
 "Schedule not found.","Schedule not found."
-"Stale jobs whose worker died (OOM, timeout, SIGKILL) are flipped from ""running"" to ""error"" after this many minutes. Set to 0 to disable.","Stale jobs whose worker died (OOM, timeout, SIGKILL) are flipped from ""running"" to ""error"" after this many minutes. Set to 0 to disable."
+"Stale jobs whose worker died (OOM, timeout, SIGKILL) are flipped from ""running"" to ""error"" after this many minutes. Keep this above the runtime of your slowest job, as any job still running past this threshold is marked as an error. Set to 0 to disable.","Stale jobs whose worker died (OOM, timeout, SIGKILL) are flipped from ""running"" to ""error"" after this many minutes. Keep this above the runtime of your slowest job, as any job still running past this threshold is marked as an error. Set to 0 to disable."
 "Success","Success"
 "Success History Lifetime","Success History Lifetime"
 "Too late for the schedule.","Too late for the schedule."

--- a/tests/Backend/Unit/Mage/Cron/StuckJobReaperTest.php
+++ b/tests/Backend/Unit/Mage/Cron/StuckJobReaperTest.php
@@ -32,6 +32,7 @@ function makeRunningSchedule(string $executedAt): Mage_Cron_Model_Schedule
 }
 
 afterEach(function () {
+    Mage::app()->getStore()->setConfig(Mage_Cron_Model_Observer::XML_PATH_MAX_RUNNING_TIME, '60');
     Mage::getModel('cron/schedule')->getCollection()
         ->addFieldToFilter('job_code', 'unit_test_stuck_job')
         ->walk('delete');
@@ -70,6 +71,5 @@ it('does nothing when the reaper is disabled', function () {
 
     $reloaded = Mage::getModel('cron/schedule')->load($schedule->getId());
     expect($reloaded->getStatus())->toBe(Mage_Cron_Model_Schedule::STATUS_RUNNING);
-
-    $store->setConfig(Mage_Cron_Model_Observer::XML_PATH_MAX_RUNNING_TIME, '60');
+    // Config is restored in afterEach so a failed assertion above cannot leak it.
 });

--- a/tests/Backend/Unit/MahoCLI/Commands/CronUnlockTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/CronUnlockTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package MahoCLI
+ */
+
+declare(strict_types=1);
+
+use MahoCLI\Commands\CronUnlock;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Coverage for the cron:unlock command (issue #1154): resetting stale "running"
+ * schedules left behind by a crashed or killed worker. Without --all only rows
+ * older than max_running_time are cleared; --all clears every running row; an
+ * optional job_code narrows the scope.
+ */
+
+function cronUnlockTester(): CommandTester
+{
+    $command = new CronUnlock('cron:unlock');
+    $application = new Application();
+    $application->addCommand($command);
+    return new CommandTester($command);
+}
+
+function makeUnlockSchedule(string $jobCode, int $executedAgo): Mage_Cron_Model_Schedule
+{
+    $locale = Mage::app()->getLocale();
+    $ts = $locale->formatDateForDb(time() - $executedAgo);
+    /** @var Mage_Cron_Model_Schedule $schedule */
+    $schedule = Mage::getModel('cron/schedule');
+    $schedule->setJobCode($jobCode)
+        ->setStatus(Mage_Cron_Model_Schedule::STATUS_RUNNING)
+        ->setCreatedAt($ts)
+        ->setScheduledAt($ts)
+        ->setExecutedAt($ts)
+        ->save();
+    return $schedule;
+}
+
+afterEach(function () {
+    Mage::app()->getStore()->setConfig(Mage_Cron_Model_Observer::XML_PATH_MAX_RUNNING_TIME, '60');
+    foreach (['unit_test_unlock_a', 'unit_test_unlock_b'] as $jobCode) {
+        Mage::getModel('cron/schedule')->getCollection()
+            ->addFieldToFilter('job_code', $jobCode)
+            ->walk('delete');
+    }
+});
+
+it('unlocks only schedules older than max_running_time by default', function () {
+    $stale = makeUnlockSchedule('unit_test_unlock_a', 3 * 3600); // 3 hours ago
+    $fresh = makeUnlockSchedule('unit_test_unlock_b', 60);       // 1 minute ago
+
+    $tester = cronUnlockTester();
+    $tester->execute([]);
+
+    expect($tester->getStatusCode())->toBe(Command::SUCCESS);
+    expect(Mage::getModel('cron/schedule')->load($stale->getId())->getStatus())
+        ->toBe(Mage_Cron_Model_Schedule::STATUS_ERROR);
+    expect(Mage::getModel('cron/schedule')->load($fresh->getId())->getStatus())
+        ->toBe(Mage_Cron_Model_Schedule::STATUS_RUNNING);
+});
+
+it('unlocks every running schedule with --all regardless of age', function () {
+    $fresh = makeUnlockSchedule('unit_test_unlock_a', 60);
+
+    $tester = cronUnlockTester();
+    $tester->execute(['--all' => true]);
+
+    expect($tester->getStatusCode())->toBe(Command::SUCCESS);
+    $reloaded = Mage::getModel('cron/schedule')->load($fresh->getId());
+    expect($reloaded->getStatus())->toBe(Mage_Cron_Model_Schedule::STATUS_ERROR);
+    expect($reloaded->getFinishedAt())->not->toBeEmpty();
+});
+
+it('restricts unlocking to the given job_code', function () {
+    $target = makeUnlockSchedule('unit_test_unlock_a', 60);
+    $other = makeUnlockSchedule('unit_test_unlock_b', 60);
+
+    $tester = cronUnlockTester();
+    $tester->execute(['job_code' => 'unit_test_unlock_a', '--all' => true]);
+
+    expect($tester->getStatusCode())->toBe(Command::SUCCESS);
+    expect(Mage::getModel('cron/schedule')->load($target->getId())->getStatus())
+        ->toBe(Mage_Cron_Model_Schedule::STATUS_ERROR);
+    expect(Mage::getModel('cron/schedule')->load($other->getId())->getStatus())
+        ->toBe(Mage_Cron_Model_Schedule::STATUS_RUNNING);
+});
+
+it('reports when no stale running schedules are found', function () {
+    makeUnlockSchedule('unit_test_unlock_a', 60); // fresh, below the default threshold
+
+    $tester = cronUnlockTester();
+    $tester->execute([]);
+
+    expect($tester->getStatusCode())->toBe(Command::SUCCESS);
+    expect($tester->getDisplay())->toContain('No stale running schedules found');
+});


### PR DESCRIPTION
Follow-up refinements from reviewing #1156, targeted at that PR's branch so they can fold into it.

## Changes

- **Clarified the `max_running_time` admin field comment** (`etc/system.xml` and its `Mage_Cron.csv` translation). The reaper flips *any* `running` row past the threshold to `error`, including a job that is legitimately still executing in a concurrent worker. The comment now tells the admin to keep the value above the runtime of the slowest legitimate job.
- **Hardened `StuckJobReaperTest`.** The "reaper is disabled" case overrides `max_running_time` to `0`; the restore now lives in `afterEach` so a failed assertion can't leak the override into sibling tests.
- **Added `CronUnlockTest`.** The `cron:unlock` command previously had no coverage. New tests exercise the default-threshold path (only rows older than `max_running_time`), `--all` (every running row regardless of age), `job_code` scoping, and the empty-result message.

## Notes

- No production logic changed — this is a documentation-string clarification plus test coverage.
- I also examined whether a stale reaper message could survive on a row that later succeeds. It cannot: `cron_schedule.messages` is nullable and the executing schedule is loaded with `messages = null`, so the success `save()` writes `NULL` via `_prepareDataForTable`, overwriting any concurrent reaper message. No code change was needed there.
- Lint and the Pest suite could not be run in this sandbox (composer cannot authenticate to github.com through the egress proxy, so `vendor/` is unavailable); CI will validate both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ee4XnSH26VkdPCYkTNX2JG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee4XnSH26VkdPCYkTNX2JG)_