### PR TITLE
Fixed serialized grids losing their selection on sort and the broken cron dialog spinner

### DIFF
--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -16,6 +16,9 @@ jobs:
   pest-db:
     name: Test Suite (${{ matrix.name }})
     runs-on: ubuntu-latest
+    # The Playwright websocket read has no timeout, so a wedged browser otherwise hangs the
+    # job until GitHub's 6h limit. A healthy run takes ~15 minutes.
+    timeout-minutes: 45
 
     env:
       MAGE_IS_DEVELOPER_MODE: 1
@@ -214,6 +217,7 @@ jobs:
   pest-sqlite:
     name: Test Suite (sqlite)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Setup PHP

--- a/app/code/core/Mage/Cron/Block/Adminhtml/System/Tools/Cronjobs/Grid.php
+++ b/app/code/core/Mage/Cron/Block/Adminhtml/System/Tools/Cronjobs/Grid.php
@@ -160,7 +160,6 @@ class Mage_Cron_Block_Adminhtml_System_Tools_Cronjobs_Grid extends Mage_Adminhtm
             .cron-run-job-name { font-family: monospace; font-size: 13px; color: #555; margin-bottom: 16px; word-break: break-all; }
             .cron-run-timer { font-size: 36px; font-weight: 600; font-variant-numeric: tabular-nums; color: #333; margin: 8px 0; }
             .cron-run-label { font-size: 13px; color: #888; display: inline-flex; align-items: center; gap: 6px; }
-            .cron-run-spinner { width: 20px; height: 20px; }
             .cron-run-result { display: inline-flex; align-items: center; gap: 6px; font-size: 15px; font-weight: 600; margin-top: 4px; }
             .cron-run-result svg { width: 20px; height: 20px; }
             .cron-run-result.success { color: #5b8a3c; }
@@ -187,7 +186,6 @@ class Mage_Cron_Block_Adminhtml_System_Tools_Cronjobs_Grid extends Mage_Adminhtm
         }
 
         async function cronRunJob(jobCode) {
-            const loadingSvg = SKIN_URL + 'images/loading.svg';
             const startTime = Date.now();
             cronCurrentJob = jobCode;
 
@@ -195,7 +193,7 @@ class Mage_Cron_Block_Adminhtml_System_Tools_Cronjobs_Grid extends Mage_Adminhtm
                 '<div class="cron-run-body">'
                 + '<div class="cron-run-job-name">' + cronEscapeHtml(jobCode) + '</div>'
                 + '<div class="cron-run-timer" id="cronTimer">0s</div>'
-                + '<div class="cron-run-label"><img class="cron-run-spinner" src="' + loadingSvg + '" alt="">{$runningLabel}</div>'
+                + '<div class="cron-run-label"><span class="maho-spinner"></span>{$runningLabel}</div>'
                 + '</div>',
                 {
                     title: '{$runNowTitle}',
@@ -312,10 +310,8 @@ class Mage_Cron_Block_Adminhtml_System_Tools_Cronjobs_Grid extends Mage_Adminhtm
         }
 
         async function cronShowHistory(jobCode) {
-            const loadingSvg = SKIN_URL + 'images/loading.svg';
-
             Dialog.info(
-                '<div style="text-align:center; padding:30px"><img src="' + loadingSvg + '" style="width:24px; height:24px"></div>',
+                '<div style="text-align:center; padding:30px"><span class="maho-spinner" style="width:24px; height:24px"></span></div>',
                 {
                     title: '{$historyTitle}: ' + jobCode,
                     className: 'cron-history-dialog',

--- a/public/js/mage/adminhtml/grid.js
+++ b/public/js/mage/adminhtml/grid.js
@@ -883,10 +883,23 @@ class serializerController {
         this.grid.rowClickCallback = this.rowClick.bind(this);
         this.grid.initRowCallback = this.rowInit.bind(this);
         this.grid.checkboxCheckCallback = this.registerData.bind(this);
+        this.updateReloadParam();
 
         if (this.grid.rows) {
             this.grid.rows.forEach(row => this.eachRow(row));
         }
+    }
+
+    // The grid reloads over ajax on sort/filter/paginate and the controller rebuilds the
+    // "in list" filter from this param, so the current selection must travel with the request.
+    updateReloadParam() {
+        if (!this.reloadParamName) {
+            return;
+        }
+        if (!this.grid.reloadParams) {
+            this.grid.reloadParams = {};
+        }
+        this.grid.reloadParams[this.reloadParamName + '[]'] = this.getDataForReloadParam();
     }
 
     setOldCallback(callbackName, callback) {
@@ -924,6 +937,7 @@ class serializerController {
         }
 
         this.hiddenDataHolder.value = this.serializeObject();
+        this.updateReloadParam();
         this.getOldCallback('checkbox_check')(grid, element, checked);
     }
 

--- a/public/skin/adminhtml/default/default/base.css
+++ b/public/skin/adminhtml/default/default/base.css
@@ -148,6 +148,16 @@ big {
     font-size: var(--maho-text-xl)
 }
 
+/* Same artwork as images/loading.svg, inlined so it renders on themes that don't ship the file */
+.maho-spinner {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    background: url('data:image/svg+xml,%3Csvg width=%2224%22 height=%2224%22 viewBox=%220 0 24 24%22 xmlns=%22http://www.w3.org/2000/svg%22%3E%3Ccircle cx=%2212%22 cy=%2212%22 r=%223%22/%3E%3Cg%3E%3Ccircle cx=%224%22 cy=%2212%22 r=%223%22/%3E%3Ccircle cx=%2220%22 cy=%2212%22 r=%223%22/%3E%3CanimateTransform attributeName=%22transform%22 type=%22rotate%22 calcMode=%22spline%22 dur=%221s%22 keySplines=%22.36,.6,.31,1;.36,.6,.31,1%22 values=%220 12 12;180 12 12;360 12 12%22 repeatCount=%22indefinite%22/%3E%3C/g%3E%3C/svg%3E') no-repeat center;
+    background-size: contain;
+    vertical-align: middle
+}
+
 #loading-process {
     position: absolute;
     top: 45%;

--- a/tests/Browser/AdminRelatedProductsGridTest.php
+++ b/tests/Browser/AdminRelatedProductsGridTest.php
@@ -8,9 +8,9 @@
 declare(strict_types=1);
 
 use Tests\Browser\MahoServer;
-use Tests\MahoBackendTestCase;
+use Tests\MahoBrowserTestCase;
 
-uses(MahoBackendTestCase::class)->group('browser');
+uses(MahoBrowserTestCase::class)->group('browser');
 
 /**
  * Regression for serialized grids losing their selection on an ajax reload.
@@ -26,8 +26,6 @@ uses(MahoBackendTestCase::class)->group('browser');
  * repo has no js test harness.
  */
 
-afterAll(fn() => MahoServer::stop());
-
 const RELATED_GRID_SKU_PREFIX = 'pest-related-grid-';
 const RELATED_GRID_ADMIN_USERNAME = 'pest_related_grid';
 const RELATED_GRID_ADMIN_PASSWORD = 'PestRelatedGrid2026!';
@@ -35,10 +33,6 @@ const RELATED_GRID_ALPHA = 'Pest Related Alpha';
 const RELATED_GRID_BETA = 'Pest Related Beta';
 
 beforeEach(function () {
-    if (!browserTestsReady()) {
-        test()->markTestSkipped('Playwright is not installed');
-    }
-
     deleteRelatedGridFixtures();
 
     // Admin urls carry a secret key derived from the session's form key, which this process
@@ -48,8 +42,6 @@ beforeEach(function () {
         '0',
     );
     Mage::app()->cleanCache();
-
-    MahoServer::start();
 });
 
 afterEach(function () {
@@ -106,8 +98,15 @@ function deleteRelatedGridFixtures(): void
     /** @var Mage_Catalog_Model_Resource_Product_Collection $products */
     $products = Mage::getResourceModel('catalog/product_collection');
     $products->addAttributeToFilter('sku', ['like' => RELATED_GRID_SKU_PREFIX . '%']);
-    foreach ($products as $product) {
-        $product->delete();
+
+    // Product deletion is admin-guarded, hence isSecureArea.
+    Mage::register('isSecureArea', true);
+    try {
+        foreach ($products as $product) {
+            $product->delete();
+        }
+    } finally {
+        Mage::unregister('isSecureArea');
     }
 
     $user = Mage::getModel('admin/user')->loadByUsername(RELATED_GRID_ADMIN_USERNAME);

--- a/tests/Browser/AdminRelatedProductsGridTest.php
+++ b/tests/Browser/AdminRelatedProductsGridTest.php
@@ -159,12 +159,14 @@ function visitRelatedProductsTab(int $parentId): object
         ->fill('#login', RELATED_GRID_ADMIN_PASSWORD)
         ->click('#step1 input[type="submit"]');
 
-    // The page assertions below don't retry, so gate on element reads, which do wait: the
-    // admin menu only exists once logged in, the grid table only once the tab's ajax landed.
-    $page->text('.nav-bar');
-    $page->navigate(MahoServer::baseUrl() . '/admin/catalog_product/edit/id/' . $parentId)
-        ->click('#product_info_tabs_related');
-    $page->text('#related_product_grid_table');
+    waitForPageLoad($page, '.nav-bar:visible');
+    $page->navigate(MahoServer::baseUrl() . '/admin/catalog_product/edit/id/' . $parentId);
+    waitForPageLoad($page, '#product_info_tabs_related');
+
+    // An inactive tab keeps its content attached, so `:visible` is what distinguishes the
+    // tab having opened from the grid merely existing in the page.
+    $page->click('#product_info_tabs_related');
+    $page->text('#related_product_grid_table:visible');
 
     return $page->assertSee(RELATED_GRID_ALPHA)
         ->assertSee(RELATED_GRID_BETA);
@@ -177,7 +179,7 @@ function sortRelatedGridBy(object $page, string $columnId): object
 
     // Only the reloaded header carries the "sorted" class, and reading it waits for it,
     // so this returns on the new markup whether or not it still lists anything.
-    $page->text('#related_product_grid_table th[data-column-id="' . $columnId . '"].sorted');
+    $page->text('#related_product_grid_table th[data-column-id="' . $columnId . '"].sorted:visible');
 
     return $page;
 }

--- a/tests/Browser/AdminRelatedProductsGridTest.php
+++ b/tests/Browser/AdminRelatedProductsGridTest.php
@@ -1,0 +1,216 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Tests\Browser\MahoServer;
+use Tests\MahoBackendTestCase;
+
+uses(MahoBackendTestCase::class)->group('browser');
+
+/**
+ * Regression for serialized grids losing their selection on an ajax reload.
+ *
+ * The product Related/Up-sell/Cross-sell/Grouped tabs, the tag "assigned products" grid and
+ * the blog category posts grid all pair a grid with a serializerController: the checked rows
+ * live in js and travel back to the server in a reload param (products_related[] here), from
+ * which the block rebuilds its "in list" filter. When serializerController stopped writing
+ * that param, sorting a column posted nothing, the block filtered on an empty set and the
+ * grid rendered "No records found" with every checkbox lost.
+ *
+ * Only a browser can catch that: the server side works fine when the param arrives, and the
+ * repo has no js test harness.
+ */
+
+afterAll(fn() => MahoServer::stop());
+
+const RELATED_GRID_SKU_PREFIX = 'pest-related-grid-';
+const RELATED_GRID_ADMIN_USERNAME = 'pest_related_grid';
+const RELATED_GRID_ADMIN_PASSWORD = 'PestRelatedGrid2026!';
+const RELATED_GRID_ALPHA = 'Pest Related Alpha';
+const RELATED_GRID_BETA = 'Pest Related Beta';
+
+beforeEach(function () {
+    if (!browserTestsReady()) {
+        test()->markTestSkipped('Playwright is not installed');
+    }
+
+    deleteRelatedGridFixtures();
+
+    // Admin urls carry a secret key derived from the session's form key, which this process
+    // can't mint, so navigating straight to the product edit page needs the key turned off.
+    Mage::getModel('core/config')->saveConfig(
+        Mage_Adminhtml_Helper_Data::XML_PATH_ADMINHTML_SECURITY_USE_FORM_KEY,
+        '0',
+    );
+    Mage::app()->cleanCache();
+
+    MahoServer::start();
+});
+
+afterEach(function () {
+    Mage::getModel('core/config')->deleteConfig(
+        Mage_Adminhtml_Helper_Data::XML_PATH_ADMINHTML_SECURITY_USE_FORM_KEY,
+    );
+    Mage::app()->cleanCache();
+    deleteRelatedGridFixtures();
+});
+
+/** A simple, saleable product the admin grid can list. */
+function createRelatedGridProduct(string $sku, string $name): Mage_Catalog_Model_Product
+{
+    $product = Mage::getModel('catalog/product');
+    $product->setStoreId(Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID)
+        ->setSku(RELATED_GRID_SKU_PREFIX . $sku)
+        ->setName($name)
+        ->setPrice(19.99)
+        ->setStatus(Mage_Catalog_Model_Product_Status::STATUS_ENABLED)
+        ->setVisibility(Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH)
+        ->setTypeId(Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)
+        ->setAttributeSetId(4)
+        ->setWebsiteIds([1])
+        ->save();
+
+    return $product;
+}
+
+/**
+ * A parent product with two related products.
+ *
+ * @return array{parent: int, alpha: int, beta: int} product ids
+ */
+function createRelatedGridFixtures(): array
+{
+    $alpha = createRelatedGridProduct('alpha', RELATED_GRID_ALPHA);
+    $beta = createRelatedGridProduct('beta', RELATED_GRID_BETA);
+
+    $parent = createRelatedGridProduct('parent', 'Pest Related Parent');
+    $parent->setRelatedLinkData([
+        $alpha->getId() => ['position' => 1],
+        $beta->getId() => ['position' => 2],
+    ])->save();
+
+    return [
+        'parent' => (int) $parent->getId(),
+        'alpha' => (int) $alpha->getId(),
+        'beta' => (int) $beta->getId(),
+    ];
+}
+
+function deleteRelatedGridFixtures(): void
+{
+    /** @var Mage_Catalog_Model_Resource_Product_Collection $products */
+    $products = Mage::getResourceModel('catalog/product_collection');
+    $products->addAttributeToFilter('sku', ['like' => RELATED_GRID_SKU_PREFIX . '%']);
+    foreach ($products as $product) {
+        $product->delete();
+    }
+
+    $user = Mage::getModel('admin/user')->loadByUsername(RELATED_GRID_ADMIN_USERNAME);
+    if ($user->getId()) {
+        $roleId = (int) $user->getRole()->getRoleId();
+        $user->delete();
+        if ($roleId) {
+            Mage::getModel('admin/roles')->load($roleId)->delete();
+        }
+    }
+}
+
+/** A throwaway admin with full access, so the test doesn't depend on the install's password. */
+function createRelatedGridAdminUser(): void
+{
+    $role = Mage::getModel('admin/roles')
+        ->setName('Pest Related Grid')
+        ->setRoleType('G')
+        ->setParentId(0)
+        ->save();
+
+    Mage::getModel('admin/rules')
+        ->setRoleId($role->getId())
+        ->setResources(['all'])
+        ->saveRel();
+
+    $user = Mage::getModel('admin/user');
+    $user->setData([
+        'username' => RELATED_GRID_ADMIN_USERNAME,
+        'firstname' => 'Pest',
+        'lastname' => 'Grid',
+        'email' => RELATED_GRID_ADMIN_USERNAME . '@example.test',
+        'password' => RELATED_GRID_ADMIN_PASSWORD,
+        'is_active' => 1,
+    ])->save();
+
+    Mage::getModel('admin/user')
+        ->setRoleId($role->getId())
+        ->setUserId($user->getId())
+        ->add();
+}
+
+/** Log in and open the product's Related Products tab, with both related products listed. */
+function visitRelatedProductsTab(int $parentId): object
+{
+    createRelatedGridAdminUser();
+
+    $page = visit(MahoServer::baseUrl() . '/admin')
+        ->fill('#username', RELATED_GRID_ADMIN_USERNAME)
+        ->fill('#login', RELATED_GRID_ADMIN_PASSWORD)
+        ->click('#step1 input[type="submit"]');
+
+    // The page assertions below don't retry, so gate on element reads, which do wait: the
+    // admin menu only exists once logged in, the grid table only once the tab's ajax landed.
+    $page->text('.nav-bar');
+    $page->navigate(MahoServer::baseUrl() . '/admin/catalog_product/edit/id/' . $parentId)
+        ->click('#product_info_tabs_related');
+    $page->text('#related_product_grid_table');
+
+    return $page->assertSee(RELATED_GRID_ALPHA)
+        ->assertSee(RELATED_GRID_BETA);
+}
+
+/** Sort the grid by a column and wait for the reloaded markup, sorted or not, to land. */
+function sortRelatedGridBy(object $page, string $columnId): object
+{
+    $page->click('#related_product_grid_table th[data-column-id="' . $columnId . '"] a');
+
+    // Only the reloaded header carries the "sorted" class, and reading it waits for it,
+    // so this returns on the new markup whether or not it still lists anything.
+    $page->text('#related_product_grid_table th[data-column-id="' . $columnId . '"].sorted');
+
+    return $page;
+}
+
+/** The grid's "in list" checkbox for a product. It's rendered without a name attribute. */
+function relatedGridCheckbox(int $productId): string
+{
+    return '#related_product_grid_table input[type="checkbox"][value="' . $productId . '"]';
+}
+
+it('keeps the related products listed and checked after sorting a column', function () {
+    $ids = createRelatedGridFixtures();
+
+    $page = sortRelatedGridBy(visitRelatedProductsTab($ids['parent']), 'name');
+
+    // Pre-fix the reload posted no selection, so the grid came back empty.
+    $page->assertSee(RELATED_GRID_ALPHA)
+        ->assertSee(RELATED_GRID_BETA)
+        ->assertDontSee('No records found')
+        ->assertChecked(relatedGridCheckbox($ids['alpha']))
+        ->assertChecked(relatedGridCheckbox($ids['beta']));
+});
+
+it('carries an unchecked row through the sort instead of restoring it', function () {
+    $ids = createRelatedGridFixtures();
+
+    $page = visitRelatedProductsTab($ids['parent'])
+        ->uncheck(relatedGridCheckbox($ids['beta']));
+
+    // The grid filters on "in list = yes", so only the still-checked product may come back.
+    sortRelatedGridBy($page, 'name')
+        ->assertSee(RELATED_GRID_ALPHA)
+        ->assertDontSee(RELATED_GRID_BETA)
+        ->assertDontSee('No records found');
+});

--- a/tests/Browser/CurrencySwitcherTest.php
+++ b/tests/Browser/CurrencySwitcherTest.php
@@ -43,13 +43,16 @@ it('switches the storefront display currency and reflects it on the new page', f
     // switcher's selected option carries the switch URL of the current currency, so
     // its value is the reliable signal of which currency is active (the visible $/€
     // symbols and both option values are in the DOM regardless of what's selected).
-    $page = visit(MahoServer::baseUrl() . $productUrl)
-        ->assertPresent('#select-currency');
+    $page = visit(MahoServer::baseUrl() . $productUrl);
+    waitForPageLoad($page, '#select-currency')->assertPresent('#select-currency');
     expect($page->page()->locator('#select-currency')->inputValue())->toContain('currency=USD');
 
     // Switch to EUR through the real <select>. Its onchange navigates to the switch
     // URL (already a fully-encoded URL), which 302s back to this page with EUR active.
+    // The sleep covers the navigation starting, which waitForPageLoad can't: the switcher is
+    // on the page being left too, so no element gate tells the two apart here.
     $page->select('#select-currency', '€')->wait(2);
+    waitForPageLoad($page, '#select-currency');
 
     // The redirect completed cleanly (regression: a double-encoded uenc back-URL used to
     // put a newline in the Location header, triggering PHP's "Header may not contain

--- a/tests/Browser/CurrencySwitcherTest.php
+++ b/tests/Browser/CurrencySwitcherTest.php
@@ -8,16 +8,11 @@
 declare(strict_types=1);
 
 use Tests\Browser\MahoServer;
-use Tests\MahoFrontendTestCase;
+use Tests\MahoBrowserTestCase;
 
-uses(MahoFrontendTestCase::class)->group('browser');
-
-afterAll(fn() => MahoServer::stop());
+uses(MahoBrowserTestCase::class)->group('browser');
 
 beforeEach(function () {
-    if (!browserTestsReady()) {
-        test()->markTestSkipped('Playwright is not installed');
-    }
     // Enable a second display currency so the storefront currency switcher renders.
     $config = Mage::getModel('core/config');
     $config->saveConfig('currency/options/base', 'USD');
@@ -26,7 +21,6 @@ beforeEach(function () {
     Mage::getModel('directory/currency')->saveRates(['USD' => ['USD' => 1.0, 'EUR' => 0.9]]);
     Mage::app()->getStore()->resetConfig();
     Mage::app()->cleanCache();
-    MahoServer::start();
 });
 
 /** A salable, priced, visible simple product page URL. */

--- a/tests/Browser/LoginRedirectTest.php
+++ b/tests/Browser/LoginRedirectTest.php
@@ -98,13 +98,16 @@ function createLoginRedirectCustomer(): void
 /** Seed beforeAuthUrl = checkout/onepage via a guest checkout visit, then open the login form. */
 function gotoLoginFormWithCheckoutPending(): object
 {
-    return visit(MahoServer::baseUrl() . loginRedirectProductUrl())
+    $page = visit(MahoServer::baseUrl() . loginRedirectProductUrl())
         ->click('Add to Cart')
         ->waitForText('Cart Subtotal')
-        ->navigate(MahoServer::baseUrl() . '/checkout/onepage')
-        ->assertPathContains('checkout/onepage')
-        ->navigate(MahoServer::baseUrl() . '/customer/account/login')
-        ->assertPresent('#email');
+        ->navigate(MahoServer::baseUrl() . '/checkout/onepage');
+
+    // Neither assertion retries, so each has to run against the page it talks about.
+    waitForPageLoad($page, '#onestep-checkout')->assertPathContains('checkout/onepage')
+        ->navigate(MahoServer::baseUrl() . '/customer/account/login');
+
+    return waitForPageLoad($page, '#email')->assertPresent('#email');
 }
 
 it('keeps a failed login on the login form instead of bouncing to checkout', function () {

--- a/tests/Browser/LoginRedirectTest.php
+++ b/tests/Browser/LoginRedirectTest.php
@@ -8,9 +8,9 @@
 declare(strict_types=1);
 
 use Tests\Browser\MahoServer;
-use Tests\MahoFrontendTestCase;
+use Tests\MahoBrowserTestCase;
 
-uses(MahoFrontendTestCase::class)->group('browser');
+uses(MahoBrowserTestCase::class)->group('browser');
 
 /**
  * Regression for the failed-login redirect bug.
@@ -29,17 +29,11 @@ uses(MahoFrontendTestCase::class)->group('browser');
  * cart/session cookie persists across requests.
  */
 
-afterAll(fn() => MahoServer::stop());
-
 beforeEach(function () {
-    if (!browserTestsReady()) {
-        test()->markTestSkipped('Playwright is not installed');
-    }
     // Drop any guest-checkout override (e.g. left behind by an aborted run on a reused DB).
     Mage::getModel('core/config')->deleteConfig(Mage_Checkout_Helper_Data::XML_PATH_GUEST_CHECKOUT);
     Mage::app()->getStore()->resetConfig();
     Mage::app()->cleanCache();
-    MahoServer::start();
 });
 
 afterEach(fn() => deleteLoginRedirectCustomer());

--- a/tests/Browser/MahoServer.php
+++ b/tests/Browser/MahoServer.php
@@ -31,11 +31,19 @@ final class MahoServer
 {
     private static ?Process $process = null;
     private static string $baseUrl = '';
+    private static bool $stopRegistered = false;
 
     public static function start(?int $port = null): string
     {
         if (self::$process && self::$process->isRunning()) {
             return self::$baseUrl;
+        }
+
+        // One server for the whole run: every test file starts it, and it lives until the
+        // process ends rather than being torn down and rebuilt between files.
+        if (!self::$stopRegistered) {
+            register_shutdown_function(self::stop(...));
+            self::$stopRegistered = true;
         }
 
         // Address host (what the browser navigates to) vs bind host (what the server binds).

--- a/tests/Browser/PaypalCheckoutTest.php
+++ b/tests/Browser/PaypalCheckoutTest.php
@@ -8,25 +8,17 @@
 declare(strict_types=1);
 
 use Tests\Browser\MahoServer;
-use Tests\MahoFrontendTestCase;
+use Tests\MahoBrowserTestCase;
 
-uses(MahoFrontendTestCase::class)->group('browser', 'paypal');
-
-afterAll(fn() => MahoServer::stop());
+uses(MahoBrowserTestCase::class)->group('browser', 'paypal');
 
 beforeEach(function () {
-    if (!browserTestsReady()) {
-        test()->markTestSkipped('Playwright is not installed');
-    }
     // Needs the store actually configured with PayPal credentials (the test harness or CI
     // injects them at install time); without them the real checkout can't run.
     if (!Mage::getModel('paypal/config')->hasCredentials()) {
         test()->markTestSkipped('PayPal sandbox credentials not configured on the store');
     }
-    // Maho is already bootstrapped by MahoFrontendTestCase::setUp(). Each test sets its
-    // own display currency, then (re)starts the server so it serves the configured DB.
     ensureSaleable(aProductId());
-    MahoServer::start();
 });
 
 /**

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -13,6 +13,8 @@ use Tests\MahoBrowserTestCase;
 uses(MahoBrowserTestCase::class)->group('browser');
 
 it('renders the storefront homepage in a real browser', function () {
-    visit(MahoServer::baseUrl() . '/')
-        ->assertNoSmoke();
+    $page = visit(MahoServer::baseUrl() . '/');
+
+    // assertNoSmoke reads once, so on a half-built page it passes as readily as it fails.
+    waitForPageLoad($page, 'body:visible')->assertNoSmoke();
 });

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -8,17 +8,9 @@
 declare(strict_types=1);
 
 use Tests\Browser\MahoServer;
+use Tests\MahoBrowserTestCase;
 
-uses()->group('browser');
-
-afterAll(fn() => MahoServer::stop());
-
-beforeEach(function () {
-    if (!browserTestsReady()) {
-        test()->markTestSkipped('Playwright is not installed');
-    }
-    MahoServer::start();
-});
+uses(MahoBrowserTestCase::class)->group('browser');
 
 it('renders the storefront homepage in a real browser', function () {
     visit(MahoServer::baseUrl() . '/')

--- a/tests/MahoBrowserTestCase.php
+++ b/tests/MahoBrowserTestCase.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Tests\Browser\MahoServer;
+
+/**
+ * Base test case for browser tests.
+ *
+ * Skips the whole suite when Playwright isn't installed and boots the dev server the tests
+ * navigate to. The server starts once per run and is stopped when the process ends, so tests
+ * only care about the fixtures and config they set up themselves.
+ */
+abstract class MahoBrowserTestCase extends MahoFrontendTestCase
+{
+    protected function setUp(): void
+    {
+        if (!browserTestsReady()) {
+            $this->markTestSkipped('Playwright is not installed');
+        }
+
+        parent::setUp();
+
+        MahoServer::start();
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -310,3 +310,26 @@ function browserTestsReady(): bool
 {
     return is_file(dirname(__DIR__) . '/node_modules/.bin/playwright');
 }
+
+/**
+ * Block until the browser has finished loading the page $selector belongs to.
+ *
+ * The plugin's own waits are no-ops (waitForEvent/waitForFunction never iterate the generator
+ * Client::execute() returns) and navigate() can return on the previous navigation's load event.
+ * $selector has to belong to the awaited page and not the one being left, since about:blank and
+ * the previous page both report readyState 'complete'; a bare tag name reads as link text.
+ */
+function waitForPageLoad(object $page, string $selector): object
+{
+    $page->text($selector);
+
+    $deadline = microtime(true) + 5;
+    while ($page->script('document.readyState') !== 'complete') {
+        if (microtime(true) >= $deadline) {
+            throw new RuntimeException("The page holding [{$selector}] did not finish loading within 5s");
+        }
+        usleep(50_000);
+    }
+
+    return $page;
+}


### PR DESCRIPTION
Two unrelated admin fixes, plus the browser coverage that guards the first one.

### Serialized grids emptied themselves on sort/filter/paginate

Sorting a product's **Related Products** grid (click any column header) emptied it: `0 items`, `No records found`, checkboxes lost. Same for Up-sells, Cross-sells, Grouped products, the tag "assigned products" grid and the blog category posts grid.

Those grids reload over ajax, and the controller rebuilds the "in list" checkbox filter from a posted param (`products_related[]`, `assigned_products[]`, ...). `serializerController` had a `getDataForReloadParam()` method but never called it, so `grid.reloadParams` stayed empty and the reload posted no selection at all. With the default `in_products = Yes` filter active, the grid then filtered on an empty set and rendered nothing.

`serializerController` now writes the current selection into `grid.reloadParams` on init and on every check/uncheck, preserving any params the grid already had.

### Broken loading image in the cron job dialogs

`System > Tools > Cron Jobs`, *Run now* and *History*: the spinner rendered as a broken image. The url was built in js as `SKIN_URL + 'images/loading.svg'`, and `SKIN_URL` is the raw base skin url of the *configured* admin theme. Unlike `getSkinUrl('images/loading.svg')` it performs no fallback, so on any admin theme that doesn't ship its own copy of the file the request 404s:

```
SKIN_URL (base): http://…/skin/adminhtml/default/mytheme/
getSkinUrl(file): http://…/skin/adminhtml/default/default/images/loading.svg
```

Same artwork as before, now carried by a reusable `.maho-spinner` class in the admin stylesheet as an inlined data uri, so it needs no asset request and no theme fallback at all.

### Browser coverage

New `tests/Browser/AdminRelatedProductsGridTest.php`: logs into the admin, opens a product's Related Products tab, sorts a column and asserts the selection survived the reload, both for the saved links and for a row unchecked in the session. Verified in both directions: it fails against the unfixed `serializerController` (grid comes back empty) and passes with the fix.

Two things worth knowing when writing further browser tests, both learned the hard way here:

- `assertSee`/`assertDontSee`/`waitForText` don't retry, they snapshot the current DOM, so right after an ajax reload they can assert against the stale markup. Element reads (`text()`, `attribute()`, `isChecked()`) do auto-wait, so the test gates on a class that only the reloaded header carries before asserting anything.
- Admin urls carry a secret key derived from the session form key, which the test process can't mint, so the test turns `admin/security/use_form_key` off for its duration and restores it after.

### Browser test bootstrapping

While in there: every browser file repeated the Playwright skip and a `MahoServer::start()` in `beforeEach`, then `MahoServer::stop()` in `afterAll`, so each file paid a full restart (two `config:set` calls, a cache flush, and a cold cache for its first request). They now inherit `Tests\\MahoBrowserTestCase`, and the server is stopped once at process exit, so a run starts it exactly once. Full Browser suite passes.

One cosmetic side effect: `SmokeTest` now boots Maho like the other browser files and so picks up the same "risky" flag they all already carry on their first test. Pre-existing suite noise, happy to chase it separately.