### PR TITLE
Fixed `email:config:show` reporting cron schedules as not configured

### DIFF
--- a/lib/MahoCLI/Commands/EmailConfigShow.php
+++ b/lib/MahoCLI/Commands/EmailConfigShow.php
@@ -68,15 +68,17 @@ class EmailConfigShow extends BaseMahoCommand
         $pendingCount = $pendingCount->addFieldToFilter('processed_at', ['null' => true])->getSize();
 
         // Get cron schedules dynamically
-        $processSchedule = Mage::getConfig()->getNode('crontab/jobs/core_email_queue_send_all/schedule/cron_expr');
-        $cleanupSchedule = Mage::getConfig()->getNode('crontab/jobs/core_email_queue_clean_up/schedule/cron_expr');
+        $cronHelper = Mage::helper('cron');
+        $cronJobs = $cronHelper->getConfiguredJobs();
+        $processSchedule = $cronJobs['core_email_queue_send_all']['cron_expr'] ?? '';
+        $cleanupSchedule = $cronJobs['core_email_queue_clean_up']['cron_expr'] ?? '';
 
         // Add separator row for queue section
         $table->addRow(['', '']);
         $table->addRows([
             ['Currently Pending', $pendingCount . ' emails'],
-            ['Process Schedule', $processSchedule ? (string) $processSchedule : 'Not configured'],
-            ['Cleanup Schedule', $cleanupSchedule ? (string) $cleanupSchedule : 'Not configured'],
+            ['Process Schedule', $processSchedule ?: 'Not configured'],
+            ['Cleanup Schedule', $cleanupSchedule ?: 'Not configured'],
         ]);
 
         // Add separator row for developer settings


### PR DESCRIPTION
`email:config:show` read the queue schedules straight from the `crontab/jobs` XML config tree, but `core_email_queue_send_all` and `core_email_queue_clean_up` are now declared with `#[CronJob]` attributes, which compile into `vendor/composer/maho_attributes.php` and are never merged into that tree. Both rows printed "Not configured" even though the jobs were scheduled and running.

Now uses `Mage_Cron_Helper_Data::getConfiguredJobs()`, the same source `cron:list` and the admin cron grid use, which unions the XML tree with the compiled attributes.

Output goes from `Not configured` to `*/1 * * * *` and `0 0 * * *`.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->