### PR TITLE
Fixed 405 Method Not Allowed after login when the stored redirect target was a POST-only route

### DIFF
--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -737,18 +737,7 @@ abstract class Mage_Core_Controller_Varien_Action
      */
     protected function _isUrlInternal($url)
     {
-        if (!str_contains($url, 'http')) {
-            return false;
-        }
-
-        // Url must start from base secure or base unsecure url
-        if (str_starts_with($url, Mage::app()->getStore()->getBaseUrl())
-            || str_starts_with($url, Mage::app()->getStore()->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_LINK, true))
-        ) {
-            return true;
-        }
-
-        return false;
+        return Mage::helper('core/url')->isInternalUrl((string) $url);
     }
 
     /**

--- a/app/code/core/Mage/Core/Helper/Url.php
+++ b/app/code/core/Mage/Core/Helper/Url.php
@@ -67,6 +67,59 @@ class Mage_Core_Helper_Url extends Mage_Core_Helper_Abstract
     }
 
     /**
+     * Check whether a URL can be reached with a GET request.
+     *
+     * A redirect is always followed with a GET, so a URL whose route is restricted to other
+     * verbs is not a usable redirect target: it answers 405 Method Not Allowed.
+     *
+     * Only known non-GET routes are rejected. External URLs, and paths that match no
+     * attributed route (URL rewrites, CMS pages, legacy path dispatch), are reported as
+     * routable — this is a guard against a specific mistake, not a general URL validator.
+     */
+    public function isGetRoutable(string $url): bool
+    {
+        $path = parse_url($url, PHP_URL_PATH);
+        if (!is_string($path) || $path === '') {
+            return true;
+        }
+
+        $request = Mage::app()->getRequest();
+
+        $baseUrl = $request->getBaseUrl();
+        if ($baseUrl !== '' && str_starts_with($path, $baseUrl)) {
+            $path = substr($path, strlen($baseUrl));
+        }
+
+        // Mirror the store-code stripping the request does when building its path info,
+        // otherwise /fr/wishlist/index/add matches nothing and is waved through.
+        if (Mage::isInstalled() && Mage::getStoreConfigFlag(Mage_Core_Model_Store::XML_PATH_STORE_IN_URL)) {
+            $storeCode = explode('/', ltrim($path, '/'), 2)[0];
+            if ($storeCode !== '' && array_key_exists($storeCode, Mage::app()->getStores(true, true))) {
+                $path = substr(ltrim($path, '/'), strlen($storeCode));
+            }
+        }
+
+        $path = '/' . ltrim($path, '/');
+        if (strlen($path) > 1) {
+            $path = rtrim($path, '/');
+        }
+
+        $context = new \Symfony\Component\Routing\RequestContext();
+        $context->fromRequest($request->getSymfonyRequest());
+        $context->setMethod('GET');
+
+        try {
+            \Maho\Routing\RouteCollectionBuilder::createMatcher($context)->match($path);
+        } catch (\Symfony\Component\Routing\Exception\MethodNotAllowedException) {
+            return false;
+        } catch (\Symfony\Component\Routing\Exception\ExceptionInterface) {
+            return true;
+        }
+
+        return true;
+    }
+
+    /**
      * Formatting string
      *
      * @param string $string

--- a/app/code/core/Mage/Core/Helper/Url.php
+++ b/app/code/core/Mage/Core/Helper/Url.php
@@ -67,56 +67,17 @@ class Mage_Core_Helper_Url extends Mage_Core_Helper_Abstract
     }
 
     /**
-     * Check whether a URL can be reached with a GET request.
-     *
-     * A redirect is always followed with a GET, so a URL whose route is restricted to other
-     * verbs is not a usable redirect target: it answers 405 Method Not Allowed.
-     *
-     * Only known non-GET routes are rejected. External URLs, and paths that match no
-     * attributed route (URL rewrites, CMS pages, legacy path dispatch), are reported as
-     * routable — this is a guard against a specific mistake, not a general URL validator.
+     * Check whether a URL points at this store, i.e. is safe to redirect to.
      */
