### PR TITLE
Added a table optimization check to health-check and a db:optimize command to reclaim the space

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/System/Tools/Healthcheck.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Tools/Healthcheck.php
@@ -243,12 +243,6 @@ class Mage_Adminhtml_Block_System_Tools_Healthcheck extends Mage_Adminhtml_Block
 
     private function formatBytes(int $bytes): string
     {
-        if ($bytes === 0) {
-            return '0 B';
-        }
-
-        $units = ['B', 'KB', 'MB', 'GB'];
-        $i = (int) floor(log($bytes, 1024));
-        return round($bytes / (1024 ** $i), 1) . ' ' . $units[$i];
+        return Mage::helper('core')->formatFileSize($bytes);
     }
 }

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -137,6 +137,22 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
     }
 
     /**
+     * Render a byte count in the largest unit that keeps it readable, e.g. "1.5 KB".
+     * Binary units (1 KB = 1024 B), since every caller measures storage or memory.
+     */
+    public function formatFileSize(int $bytes, int $precision = 2): string
+    {
+        if ($bytes <= 0) {
+            return '0 B';
+        }
+
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $unit = min((int) floor(log($bytes, 1024)), count($units) - 1);
+
+        return round($bytes / 1024 ** $unit, $unit === 0 ? 0 : $precision) . ' ' . $units[$unit];
+    }
+
+    /**
      * Format date for display using the store's locale and timezone.
      *
      * Produces locale-aware output (e.g. "April 16, 2026" in en_US, "16 avril 2026" in fr_FR).

--- a/app/code/core/Maho/FeedManager/Helper/Data.php
+++ b/app/code/core/Maho/FeedManager/Helper/Data.php
@@ -107,13 +107,7 @@ class Maho_FeedManager_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function formatFileSize(int $bytes): string
     {
-        $units = ['B', 'KB', 'MB', 'GB'];
-        $i = 0;
-        while ($bytes >= 1024 && $i < count($units) - 1) {
-            $bytes /= 1024;
-            $i++;
-        }
-        return round($bytes, 2) . ' ' . $units[$i];
+        return Mage::helper('core')->formatFileSize($bytes);
     }
 
     /**

--- a/app/code/core/Maho/FeedManager/Model/Log.php
+++ b/app/code/core/Maho/FeedManager/Model/Log.php
@@ -177,14 +177,7 @@ class Maho_FeedManager_Model_Log extends Mage_Core_Model_Abstract
             return 'N/A';
         }
 
-        $units = ['B', 'KB', 'MB', 'GB'];
-        $i = 0;
-        while ($bytes >= 1024 && $i < count($units) - 1) {
-            $bytes /= 1024;
-            $i++;
-        }
-
-        return round($bytes, 2) . ' ' . $units[$i];
+        return Mage::helper('core')->formatFileSize((int) $bytes);
     }
 
     /**

--- a/lib/MahoCLI/Commands/BaseMahoCommand.php
+++ b/lib/MahoCLI/Commands/BaseMahoCommand.php
@@ -42,11 +42,6 @@ abstract class BaseMahoCommand extends Command
 
     public function humanReadableSize(int $bytes): string
     {
-        if ($bytes <= 0) {
-            return '0';
-        }
-
-        $i = (int) floor(log($bytes, 1024));
-        return round($bytes / 1024 ** $i, [0, 0, 2, 2, 3][$i]) . ['B', 'kB', 'MB', 'GB', 'TB'][$i];
+        return Mage::helper('core')->formatFileSize($bytes);
     }
 }

--- a/lib/MahoCLI/Commands/DBOptimize.php
+++ b/lib/MahoCLI/Commands/DBOptimize.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Commands;
+
+use Mage;
+use MahoCLI\Helper\TableBloatScanner;
+use Maho\Db\Adapter\AdapterInterface;
+use Maho\Db\Adapter\Pdo\Pgsql;
+use Maho\Db\Adapter\Pdo\Sqlite;
+use Maho\Db\Schema\Collector;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+#[AsCommand(
+    name: 'db:optimize',
+    description: 'Rebuild bloated tables to return their free space to the filesystem',
+)]
+class DBOptimize extends BaseMahoCommand
+{
+    #[\Override]
+    protected function configure(): void
+    {
+        $this->addOption(
+            'table',
+            null,
+            InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+            'Optimize this table regardless of how much space it would reclaim (repeatable)',
+        );
+        $this->addOption(
+            'all',
+            null,
+            InputOption::VALUE_NONE,
+            'Optimize every table, not just the ones the bloat thresholds flag',
+        );
+        $this->addOption(
+            'dry-run',
+            null,
+            InputOption::VALUE_NONE,
+            'Show the statements that would run without executing anything',
+        );
+        $this->addOption(
+            'force',
+            null,
+            InputOption::VALUE_NONE,
+            'Skip the confirmation prompt (for scripted maintenance windows)',
+        );
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->initMaho();
+
+        /** @var AdapterInterface $adapter */
+        $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+
+        // Every backend's rebuild is either non-transactional or forbidden inside a
+        // transaction block, so refuse rather than fail halfway through the list.
+        if ($adapter->getTransactionLevel() > 0) {
+            $output->writeln('<error>A transaction is open on this connection; optimization cannot run inside one.</error>');
+            return Command::FAILURE;
+        }
+
+        /** @var list<string> $requested */
+        $requested = $input->getOption('table');
+        try {
+            $targets = $this->resolveTargets($adapter, $output, $requested, (bool) $input->getOption('all'));
+        } catch (\InvalidArgumentException $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return Command::INVALID;
+        }
+
+        if ($targets === []) {
+            return Command::SUCCESS;
+        }
+
+        $statements = TableBloatScanner::optimizeStatements($adapter, array_column($targets, 'table'));
+
+        if ($input->getOption('dry-run')) {
+            $output->writeln('<info>Dry run: no changes will be applied.</info>');
+            foreach ($statements as $statement) {
+                $output->writeln('  ' . $statement);
+            }
+            return Command::SUCCESS;
+        }
+
+        $this->warnAboutLocking($adapter, $output);
+
+        if (!$input->getOption('force')) {
+            /** @var \Symfony\Component\Console\Helper\QuestionHelper $helper */
+            $helper = $this->getHelper('question');
+            $question = new ConfirmationQuestion(
+                sprintf('<question>Run %d statement(s) now? [y/N]</question> ', count($statements)),
+                false,
+            );
+            if (!$helper->ask($input, $output, $question)) {
+                $output->writeln('Aborted.');
+                return Command::SUCCESS;
+            }
+        }
+
+        return $this->runStatements($adapter, $output, $statements, $targets);
+    }
+
+    /**
+     * The tables to rebuild, either named explicitly, taken wholesale, or found by
+     * the scan. Prints its own explanation when there is nothing to do.
+     *
+     * @param list<string> $requested
+     * @return list<array{table: string, total: int, reclaimable: int, ratio: float, detail: string}>
+     * @throws \InvalidArgumentException
+     */
+    private function resolveTargets(AdapterInterface $adapter, OutputInterface $output, array $requested, bool $all): array
+    {
+        if ($requested !== [] && $all) {
+            throw new \InvalidArgumentException('--table and --all are mutually exclusive.');
+        }
+
+        if ($requested !== []) {
+            $missing = array_values(array_filter($requested, static fn(string $t): bool => !$adapter->isTableExists($t)));
+            if ($missing !== []) {
+                throw new \InvalidArgumentException('Unknown table(s): ' . implode(', ', $missing));
+            }
+            return self::asTargets($requested);
+        }
+
+        if ($all) {
+            $prefix = Collector::tablePrefix();
+            return self::asTargets(array_values(array_filter(
+                $adapter->listTables(),
+                static fn(string $t): bool => $prefix === '' || str_starts_with($t, $prefix),
+            )));
+        }
+
+        $findings = TableBloatScanner::scan($adapter, Collector::tablePrefix());
+        if ($findings === []) {
+            $output->writeln('<info>Nothing to optimize: no table holds enough reclaimable space to be worth a rebuild.</info>');
+            $reason = TableBloatScanner::reclaimUnavailableReason($adapter);
+            if ($reason !== null) {
+                $output->writeln('<comment>Note: ' . $reason . '</comment>');
+            }
+            $output->writeln('Use --table to rebuild a specific table anyway, or --all for the whole database.');
+            return [];
+        }
+
+        $this->renderFindings($output, $findings);
+
+        return $findings;
+    }
+
+    /**
+     * Tables chosen by name rather than by the scan carry no measurement: nothing
+     * claimed there would be reclaimed, and runStatements() reports what actually was.
+     *
+     * @param list<string> $tables
+     * @return list<array{table: string, total: int, reclaimable: int, ratio: float, detail: string}>
+     */
+    private static function asTargets(array $tables): array
+    {
+        return array_map(
+            static fn(string $table): array => [
+                'table' => $table,
+                'total' => 0,
+                'reclaimable' => 0,
+                'ratio' => 0.0,
+                'detail' => '',
+            ],
+            $tables,
+        );
+    }
+
+    /**
+     * @param list<array{table: string, total: int, reclaimable: int, ratio: float, detail: string}> $findings
+     */
+    private function renderFindings(OutputInterface $output, array $findings): void
+    {
+        $output->writeln(sprintf('<comment>%d table(s) hold reclaimable space:</comment>', count($findings)));
+
+        $helper = Mage::helper('core');
+        $table = new Table($output);
+        $table->setHeaders(['Table', 'Size on disk', 'Reclaimable', '%', 'Detail']);
+        foreach ($findings as $finding) {
+            $table->addRow([
+                $finding['table'],
+                $helper->formatFileSize($finding['total']),
+                $helper->formatFileSize($finding['reclaimable']),
+                round($finding['ratio'] * 100) . '%',
+                $finding['detail'],
+            ]);
+        }
+        $table->render();
+        $output->writeln('');
+    }
+
+    private function warnAboutLocking(AdapterInterface $adapter, OutputInterface $output): void
+    {
+        $warning = match (true) {
+            $adapter instanceof Sqlite => 'VACUUM rewrites the whole database file and needs free disk equal to its size.',
+            $adapter instanceof Pgsql => 'VACUUM FULL holds an ACCESS EXCLUSIVE lock for its entire duration: every read and'
+                . ' write against the table blocks until it finishes.',
+            default => 'OPTIMIZE TABLE rebuilds the table and needs free disk equal to its size. It is online for'
+                . ' InnoDB, but concurrent writes are still slowed for the duration.',
+        };
+
+        $output->writeln('<comment>This is a maintenance-window operation.</comment> ' . $warning);
+        $output->writeln('');
+    }
+
+    /**
+     * SQLite collapses any target list into a single whole-file VACUUM, so the
+     * statements do not line up one-to-one with the targets there. Measuring
+     * against the first target still works: totalSize() reports the whole file.
+     *
+     * @param list<string> $statements
+     * @param list<array{table: string, total: int, reclaimable: int, ratio: float, detail: string}> $targets
+     */
+    private function runStatements(AdapterInterface $adapter, OutputInterface $output, array $statements, array $targets): int
+    {
+        $perTable = !($adapter instanceof Sqlite);
+        $totalFreed = 0;
+
+        foreach ($statements as $index => $statement) {
+            $measured = $targets[$perTable ? $index : 0]['table'];
+            $output->write(sprintf('Optimizing %s... ', $perTable ? $measured : 'the database file'));
+
+            $before = TableBloatScanner::totalSize($adapter, $measured) ?? 0;
+
+            try {
+                TableBloatScanner::runStatement($adapter, $statement);
+            } catch (\Exception $e) {
+                $output->writeln('<error>failed: ' . $e->getMessage() . '</error>');
+                return Command::FAILURE;
+            }
+
+            $after = TableBloatScanner::totalSize($adapter, $measured) ?? $before;
+            $freed = max(0, $before - $after);
+            $totalFreed += $freed;
+            $output->writeln(sprintf('<info>done</info> (freed %s)', Mage::helper('core')->formatFileSize($freed)));
+        }
+
+        $output->writeln('');
+        $output->writeln(sprintf('<info>Reclaimed %s in total.</info>', Mage::helper('core')->formatFileSize($totalFreed)));
+
+        return Command::SUCCESS;
+    }
+}

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -166,6 +166,19 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
+     * Tables holding enough reclaimable free space to be worth a rebuild.
+     * Works on all three backends, each measuring its own form of bloat.
+     *
+     * @return list<array{table: string, total: int, reclaimable: int, ratio: float, detail: string}>
+     */
+    public static function findBloatedTables(): array
+    {
+        $adapter = Mage::getSingleton('core/resource')->getConnection('core_read');
+
+        return \MahoCLI\Helper\TableBloatScanner::scan($adapter, \Maho\Db\Schema\Collector::tablePrefix());
+    }
+
+    /**
      * Scans user code (app/code/local and app/code/community) for legacy XML config
      * declarations that have PHP-attribute equivalents introduced in v26.5.
      *
@@ -379,6 +392,28 @@ class HealthCheck extends BaseMahoCommand
                 'check' => 'Table Storage Engines',
                 'severity' => 'error',
                 'details' => 'Unable to check table storage engines.',
+            ];
+        }
+
+        try {
+            $bloated = self::findBloatedTables();
+            $checks[] = [
+                'check' => 'Table Optimization',
+                'severity' => empty($bloated) ? 'ok' : 'warning',
+                'details' => empty($bloated) ? '' : sprintf(
+                    '%d table(s) hold ~%s of reclaimable free space (%s). Bloat this size usually means rows were '
+                    . 'purged in bulk, or that a cleanup job (./maho log:clean) is not running. Run "./maho db:optimize" '
+                    . 'during a maintenance window to return the space to the filesystem.',
+                    count($bloated),
+                    Mage::helper('core')->formatFileSize((int) array_sum(array_column($bloated, 'reclaimable'))),
+                    implode(', ', array_column($bloated, 'table')),
+                ),
+            ];
+        } catch (\Exception) {
+            $checks[] = [
+                'check' => 'Table Optimization',
+                'severity' => 'error',
+                'details' => 'Unable to check table optimization.',
             ];
         }
 
@@ -947,6 +982,7 @@ class HealthCheck extends BaseMahoCommand
 
         $this->checkZeroDates($output, (bool) $input->getOption('check-zero-dates'));
         $this->checkTableEngines($output);
+        $this->checkTableBloat($output);
 
         if ($hasErrors) {
             return Command::FAILURE;
@@ -1046,6 +1082,51 @@ class HealthCheck extends BaseMahoCommand
             $output->writeln(sprintf('- %s (%s)', $table, $engine));
         }
         $output->writeln('Run: ./maho migrate');
+        $output->writeln('');
+    }
+
+    /**
+     * Detect tables whose on-disk footprint is mostly free space left behind by
+     * bulk deletes. All three backends are covered, each with its own measure:
+     * InnoDB's DATA_FREE, PostgreSQL's dead-tuple share, and SQLite's page
+     * freelist. Detection is metadata-only; the rebuild that reclaims the space
+     * is a maintenance-window operation, so it is never run from here.
+     */
+    private function checkTableBloat(OutputInterface $output): void
+    {
+        $output->write('Checking table optimization... ');
+
+        $adapter = \Mage::getSingleton('core/resource')->getConnection('core_read');
+        $tables = \MahoCLI\Helper\TableBloatScanner::scan($adapter, \Maho\Db\Schema\Collector::tablePrefix());
+
+        if ($tables === []) {
+            $output->writeln('<info>OK</info>');
+            $reason = \MahoCLI\Helper\TableBloatScanner::reclaimUnavailableReason($adapter);
+            if ($reason !== null) {
+                $output->writeln('(not measurable here: ' . $reason . ')');
+            }
+            return;
+        }
+
+        $output->writeln('');
+        $output->writeln(sprintf(
+            '<comment>Warning: %d table(s) hold reclaimable free space:</comment>',
+            count($tables),
+        ));
+        $helper = Mage::helper('core');
+        foreach ($tables as $table) {
+            $output->writeln(sprintf(
+                '- %s: %s of %s reclaimable (%d%%)%s',
+                $table['table'],
+                $helper->formatFileSize($table['reclaimable']),
+                $helper->formatFileSize($table['total']),
+                (int) round($table['ratio'] * 100),
+                $table['detail'] === '' ? '' : ', ' . $table['detail'],
+            ));
+        }
+        $output->writeln('Bloat this size usually means rows were purged in bulk, or that a cleanup job is not');
+        $output->writeln('running: check ./maho log:status and ./maho log:clean before rebuilding.');
+        $output->writeln('Run: ./maho db:optimize (during a maintenance window)');
         $output->writeln('');
     }
 

