### PR TITLE
Fixed currency prices rendering ¤ instead of the currency symbol

### DIFF
--- a/app/code/core/Mage/Core/Model/Locale.php
+++ b/app/code/core/Mage/Core/Model/Locale.php
@@ -946,6 +946,29 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
     }
 
     /**
+     * Convert the ICU currency pattern for a currency into a printf-style format with a single %s
+     * placeholder, resolving the generic currency placeholders (¤, ¤¤, ¤¤¤) to real symbols.
+     */
+    public function getCurrencyOutputFormat(string $currencyCode): string
+    {
+        $formatter = $this->currency($currencyCode);
+        $pattern = $formatter->getPattern();
+
+        $pos = strpos($pattern, ';');
+        if ($pos !== false) {
+            $pattern = substr($pattern, 0, $pos);
+        }
+
+        $pattern = preg_replace('/[#0,\.]+/', '%s', $pattern);
+
+        return strtr($pattern, [
+            '¤¤¤' => $currencyCode,
+            '¤¤' => $formatter->getSymbol(NumberFormatter::INTL_CURRENCY_SYMBOL) ?: $currencyCode,
+            '¤' => $this->getCurrencySymbol($currencyCode),
+        ]);
+    }
+
+    /**
      * Normalize a locale-formatted number string to float
      */
     public function normalizeNumber(string $value): float|false
