### PR TITLE
Fixed flaky order assertion in catalog link rule target-cache test

### DIFF
--- a/tests/Backend/Integration/CatalogLinkRule/Model/RuleTargetCacheTest.php
+++ b/tests/Backend/Integration/CatalogLinkRule/Model/RuleTargetCacheTest.php
@@ -105,7 +105,9 @@ describe('CatalogLinkRule target-scan caching', function () {
         $rule->getTargetConditions()->addCondition(Mage::getModel('cataloglinkrule/rule_target_product'));
 
         for ($i = 0; $i < 50; $i++) {
-            expect($rule->getMatchingTargetProductIds())->toBe([11, 22, 33]);
+            // No sort order is configured, so the default random sort shuffles a fresh copy per
+            // call; only the matched set is stable, not its order.
+            expect($rule->getMatchingTargetProductIds())->toEqualCanonicalizing([11, 22, 33]);
         }
 
         // The whole point of the change: one scan, not one per source product.


### PR DESCRIPTION
## Problem

The `sqlite` test suite on #1155 failed in `RuleTargetCacheTest`:

```
FAILED Tests\Backend\Integration\CatalogLinkRule\Model\RuleTargetCacheTest
Failed asserting that two arrays are identical.
-    0 => 11,  -    1 => 22,  -    2 => 33,
+    0 => 22,  +    1 => 33,  +    2 => 11,
at tests/.../RuleTargetCacheTest.php:108
```

The **"an unchanged rule scans only once across many source products"** test configured **no** sort order. With no sort order, `Rule::_isRandomSort()` returns `true`, so `getMatchingTargetProductIds()` calls `shuffle()` on a fresh copy for every invocation. The test then asserted **exact** order (`->toBe([11, 22, 33])`) inside a 50-iteration loop, so it failed whenever `shuffle()` produced a different permutation — an inherently flaky assertion.

The production caching code is correct: it still scans the catalog only once and reuses the cached set, shuffling per call by design (each source product keeps its own randomized pick). Only the test's assertion was wrong.

## Change

- `RuleTargetCacheTest.php`: assert the matched set order-independently with `toEqualCanonicalizing([11, 22, 33])`, matching the sibling *source-independent scan* test that already does this. The caching assertion (`collectCalls === 1` across 50 calls) — the actual point of the test — is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmqHYnsFxrc8VAVFnhLJck)_