--- a/lib/MahoCLI/Helper/TableBloatScanner.php
+++ b/lib/MahoCLI/Helper/TableBloatScanner.php
@@ -1,0 +1,279 @@
+<?php
+
+/**
+ * Finds tables whose on-disk footprint is mostly reclaimable free space.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package MahoCLI
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Helper;
+
+use Maho\Db\Adapter\AdapterInterface;
+use Maho\Db\Adapter\Pdo\Mysql;
+use Maho\Db\Adapter\Pdo\Pgsql;
+use Maho\Db\Adapter\Pdo\Sqlite;
+
+class TableBloatScanner
+{
+    /** Below this, a rebuild costs more downtime than the space it returns. */
+    public const MIN_TOTAL_BYTES = 50 * 1024 * 1024;
+
+    /** Free share of a table below which fragmentation is ordinary churn, not bloat. */
+    public const MIN_RECLAIMABLE_RATIO = 0.30;
+
+    /**
+     * Tables holding more reclaimable space than the thresholds allow, largest first.
+     * The three backends measure different things, so `reclaimable` is an estimate
+     * everywhere except MySQL: PostgreSQL infers it from the dead-tuple share, and
+     * SQLite reports the whole database file rather than individual tables.
+     *
+     * @return list<array{table: string, total: int, reclaimable: int, ratio: float, detail: string}>
+     */
+    public static function scan(
+        AdapterInterface $adapter,
+        string $tablePrefix = '',
+        int $minTotalBytes = self::MIN_TOTAL_BYTES,
+        float $minRatio = self::MIN_RECLAIMABLE_RATIO,
+    ): array {
+        $candidates = match (true) {
+            $adapter instanceof Mysql => self::mysqlCandidates($adapter, $tablePrefix),
+            $adapter instanceof Pgsql => self::pgsqlCandidates($adapter, $tablePrefix),
+            $adapter instanceof Sqlite => self::sqliteCandidates($adapter),
+            default => [],
+        };
+
+        $findings = array_values(array_filter(
+            $candidates,
+            static fn(array $c): bool => $c['total'] >= $minTotalBytes && $c['ratio'] >= $minRatio,
+        ));
+
+        usort($findings, static fn(array $a, array $b): int => $b['reclaimable'] <=> $a['reclaimable']);
+
+        return $findings;
+    }
+
+    /**
+     * Why a rebuild would not hand space back to the filesystem on this server,
+     * or null when it would. Reported alongside an empty scan so the absence of
+     * findings is not mistaken for the absence of bloat.
+     */
+    public static function reclaimUnavailableReason(AdapterInterface $adapter): ?string
+    {
+        if (!($adapter instanceof Mysql) || self::mysqlFilePerTable($adapter)) {
+            return null;
+        }
+
+        return 'innodb_file_per_table is OFF, so every table lives in the shared tablespace:'
+            . ' a rebuild returns free space to that tablespace but never to the filesystem,'
+            . ' and DATA_FREE cannot be attributed to individual tables.';
+    }
+
+    /**
+     * The statements that reclaim the space. Every backend rebuilds the data in
+     * place, so all of them are maintenance-window operations: MySQL's OPTIMIZE
+     * TABLE is an online rebuild needing free disk equal to the table, PostgreSQL's
+     * VACUUM FULL holds an ACCESS EXCLUSIVE lock for its duration, and SQLite's
+     * VACUUM rewrites the entire database file.
+     *
+     * @param list<string> $tables
+     * @return list<string>
+     */
+    public static function optimizeStatements(AdapterInterface $adapter, array $tables): array
+    {
+        if ($adapter instanceof Sqlite) {
+            // SQLite has no per-table storage accounting; VACUUM is all or nothing.
+            return $tables === [] ? [] : ['VACUUM'];
+        }
+
+        $template = $adapter instanceof Pgsql ? 'VACUUM (FULL, ANALYZE) %s' : 'OPTIMIZE TABLE %s';
+
+        return array_map(
+            static fn(string $table): string => sprintf($template, $adapter->quoteIdentifier($table)),
+            array_values($tables),
+        );
+    }
+
+    /**
+     * MySQL returns a status result set from OPTIMIZE TABLE that has to be consumed
+     * before the connection accepts another statement; VACUUM returns nothing.
+     */
+    public static function runStatement(AdapterInterface $adapter, string $sql): void
+    {
+        if (str_starts_with(strtoupper(ltrim($sql)), 'OPTIMIZE')) {
+            $adapter->getConnection()->executeQuery($sql)->fetchAllAssociative();
+            return;
+        }
+
+        $adapter->getConnection()->executeStatement($sql);
+    }
+
+    /**
+     * Bytes the table occupies on disk including indexes and free space, so a
+     * before/after difference is the space actually returned. Null when the table
+     * is unknown to the server. SQLite reports the whole database file.
+     */
+    public static function totalSize(AdapterInterface $adapter, string $table): ?int
+    {
+        $size = match (true) {
+            $adapter instanceof Mysql => $adapter->fetchOne(
+                'SELECT DATA_LENGTH + INDEX_LENGTH + DATA_FREE FROM information_schema.TABLES'
+                . ' WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+                [$table],
+            ),
+            $adapter instanceof Pgsql => $adapter->fetchOne(
+                'SELECT pg_total_relation_size(oid) FROM pg_class WHERE oid = to_regclass(?)',
+                [$table],
+            ),
+            $adapter instanceof Sqlite => (int) $adapter->fetchOne('PRAGMA page_count')
+                * (int) $adapter->fetchOne('PRAGMA page_size'),
+            default => false,
+        };
+
+        return $size === false || $size === null ? null : (int) $size;
+    }
+
+    /**
+     * @return list<array{table: string, total: int, reclaimable: int, ratio: float, detail: string}>
+     */
+    private static function mysqlCandidates(Mysql $adapter, string $tablePrefix): array
+    {
+        if (!self::mysqlFilePerTable($adapter)) {
+            return [];
+        }
+
+        // Restricted to InnoDB: any other engine is already reported by the storage
+        // engine check, and converting it rebuilds the table anyway.
+        $rows = $adapter->fetchAll(
+            'SELECT TABLE_NAME, DATA_LENGTH, INDEX_LENGTH, DATA_FREE FROM information_schema.TABLES'
+            . " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE = 'BASE TABLE' AND ENGINE = 'InnoDB'",
+        );
+
+        $candidates = [];
+        foreach (self::filterByPrefix($rows, 'TABLE_NAME', $tablePrefix) as $row) {
+            // DATA_FREE is extent-granular, so a small table reads as heavily
+            // fragmented on a single unused extent. MIN_TOTAL_BYTES filters those out.
+            $free = (int) $row['DATA_FREE'];
+            $total = (int) $row['DATA_LENGTH'] + (int) $row['INDEX_LENGTH'] + $free;
+            $candidates[] = [
+                'table' => (string) $row['TABLE_NAME'],
+                'total' => $total,
+                'reclaimable' => $free,
+                'ratio' => $total > 0 ? $free / $total : 0.0,
+                'detail' => '',
+            ];
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @return list<array{table: string, total: int, reclaimable: int, ratio: float, detail: string}>
+     */
+    private static function pgsqlCandidates(Pgsql $adapter, string $tablePrefix): array
+    {
+        // Dead tuples are what autovacuum normally reclaims for reuse; a large
+        // standing share of them means it is not keeping up (or is blocked by a
+        // long-running transaction or an abandoned replication slot).
+        $rows = $adapter->fetchAll(
+            'SELECT c.relname AS table_name, pg_total_relation_size(c.oid) AS total_bytes,'
+            . ' s.n_live_tup, s.n_dead_tup, s.last_autovacuum, s.last_vacuum'
+            . ' FROM pg_stat_user_tables s JOIN pg_class c ON c.oid = s.relid'
+            . ' WHERE s.schemaname = current_schema()',
+        );
+
+        $candidates = [];
+        foreach (self::filterByPrefix($rows, 'table_name', $tablePrefix) as $row) {
+            $dead = (int) $row['n_dead_tup'];
+            $tuples = (int) $row['n_live_tup'] + $dead;
+            if ($tuples === 0) {
+                continue;
+            }
+
+            $total = (int) $row['total_bytes'];
+            $ratio = $dead / $tuples;
+            $lastVacuum = $row['last_autovacuum'] ?? $row['last_vacuum'];
+            $candidates[] = [
+                'table' => (string) $row['table_name'],
+                'total' => $total,
+                // Estimated from the tuple counts, which are themselves statistics
+                // estimates reset by pg_stat_reset(). Treat as an order of magnitude.
+                'reclaimable' => (int) round($total * $ratio),
+                'ratio' => $ratio,
+                'detail' => sprintf(
+                    '%s dead rows, last vacuum %s',
+                    number_format($dead),
+                    $lastVacuum === null ? 'never' : substr((string) $lastVacuum, 0, 19),
+                ),
+            ];
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @return list<array{table: string, total: int, reclaimable: int, ratio: float, detail: string}>
+     */
+    private static function sqliteCandidates(Sqlite $adapter): array
+    {
+        $pageSize = (int) $adapter->fetchOne('PRAGMA page_size');
+        $pageCount = (int) $adapter->fetchOne('PRAGMA page_count');
+        $freelist = (int) $adapter->fetchOne('PRAGMA freelist_count');
+        if ($pageCount === 0) {
+            return [];
+        }
+
+        return [[
+            'table' => self::sqliteDatabaseName($adapter),
+            'total' => $pageCount * $pageSize,
+            'reclaimable' => $freelist * $pageSize,
+            'ratio' => $freelist / $pageCount,
+            'detail' => sprintf('%s free page(s) of %s, whole database file', number_format($freelist), number_format($pageCount)),
+        ]];
+    }
+
+    private static function sqliteDatabaseName(Sqlite $adapter): string
+    {
+        $rows = $adapter->fetchAll('PRAGMA database_list');
+        foreach ($rows as $row) {
+            if (($row['name'] ?? '') === 'main') {
+                $file = (string) ($row['file'] ?? '');
+                return $file === '' ? 'main' : basename($file);
+            }
+        }
+        return 'main';
+    }
+
+    /**
+     * A prefix means the database may be shared with another application, whose
+     * tables are none of our business. Filtered here rather than with LIKE, whose
+     * pattern would need escaping ('_' is a wildcard).
+     *
+     * @param list<array<string, mixed>> $rows
+     * @return list<array<string, mixed>>
+     */
+    private static function filterByPrefix(array $rows, string $column, string $tablePrefix): array
+    {
+        if ($tablePrefix === '') {
+            return $rows;
+        }
+
+        return array_values(array_filter(
+            $rows,
+            static fn(array $row): bool => str_starts_with((string) $row[$column], $tablePrefix),
+        ));
+    }
+
+    private static function mysqlFilePerTable(Mysql $adapter): bool
+    {
+        try {
+            return in_array((string) $adapter->fetchOne('SELECT @@innodb_file_per_table'), ['1', 'ON'], true);
+        } catch (\Exception) {
+            // Variable absent: assume the modern default rather than suppress the check.
+            return true;
+        }
+    }
+}

--- a/tests/Backend/Integration/Db/Adapter/TableBloatScannerTest.php
+++ b/tests/Backend/Integration/Db/Adapter/TableBloatScannerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+use MahoCLI\Helper\TableBloatScanner;
+use Maho\Db\Adapter\Pdo\Pgsql;
+use Maho\Db\Adapter\Pdo\Sqlite;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Each backend measures bloat differently and reclaims it with different syntax,
+ * so the value of these tests is that they run unchanged on all three: a query or
+ * statement that only parses on MySQL fails here on PostgreSQL and SQLite.
+ *
+ * Deliberately absent: a test that creates bloat and asserts the scan finds it.
+ * MySQL caches information_schema statistics for a day by default and PostgreSQL
+ * updates its tuple counters asynchronously, so that assertion would be flaky
+ * everywhere except SQLite.
+ */
+function bloatProbeTable(\Maho\Db\Adapter\AdapterInterface $adapter): string
+{
+    $table = 'bloat_scanner_probe';
+    $adapter->query(sprintf(
+        'CREATE TABLE %s (id INTEGER NOT NULL, payload VARCHAR(255) NOT NULL)',
+        $adapter->quoteIdentifier($table),
+    ));
+
+    for ($i = 1; $i <= 200; $i++) {
+        $adapter->insert($table, ['id' => $i, 'payload' => str_repeat('x', 200)]);
+    }
+    $adapter->delete($table, 'id > 10');
+
+    return $table;
+}
+
+it('runs its bloat introspection against this backend', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+
+    $findings = TableBloatScanner::scan($adapter);
+
+    foreach ($findings as $finding) {
+        expect($finding)->toHaveKeys(['table', 'total', 'reclaimable', 'ratio', 'detail']);
+        expect($finding['total'])->toBeGreaterThanOrEqual(TableBloatScanner::MIN_TOTAL_BYTES);
+        expect($finding['ratio'])->toBeGreaterThanOrEqual(TableBloatScanner::MIN_RECLAIMABLE_RATIO);
+    }
+});
+
+it('honors the thresholds it is given', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+
+    // A ratio no table can reach: whatever the backend reports, nothing survives.
+    expect(TableBloatScanner::scan($adapter, '', 0, 1.01))->toBe([]);
+});
+
+it('scopes the scan to the table prefix when the database is shared', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    if ($adapter instanceof Sqlite) {
+        $this->markTestSkipped('SQLite reports the database file, which no table prefix can narrow.');
+    }
+
+    expect(TableBloatScanner::scan($adapter, 'someotherapp_', 0, 0.0))->toBe([]);
+});
+
+it('emits a rebuild statement this backend accepts and leaves the rows intact', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    $table = bloatProbeTable($adapter);
+
+    try {
+        $statements = TableBloatScanner::optimizeStatements($adapter, [$table]);
+        expect($statements)->toHaveCount(1);
+
+        $expected = match (true) {
+            $adapter instanceof Sqlite => 'VACUUM',
+            $adapter instanceof Pgsql => 'VACUUM (FULL, ANALYZE) ' . $adapter->quoteIdentifier($table),
+            default => 'OPTIMIZE TABLE ' . $adapter->quoteIdentifier($table),
+        };
+        expect($statements[0])->toBe($expected);
+
+        TableBloatScanner::runStatement($adapter, $statements[0]);
+
+        // MySQL returns a status result set from OPTIMIZE TABLE that has to be
+        // consumed before the connection accepts anything else; this read fails
+        // with "commands out of sync" if runStatement() stops doing that.
+        expect((int) $adapter->fetchOne(sprintf('SELECT COUNT(*) FROM %s', $adapter->quoteIdentifier($table))))->toBe(10);
+    } finally {
+        $adapter->dropTable($table);
+    }
+});
+
+it('asks for no statement when there is nothing to optimize', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+
+    expect(TableBloatScanner::optimizeStatements($adapter, []))->toBe([]);
+});
+
+it('measures a table footprint on this backend', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    $table = bloatProbeTable($adapter);
+
+    try {
+        expect(TableBloatScanner::totalSize($adapter, $table))->toBeInt()->toBeGreaterThan(0);
+    } finally {
+        $adapter->dropTable($table);
+    }
+});
+
+it('reports no footprint for a table the server does not have', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    if ($adapter instanceof Sqlite) {
+        $this->markTestSkipped('SQLite has no per-table storage accounting: totalSize() reports the database file.');
+    }
+
+    expect(TableBloatScanner::totalSize($adapter, 'no_such_table_' . uniqid()))->toBeNull();
+});