@@ -1012,17 +1035,13 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
     public function getJsPriceFormat(): array
     {
         $formatter = new NumberFormatter($this->getLocaleCode(), NumberFormatter::DECIMAL);
-        $pattern = $formatter->getPattern();
 
         // Extract decimal and grouping separators
         $decimalSymbol = $formatter->getSymbol(NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
         $groupSymbol = $formatter->getSymbol(NumberFormatter::GROUPING_SEPARATOR_SYMBOL);
 
-        // Get currency pattern with actual symbol (not generic ¤)
-        $currency = Mage::app()->getStore()->getCurrentCurrency();
-        $currencyFormatter = $this->currency($currency->getCode());
-        $currencyPattern = $currencyFormatter->getPattern();
-        $currencySymbol = $currencyFormatter->getSymbol(NumberFormatter::CURRENCY_SYMBOL);
+        $currencyCode = Mage::app()->getStore()->getCurrentCurrencyCode();
+        $currencyPattern = $this->currency($currencyCode)->getPattern();
 
         // Parse the CURRENCY pattern to determine precision (not decimal pattern)
         $pos = strpos($currencyPattern, ';');
@@ -1055,12 +1074,8 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
         // Count required integer digits from currency pattern
         $integerRequired = substr_count($integerPart, '0');
 
-        // Replace generic currency symbol ¤ with actual currency symbol
-        $jsPattern = preg_replace('/[#0,\.]+/', '%s', $currencyPattern);
-        $jsPattern = str_replace('¤', $currencySymbol, $jsPattern);
-
         return [
-            'pattern' => $jsPattern,
+            'pattern' => $this->getCurrencyOutputFormat($currencyCode),
             'precision' => $totalPrecision,
             'requiredPrecision' => $requiredPrecision,
             'decimalSymbol' => $decimalSymbol,

--- a/app/code/core/Mage/Directory/Model/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Currency.php
@@ -260,13 +260,15 @@ class Mage_Directory_Model_Currency extends Mage_Core_Model_Abstract
      */
     public function getOutputFormat()
     {
-        $formatter = Mage::app()->getLocale()->currency($this->getCode());
-        $pattern = $formatter->getPattern();
+        return Mage::app()->getLocale()->getCurrencyOutputFormat($this->getCode());
+    }
 
-        // Convert ICU number pattern to simple %s placeholder
-        // Replace sequences of number format characters (#, 0, comma, period) with %s
-        // This preserves currency symbols and other formatting elements
-        return preg_replace('/[#0,\.]+/', '%s', $pattern);
+    /**
+     * Returns the localized symbol for this currency, falling back to its code
+     */
+    public function getCurrencySymbol(): string
+    {
+        return Mage::app()->getLocale()->getCurrencySymbol($this->getCode());
     }
 
     /**

--- a/app/code/core/Mage/Tax/Helper/Data.php
+++ b/app/code/core/Mage/Tax/Helper/Data.php
@@ -392,10 +392,10 @@ class Mage_Tax_Helper_Data extends Mage_Core_Helper_Abstract
     {
         $this->_app->getLocale()->emulate($store);
         $priceFormat = $this->_app->getLocale()->getJsPriceFormat();
-        $this->_app->getLocale()->revert();
         if ($store) {
             $priceFormat['pattern'] = $this->_app->getStore($store)->getCurrentCurrency()->getOutputFormat();
         }
+        $this->_app->getLocale()->revert();
         return Mage::helper('core')->jsonEncode($priceFormat);
     }
 

--- a/tests/Backend/Unit/Core/Model/LocaleCurrencyFormatTest.php
+++ b/tests/Backend/Unit/Core/Model/LocaleCurrencyFormatTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('currency output formats', function () {
+    beforeEach(function () {
+        $this->locale = Mage::app()->getLocale();
+        $this->originalLocaleCode = $this->locale->getLocaleCode();
+    });
+
+    afterEach(function () {
+        $this->locale->setLocaleCode($this->originalLocaleCode);
+    });
+
+    it('resolves the generic currency placeholder to a real symbol', function () {
+        $this->locale->setLocaleCode('en_GB');
+
+        expect($this->locale->getCurrencyOutputFormat('GBP'))->toBe('£%s');
+        expect($this->locale->getCurrencyOutputFormat('EUR'))->toBe('€%s');
+    });
+
+    it('keeps the locale symbol placement', function () {
+        $this->locale->setLocaleCode('de_DE');
+
+        expect($this->locale->getCurrencyOutputFormat('EUR'))->toBe("%s\u{a0}€");
+    });
+
+    it('never leaves ¤ in a currency model output format', function () {
+        foreach (['en_US', 'en_GB', 'de_DE', 'fr_FR', 'ja_JP'] as $localeCode) {
+            $this->locale->setLocaleCode($localeCode);
+            foreach (['GBP', 'EUR', 'USD', 'JPY'] as $code) {
+                $format = Mage::getModel('directory/currency')->load($code)->getOutputFormat();
+
+                expect($format)->not->toContain('¤');
+                expect($format)->toContain('%s');
+            }
+        }
+    });
+
+    it('exposes the currency symbol on the currency model', function () {
+        $this->locale->setLocaleCode('en_GB');
+
+        expect(Mage::getModel('directory/currency')->load('GBP')->getCurrencySymbol())->toBe('£');
+    });
+
+    it('never leaves ¤ in the js price format used by the admin product form', function () {
+        foreach (Mage::app()->getStores() as $store) {
+            $priceFormat = Mage::helper('core')->jsonDecode(Mage::helper('tax')->getPriceFormat($store));
+
+            expect($priceFormat['pattern'])->not->toContain('¤');
+            expect($priceFormat['pattern'])->toContain('%s');
+        }
+    });
+});


### PR DESCRIPTION
Reported on the admin product form, where the inc-tax label read `[Inc. Tax ¤63.82]` instead of `£63.82`.

`Mage_Directory_Model_Currency::getOutputFormat()` replaced the ICU pattern's digit run with `%s` but left ICU's generic currency placeholder `¤` untouched, so it returned `'¤%s'` for every currency in every locale. Two paths consume it: `Mage_Tax_Helper_Data::getPriceFormat()`, which overwrote the already-correct pattern from `getJsPriceFormat()` before handing it to the admin product form's JS, and `Mage_Catalog_Block_Product_View_Type_Configurable`, which feeds it to the storefront configurable price template.

Placeholder resolution now lives in `Mage_Core_Model_Locale::getCurrencyOutputFormat()` (handling `¤`, `¤¤` and `¤¤¤`), with `getJsPriceFormat()` sharing it. The tax helper's pattern override moved inside the locale emulation, so symbol placement follows the store locale the way the separators already did — de_DE was getting German separators with US symbol placement.

Also adds the missing `Mage_Directory_Model_Currency::getCurrencySymbol()`, which fell through to the magic getter and returned `null`, affecting the giftcard amount placeholders and `Mage_Directory_Api_CurrencyProvider`'s `symbol` field.

Verified against a GBP / en_GB / prices-include-tax store: `¤%s` becomes `£%s` across en_US, en_GB, de_DE, fr_FR and ja_JP × GBP, EUR, USD, JPY.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->