### PR TITLE
Updated PHPStan to 2.2.6 and fixed the new unnecessary null-coalesce errors

### DIFF
--- a/app/code/core/Mage/Admin/Model/Session.php
+++ b/app/code/core/Mage/Admin/Model/Session.php
@@ -162,6 +162,8 @@ class Mage_Admin_Model_Session extends Mage_Core_Model_Session_Abstract
             return null;
         }
 
+        $user = null;
+
         try {
             /** @var Mage_Admin_Model_User $user */
             $user = $this->_factory->getModel('admin/user');
@@ -200,7 +202,7 @@ class Mage_Admin_Model_Session extends Mage_Core_Model_Session_Abstract
             $this->_loginFailed($e, $request, $username, $message);
         }
 
-        return $user ?? null;
+        return $user;
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
@@ -40,7 +40,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Datetime extends Mage_Adm
         if ($data = $this->_getValue($row)) {
             try {
                 $useTimezone = $this->getColumn()->getUseTimezone() ?? true;
-                $locale = $this->getColumn()->getLocale() ?? null;
+                $locale = $this->getColumn()->getLocale();
 
                 $dateObj = $useTimezone
                     ? Mage::app()->getLocale()->utcToStore(null, $data)

--- a/app/code/core/Mage/Payment/Model/Restriction/Rule/Condition/Product.php
+++ b/app/code/core/Mage/Payment/Model/Restriction/Rule/Condition/Product.php
@@ -38,7 +38,7 @@ class Mage_Payment_Model_Restriction_Rule_Condition_Product extends Mage_Rule_Mo
      */
     public function getRule()
     {
-        return $this->_rule ?? null;
+        return $this->_rule;
     }
 
     /**

--- a/app/code/core/Mage/Sales/Helper/Guest.php
+++ b/app/code/core/Mage/Sales/Helper/Guest.php
@@ -149,7 +149,7 @@ class Mage_Sales_Helper_Guest extends Mage_Core_Helper_Data
     {
         if (!is_null($cookie)) {
             $cookieData = explode(':', base64_decode($cookie));
-            $protectCode = $cookieData[0] ?? null;
+            $protectCode = $cookieData[0];
             $incrementId = $cookieData[1] ?? null;
 
             if (!empty($protectCode) && !empty($incrementId)) {

--- a/app/code/core/Maho/Ai/Helper/Data.php
+++ b/app/code/core/Maho/Ai/Helper/Data.php
@@ -130,7 +130,7 @@ class Maho_Ai_Helper_Data extends Mage_Core_Helper_Abstract
         // path in invoke(). Without this the async queue would be a bypass
         // around the same guard that protects synchronous calls.
         foreach ($data['messages'] ?? [] as $msg) {
-            if (($msg['role'] ?? null) === 'user') {
+            if (($msg['role'] ?? '') === 'user') {
                 $validation = $this->getInputValidator()->validate((string) ($msg['content'] ?? ''));
                 if (!$validation['safe']) {
                     throw new Mage_Core_Exception('AI request rejected: ' . $validation['reason']);

--- a/composer.lock
+++ b/composer.lock
@@ -1776,16 +1776,16 @@
         },
         {
             "name": "mahocommerce/icons",
-            "version": "3.44.0",
+            "version": "3.45.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MahoCommerce/icons.git",
-                "reference": "7ac5bd40750af89360324c7a0685575e1fb01d30"
+                "reference": "ca3750ff257ef58d517ed1f2e551b824f1341e4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MahoCommerce/icons/zipball/7ac5bd40750af89360324c7a0685575e1fb01d30",
-                "reference": "7ac5bd40750af89360324c7a0685575e1fb01d30",
+                "url": "https://api.github.com/repos/MahoCommerce/icons/zipball/ca3750ff257ef58d517ed1f2e551b824f1341e4d",
+                "reference": "ca3750ff257ef58d517ed1f2e551b824f1341e4d",
                 "shasum": ""
             },
             "type": "library",
@@ -1796,9 +1796,9 @@
             "description": "A huge package of optimized SVG icons",
             "support": {
                 "issues": "https://github.com/MahoCommerce/icons/issues",
-                "source": "https://github.com/MahoCommerce/icons/tree/3.44.0"
+                "source": "https://github.com/MahoCommerce/icons/tree/3.45.0"
             },
-            "time": "2026-05-09T03:33:15+00:00"
+            "time": "2026-07-26T13:00:27+00:00"
         },
         {
             "name": "mahocommerce/maho-composer-plugin",
@@ -7016,16 +7016,16 @@
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "2f3ebed5a4f663968a0590dbb7654a8b32cb63cb"
+                "reference": "73c38b323ff8d790abf0f76c56fcc892bda4111a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/2f3ebed5a4f663968a0590dbb7654a8b32cb63cb",
-                "reference": "2f3ebed5a4f663968a0590dbb7654a8b32cb63cb",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/73c38b323ff8d790abf0f76c56fcc892bda4111a",
+                "reference": "73c38b323ff8d790abf0f76c56fcc892bda4111a",
                 "shasum": ""
             },
             "require": {
@@ -7085,7 +7085,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v3.1.2"
+                "source": "https://github.com/amphp/amp/tree/v3.1.3"
             },
             "funding": [
                 {
@@ -7093,7 +7093,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-21T13:59:44+00:00"
+            "time": "2026-07-19T17:59:20+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -7720,16 +7720,16 @@
         },
         {
             "name": "amphp/pipeline",
-            "version": "v1.2.6",
+            "version": "v1.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/pipeline.git",
-                "reference": "10941bf38de5c585aa2407b2ec4265d806d4eef2"
+                "reference": "cf2d67696c2015ea7c7fd8f6ec5f8ed7c2d17c17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/pipeline/zipball/10941bf38de5c585aa2407b2ec4265d806d4eef2",
-                "reference": "10941bf38de5c585aa2407b2ec4265d806d4eef2",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/cf2d67696c2015ea7c7fd8f6ec5f8ed7c2d17c17",
+                "reference": "cf2d67696c2015ea7c7fd8f6ec5f8ed7c2d17c17",
                 "shasum": ""
             },
             "require": {
@@ -7775,7 +7775,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/pipeline/issues",
-                "source": "https://github.com/amphp/pipeline/tree/v1.2.6"
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.7"
             },
             "funding": [
                 {
@@ -7783,7 +7783,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-27T16:15:40+00:00"
+            "time": "2026-07-26T14:50:43+00:00"
         },
         {
             "name": "amphp/process",
@@ -10166,21 +10166,21 @@
         },
         {
             "name": "mahocommerce/maho-phpstan-plugin",
-            "version": "v4.2.1",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MahoCommerce/maho-phpstan-plugin.git",
-                "reference": "99314b979dddbc4aa0188fc9d8a2805f1ec7670f"
+                "reference": "f46b2ee678b8c26487ce2d2626dc6a55e8f07209"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MahoCommerce/maho-phpstan-plugin/zipball/99314b979dddbc4aa0188fc9d8a2805f1ec7670f",
-                "reference": "99314b979dddbc4aa0188fc9d8a2805f1ec7670f",
+                "url": "https://api.github.com/repos/MahoCommerce/maho-phpstan-plugin/zipball/f46b2ee678b8c26487ce2d2626dc6a55e8f07209",
+                "reference": "f46b2ee678b8c26487ce2d2626dc6a55e8f07209",
                 "shasum": ""
             },
             "require": {
-                "php": ">= 8.2",
-                "phpstan/phpstan": "^2.1"
+                "php": ">=8.3",
+                "phpstan/phpstan": "^2.2.6"
             },
             "require-dev": {
                 "phpstan/phpstan-deprecation-rules": "^2.0",
@@ -10205,9 +10205,23 @@
             ],
             "description": "Extension for PHPStan to allow static analysis of Maho projects.",
             "support": {
-                "source": "https://github.com/MahoCommerce/maho-phpstan-plugin/tree/v4.2.1"
+                "source": "https://github.com/MahoCommerce/maho-phpstan-plugin/tree/v4.3.0"
             },
-            "time": "2026-05-30T22:42:12+00:00"
+            "funding": [
+                {
+                    "url": "https://www.buymeacoffee.com/fballiano",
+                    "type": "buy_me_a_coffee"
+                },
+                {
+                    "url": "https://paypal.me/fabrizioballiano",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fballiano",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-27T08:31:47+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -11326,11 +11340,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.5",
+            "version": "2.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
-                "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a6e9b5a9420f6109c091e87d82683bd1a80b87ed",
+                "reference": "a6e9b5a9420f6109c091e87d82683bd1a80b87ed",
                 "shasum": ""
             },
             "require": {
@@ -11386,7 +11400,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-05T06:31:06+00:00"
+            "time": "2026-07-26T21:22:49+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -12635,21 +12649,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.5.7",
+            "version": "2.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "ba22f8c087848278fed6b4910d4cf1108096d8d3"
+                "reference": "861c77fd2a6d45317a401f4e0b617f947e8b6f96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/ba22f8c087848278fed6b4910d4cf1108096d8d3",
-                "reference": "ba22f8c087848278fed6b4910d4cf1108096d8d3",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/861c77fd2a6d45317a401f4e0b617f947e8b6f96",
+                "reference": "861c77fd2a6d45317a401f4e0b617f947e8b6f96",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.2.2"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -12683,7 +12697,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.5.7"
+                "source": "https://github.com/rectorphp/rector/tree/2.5.8"
             },
             "funding": [
                 {
@@ -12691,7 +12705,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-13T15:24:18+00:00"
+            "time": "2026-07-27T06:19:16+00:00"
         },
         {
             "name": "revolt/event-loop",


### PR DESCRIPTION
Updating PHPStan to 2.2.6 broke `composer lint:phpstan` in two ways.

## The fatal

PHPStan 2.2.6 added `getPureUnlessCallableIsImpureParameters()` to `ExtendedMethodReflection`. `maho-phpstan-plugin`'s `PublicMethodReflection` did not implement it, so every run died as soon as that class was autoloaded — which happens via `BindThisScopeResolverExtension`, i.e. any phtml template or install script calling a protected method on `$this`:

```
Child process error (exit code 255): PHP Fatal error: Class Maho\PHPStanPlugin\Reflection\PublicMethodReflection
contains 1 abstract method and must therefore be declared abstract or implement the remaining method
(PHPStan\Reflection\ExtendedMethodReflection::getPureUnlessCallableIsImpureParameters)
```

Fixed upstream in MahoCommerce/maho-phpstan-plugin#28 and released as [v4.3.0](https://github.com/MahoCommerce/maho-phpstan-plugin/releases/tag/v4.3.0), which this lockfile picks up.

## The new check

2.2.6 also adds `nullCoalesce.unnecessary`, which flags `?? null` on an expression that is always set. Five call sites tripped it:

* **`Mage_Admin_Model_Session::login()`** — initialize `$user = null` before the `try` and return it directly. PHPStan considers the variable always set after the block, but only because it treats `getModel()` as a non-throw point; `Mage::throwException()` from an invalid model would leave `$user` undefined at runtime. Initializing up front makes the guard explicit instead of inferred, so the behaviour does not depend on that inference being right.
* **`Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Datetime`**, **`Mage_Payment_Model_Restriction_Rule_Condition_Product::getRule()`**, **`Mage_Sales_Helper_Guest::_loadOrderByCookie()`** — drop a genuine no-op `?? null`: `explode()` always yields index 0, and an untyped `$_rule` property already defaults to null. The `?? null` on `$cookieData[1]` stays, since that index really can be missing.
* **`Maho_Ai_Helper_Data::submitTask()`** — default a missing message role to `''` rather than `null`. PHPStan trusts the `array{role: string, ...}` docblock, but the parameter is a plain `array` at runtime, so the fallback has to stay: dropping it would let a payload without `role` silently skip the prompt-injection check, which is exactly the bypass that guard exists to close.

## Verification

`composer lint` is clean: PHPStan 5261/5261 with no errors, php-cs-fixer 0 of 4769 fixable, Rector OK.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->