-    public function isGetRoutable(string $url): bool
+    public function isInternalUrl(string $url): bool
     {
-        $path = parse_url($url, PHP_URL_PATH);
-        if (!is_string($path) || $path === '') {
-            return true;
-        }
-
-        $request = Mage::app()->getRequest();
-
-        $baseUrl = $request->getBaseUrl();
-        if ($baseUrl !== '' && str_starts_with($path, $baseUrl)) {
-            $path = substr($path, strlen($baseUrl));
-        }
-
-        // Mirror the store-code stripping the request does when building its path info,
-        // otherwise /fr/wishlist/index/add matches nothing and is waved through.
-        if (Mage::isInstalled() && Mage::getStoreConfigFlag(Mage_Core_Model_Store::XML_PATH_STORE_IN_URL)) {
-            $storeCode = explode('/', ltrim($path, '/'), 2)[0];
-            if ($storeCode !== '' && array_key_exists($storeCode, Mage::app()->getStores(true, true))) {
-                $path = substr(ltrim($path, '/'), strlen($storeCode));
-            }
-        }
-
-        $path = '/' . ltrim($path, '/');
-        if (strlen($path) > 1) {
-            $path = rtrim($path, '/');
-        }
-
-        $context = new \Symfony\Component\Routing\RequestContext();
-        $context->fromRequest($request->getSymfonyRequest());
-        $context->setMethod('GET');
-
-        try {
-            \Maho\Routing\RouteCollectionBuilder::createMatcher($context)->match($path);
-        } catch (\Symfony\Component\Routing\Exception\MethodNotAllowedException) {
+        if (!str_contains($url, 'http')) {
             return false;
-        } catch (\Symfony\Component\Routing\Exception\ExceptionInterface) {
-            return true;
         }
 
-        return true;
+        // Url must start from base secure or base unsecure url
+        return str_starts_with($url, Mage::app()->getStore()->getBaseUrl())
+            || str_starts_with($url, Mage::app()->getStore()->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_LINK, true));
     }
 
     /**

--- a/app/code/core/Mage/Customer/Block/Form/Login.php
+++ b/app/code/core/Mage/Customer/Block/Form/Login.php
@@ -46,7 +46,11 @@ class Mage_Customer_Block_Form_Login extends Mage_Core_Block_Template
             return;
         }
 
-        if (Mage::getStoreConfigFlag(Mage_Customer_Helper_Data::XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD)) {
+        if (!$this->getRequest()->isGet()) {
+            // This block renders on ordinary pages too, so the current URL here can be a
+            // POST-only endpoint (customer/account/prelogin) that a redirect cannot reach.
+            $url = Mage::helper('customer')->getDefaultBeforeAuthUrl();
+        } elseif (Mage::getStoreConfigFlag(Mage_Customer_Helper_Data::XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD)) {
             $url = Mage::helper('customer')->getDashboardUrl();
         } else {
             $pathInfo = $this->getRequest()->getOriginalPathInfo();

--- a/app/code/core/Mage/Customer/Helper/Data.php
+++ b/app/code/core/Mage/Customer/Helper/Data.php
@@ -296,7 +296,11 @@ class Mage_Customer_Helper_Data extends Mage_Core_Helper_Abstract
         if (!$referer && !Mage::getStoreConfigFlag(self::XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD)
             && !Mage::getSingleton('customer/session')->getNoReferer()
         ) {
-            $referer = Mage::getUrl('*/*/*', ['_current' => true, '_use_rewrite' => true]);
+            // _loginPostRedirect() replays this param as the post-login target, so it has to be
+            // a URL a redirect can reach: the current one is only that on a GET request.
+            $referer = $this->_getRequest()->isGet()
+                ? Mage::getUrl('*/*/*', ['_current' => true, '_use_rewrite' => true])
+                : $this->getPostAuthUrl();
             $referer = Mage::helper('core')->urlEncode($referer);
         }
 
@@ -305,6 +309,28 @@ class Mage_Customer_Helper_Data extends Mage_Core_Helper_Abstract
         }
 
         return $params;
+    }
+
+    /**
+     * Where to send the customer after login when the interrupted request cannot be replayed.
+     *
+     * A redirect is always followed with a GET, so the URL of a POST-only action (say
+     * wishlist/index/add) is not a usable target: it answers 405 Method Not Allowed. The page
+     * that held the form is, and it is what the customer expects to come back to.
+     */
+    public function getPostAuthUrl(): string
+    {
+        if (Mage::getStoreConfigFlag(self::XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD)) {
+            return $this->getDashboardUrl();
+        }
+
+        $referer = (string) $this->_getRequest()->getServer('HTTP_REFERER');
+
+        if ($referer !== '' && Mage::helper('core/url')->isInternalUrl($referer)) {
+            return $referer;
+        }
+
+        return $this->getAccountUrl();
     }
 
     /**

--- a/app/code/core/Mage/Customer/Helper/Data.php
+++ b/app/code/core/Mage/Customer/Helper/Data.php
@@ -296,11 +296,9 @@ class Mage_Customer_Helper_Data extends Mage_Core_Helper_Abstract
         if (!$referer && !Mage::getStoreConfigFlag(self::XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD)
             && !Mage::getSingleton('customer/session')->getNoReferer()
         ) {
-            // _loginPostRedirect() replays this param as the post-login target, so it has to be
-            // a URL a redirect can reach: the current one is only that on a GET request.
             $referer = $this->_getRequest()->isGet()
                 ? Mage::getUrl('*/*/*', ['_current' => true, '_use_rewrite' => true])
-                : $this->getPostAuthUrl();
+                : $this->getDefaultBeforeAuthUrl();
             $referer = Mage::helper('core')->urlEncode($referer);
         }
 
@@ -312,13 +310,10 @@ class Mage_Customer_Helper_Data extends Mage_Core_Helper_Abstract
     }
 
     /**
-     * Where to send the customer after login when the interrupted request cannot be replayed.
-     *
-     * A redirect is always followed with a GET, so the URL of a POST-only action (say
-     * wishlist/index/add) is not a usable target: it answers 405 Method Not Allowed. The page
-     * that held the form is, and it is what the customer expects to come back to.
+     * Post-login target for an interrupted request that a redirect cannot replay, i.e. a
+     * POST-only action: replayed as a GET it would answer 405 Method Not Allowed.
      */