--- a/tests/Backend/Unit/Core/Helper/FormatFileSizeTest.php
+++ b/tests/Backend/Unit/Core/Helper/FormatFileSizeTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+it('renders a byte count in the largest readable binary unit', function (int $bytes, string $expected) {
+    expect(Mage::helper('core')->formatFileSize($bytes))->toBe($expected);
+})->with([
+    [0, '0 B'],
+    [500, '500 B'],
+    [1023, '1023 B'],
+    [1024, '1 KB'],
+    [1536, '1.5 KB'],
+    [1048576, '1 MB'],
+    [1073741824, '1 GB'],
+    [1099511627776, '1 TB'],
+]);
+
+it('never renders a fractional byte', function () {
+    expect(Mage::helper('core')->formatFileSize(1))->toBe('1 B');
+});
+
+it('treats a negative size as empty rather than rendering a negative unit', function () {
+    expect(Mage::helper('core')->formatFileSize(-1))->toBe('0 B');
+});
+
+it('keeps using the largest unit beyond its range instead of overflowing the unit list', function () {
+    expect(Mage::helper('core')->formatFileSize(5 * 1024 ** 5))->toBe('5120 TB');
+});


### PR DESCRIPTION
`health-check` now reports tables whose on-disk footprint is mostly reclaimable free space, and `db:optimize` performs the rebuild that returns it to the filesystem. All three backends are covered, each with its own measure of bloat:

