### PR TITLE
Fixed alignment of editable columns in admin grids

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
@@ -182,7 +182,6 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Crosssell extends Mage_Admin
             'validate_class'            => 'validate-number',
             'index'                     => 'position',
             'editable'                  => !$this->isReadonly(),
-            'edit_only'                 => !$this->_getProduct()->getId(),
             'filter_condition_callback' => [$this, '_addLinkModelFilterCallback'],
         ]);
 

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
@@ -190,7 +190,6 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Related extends Mage_Adminht
             'index'                     => 'position',
             'width'                     => 60,
             'editable'                  => !$this->_getProduct()->getRelatedReadonly(),
-            'edit_only'                 => !$this->_getProduct()->getId(),
             'filter_condition_callback' => [$this, '_addLinkModelFilterCallback'],
         ]);
 

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Group.php
@@ -155,7 +155,6 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Super_Group extends Mage_Adm
             'index'     => 'position',
             'width'     => '1',
             'editable'  => true,
-            'edit_only' => !$this->_getProduct()->getId(),
             'filter_condition_callback' => [$this, '_addLinkModelFilterCallback'],
         ]);
 

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
@@ -189,7 +189,6 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Upsell extends Mage_Adminhtm
             'validate_class'            => 'validate-number',
             'index'                     => 'position',
             'editable'                  => !$this->_getProduct()->getUpsellReadonly(),
-            'edit_only'                 => !$this->_getProduct()->getId(),
             'filter_condition_callback' => [$this, '_addLinkModelFilterCallback'],
         ]);
 

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Abstract.php
@@ -43,10 +43,7 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract extends
     public function render(\Maho\DataObject $row)
     {
         if ($this->getColumn()->getEditable()) {
-            $value = $this->_getValue($row);
-            return $value
-                   . ($this->getColumn()->getEditOnly() ? '' : ($value != '' ? '' : '&nbsp;'))
-                   . $this->_getInputValueElement($row);
+            return $this->_getInputValueElement($row);
         }
         return $this->_getValue($row);
     }
@@ -58,6 +55,9 @@ abstract class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract extends
      */
     public function renderExport(\Maho\DataObject $row)
     {
+        if ($this->getColumn()->getEditable()) {
+            return (string) $this->_getValue($row);
+        }
         return $this->render($row);
     }
 