-    public function getPostAuthUrl(): string
+    public function getDefaultBeforeAuthUrl(): string
     {
         if (Mage::getStoreConfigFlag(self::XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD)) {
             return $this->getDashboardUrl();

--- a/app/code/core/Mage/Customer/Helper/Data.php
+++ b/app/code/core/Mage/Customer/Helper/Data.php
@@ -315,17 +315,14 @@ class Mage_Customer_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function getDefaultBeforeAuthUrl(): string
     {
-        if (Mage::getStoreConfigFlag(self::XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD)) {
-            return $this->getDashboardUrl();
+        if (!Mage::getStoreConfigFlag(self::XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD)) {
+            $referer = (string) $this->_getRequest()->getServer('HTTP_REFERER');
+            if ($referer !== '' && Mage::helper('core/url')->isInternalUrl($referer)) {
+                return $referer;
+            }
         }
 
-        $referer = (string) $this->_getRequest()->getServer('HTTP_REFERER');
-
-        if ($referer !== '' && Mage::helper('core/url')->isInternalUrl($referer)) {
-            return $referer;
-        }
-
-        return $this->getAccountUrl();
+        return $this->getDashboardUrl();
     }
 
     /**

--- a/app/code/core/Mage/Customer/Model/Session.php
+++ b/app/code/core/Mage/Customer/Model/Session.php
@@ -355,11 +355,9 @@ class Mage_Customer_Model_Session extends Mage_Core_Model_Session_Abstract
             return true;
         }
 
-        // A redirect is always followed with a GET, so the current URL is only a usable
-        // post-login target on a GET: a POST-only action replayed as GET answers 405.
         $this->setBeforeAuthUrl($action->getRequest()->isGet()
             ? Mage::getUrl('*/*/*', ['_current' => true])
-            : Mage::helper('customer')->getPostAuthUrl());
+            : Mage::helper('customer')->getDefaultBeforeAuthUrl());
 
         if (isset($loginUrl)) {
             $action->getResponse()->setRedirect($loginUrl);

--- a/app/code/core/Mage/Customer/Model/Session.php
+++ b/app/code/core/Mage/Customer/Model/Session.php
@@ -356,9 +356,7 @@ class Mage_Customer_Model_Session extends Mage_Core_Model_Session_Abstract
         }
 
         // A redirect is always followed with a GET, so the current URL is only a usable
-        // post-login target when the interrupted request was itself a GET: replaying a
-        // POST-only action (wishlist/index/add, customer/address/formPost, ...) with a GET
-        // answers 405 Method Not Allowed.
+        // post-login target on a GET: a POST-only action replayed as GET answers 405.
         $this->setBeforeAuthUrl($action->getRequest()->isGet()
             ? Mage::getUrl('*/*/*', ['_current' => true])
             : Mage::helper('customer')->getPostAuthUrl());

--- a/app/code/core/Mage/Customer/Model/Session.php
+++ b/app/code/core/Mage/Customer/Model/Session.php
@@ -355,7 +355,14 @@ class Mage_Customer_Model_Session extends Mage_Core_Model_Session_Abstract
             return true;
         }
 
-        $this->setBeforeAuthUrl(Mage::getUrl('*/*/*', ['_current' => true]));
+        // A redirect is always followed with a GET, so the current URL is only a usable
+        // post-login target when the interrupted request was itself a GET: replaying a
+        // POST-only action (wishlist/index/add, customer/address/formPost, ...) with a GET
+        // answers 405 Method Not Allowed.
+        $this->setBeforeAuthUrl($action->getRequest()->isGet()
+            ? Mage::getUrl('*/*/*', ['_current' => true])
+            : Mage::helper('customer')->getPostAuthUrl());
+
         if (isset($loginUrl)) {
             $action->getResponse()->setRedirect($loginUrl);
         } else {
@@ -381,14 +388,6 @@ class Mage_Customer_Model_Session extends Mage_Core_Model_Session_Abstract
             ->removeRequestParam($url, Mage::getSingleton('core/session')->getSessionIdQueryParam());
         // Add correct session ID to URL if needed
         $url = Mage::getModel('core/url')->getRebuiltUrl($url);
-
-        // Auth URLs are replayed with a redirect, i.e. a GET. Keeping the URL of a route that
-        // only accepts other verbs (say the POST-only wishlist/index/add a guest was bounced
-        // away from) would answer 405 Method Not Allowed right after a successful login.
-        if (!Mage::helper('core/url')->isGetRoutable($url)) {
-            return $this;
-        }
-
         return $this->setData($key, $url);
     }
 

--- a/app/code/core/Mage/Customer/Model/Session.php
+++ b/app/code/core/Mage/Customer/Model/Session.php
@@ -381,6 +381,14 @@ class Mage_Customer_Model_Session extends Mage_Core_Model_Session_Abstract
             ->removeRequestParam($url, Mage::getSingleton('core/session')->getSessionIdQueryParam());
         // Add correct session ID to URL if needed
         $url = Mage::getModel('core/url')->getRebuiltUrl($url);
+
+        // Auth URLs are replayed with a redirect, i.e. a GET. Keeping the URL of a route that
+        // only accepts other verbs (say the POST-only wishlist/index/add a guest was bounced
+        // away from) would answer 405 Method Not Allowed right after a successful login.
+        if (!Mage::helper('core/url')->isGetRoutable($url)) {
+            return $this;
+        }
+
         return $this->setData($key, $url);
     }
 

--- a/app/code/core/Mage/Review/controllers/ProductController.php
+++ b/app/code/core/Mage/Review/controllers/ProductController.php
@@ -27,9 +27,9 @@ class Mage_Review_ProductController extends Mage_Core_Controller_Front_Action
         if (!$allowGuest && $action == 'post' && $this->getRequest()->isPost()) {
             if (!Mage::getSingleton('customer/session')->isLoggedIn()) {
                 $this->setFlag('', self::FLAG_NO_DISPATCH, true);
-                // Not the current URL: review/product/post is POST-only, and a post-login
-                // redirect is a GET, so replaying it would answer 405 Method Not Allowed.
-                // The product page is where the (preserved) form data is rendered again.
+                // Not the current URL: review/product/post is POST-only, so replaying it with
+                // the post-login GET answers 405. The referring product page re-renders the
+                // form data preserved just below.
                 Mage::getSingleton('customer/session')->setBeforeAuthUrl($this->_getRefererUrl());
                 Mage::getSingleton('review/session')->setFormData($this->getRequest()->getPost())
                     ->setRedirectUrl($this->_getRefererUrl());

--- a/app/code/core/Mage/Review/controllers/ProductController.php
+++ b/app/code/core/Mage/Review/controllers/ProductController.php
@@ -27,7 +27,10 @@ class Mage_Review_ProductController extends Mage_Core_Controller_Front_Action
         if (!$allowGuest && $action == 'post' && $this->getRequest()->isPost()) {
             if (!Mage::getSingleton('customer/session')->isLoggedIn()) {
                 $this->setFlag('', self::FLAG_NO_DISPATCH, true);
-                Mage::getSingleton('customer/session')->setBeforeAuthUrl(Mage::getUrl('*/*/*', ['_current' => true]));
+                // Not the current URL: review/product/post is POST-only, and a post-login
+                // redirect is a GET, so replaying it would answer 405 Method Not Allowed.
+                // The product page is where the (preserved) form data is rendered again.
+                Mage::getSingleton('customer/session')->setBeforeAuthUrl($this->_getRefererUrl());
                 Mage::getSingleton('review/session')->setFormData($this->getRequest()->getPost())
                     ->setRedirectUrl($this->_getRefererUrl());
                 $this->_redirectUrl(Mage::helper('customer')->getLoginUrl());

--- a/app/code/core/Mage/Review/controllers/ProductController.php
+++ b/app/code/core/Mage/Review/controllers/ProductController.php
@@ -27,9 +27,7 @@ class Mage_Review_ProductController extends Mage_Core_Controller_Front_Action
         if (!$allowGuest && $action == 'post' && $this->getRequest()->isPost()) {
             if (!Mage::getSingleton('customer/session')->isLoggedIn()) {
                 $this->setFlag('', self::FLAG_NO_DISPATCH, true);
-                // Not the current URL: review/product/post is POST-only, so replaying it with
-                // the post-login GET answers 405. The referring product page re-renders the
-                // form data preserved just below.
+                // Not the current URL: review/product/post is POST-only, so it would 405.
                 Mage::getSingleton('customer/session')->setBeforeAuthUrl($this->_getRefererUrl());
                 Mage::getSingleton('review/session')->setFormData($this->getRequest()->getPost())
                     ->setRedirectUrl($this->_getRefererUrl());

--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -43,9 +43,7 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
             }
             Mage::getSingleton('customer/session')->setBeforeWishlistRequest($this->getRequest()->getParams());
 
-            // Every wishlist action that mutates the list is POST-only, so it cannot be the
-            // post-login target. Routing to the wishlist instead revives indexAction's
-            // "add product to wishlist again" notice, unreachable until now.
+            // The mutating wishlist actions are POST-only, so they would 405.
             if (!$this->getRequest()->isGet()) {
                 Mage::getSingleton('customer/session')->setBeforeAuthUrl(Mage::getUrl('wishlist'));
             }

--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -44,8 +44,8 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
             Mage::getSingleton('customer/session')->setBeforeWishlistRequest($this->getRequest()->getParams());
 
             // Every wishlist action that mutates the list is POST-only, so it cannot be the
-            // post-login target. The wishlist itself is the better landing page anyway: it
-            // reports the interrupted add (see indexAction).
+            // post-login target. Routing to the wishlist instead revives indexAction's
+            // "add product to wishlist again" notice, unreachable until now.
             if (!$this->getRequest()->isGet()) {
                 Mage::getSingleton('customer/session')->setBeforeAuthUrl(Mage::getUrl('wishlist'));
             }

--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -42,6 +42,13 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
                 Mage::getSingleton('customer/session')->setBeforeWishlistUrl($this->_getRefererUrl());
             }
             Mage::getSingleton('customer/session')->setBeforeWishlistRequest($this->getRequest()->getParams());
+
+            // Every wishlist action that mutates the list is POST-only, and authenticate()
+            // stored the current URL as the post-login target. Send the customer to the
+            // wishlist itself instead, which reports the interrupted add (see indexAction).
+            if (!$this->getRequest()->isGet()) {
+                Mage::getSingleton('customer/session')->setBeforeAuthUrl(Mage::getUrl('wishlist'));
+            }
         }
         if (!Mage::getStoreConfigFlag('wishlist/general/active')) {
             $this->norouteAction();

--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -43,9 +43,9 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
             }
             Mage::getSingleton('customer/session')->setBeforeWishlistRequest($this->getRequest()->getParams());
 
-            // Every wishlist action that mutates the list is POST-only, and authenticate()
-            // stored the current URL as the post-login target. Send the customer to the
-            // wishlist itself instead, which reports the interrupted add (see indexAction).
+            // Every wishlist action that mutates the list is POST-only, so it cannot be the
+            // post-login target. The wishlist itself is the better landing page anyway: it
+            // reports the interrupted add (see indexAction).
             if (!$this->getRequest()->isGet()) {
                 Mage::getSingleton('customer/session')->setBeforeAuthUrl(Mage::getUrl('wishlist'));
             }

--- a/tests/Frontend/Integration/Customer/PostLoginRedirectTest.php
+++ b/tests/Frontend/Integration/Customer/PostLoginRedirectTest.php
@@ -21,55 +21,129 @@ uses(Tests\MahoFrontendTestCase::class);
  * right after a successful login — the customer was logged in but stared at an error page.
  */
 
-// The session models would otherwise try to name a PHP session another suite already
-// started in this process. Mage::reset() in tearDown drops this again per test.
 beforeEach(function () {
+    // The session models would otherwise try to name a PHP session another suite already
+    // started in this process. Mage::reset() in tearDown drops this again per test.
     Mage::unregister(Mage_Core_Model_Session_Abstract::REGISTRY_KEY);
     $session = new Session(new MockArraySessionStorage());
     $session->start();
     Mage::register(Mage_Core_Model_Session_Abstract::REGISTRY_KEY, $session);
+
+    $customerSession = Mage::getSingleton('customer/session');
+    $customerSession->logout();
+    $customerSession->unsBeforeAuthUrl();
+
+    Mage::app()->getStore()->setConfig('customer/account/enabled_in_frontend', '1');
+    Mage::app()->getStore()->setConfig(Mage_Customer_Helper_Data::XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD, '0');
+
+    // The page that held the form the guest submitted.
+    $_SERVER['HTTP_REFERER'] = Mage::getUrl('customer/address');
 });
 
-it('reports a GET-only route as routable', function () {
-    expect(Mage::helper('core/url')->isGetRoutable(Mage::getUrl('wishlist')))->toBeTrue();
+afterEach(function () {
+    unset($_SERVER['HTTP_REFERER']);
 });
 
-it('reports a POST-only route as not routable', function () {
-    expect(Mage::helper('core/url')->isGetRoutable(Mage::getUrl('wishlist/index/add')))->toBeFalse();
-    expect(Mage::helper('core/url')->isGetRoutable(Mage::getUrl('review/product/post')))->toBeFalse();
-    expect(Mage::helper('core/url')->isGetRoutable(Mage::getUrl('customer/account/loginPost')))->toBeFalse();
+it('keeps the current URL as the post-login target when the request was a GET', function () {
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/customer/address/edit', 'GET'),
+    );
+    $request->setRouteName('customer')
+        ->setControllerName('address')
+        ->setActionName('edit')
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+
+    Mage::getSingleton('customer/session')->authenticate(
+        new Mage_Core_Controller_Front_Action($request, new Mage_Core_Controller_Response_Http()),
+    );
+
+    expect(Mage::getSingleton('customer/session')->getBeforeAuthUrl())
+        ->toBe(Mage::getUrl('*/*/*', ['_current' => true]));
 });
 
-it('treats unrouted and external URLs as routable', function () {
-    // URL rewrites, CMS pages and legacy path dispatch match no attributed route.
-    expect(Mage::helper('core/url')->isGetRoutable(Mage::getBaseUrl() . 'some-cms-page'))->toBeTrue();
-    expect(Mage::helper('core/url')->isGetRoutable('https://example.com/whatever'))->toBeTrue();
+it('sends the customer back to the page holding the form when the request was a POST', function () {
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/customer/address/formPost', 'POST'),
+    );
+    $request->setRouteName('customer')
+        ->setControllerName('address')
+        ->setActionName('formPost')
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+
+    Mage::getSingleton('customer/session')->authenticate(
+        new Mage_Core_Controller_Front_Action($request, new Mage_Core_Controller_Response_Http()),
+    );
+
+    expect(Mage::getSingleton('customer/session')->getBeforeAuthUrl())
+        ->not->toContain('formPost')
+        ->toBe($_SERVER['HTTP_REFERER']);
 });
 
-it('refuses to store a POST-only URL as the post-login target', function () {
-    $session = Mage::getSingleton('customer/session');
-    $session->setBeforeAuthUrl(Mage::getUrl('customer/account'));
+it('falls back to the account page when the referer is not usable', function () {
+    $_SERVER['HTTP_REFERER'] = 'https://example.com/whatever';
 
-    $session->setBeforeAuthUrl(Mage::getUrl('wishlist/index/add'));
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/newsletter/manage/save', 'POST'),
+    );
+    $request->setRouteName('newsletter')
+        ->setControllerName('manage')
+        ->setActionName('save')
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
 
-    expect($session->getBeforeAuthUrl())->not->toContain('wishlist/index/add');
+    Mage::getSingleton('customer/session')->authenticate(
+        new Mage_Core_Controller_Front_Action($request, new Mage_Core_Controller_Response_Http()),
+    );
+
+    expect(Mage::getSingleton('customer/session')->getBeforeAuthUrl())
+        ->toBe(Mage::helper('customer')->getAccountUrl());
 });
 
-it('stores a GET-routable post-login target', function () {
-    $session = Mage::getSingleton('customer/session');
+it('ignores the referer when the store redirects to the dashboard after login', function () {
+    Mage::app()->getStore()->setConfig(Mage_Customer_Helper_Data::XML_PATH_CUSTOMER_LOGIN_REDIRECT_TO_DASHBOARD, '1');
 
-    $session->setBeforeAuthUrl(Mage::getUrl('wishlist'));
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/customer/address/formPost', 'POST'),
+    );
+    $request->setRouteName('customer')
+        ->setControllerName('address')
+        ->setActionName('formPost')
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
 
-    expect($session->getBeforeAuthUrl())->toContain('wishlist');
+    Mage::getSingleton('customer/session')->authenticate(
+        new Mage_Core_Controller_Front_Action($request, new Mage_Core_Controller_Response_Http()),
+    );
+
+    expect(Mage::getSingleton('customer/session')->getBeforeAuthUrl())
+        ->toBe(Mage::helper('customer')->getDashboardUrl());
+});
+
+it('does not stamp a POST-only URL into the login referer param', function () {
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/customer/address/formPost', 'POST'),
+    );
+    $request->setRouteName('customer')
+        ->setControllerName('address')
+        ->setActionName('formPost')
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+
+    $params = Mage::helper('customer')->getLoginUrlParams();
+
+    // _loginPostRedirect() replays this param as the post-login target when none is stored.
+    $referer = Mage::helper('core')->urlDecodeAndEscape(
+        $params[Mage_Customer_Helper_Data::REFERER_QUERY_PARAM_NAME],
+    );
+    expect($referer)
+        ->not->toContain('formPost')
+        ->toBe($_SERVER['HTTP_REFERER']);
 });
 
 it('sends a guest bounced off a wishlist POST to the wishlist page after login', function () {
-    Mage::app()->getStore()->setConfig('customer/account/enabled_in_frontend', '1');
     Mage::app()->getStore()->setConfig('wishlist/general/active', '1');
-
-    $session = Mage::getSingleton('customer/session');
-    $session->logout();
-    $session->unsBeforeAuthUrl();
 
     $request = new Mage_Core_Controller_Request_Http(
         SymfonyRequest::create('/wishlist/index/add?product=1', 'POST'),
@@ -78,8 +152,29 @@ it('sends a guest bounced off a wishlist POST to the wishlist page after login',
         ->setControllerName('index')
         ->setActionName('add')
         ->setDispatched(true);
+    Mage::app()->setRequest($request);
 
     (new Mage_Wishlist_IndexController($request, new Mage_Core_Controller_Response_Http()))->preDispatch();
 
-    expect($session->getBeforeAuthUrl())->toBe(Mage::getUrl('wishlist'));
+    expect(Mage::getSingleton('customer/session')->getBeforeAuthUrl())->toBe(Mage::getUrl('wishlist'));
+});
+
+it('sends a guest bounced off a review POST back to the product page', function () {
+    Mage::app()->getStore()->setConfig(Mage_Review_Helper_Data::XML_REVIEW_GUETS_ALLOW, '0');
+    $_SERVER['HTTP_REFERER'] = Mage::getUrl('catalog/product/view', ['id' => 1]);
+
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/review/product/post', 'POST'),
+    );
+    $request->setRouteName('review')
+        ->setControllerName('product')
+        ->setActionName('post')
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+
+    (new Mage_Review_ProductController($request, new Mage_Core_Controller_Response_Http()))->preDispatch();
+
+    expect(Mage::getSingleton('customer/session')->getBeforeAuthUrl())
+        ->not->toContain('review/product/post')
+        ->toBe($_SERVER['HTTP_REFERER']);
 });

--- a/tests/Frontend/Integration/Customer/PostLoginRedirectTest.php
+++ b/tests/Frontend/Integration/Customer/PostLoginRedirectTest.php
@@ -14,11 +14,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 uses(Tests\MahoFrontendTestCase::class);
 
 /**
- * A guest who is bounced to the login page from a login-protected action has that action's
- * URL stored as the post-login target. Routes are method-restricted, and a redirect is
- * always followed with a GET, so storing the URL of a POST-only action (wishlist/index/add,
- * review/product/post, customer/address/formPost, ...) answered 405 Method Not Allowed
- * right after a successful login: the customer was logged in but stared at an error page.
+ * A guest bounced to the login page had the interrupted action's URL stored as the post-login
+ * target. For a POST-only action the redirect back answered 405 Method Not Allowed.
  */
 
 beforeEach(function () {

--- a/tests/Frontend/Integration/Customer/PostLoginRedirectTest.php
+++ b/tests/Frontend/Integration/Customer/PostLoginRedirectTest.php
@@ -175,3 +175,22 @@ it('sends a guest bounced off a review POST back to the product page', function 
         ->not->toContain('review/product/post')
         ->toBe($_SERVER['HTTP_REFERER']);
 });
+
+it('does not let the login block capture a POST-only endpoint as the post-login target', function () {
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/customer/account/prelogin/?isAjax=true', 'POST'),
+    );
+    $request->setRouteName('customer')
+        ->setControllerName('account')
+        ->setActionName('prelogin')
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+
+    $block = new Mage_Customer_Block_Form_Login();
+    $block->setLayout(Mage::app()->getLayout());
+    $block->canShowLogin();
+
+    expect(Mage::getSingleton('customer/session')->getBeforeAuthUrl())
+        ->not->toContain('prelogin')
+        ->toBe($_SERVER['HTTP_REFERER']);
+});

--- a/tests/Frontend/Integration/Customer/PostLoginRedirectTest.php
+++ b/tests/Frontend/Integration/Customer/PostLoginRedirectTest.php
@@ -18,7 +18,7 @@ uses(Tests\MahoFrontendTestCase::class);
  * URL stored as the post-login target. Routes are method-restricted, and a redirect is
  * always followed with a GET, so storing the URL of a POST-only action (wishlist/index/add,
  * review/product/post, customer/address/formPost, ...) answered 405 Method Not Allowed
- * right after a successful login — the customer was logged in but stared at an error page.
+ * right after a successful login: the customer was logged in but stared at an error page.
  */
 
 beforeEach(function () {

--- a/tests/Frontend/Integration/Customer/PostLoginRedirectTest.php
+++ b/tests/Frontend/Integration/Customer/PostLoginRedirectTest.php
@@ -8,6 +8,8 @@
 declare(strict_types=1);
 
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 uses(Tests\MahoFrontendTestCase::class);
 
@@ -18,10 +20,15 @@ uses(Tests\MahoFrontendTestCase::class);
  * review/product/post, customer/address/formPost, ...) answered 405 Method Not Allowed
  * right after a successful login — the customer was logged in but stared at an error page.
  */
-function makeRequest(string $uri, string $method = 'GET'): Mage_Core_Controller_Request_Http
-{
-    return new Mage_Core_Controller_Request_Http(SymfonyRequest::create($uri, $method));
-}
+
+// The session models would otherwise try to name a PHP session another suite already
+// started in this process. Mage::reset() in tearDown drops this again per test.
+beforeEach(function () {
+    Mage::unregister(Mage_Core_Model_Session_Abstract::REGISTRY_KEY);
+    $session = new Session(new MockArraySessionStorage());
+    $session->start();
+    Mage::register(Mage_Core_Model_Session_Abstract::REGISTRY_KEY, $session);
+});
 
 it('reports a GET-only route as routable', function () {
     expect(Mage::helper('core/url')->isGetRoutable(Mage::getUrl('wishlist')))->toBeTrue();
@@ -64,7 +71,9 @@ it('sends a guest bounced off a wishlist POST to the wishlist page after login',
     $session->logout();
     $session->unsBeforeAuthUrl();
 
-    $request = makeRequest('/wishlist/index/add?product=1', 'POST');
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/wishlist/index/add?product=1', 'POST'),
+    );
     $request->setRouteName('wishlist')
         ->setControllerName('index')
         ->setActionName('add')

--- a/tests/Frontend/Integration/Customer/PostLoginRedirectTest.php
+++ b/tests/Frontend/Integration/Customer/PostLoginRedirectTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+uses(Tests\MahoFrontendTestCase::class);
+
+/**
+ * A guest who is bounced to the login page from a login-protected action has that action's
+ * URL stored as the post-login target. Routes are method-restricted, and a redirect is
+ * always followed with a GET, so storing the URL of a POST-only action (wishlist/index/add,
+ * review/product/post, customer/address/formPost, ...) answered 405 Method Not Allowed
+ * right after a successful login — the customer was logged in but stared at an error page.
+ */
+function makeRequest(string $uri, string $method = 'GET'): Mage_Core_Controller_Request_Http
+{
+    return new Mage_Core_Controller_Request_Http(SymfonyRequest::create($uri, $method));
+}
+
+it('reports a GET-only route as routable', function () {
+    expect(Mage::helper('core/url')->isGetRoutable(Mage::getUrl('wishlist')))->toBeTrue();
+});
+
+it('reports a POST-only route as not routable', function () {
+    expect(Mage::helper('core/url')->isGetRoutable(Mage::getUrl('wishlist/index/add')))->toBeFalse();
+    expect(Mage::helper('core/url')->isGetRoutable(Mage::getUrl('review/product/post')))->toBeFalse();
+    expect(Mage::helper('core/url')->isGetRoutable(Mage::getUrl('customer/account/loginPost')))->toBeFalse();
+});
+
+it('treats unrouted and external URLs as routable', function () {
+    // URL rewrites, CMS pages and legacy path dispatch match no attributed route.
+    expect(Mage::helper('core/url')->isGetRoutable(Mage::getBaseUrl() . 'some-cms-page'))->toBeTrue();
+    expect(Mage::helper('core/url')->isGetRoutable('https://example.com/whatever'))->toBeTrue();
+});
+
+it('refuses to store a POST-only URL as the post-login target', function () {
+    $session = Mage::getSingleton('customer/session');
+    $session->setBeforeAuthUrl(Mage::getUrl('customer/account'));
+
+    $session->setBeforeAuthUrl(Mage::getUrl('wishlist/index/add'));
+
+    expect($session->getBeforeAuthUrl())->not->toContain('wishlist/index/add');
+});
+
+it('stores a GET-routable post-login target', function () {
+    $session = Mage::getSingleton('customer/session');
+
+    $session->setBeforeAuthUrl(Mage::getUrl('wishlist'));
+
+    expect($session->getBeforeAuthUrl())->toContain('wishlist');
+});
+
+it('sends a guest bounced off a wishlist POST to the wishlist page after login', function () {
+    Mage::app()->getStore()->setConfig('customer/account/enabled_in_frontend', '1');
+    Mage::app()->getStore()->setConfig('wishlist/general/active', '1');
+
+    $session = Mage::getSingleton('customer/session');
+    $session->logout();
+    $session->unsBeforeAuthUrl();
+
+    $request = makeRequest('/wishlist/index/add?product=1', 'POST');
+    $request->setRouteName('wishlist')
+        ->setControllerName('index')
+        ->setActionName('add')
+        ->setDispatched(true);
+
+    (new Mage_Wishlist_IndexController($request, new Mage_Core_Controller_Response_Http()))->preDispatch();
+
+    expect($session->getBeforeAuthUrl())->toBe(Mage::getUrl('wishlist'));
+});


### PR DESCRIPTION
## The bug

A guest who triggers a login-protected action gets bounced to the login page, and that action's URL is stored as the post-login target (`beforeAuthUrl`). Routes are method-restricted now, and a redirect is always followed with a **GET**, so when the stored URL belongs to a POST-only action, logging in lands the customer on:

```
Method Not Allowed
```

They *are* logged in (a refresh shows the account), but the page they got is an error, and the action they were trying to perform is silently dropped.

Reproduced end to end against a store, and the first two steps reproduce on `demo.mahocommerce.com` as well:

```
POST /wishlist/index/add        (guest)  → 302 /customer/account/login/?referer=…
                                               referer decodes to /wishlist/index/add/
POST /customer/account/loginPost/        → 302 /wishlist/index/add/
GET  /wishlist/index/add/                → 405 Method Not Allowed   (Allow: POST)
GET  /customer/account/                  → 200 "Hello, …!"
```

Same family as #988. Affected entry points, login-protected *and* POST-only:

- `wishlist/index/{add,cart,fromcart,remove,update,updateItemOptions,send}`
- `review/product/post` (guest review submission, when guest reviews are off, 405s every time)
- `customer/address/{formPost,delete}`, `customer/account/editPost`
- `newsletter/manage/save`, `sales/recurring_profile/*`

Plain login is **not** immune. The login form block renders on ordinary pages as `customer_form_mini_login`, and it captured the current URL too, so a plain login could store the POST-only `customer/account/prelogin` AJAX endpoint and 405 on exactly the same redirect.

## The fix

The rule is applied at every place that captures "the URL we are on right now" as a post-login target, rather than guarding every auth URL that passes through the session.

- **`Mage_Customer_Model_Session::authenticate()`**: keeps the current URL as the post-login target only when the interrupted request was a GET.
- **`Mage_Customer_Block_Form_Login::_setBeforeAuthUrl()`**: same rule. This block renders on ordinary pages, so its `_current` capture can pick up any URL the request happens to be on, including the POST-only `customer/account/prelogin`.
- **`Mage_Customer_Helper_Data::getLoginUrlParams()`**: same rule for the `?referer=` it stamps onto the login URL. That param is the second channel: `_loginPostRedirect()` replays it through `setBeforeAuthUrl()` whenever no target is stored.
- **`Mage_Customer_Helper_Data::getDefaultBeforeAuthUrl()`**: the fallback the three above share. Honors the existing `customer/login/redirect_dashboard` setting; otherwise returns the referring page (the one that held the form), falling back to the account page when the referer is missing or external. The customer lands back where they were instead of on an error page.
- **`Mage_Wishlist_IndexController::preDispatch()`**: points the post-login target at `/wishlist` for non-GET requests. That revives the existing "Please add product to wishlist again." path in `indexAction()`, which until now could never be reached.
- **`Mage_Review_ProductController::preDispatch()`**: stores the referer (the product page) instead of the POST-only `review/product/post`. The form data was already preserved in `review/session`, so the customer returns to the page that re-renders it.
- **`Mage_Core_Helper_Url::isInternalUrl()`**: the base-secure/base-unsecure prefix rule that was inline in `Mage_Core_Controller_Varien_Action::_isUrlInternal()`, now shared by both callers.

### Why not a general guard

The first draft added `Mage_Core_Helper_Url::isGetRoutable()`, which matched a URL against the compiled route collection with a GET context, and had `_setAuthUrl()` silently refuse to store anything it rejected. That would cover third-party callers too, but it duplicated the request's base-url and store-code path normalization, matched external URLs against local routes, and left whatever stale target was already in the session when it rejected one.

Every `_current`-based capture in core is now guarded, which is the full surface for this bug in our own code. Third-party code that calls `setBeforeAuthUrl(Mage::getUrl('*/*/*', ['_current' => true]))` from its own POST-only action still stores an unreplayable URL, unchanged from today's behavior. `_setAuthUrl()` remains the single choke point for both `before_auth_url` and `after_auth_url`, so a general guard can be added later without touching any public API. That belongs in its own PR: it needs URL-to-path normalization (secure vs unsecure base URL, store code in URL) and has to distinguish `MethodNotAllowedException` from `ResourceNotFoundException` for rewrites and legacy paths.

## Tests

`tests/Frontend/Integration/Customer/PostLoginRedirectTest.php` covers all four capture sites plus the GET path as a regression guard. Each case fails against the unfixed code.