- **InnoDB**: `DATA_FREE` from `information_schema.TABLES`. Skipped, with an explanation, when `innodb_file_per_table` is OFF: a rebuild can't return space to the filesystem from a shared tablespace, and `DATA_FREE` can't be attributed to individual tables there.
- **PostgreSQL**: dead-tuple share from `pg_stat_user_tables`, with the last vacuum time in the detail so a starved or blocked autovacuum is visible.
- **SQLite**: page freelist, reported as the whole database file, since SQLite has no per-table storage accounting.

Thresholds are 50 MB and 30% free, so ordinary churn and InnoDB's extent-granular `DATA_FREE` don't produce noise.

Detection is metadata-only and never rebuilds anything. `db:optimize` (`--table`, `--all`, `--dry-run`, `--force`) refuses to run inside an open transaction, warns per backend about what the rebuild costs, confirms, then reports the bytes actually freed. The health-check message points at `log:status` / `log:clean` first, since bloat that size is usually a cleanup job that isn't running rather than something a rebuild fixes for good.

Also consolidates the four separate byte formatters (`BaseMahoCommand`, the admin Healthcheck block, `FeedManager_Helper_Data`, `FeedManager_Model_Log`) into `Mage_Core_Helper_Data::formatFileSize()`. One cosmetic change falls out: the CLI formatter rendered `1.5MB`, now `1.5 KB`-style like the rest.

Verified on SQLite: a 98 MB file at 90% free pages was flagged by health-check, and `db:optimize` reclaimed 88.11 MB (98M to 10M).

There is deliberately no "create bloat, assert the scan finds it" test: MySQL caches `information_schema` statistics for a day by default and PostgreSQL updates its tuple counters asynchronously, so that assertion would be flaky on two of three backends. The integration test instead proves the introspection queries and rebuild statements parse and run on whichever backend CI is using, and that MySQL's `OPTIMIZE TABLE` result set is consumed (otherwise the next read fails with "commands out of sync").

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->