### PR TITLE
Fixed migrations blocked by legacy zero-date column defaults

### DIFF
--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -36,6 +36,17 @@ class Mysql extends AbstractPdoAdapter
     protected string $_debugFile = 'pdo_mysql.log';
 
     /**
+     * Nesting depth of startSetup()/endSetup(): only the outermost pair saves
+     * and restores SQL_MODE.
+     */
+    protected int $_setupNesting = 0;
+
+    /**
+     * SQL_MODE saved by the outermost startSetup(), null outside setup.
+     */
+    protected ?string $_setupSqlMode = null;
+
+    /**
      * MySQL column - Table DDL type pairs
      */
     protected array $_ddlColumnTypes = [
@@ -142,7 +153,8 @@ class Mysql extends AbstractPdoAdapter
         // PostgreSQL and SQLite already behave, so insert semantics are
         // identical across all three engines. New-row inserts omit the PK (or
         // bind NULL) and still auto-generate as usual. Because it is now always
-        // on, startSetup()/insertForce() no longer need to toggle SQL_MODE.
+        // on, insertForce() no longer needs to toggle SQL_MODE; startSetup()
+        // still lifts the two zero-date flags, and only those, see there.
         if (isset($this->_config['sql_mode'])) {
             // Escape hatch: a <sql_mode> node on the connection in local.xml
             // overrides the baseline verbatim (an empty value restores the
@@ -2832,10 +2844,22 @@ class Mysql extends AbstractPdoAdapter
     #[\Override]
     public function startSetup(): self
     {
-        // SQL_MODE is left untouched: the connection baseline already pins the strict
-        // flags plus NO_AUTO_VALUE_ON_ZERO (data scripts may insert explicit ids,
-        // including 0), so install/upgrade scripts run under the same mode as
-        // production and get fully validated.
+        // Setup lifts the two zero-date flags, and only those: a legacy
+        // '0000-00-00 00:00:00' DEFAULT or stored value makes MySQL reject *any*
+        // ALTER on that table (error 1067/1292), including a DROP INDEX naming
+        // other columns and the very ALTER that would remove the offending
+        // default, which leaves a store migrated from Magento/OpenMage with no way
+        // to upgrade. What survives the migration is reported by health-check and
+        // cleaned up by ./maho legacy:fix-zero-dates.
+        if ($this->_setupNesting++ === 0) {
+            $this->_setupSqlMode = (string) $this->fetchOne('SELECT @@SESSION.sql_mode');
+            $relaxed = array_diff(
+                explode(',', $this->_setupSqlMode),
+                ['NO_ZERO_DATE', 'NO_ZERO_IN_DATE'],
+            );
+            $this->raw_query('SET SESSION SQL_MODE=' . $this->quote(implode(',', $relaxed)));
+        }
+
         $this->raw_query('SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0');
 
         return $this;
@@ -2848,6 +2872,13 @@ class Mysql extends AbstractPdoAdapter
     public function endSetup(): self
     {
         $this->raw_query('SET FOREIGN_KEY_CHECKS=IF(@OLD_FOREIGN_KEY_CHECKS=0, 0, 1)');
+
+        // Guard: a script calling endSetup() without a matching startSetup()
+        // must not restore a mode that was never saved.
+        if ($this->_setupNesting > 0 && --$this->_setupNesting === 0) {
+            $this->raw_query('SET SESSION SQL_MODE=' . $this->quote((string) $this->_setupSqlMode));
+            $this->_setupSqlMode = null;
+        }
 
         return $this;
     }

--- a/tests/Backend/Integration/Db/Adapter/MysqlStrictModeTest.php
+++ b/tests/Backend/Integration/Db/Adapter/MysqlStrictModeTest.php
@@ -151,20 +151,20 @@ it('preserves the strict baseline across startSetup and endSetup', function () {
     expect(fetchSqlMode($adapter))->toBe($modeBefore);
 });
 
-it('keeps the strict baseline active during setup without touching SQL_MODE', function () {
+it('keeps the strict baseline active during setup apart from the zero-date flags', function () {
     $adapter = createFreshMysqlAdapter();
-    $modeBefore = fetchSqlMode($adapter);
     $adapter->startSetup();
     // Setup scripts must run under the same strict mode as production, so a bad
     // write in an install/upgrade script is caught instead of silently truncated.
-    // The baseline already carries NO_AUTO_VALUE_ON_ZERO, so setup leaves SQL_MODE alone.
+    // Only the two zero-date flags are lifted, so a legacy '0000-00-00' default
+    // inherited from Magento/OpenMage cannot block the ALTER that would remove it.
     $modeDuring = fetchSqlMode($adapter);
     $adapter->endSetup();
 
-    expect($modeDuring)->toBe($modeBefore);
     expect($modeDuring)->toContain('STRICT_TRANS_TABLES');
-    expect($modeDuring)->toContain('NO_ZERO_DATE');
     expect($modeDuring)->toContain('NO_AUTO_VALUE_ON_ZERO');
+    expect($modeDuring)->not->toContain('NO_ZERO_DATE');
+    expect($modeDuring)->not->toContain('NO_ZERO_IN_DATE');
 });
 
 it('stores an explicit 0 in an identity column via both insert and insertForce', function () {

--- a/tests/Backend/Integration/Db/Adapter/SetupSqlModeTest.php
+++ b/tests/Backend/Integration/Db/Adapter/SetupSqlModeTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+use Maho\Db\Adapter\Pdo\Mysql;
+
+uses(Tests\MahoBackendTestCase::class);
+
+beforeEach(function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    if (!($adapter instanceof Mysql)) {
+        $this->markTestSkipped('MySQL-only test: zero dates only exist on MySQL/MariaDB.');
+    }
+});
+
+it('runs DDL on a legacy zero-date table between startSetup() and endSetup()', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    $table = 'setup_sql_mode_probe';
+    $modeBefore = (string) $adapter->fetchOne('SELECT @@SESSION.sql_mode');
+
+    try {
+        // The shape a store migrated from Magento/OpenMage actually has: a zero-date
+        // DEFAULT on a NOT NULL column, holding zero-date rows. Seeded under the
+        // relaxed mode, the way it got there in the first place.
+        $adapter->query("SET SESSION sql_mode=''");
+        $adapter->query(
+            "CREATE TABLE {$table} ("
+            . ' id INT PRIMARY KEY,'
+            . ' note VARCHAR(10),'
+            . ' idx_col INT,'
+            . " updated_at TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00',"
+            . ' KEY k_probe (idx_col)'
+            . ')',
+        );
+        $adapter->query("INSERT INTO {$table} VALUES (1, 'x', 5, '0000-00-00 00:00:00')");
+        $adapter->query('SET SESSION sql_mode = ' . $adapter->quote($modeBefore));
+
+        // Under the strict baseline, MySQL refuses every ALTER on the table, even
+        // one naming a different column entirely (error 1067).
+        expect(fn() => $adapter->query("ALTER TABLE {$table} DROP INDEX k_probe"))
+            ->toThrow(Exception::class);
+
+        $adapter->startSetup();
+        try {
+            $adapter->query("ALTER TABLE {$table} DROP INDEX k_probe");
+            // The TIMESTAMP→DATETIME conversion of upgrade-1.6.0.10-2.0.0: rebuilding
+            // rows that hold zero dates is the other half of the problem (error 1292).
+            $adapter->query("ALTER TABLE {$table} MODIFY COLUMN updated_at DATETIME NOT NULL");
+        } finally {
+            $adapter->endSetup();
+        }
+
+        expect((string) $adapter->fetchOne(
+            'SELECT DATA_TYPE FROM information_schema.COLUMNS'
+            . ' WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?',
+            [$table, 'updated_at'],
+        ))->toBe('datetime');
+
+        // The relaxation is scoped to setup: the strict baseline is back afterwards.
+        expect((string) $adapter->fetchOne('SELECT @@SESSION.sql_mode'))->toBe($modeBefore);
+    } finally {
+        $adapter->query("SET SESSION sql_mode=''");
+        $adapter->query("DROP TABLE IF EXISTS {$table}");
+        $adapter->query('SET SESSION sql_mode = ' . $adapter->quote($modeBefore));
+    }
+});
+
+it('restores SQL_MODE only once nested setup blocks have all closed', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    $modeBefore = (string) $adapter->fetchOne('SELECT @@SESSION.sql_mode');
+    expect($modeBefore)->toContain('NO_ZERO_DATE');
+
+    $adapter->startSetup();
+    $adapter->startSetup();
+    expect((string) $adapter->fetchOne('SELECT @@SESSION.sql_mode'))->not->toContain('NO_ZERO_DATE');
+
+    $adapter->endSetup();
+    expect((string) $adapter->fetchOne('SELECT @@SESSION.sql_mode'))->not->toContain('NO_ZERO_DATE');
+
+    $adapter->endSetup();
+    expect((string) $adapter->fetchOne('SELECT @@SESSION.sql_mode'))->toBe($modeBefore);
+
+    // Unbalanced: an endSetup() with no startSetup() must not restore anything
+    $adapter->endSetup();
+    expect((string) $adapter->fetchOne('SELECT @@SESSION.sql_mode'))->toBe($modeBefore);
+});


### PR DESCRIPTION
## Problem

A store migrated from Magento/OpenMage carries legacy `'0000-00-00 00:00:00'` column DEFAULTs. MySQL re-validates **every** column default of a table it rebuilds, so under the strict `NO_ZERO_DATE` baseline Maho pins on connect, one such column makes *any* `ALTER` on that table fail — even one naming entirely different columns:

```sql
-- table has: updated_at TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00'
ALTER TABLE customer_entity DROP INDEX IDX_CUSTOMER_ENTITY_EMAIL_WEBSITE_ID;
ERROR 1067 (42000): Invalid default value for 'updated_at'
```

Rebuilding rows that *hold* zero dates fails the same way (error 1292).

This blocked both halves of `./maho migrate` on such stores:

- the declarative convergence in `Applier::execute()` (the reported failure: a `DROP INDEX` on `customer_entity`),
- the TIMESTAMP→DATETIME conversion in `Mage_Core` `upgrade-1.6.0.10-2.0.0.php`, which fails on both the foreign defaults and the zero-date rows it converts.

It's a catch-22: the very `ALTER` that would remove the offending default is refused because of it. `./maho legacy:fix-zero-dates` is no escape either — it deliberately never touches NOT NULL columns, which is exactly the shape M1 leaves behind. The store ends up unupgradable, with the storefront failing on every request once the setup script starts running from `index.php`.

## Fix

`Mysql::startSetup()` lifts `NO_ZERO_DATE` and `NO_ZERO_IN_DATE` for the duration of setup; `endSetup()` restores the exact prior mode. Nesting-safe (only the outermost pair saves/restores) and guarded against an unbalanced `endSetup()`.

`STRICT_TRANS_TABLES` and the rest of the connection baseline stay pinned, so setup scripts still run fully validated — only the two flags that reject pre-existing legacy data are relaxed, and only while migrating. Both migration paths already go through `startSetup()`/`endSetup()`, so a single place covers them.

Zero dates surviving a migration are unaffected: still reported by `./maho health-check` and cleaned up by `./maho legacy:fix-zero-dates`.

## Tests

`tests/Backend/Integration/Db/Adapter/SetupSqlModeTest.php` (MySQL-only, skips on PgSQL/SQLite) builds the legacy shape — a NOT NULL zero-date DEFAULT holding a zero-date row — and asserts:

- the `DROP INDEX` fails under the strict baseline (error 1067), and succeeds between `startSetup()`/`endSetup()`,
- the TIMESTAMP→DATETIME conversion over zero-date rows succeeds there too (error 1292),
- the prior `SQL_MODE` is restored afterwards, and only once nested setup blocks have all closed.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->