### PR TITLE
Made failed backports visible and kept conflicting ones as draft PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Open backport pull requests
+        id: backport
         uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
         with:
           # Pattern-based labels: the label `backport 26.7` targets branch `26.7`.
@@ -44,3 +45,21 @@ jobs:
             patch release.
           # Leave the source PR's non-backport labels off the backport PR.
           copy_labels_pattern: '^(?!backport ).*$'
+          # A conflicting cherry-pick still gets a draft PR with the conflict
+          # markers committed, so the resolution happens on a branch instead of
+          # the backport silently evaporating. Such a target still counts as
+          # successful, so only a real failure turns this job red.
+          experimental: '{ "conflict_resolution": "draft_commit_conflicts" }'
+
+      # The action reports per-target failures only as a comment on the source
+      # PR, which is easy to miss on an already-merged PR. Mirror it into the
+      # job status. Note that GITHUB_TOKEN carries no `workflows` scope, so a
+      # PR touching `.github/workflows/**` always lands here and has to be
+      # backported by hand.
+      - name: Fail when a target could not be backported
+        if: steps.backport.outputs.was_successful != 'true'
+        env:
+          RESULT_BY_TARGET: ${{ steps.backport.outputs.was_successful_by_target }}
+        run: |
+          echo "::error::Backport failed, see the comment on the source PR: $RESULT_BY_TARGET"
+          exit 1


### PR DESCRIPTION
The backport of #1169 to `26.7` never happened, and the `Backport merged PR` job went **green** anyway. The only trace was a one-line comment on the already-merged PR, which is easy to miss.

Two changes:

### Failures now turn the job red

`korthout/backport-action` reports per-target outcome through its `was_successful` output and a comment on the source PR, but it does not fail the step. A follow-up step now mirrors that output into the job status.

### Conflicts produce a draft PR instead of nothing

`conflict_resolution: draft_commit_conflicts` makes the action commit the first conflict with its markers and open a **draft** PR, so the resolution happens on a branch with the context attached rather than the backport evaporating. A target resolved this way still counts as successful, so it does not turn the job red, only a genuine failure does.

### What actually broke #1169

Not a conflict. The cherry-pick applied cleanly; the *push* was rejected:

```
! [remote rejected] backport-1169-to-26.7 -> backport-1169-to-26.7
  (refusing to allow a GitHub App to create or update workflow
   .github/workflows/pest.yml without `workflows` permission)
```

The commit touches `.github/workflows/pest.yml`. `workflows` is not one of the scopes `GITHUB_TOKEN` can be granted via `permissions:`, so **every** backport of a PR that touches a workflow file will hit this. Fixing that needs a GitHub App or PAT with the `workflow` scope; deliberately not doing that here, since it is a rare case and the failure is now loud. The comment above the new step records why.

#1171 backports #1169 by hand.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->