--- a/public/skin/adminhtml/default/default/base.css
+++ b/public/skin/adminhtml/default/default/base.css
@@ -301,7 +301,10 @@ big {
 
 .grid {
     border-bottom: 0;
-    padding-bottom: .5em
+    padding-bottom: .5em;
+    /* Total footprint of the >=/<= label in a range filter. Editable cells inset
+       their input by the same amount so it lines up with the filter above it. */
+    --maho-grid-range-label: 1.25rem
 }
 
 .grid table {
@@ -340,8 +343,17 @@ big {
 }
 
 .grid td.editable input.input-text {
-    width: 50px!important;
-    margin-left: var(--maho-space-2)!important
+    width: calc(100% - var(--maho-grid-range-label))!important;
+    min-width: 0;
+    margin: 0!important
+}
+
+.grid td.a-right.editable input.input-text {
+    text-align: right
+}
+
+.grid td.a-center.editable input.input-text {
+    text-align: center
 }
 
 .grid td input.input-text {
@@ -694,6 +706,9 @@ table.actions td {
 .grid tr.filter th {
     padding-top: var(--maho-space-2);
     padding-bottom: var(--maho-space-2);
+    /* match the headings row and the body cells, which both use space-3 */
+    padding-left: var(--maho-space-3);
+    padding-right: var(--maho-space-3);
     border: 0;
     border-bottom: 1px solid var(--maho-border-soft);
     white-space: normal
@@ -5045,7 +5060,7 @@ small {
 .grid tr.filter .range .label {
     flex: 0 0 auto;
     font-weight: 400;
-    width: 0.625rem;
+    width: calc(var(--maho-grid-range-label) - var(--maho-space-2) * 2);
     padding: 0 var(--maho-space-2);
     font-size: var(--maho-text-lg);
     color: var(--maho-ink-muted);

--- a/tests/Backend/Unit/Adminhtml/Block/Widget/Grid/Column/Renderer/AbstractTest.php
+++ b/tests/Backend/Unit/Adminhtml/Block/Widget/Grid/Column/Renderer/AbstractTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * The renderer only ever reads its column, so a bare column block (no grid) is enough.
+ */
+function makePositionColumnRenderer(array $columnData): Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Number
+{
+    /** @var Mage_Adminhtml_Block_Widget_Grid_Column $column */
+    $column = Mage::app()->getLayout()->createBlock('adminhtml/widget_grid_column');
+    $column->setData($columnData + ['index' => 'position']);
+    $column->setId('position');
+
+    /** @var Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Number $renderer */
+    $renderer = Mage::app()->getLayout()->createBlock('adminhtml/widget_grid_column_renderer_number');
+    return $renderer->setColumn($column);
+}
+
+describe('Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract::render', function () {
+    it('renders only the input element for an editable column', function () {
+        $html = makePositionColumnRenderer(['editable' => true])
+            ->render(new Maho\DataObject(['position' => 7]));
+
+        expect($html)->toStartWith('<input ')
+            ->and($html)->toContain('name="position"')
+            ->and($html)->toContain('value="7"')
+            // the value used to be printed next to the input as well
+            ->and(substr_count($html, '7'))->toBe(1);
+    });
+
+    it('still renders the input for an editable column with an empty value', function () {
+        $html = makePositionColumnRenderer(['editable' => true])
+            ->render(new Maho\DataObject(['position' => null]));
+
+        expect($html)->toStartWith('<input ')
+            ->and($html)->not->toContain('&nbsp;');
+    });
+
+    it('renders the plain value for a non-editable column', function () {
+        $html = makePositionColumnRenderer([])
+            ->render(new Maho\DataObject(['position' => 7]));
+
+        expect($html)->toBe(7);
+    });
+});
+
+describe('Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract::renderExport', function () {
+    it('exports the raw value of an editable column, not its input markup', function () {
+        $html = makePositionColumnRenderer(['editable' => true])
+            ->renderExport(new Maho\DataObject(['position' => 7]));
+
+        expect($html)->toBe('7');
+    });
+});


### PR DESCRIPTION
Follow-up to the report that the Position column in the category products grid looks misaligned.

## What was wrong

Three separate things, only the first of which is visible at a glance.

**1. The input wrapped onto a second line.** `.grid td input.input-text` sets `min-width: 80px`, and `min-width` beats `width`, so the `width: 50px` that `.grid td.editable input.input-text` asked for never applied. The position column is declared `width: 1` (the default for the `number` type in `Mage_Adminhtml/etc/config.xml`), i.e. shrink-to-min-content, so an 80px input no longer fitted beside the value and wrapped — leaving a right-aligned number above a left-aligned input.

**2. The value was rendered twice.** `Renderer_Abstract::render()` emitted a static text node *and* an input carrying the identical value. Nothing in the codebase overrides `_getValue()` / `_getInputValue()` to make them differ, so this was guaranteed duplication on every row of every editable grid. The related `edit_only` flag — whose name says "show only the editor" — was inert, because `$value` was concatenated outside its ternary, which only ever toggled an `&nbsp;`. The four blocks that set the flag are updated accordingly.

**3. The filter row had different padding from every other row.** `.grid tr.headings th` and `.grid table td` both use `--maho-space-3` (10px), but `.grid tr.filter th` was never given it and fell through to the base `.grid th,.grid td` rule at 5px. Every filter box in every admin grid therefore sat 5px outside its column's content edges on both sides. This is why the input could not be made to line up by adjusting its width alone — it was flush with a different box than the filter above it.

## Changes

- `Renderer_Abstract::render()` emits just the input for editable columns.
- `Renderer_Abstract::renderExport()` returns the raw value for editable columns; previously a CSV/XML export of one contained `0<input …>` markup.
- Removed the four now-dead `edit_only` column flags.
- `.grid tr.filter th` gets the same horizontal padding as the headings and body rows.
- Editable inputs inset by the range filter's label footprint, via a new `--maho-grid-range-label` variable that the label rule also derives its own width from, so the two cannot drift.
- Editable inputs inherit their column's alignment (`a-right` / `a-center`).

## Verification

Checked in the admin against sample data. In the category products grid the `≥` filter, the `≤` filter and every row's input now report identical bounds to the pixel. Because the padding fix touches every grid, also checked Sales → Orders (date-range filters and selects render correctly, no overflow) and Manage Products (11 columns; headings and filter cells report identical bounds, no table or body overflow).

Added `tests/Backend/Unit/Adminhtml/Block/Widget/Grid/Column/Renderer/AbstractTest.php` covering editable render, empty value, non-editable render and export. The first case fails against the unfixed code, which returned `7<input …>`.

`composer lint` is clean.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->