### PR TITLE
Added accordion and tabs blocks to the WYSIWYG editor

### DIFF
--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
@@ -1,15 +1,16 @@
 // SPDX-FileCopyrightText: 2025-2026 Maho <https://mahocommerce.com>
 // SPDX-License-Identifier: AFL-3.0
 
-import { Editor, Node, Mark, Extension, mergeAttributes, ResizableNodeView } from 'https://esm.sh/@tiptap/core@3.27.1';
-import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.27.1';
-import Image from 'https://esm.sh/@tiptap/extension-image@3.27.1';
-import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.27.1';
-import { Table, TableRow as BaseTableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.27.1';
-import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.27.1';
-import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.27.1';
+import { Editor, Node, Mark, Extension, mergeAttributes, ResizableNodeView } from 'https://esm.sh/@tiptap/core@3.29.2';
+import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.29.2';
+import Image from 'https://esm.sh/@tiptap/extension-image@3.29.2';
+import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.29.2';
+import { Table, TableRow as BaseTableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.29.2';
+import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.29.2';
+import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.29.2';
 import { MahoColumns, MahoColumn, COLUMN_PRESETS } from './extensions/columns.js';
 import { MahoBentoGrid, MahoBentoCell, BENTO_PRESETS } from './extensions/bento.js';
+import { MahoAccordion, MahoDetails, DetailsSummary, DetailsContent, ACCORDION_STYLES } from './extensions/details.js';
 
 // prosemirror-tables has no parse rules for the table wrappers browsers (and TipTap itself) emit,
 // so with `enableContentCheck` on TipTap's catch-all rule flags them and falsely warns that valid
@@ -32,6 +33,7 @@ export {
     Table, TableRow, TableCell, TableHeader, BubbleMenu, DragHandle,
     MahoColumns, MahoColumn, COLUMN_PRESETS,
     MahoBentoGrid, MahoBentoCell, BENTO_PRESETS,
+    MahoAccordion, MahoDetails, DetailsSummary, DetailsContent, ACCORDION_STYLES,
 };
 
 const parseDirective = (directiveStr) => {
@@ -132,6 +134,7 @@ export const GlobalAttributes = Extension.create({
                     'tableRow', 'tableCell', 'tableHeader', 'table',
                     'mahoColumns', 'mahoColumn',
                     'mahoBentoGrid', 'mahoBentoCell',
+                    'mahoAccordion', 'details', 'detailsSummary', 'detailsContent',
                 ],
                 attributes: {
                     class: {

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/bento.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/bento.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
 // SPDX-License-Identifier: AFL-3.0
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.27.1';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.29.2';
 import { findParentNodeOfType, createGridNodeView } from './grid-utils.js';
 
 /**
@@ -235,10 +235,12 @@ export const MahoBentoGrid = Node.create({
                 parseHTML: element => element.getAttribute('data-gap') || 'medium',
                 renderHTML: attributes => ({ 'data-gap': attributes.gap }),
             },
-            style: {
+            // Not named `style`: that shadows the global style attribute preserved on every
+            // node, so any inline style on the element would be dropped on the next save
+            gridStyle: {
                 default: 'none',
                 parseHTML: element => element.getAttribute('data-style') || 'none',
-                renderHTML: attributes => ({ 'data-style': attributes.style }),
+                renderHTML: attributes => ({ 'data-style': attributes.gridStyle }),
             },
         };
     },
@@ -254,7 +256,7 @@ export const MahoBentoGrid = Node.create({
             'data-type': 'maho-bento',
             'data-preset': node.attrs.preset,
             'data-gap': node.attrs.gap,
-            'data-style': node.attrs.style,
+            'data-style': node.attrs.gridStyle,
             'style': `grid-template-areas: ${node.attrs.areas}; grid-template-columns: ${node.attrs.columns}; grid-template-rows: ${node.attrs.rows}`,
         }), 0];
     },
@@ -270,7 +272,7 @@ export const MahoBentoGrid = Node.create({
             setDataAttrs(dom, node) {
                 dom.setAttribute('data-preset', node.attrs.preset);
                 dom.setAttribute('data-gap', node.attrs.gap);
-                dom.setAttribute('data-style', node.attrs.style);
+                dom.setAttribute('data-style', node.attrs.gridStyle);
             },
 
             updateGridStyles(contentDOM, node, gap) {
@@ -281,7 +283,7 @@ export const MahoBentoGrid = Node.create({
             },
 
             onBadgeClick(node, bubbleMenu) {
-                const currentStyle = node.attrs.style || 'none';
+                const currentStyle = node.attrs.gridStyle || 'none';
                 for (const btn of bubbleMenu.querySelectorAll('[data-grid-style]')) {
                     btn.classList.toggle('is-active', btn.dataset.gridStyle === currentStyle);
                 }
@@ -394,7 +396,7 @@ export const MahoBentoGrid = Node.create({
                 if (dispatch) {
                     tr.setNodeMarkup(bentoNode.pos, null, {
                         ...bentoNode.node.attrs,
-                        style,
+                        gridStyle: style,
                     });
                     dispatch(tr);
                 }

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025-2026 Maho <https://mahocommerce.com>
 // SPDX-License-Identifier: AFL-3.0
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.27.1';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.29.2';
 import { findParentNodeOfType, createGridNodeView } from './grid-utils.js';
 
 /**
@@ -112,10 +112,12 @@ export const MahoColumns = Node.create({
                 parseHTML: element => element.getAttribute('data-gap') || 'medium',
                 renderHTML: attributes => ({ 'data-gap': attributes.gap }),
             },
-            style: {
+            // Not named `style`: that shadows the global style attribute preserved on every
+            // node, so any inline style on the element would be dropped on the next save
+            gridStyle: {
                 default: 'none',
                 parseHTML: element => element.getAttribute('data-style') || 'none',
-                renderHTML: attributes => ({ 'data-style': attributes.style }),
+                renderHTML: attributes => ({ 'data-style': attributes.gridStyle }),
             },
         };
     },
@@ -131,7 +133,7 @@ export const MahoColumns = Node.create({
             'data-type': 'maho-columns',
             'data-preset': node.attrs.preset,
             'data-gap': node.attrs.gap,
-            'data-style': node.attrs.style,
+            'data-style': node.attrs.gridStyle,
         };
 
         // Only inline grid-template-columns for custom (drag-resized) layouts;
@@ -154,7 +156,7 @@ export const MahoColumns = Node.create({
             setDataAttrs(dom, node) {
                 dom.setAttribute('data-preset', node.attrs.preset);
                 dom.setAttribute('data-gap', node.attrs.gap);
-                dom.setAttribute('data-style', node.attrs.style);
+                dom.setAttribute('data-style', node.attrs.gridStyle);
             },
 
             updateGridStyles(contentDOM, node, gap) {
@@ -180,7 +182,7 @@ export const MahoColumns = Node.create({
             },
 
             onBadgeClick(node, bubbleMenu) {
-                const currentStyle = node.attrs.style || 'none';
+                const currentStyle = node.attrs.gridStyle || 'none';
                 for (const btn of bubbleMenu.querySelectorAll('[data-grid-style]')) {
                     btn.classList.toggle('is-active', btn.dataset.gridStyle === currentStyle);
                 }
@@ -254,7 +256,7 @@ export const MahoColumns = Node.create({
                 if (dispatch) {
                     tr.setNodeMarkup(columnsNode.pos, null, {
                         ...columnsNode.node.attrs,
-                        style,
+                        gridStyle: style,
                     });
                     dispatch(tr);
                 }

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/details.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/details.js
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+// SPDX-License-Identifier: AFL-3.0
+
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.29.2';
+import { Details, DetailsSummary, DetailsContent } from 'https://esm.sh/@tiptap/extension-details@3.29.2';
+import { Plugin, PluginKey } from 'https://esm.sh/@tiptap/pm@3.29.2/state';
+import { createBadge, setBadgeLabel, findParentNodeOfType } from './grid-utils.js';
+
+export { DetailsSummary, DetailsContent };
+
+/**
+ * Accordion styles and the wording used for new items in each
+ */
+export const ACCORDION_STYLES = {
+    'accordion': { label: 'Accordion', itemLabel: 'Section' },
+    'tabs': { label: 'Tabs', itemLabel: 'Tab' },
+};
+
+const groupName = () => `maho-accordion-${Math.random().toString(36).slice(2, 10)}`;
+
+const createItem = (title) => ({
+    type: 'details',
+    content: [
+        { type: 'detailsSummary', content: [{ type: 'text', text: title }] },
+        { type: 'detailsContent', content: [{ type: 'paragraph' }] },
+    ],
+});
+
+/**
+ * Details node with a `name` attribute, which is how the browser keeps a group of
+ * items exclusive: opening one closes its siblings, as tabs require
+ */
+export const MahoDetails = Details.extend({
+    addAttributes() {
+        return {
+            ...this.parent?.(),
+            name: {
+                default: null,
+                parseHTML: (element) => element.getAttribute('name'),
+                renderHTML: (attributes) => attributes.name ? { name: attributes.name } : {},
+            },
+        };
+    },
+});
+
+/**
+ * MahoAccordion Node
+ *
+ * Container for a group of <details> items, rendered on the storefront as an
+ * accordion or as tabs depending on its style
+ */
+export const MahoAccordion = Node.create({
+    name: 'mahoAccordion',
+    group: 'block',
+    content: 'details+',
+    defining: true,
+    isolating: true,
+
+    addOptions() {
+        return {
+            bubbleMenu: null,
+        };
+    },
+
+    addStorage() {
+        return {
+            bubbleMenu: this.options.bubbleMenu,
+            activePos: null,
+        };
+    },
+
+    addAttributes() {
+        return {
+            // Not named `style`: that collides with the global style attribute preserved
+            // on every node and leaves an empty style="" on the saved markup
+            accordionStyle: {
+                default: 'accordion',
+                parseHTML: (element) => element.getAttribute('data-style') || 'accordion',
+                renderHTML: (attributes) => ({ 'data-style': attributes.accordionStyle }),
+            },
+        };
+    },
+
+    parseHTML() {
+        return [{
+            tag: 'div[data-type="maho-accordion"]',
+        }];
+    },
+
+    addProseMirrorPlugins() {
+        return [
+            new Plugin({
+                key: new PluginKey('mahoAccordionGroupName'),
+
+                // Tabs are exclusive through a name shared by every item in the group, and
+                // accordion items are independent, so the name is a property of the group
+                // rather than something an item can be left holding after a paste or a split
+                appendTransaction: (transactions, oldState, newState) => {
+                    if (!transactions.some((transaction) => transaction.docChanged)) {
+                        return null;
+                    }
+
+                    const { tr } = newState;
+                    let changed = false;
+
+                    newState.doc.descendants((node, pos) => {
+                        if (node.type !== newState.schema.nodes[this.name]) {
+                            return;
+                        }
+
+                        let name = null;
+                        if (node.attrs.accordionStyle === 'tabs') {
+                            node.forEach((child) => name ??= child.attrs.name);
+                            name ??= groupName();
+                        }
+
+                        node.forEach((child, offset) => {
+                            if (child.attrs.name !== name) {
+                                tr.setNodeMarkup(pos + 1 + offset, null, { ...child.attrs, name });
+                                changed = true;
+                            }
+                        });
+                    });
+
+                    return changed ? tr : null;
+                },
+            }),
+        ];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        return ['div', mergeAttributes(HTMLAttributes, { 'data-type': 'maho-accordion' }), 0];
+    },
+
+    addNodeView() {
+        return ({ node: initialNode, editor, getPos }) => {
+            let node = initialNode;
+
+            const dom = document.createElement('div');
+            dom.setAttribute('data-type', 'maho-accordion');
+            dom.setAttribute('data-style', node.attrs.accordionStyle);
+            dom.style.position = 'relative';
+
+            const badge = createBadge(ACCORDION_STYLES[node.attrs.accordionStyle].label, editor, this.name, (bubbleMenu) => {
+                // The badge is clicked without moving the cursor, so remember which
+                // accordion the menu was opened for
+                editor.storage[this.name].activePos = getPos();
+
+                for (const button of bubbleMenu.querySelectorAll('[data-accordion-style]')) {
+                    button.classList.toggle('is-active', button.dataset.accordionStyle === node.attrs.accordionStyle);
+                }
+            });
+            dom.append(badge);
+
+            const contentDOM = document.createElement('div');
+            contentDOM.className = 'accordion-inner';
+            dom.append(contentDOM);
+
+            return {
+                dom,
+                contentDOM,
+                update: (updatedNode) => {
+                    if (updatedNode.type.name !== this.name) {
+                        return false;
+                    }
+                    node = updatedNode;
+                    dom.setAttribute('data-style', node.attrs.accordionStyle);
+                    setBadgeLabel(badge, ACCORDION_STYLES[node.attrs.accordionStyle].label);
+                    return true;
+                },
+            };
+        };
+    },
+
+    addCommands() {
+        const translate = (editor, text) => editor.options.wysiwygSetup?.translate(text) ?? text;
+
+        const findAccordion = (editor, state) => {
+            const found = findParentNodeOfType(state.schema.nodes[this.name])(state.selection);
+            if (found) {
+                return found;
+            }
+            // Fall back to the accordion whose badge opened the bubble menu
+            const pos = editor.storage[this.name].activePos;
+            const node = typeof pos === 'number' ? state.doc.nodeAt(pos) : null;
+            return node?.type === state.schema.nodes[this.name] ? { node, pos } : null;
+        };
+
+        return {
+            insertAccordion: (style = 'accordion') => ({ editor, commands }) => {
+                const { itemLabel } = ACCORDION_STYLES[style] ?? ACCORDION_STYLES.accordion;
+
+                return commands.insertContent({
+                    type: this.name,
+                    attrs: { accordionStyle: style },
+                    content: [1, 2].map((i) => createItem(`${translate(editor, itemLabel)} ${i}`)),
+                });
+            },
+
+            setAccordionStyle: (style) => ({ editor, state, tr, dispatch }) => {
+                const accordion = findAccordion(editor, state);
+                if (!accordion || !ACCORDION_STYLES[style]) {
+                    return false;
+                }
+
+                if (dispatch) {
+                    tr.setNodeMarkup(accordion.pos, null, { ...accordion.node.attrs, accordionStyle: style });
+                    dispatch(tr);
+                }
+
+                return true;
+            },
+
+            addAccordionItem: () => ({ editor, state, chain }) => {
+                const accordion = findAccordion(editor, state);
+                if (!accordion) {
+                    return false;
+                }
+
+                const { itemLabel } = ACCORDION_STYLES[accordion.node.attrs.accordionStyle] ?? ACCORDION_STYLES.accordion;
+                const title = `${translate(editor, itemLabel)} ${accordion.node.childCount + 1}`;
+
+                return chain()
+                    .insertContentAt(accordion.pos + accordion.node.nodeSize - 1, createItem(title))
+                    .run();
+            },
+
+            deleteAccordionItem: () => ({ editor, state, tr, dispatch }) => {
+                const accordion = findAccordion(editor, state);
+                if (!accordion) {
+                    return false;
+                }
+
+                // Without a cursor in a specific item (the menu was opened from the
+                // badge) the last one is the only unambiguous target
+                let item = findParentNodeOfType(state.schema.nodes.details)(state.selection);
+                if (!item || item.pos < accordion.pos || item.pos > accordion.pos + accordion.node.nodeSize) {
+                    const lastChild = accordion.node.lastChild;
+                    item = {
+                        node: lastChild,
+                        pos: accordion.pos + accordion.node.nodeSize - 1 - lastChild.nodeSize,
+                    };
+                }
+
+                if (dispatch) {
+                    // The last item leaves an empty accordion behind, so drop the group with it
+                    const target = accordion.node.childCount <= 1 ? accordion : item;
+                    tr.delete(target.pos, target.pos + target.node.nodeSize);
+                    dispatch(tr);
+                }
+
+                return true;
+            },
+
+            deleteAccordion: () => ({ editor, state, tr, dispatch }) => {
+                const accordion = findAccordion(editor, state);
+                if (!accordion) {
+                    return false;
+                }
+
+                if (dispatch) {
+                    tr.delete(accordion.pos, accordion.pos + accordion.node.nodeSize);
+                    dispatch(tr);
+                }
+
+                return true;
+            },
+        };
+    },
+});

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/details.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/details.js
@@ -96,14 +96,35 @@ export const MahoAccordion = Node.create({
                 // accordion items are independent, so the name is a property of the group
                 // rather than something an item can be left holding after a paste or a split
                 appendTransaction: (transactions, oldState, newState) => {
-                    if (!transactions.some((transaction) => transaction.docChanged)) {
+                    // Checking only the touched span keeps a keystroke off a walk of the whole doc
+                    let from = Infinity;
+                    let to = -Infinity;
+
+                    for (const transaction of transactions) {
+                        if (from <= to) {
+                            from = transaction.mapping.map(from, -1);
+                            to = transaction.mapping.map(to, 1);
+                        }
+                        transaction.mapping.maps.forEach((stepMap, index) => {
+                            const rest = transaction.mapping.slice(index + 1);
+                            stepMap.forEach((oldFrom, oldTo, newFrom, newTo) => {
+                                from = Math.min(from, rest.map(newFrom, -1));
+                                to = Math.max(to, rest.map(newTo, 1));
+                            });
+                        });
+                    }
+
+                    if (from > to) {
                         return null;
                     }
 
                     const { tr } = newState;
                     let changed = false;
 
-                    newState.doc.descendants((node, pos) => {
+                    const start = Math.max(from, 0);
+                    const end = Math.min(to, newState.doc.content.size);
+
+                    newState.doc.nodesBetween(start, end, (node, pos) => {
                         if (node.type !== newState.schema.nodes[this.name]) {
                             return;
                         }
@@ -175,15 +196,14 @@ export const MahoAccordion = Node.create({
     addCommands() {
         const translate = (editor, text) => editor.options.wysiwygSetup?.translate(text) ?? text;
 
+        // The menu only opens from a badge, so its accordion wins over wherever the cursor is
         const findAccordion = (editor, state) => {
-            const found = findParentNodeOfType(state.schema.nodes[this.name])(state.selection);
-            if (found) {
-                return found;
-            }
-            // Fall back to the accordion whose badge opened the bubble menu
             const pos = editor.storage[this.name].activePos;
             const node = typeof pos === 'number' ? state.doc.nodeAt(pos) : null;
-            return node?.type === state.schema.nodes[this.name] ? { node, pos } : null;
+            if (node?.type === state.schema.nodes[this.name]) {
+                return { node, pos };
+            }
+            return findParentNodeOfType(state.schema.nodes[this.name])(state.selection);
         };
 
         return {
@@ -245,6 +265,9 @@ export const MahoAccordion = Node.create({
                 if (dispatch) {
                     // The last item leaves an empty accordion behind, so drop the group with it
                     const target = accordion.node.childCount <= 1 ? accordion : item;
+                    if (target === accordion) {
+                        editor.storage[this.name].activePos = null;
+                    }
                     tr.delete(target.pos, target.pos + target.node.nodeSize);
                     dispatch(tr);
                 }
@@ -259,6 +282,7 @@ export const MahoAccordion = Node.create({
                 }
 
                 if (dispatch) {
+                    editor.storage[this.name].activePos = null;
                     tr.delete(accordion.pos, accordion.pos + accordion.node.nodeSize);
                     dispatch(tr);
                 }

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/grid-utils.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/grid-utils.js
@@ -45,6 +45,57 @@ export function findParentNodeOfType(nodeType) {
 }
 
 /**
+ * Badge button that opens an extension's bubble menu below itself
+ *
+ * @param {string} label - Text shown on the badge
+ * @param {Object} editor - TipTap editor instance
+ * @param {string} storageName - Key in editor.storage holding the bubble menu ref
+ * @param {Function} [onOpen] - (bubbleMenu) => sync the menu to the current node before showing it
+ */
+export function createBadge(label, editor, storageName, onOpen) {
+    const badge = document.createElement('button');
+    badge.type = 'button';
+    badge.className = 'grid-badge';
+    badge.innerHTML = `<span class="grid-badge-label"></span>${SETTINGS_ICON}`;
+    badge.querySelector('.grid-badge-label').textContent = label;
+
+    badge.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const bubbleMenu = editor.storage[storageName]?.bubbleMenu;
+        if (!bubbleMenu) return;
+
+        onOpen?.(bubbleMenu);
+
+        // Position below the badge
+        const rect = badge.getBoundingClientRect();
+        bubbleMenu.style.position = 'fixed';
+        bubbleMenu.style.top = `${rect.bottom + 6}px`;
+        bubbleMenu.style.left = `${rect.left}px`;
+        bubbleMenu.style.display = 'flex';
+
+        // Close when clicking outside
+        const closeMenu = (event) => {
+            if (!bubbleMenu.contains(event.target) && event.target !== badge) {
+                bubbleMenu.style.display = 'none';
+                document.removeEventListener('click', closeMenu);
+            }
+        };
+        setTimeout(() => document.addEventListener('click', closeMenu), 0);
+    });
+
+    return badge;
+}
+
+/**
+ * Update the text of a badge created by createBadge()
+ */
+export function setBadgeLabel(badge, label) {
+    badge.querySelector('.grid-badge-label').textContent = label;
+}
+
+/**
  * Factory for creating grid-based TipTap NodeViews (Columns, Bento Grid)
  *
  * Handles the shared boilerplate: outer wrapper, badge button with bubble menu,
@@ -74,18 +125,7 @@ export function createGridNodeView(config) {
         dom.style.width = '100%';
 
         // Badge button
-        const badge = document.createElement('button');
-        badge.type = 'button';
-        badge.className = 'grid-badge';
-        badge.innerHTML = `${config.badgeLabel} ${SETTINGS_ICON}`;
-
-        badge.addEventListener('click', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-
-            const bubbleMenu = editor.storage[config.storageName]?.bubbleMenu;
-            if (!bubbleMenu) return;
-
+        const badge = createBadge(config.badgeLabel, editor, config.storageName, (bubbleMenu) => {
             // Update gap button active states
             const currentGap = node.attrs.gap || 'medium';
             for (const btn of bubbleMenu.querySelectorAll('[data-gap]')) {
@@ -94,22 +134,6 @@ export function createGridNodeView(config) {
 
             // Extension-specific bubble menu updates
             config.onBadgeClick?.(node, bubbleMenu);
-
-            // Position below the badge
-            const rect = badge.getBoundingClientRect();
-            bubbleMenu.style.position = 'fixed';
-            bubbleMenu.style.top = `${rect.bottom + 6}px`;
-            bubbleMenu.style.left = `${rect.left}px`;
-            bubbleMenu.style.display = 'flex';
-
-            // Close when clicking outside
-            const closeMenu = (event) => {
-                if (!bubbleMenu.contains(event.target) && event.target !== badge) {
-                    bubbleMenu.style.display = 'none';
-                    document.removeEventListener('click', closeMenu);
-                }
-            };
-            setTimeout(() => document.addEventListener('click', closeMenu), 0);
         });
 
         dom.appendChild(badge);

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
@@ -219,6 +219,10 @@ class tiptapWysiwygSetup {
         const bentoBubbleMenu = this.createBentoBubbleMenu();
         this.wrapper.appendChild(bentoBubbleMenu);
 
+        // Create accordion bubble menu
+        const accordionBubbleMenu = this.createAccordionBubbleMenu();
+        this.wrapper.appendChild(accordionBubbleMenu);
+
         // Create container for Tiptap editor content
         const container = document.createElement('div');
         container.id = `${this.id}_editor`;
@@ -314,6 +318,23 @@ class tiptapWysiwygSetup {
                     bubbleMenu: bentoBubbleMenu,
                 }),
                 TiptapModules.MahoBentoCell,
+                TiptapModules.MahoAccordion.configure({
+                    bubbleMenu: accordionBubbleMenu,
+                }),
+                // Without persist the toggle only expands an item for editing: it never
+                // writes `open`, so opening every section to type in it does not publish
+                // the page with every section expanded
+                TiptapModules.MahoDetails.configure({
+                    persist: false,
+                    renderToggleButton: ({ element, isOpen }) => {
+                        const label = this.translate(isOpen ? 'Collapse' : 'Expand');
+                        element.innerHTML = this.getIcon('chevron-down');
+                        element.title = label;
+                        element.setAttribute('aria-label', label);
+                    },
+                }),
+                TiptapModules.DetailsSummary,
+                TiptapModules.DetailsContent,
                 TiptapModules.MahoFullscreen,
                 TiptapModules.DragHandle.configure({
                     render: () => {
@@ -443,6 +464,17 @@ class tiptapWysiwygSetup {
                     { title: 'Banner + Cards', icon: 'bento-banner-cards', command: 'insertBentoGrid', args: ['banner-cards'] },
                 ],
             },
+            {
+                type: 'dropdown',
+                title: 'Accordion',
+                icon: 'accordion',
+                showTitle: false,
+                showChevron: false,
+                items: [
+                    { title: 'Accordion', icon: 'accordion', command: 'insertAccordion', args: ['accordion'] },
+                    { title: 'Tabs', icon: 'tabs', command: 'insertAccordion', args: ['tabs'] },
+                ],
+            },
             { type: 'button', title: 'Insert Image', icon: 'image', command: 'insertMahoImage', enabled: this.config.add_images },
             { type: 'button', title: 'Insert Slideshow', icon: 'slideshow', command: 'insertMahoSlideshow', enabled: this.config.add_images && this.config.add_slideshows !== false },
             { type: 'button', title: 'Insert Widget', icon: 'widget', command: 'insertMahoWidget', enabled: this.config.add_widgets },
@@ -514,15 +546,15 @@ class tiptapWysiwygSetup {
     createColumnsBubbleMenu() {
         const bubbleMenu = this.createToolbar([
             { type: 'label', text: 'Gap:' },
-            { type: 'button', title: 'No Gap', icon: 'gap-none', command: 'setColumnsGap', args: ['none'], dataGap: 'none' },
-            { type: 'button', title: 'Small', icon: 'gap-small', command: 'setColumnsGap', args: ['small'], dataGap: 'small' },
-            { type: 'button', title: 'Medium', icon: 'gap-medium', command: 'setColumnsGap', args: ['medium'], dataGap: 'medium' },
-            { type: 'button', title: 'Large', icon: 'gap-large', command: 'setColumnsGap', args: ['large'], dataGap: 'large' },
+            { type: 'button', title: 'No Gap', icon: 'gap-none', command: 'setColumnsGap', args: ['none'], data: { gap: 'none' } },
+            { type: 'button', title: 'Small', icon: 'gap-small', command: 'setColumnsGap', args: ['small'], data: { gap: 'small' } },
+            { type: 'button', title: 'Medium', icon: 'gap-medium', command: 'setColumnsGap', args: ['medium'], data: { gap: 'medium' } },
+            { type: 'button', title: 'Large', icon: 'gap-large', command: 'setColumnsGap', args: ['large'], data: { gap: 'large' } },
             { type: 'separator' },
             { type: 'label', text: 'Style:' },
-            { type: 'button', title: 'None', icon: 'style-none', command: 'setColumnsStyle', args: ['none'], dataGridStyle: 'none' },
-            { type: 'button', title: 'Cards', icon: 'style-cards', command: 'setColumnsStyle', args: ['cards'], dataGridStyle: 'cards' },
-            { type: 'button', title: 'Separated', icon: 'style-separated', command: 'setColumnsStyle', args: ['separated'], dataGridStyle: 'separated' },
+            { type: 'button', title: 'None', icon: 'style-none', command: 'setColumnsStyle', args: ['none'], data: { gridStyle: 'none' } },
+            { type: 'button', title: 'Cards', icon: 'style-cards', command: 'setColumnsStyle', args: ['cards'], data: { gridStyle: 'cards' } },
+            { type: 'button', title: 'Separated', icon: 'style-separated', command: 'setColumnsStyle', args: ['separated'], data: { gridStyle: 'separated' } },
             { type: 'separator' },
             { type: 'button', title: 'Delete Columns', icon: 'trash', command: 'deleteColumns' },
         ]);
@@ -536,19 +568,37 @@ class tiptapWysiwygSetup {
     createBentoBubbleMenu() {
         const bubbleMenu = this.createToolbar([
             { type: 'label', text: 'Gap:' },
-            { type: 'button', title: 'No Gap', icon: 'gap-none', command: 'setBentoGap', args: ['none'], dataGap: 'none' },
-            { type: 'button', title: 'Small', icon: 'gap-small', command: 'setBentoGap', args: ['small'], dataGap: 'small' },
-            { type: 'button', title: 'Medium', icon: 'gap-medium', command: 'setBentoGap', args: ['medium'], dataGap: 'medium' },
-            { type: 'button', title: 'Large', icon: 'gap-large', command: 'setBentoGap', args: ['large'], dataGap: 'large' },
+            { type: 'button', title: 'No Gap', icon: 'gap-none', command: 'setBentoGap', args: ['none'], data: { gap: 'none' } },
+            { type: 'button', title: 'Small', icon: 'gap-small', command: 'setBentoGap', args: ['small'], data: { gap: 'small' } },
+            { type: 'button', title: 'Medium', icon: 'gap-medium', command: 'setBentoGap', args: ['medium'], data: { gap: 'medium' } },
+            { type: 'button', title: 'Large', icon: 'gap-large', command: 'setBentoGap', args: ['large'], data: { gap: 'large' } },
             { type: 'separator' },
             { type: 'label', text: 'Style:' },
-            { type: 'button', title: 'None', icon: 'style-none', command: 'setBentoStyle', args: ['none'], dataGridStyle: 'none' },
-            { type: 'button', title: 'Cards', icon: 'style-cards', command: 'setBentoStyle', args: ['cards'], dataGridStyle: 'cards' },
+            { type: 'button', title: 'None', icon: 'style-none', command: 'setBentoStyle', args: ['none'], data: { gridStyle: 'none' } },
+            { type: 'button', title: 'Cards', icon: 'style-cards', command: 'setBentoStyle', args: ['cards'], data: { gridStyle: 'cards' } },
             { type: 'separator' },
             { type: 'button', title: 'Delete Bento Grid', icon: 'trash', command: 'deleteBentoGrid' },
         ]);
 
         bubbleMenu.id = `${this.id}_bento_bubble_menu`;
+        bubbleMenu.className = 'tiptap-bubble-menu';
+        bubbleMenu.style.display = 'none';
+        return bubbleMenu;
+    }
+
+    createAccordionBubbleMenu() {
+        const bubbleMenu = this.createToolbar([
+            { type: 'label', text: 'Style:' },
+            { type: 'button', title: 'Accordion', icon: 'accordion', command: 'setAccordionStyle', args: ['accordion'], data: { accordionStyle: 'accordion' } },
+            { type: 'button', title: 'Tabs', icon: 'tabs', command: 'setAccordionStyle', args: ['tabs'], data: { accordionStyle: 'tabs' } },
+            { type: 'separator' },
+            { type: 'button', title: 'Add Item', icon: 'plus', command: 'addAccordionItem' },
+            { type: 'button', title: 'Delete Item', icon: 'row-remove', command: 'deleteAccordionItem' },
+            { type: 'separator' },
+            { type: 'button', title: 'Delete Accordion', icon: 'trash', command: 'deleteAccordion' },
+        ]);
+
+        bubbleMenu.id = `${this.id}_accordion_bubble_menu`;
         bubbleMenu.className = 'tiptap-bubble-menu';
         bubbleMenu.style.display = 'none';
         return bubbleMenu;
@@ -670,11 +720,8 @@ class tiptapWysiwygSetup {
                     button.dataset.command = item.command;
                     button.dataset.args = JSON.stringify(item.args);
                 }
-                if (item.dataGap) {
-                    button.dataset.gap = item.dataGap;
-                }
-                if (item.dataGridStyle) {
-                    button.dataset.gridStyle = item.dataGridStyle;
+                for (const [key, value] of Object.entries(item.data ?? {})) {
+                    button.dataset[key] = value;
                 }
                 group.append(button);
             }
@@ -779,6 +826,11 @@ class tiptapWysiwygSetup {
         'block': '<path d="M3 3m0 2a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v14a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z"/><path d="M9 9h6v6h-6z"/><path d="M3 15h6m6 0h6m-18 -6h6m6 0h6"/>',
         'variable': '<path d="M5 4c-2.5 5 -2.5 10 0 16m14 -16c2.5 5 2.5 10 0 16m-10 -11h1c1 0 1 1 2.016 3.527c.984 2.473 .984 3.473 1.984 3.473h1"/><path d="M8 16c1.5 0 3 -2 4 -3.5s2.5 -3.5 4 -3.5"/>',
         'slideshow': '<path d="M15 6l.01 0"/><path d="M3 3m0 3a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v8a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3z"/><path d="M3 13l4 -4a3 5 0 0 1 3 0l4 4"/><path d="M13 12l2 -2a3 5 0 0 1 3 0l3 3"/><path d="M8 21l.01 0"/><path d="M12 21l.01 0"/><path d="M16 21l.01 0"/>',
+
+        // Accordion icons
+        'accordion': '<rect x="3" y="4" width="18" height="5" rx="1"/><rect x="3" y="12" width="18" height="8" rx="1"/><path d="M15 6.5h3"/>',
+        'tabs': '<path d="M3 8h18v11a1 1 0 0 1 -1 1h-16a1 1 0 0 1 -1 -1z"/><path d="M4 8v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3"/>',
+        'plus': '<path d="M12 5l0 14"/><path d="M5 12l14 0"/>',
 
         // Table operation icons
         'column-insert-left': '<path d="M14 4h4a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-14a1 1 0 0 1 1 -1z"/><path d="M5 12l4 0"/><path d="M7 10l0 4"/>',

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
@@ -321,9 +321,8 @@ class tiptapWysiwygSetup {
                 TiptapModules.MahoAccordion.configure({
                     bubbleMenu: accordionBubbleMenu,
                 }),
-                // Without persist the toggle only expands an item for editing: it never
-                // writes `open`, so opening every section to type in it does not publish
-                // the page with every section expanded
+                // Without persist, `open` is outside the schema: the toggle only expands an item
+                // for editing, so opening sections to type in them never publishes them expanded
                 TiptapModules.MahoDetails.configure({
                     persist: false,
                     renderToggleButton: ({ element, isOpen }) => {

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/tiptap.css
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/tiptap.css
@@ -1061,9 +1061,15 @@
     --accent-hover: #0e7490;
 }
 
+.ProseMirror [data-type="maho-accordion"] {
+    --accent: #d97706;
+    --accent-hover: #b45309;
+}
+
 /* Container */
 .ProseMirror [data-type="maho-columns"],
-.ProseMirror [data-type="maho-bento"] {
+.ProseMirror [data-type="maho-bento"],
+.ProseMirror [data-type="maho-accordion"] {
     margin: 1rem 0;
 }
 
@@ -1104,14 +1110,14 @@
 }
 
 /* Badge visibility on hover/selection */
-.ProseMirror :is([data-type="maho-columns"], [data-type="maho-bento"]):hover .grid-badge,
-.ProseMirror :is([data-type="maho-columns"], [data-type="maho-bento"]).ProseMirror-selectednode .grid-badge {
+.ProseMirror :is([data-type="maho-columns"], [data-type="maho-bento"], [data-type="maho-accordion"]):hover .grid-badge,
+.ProseMirror :is([data-type="maho-columns"], [data-type="maho-bento"], [data-type="maho-accordion"]).ProseMirror-selectednode .grid-badge {
     opacity: 1;
 }
 
 /* Hover/selected outline */
-.ProseMirror :is([data-type="maho-columns"], [data-type="maho-bento"]):hover,
-.ProseMirror :is([data-type="maho-columns"], [data-type="maho-bento"]).ProseMirror-selectednode {
+.ProseMirror :is([data-type="maho-columns"], [data-type="maho-bento"], [data-type="maho-accordion"]):hover,
+.ProseMirror :is([data-type="maho-columns"], [data-type="maho-bento"], [data-type="maho-accordion"]).ProseMirror-selectednode {
     outline: 2px dashed var(--accent);
     outline-offset: 4px;
     border-radius: 4px;
@@ -1283,3 +1289,86 @@
     }
 }
 
+
+
+/* ========================================
+   ACCORDION & TABS — SPECIFIC STYLES
+   ======================================== */
+
+/* Overrides the display:table shared by the maho-* placeholder nodes */
+.ProseMirror div[data-type="maho-accordion"] {
+    display: block;
+}
+
+.ProseMirror .accordion-inner {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+/* An item: toggle button next to the summary and content wrapper */
+.ProseMirror [data-type="details"] {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--tt-color-border);
+    border-radius: var(--tt-radius-md);
+    background: var(--tt-color-bg);
+
+    > button {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.5rem;
+        height: 1.5rem;
+        margin-top: 0.1rem;
+        padding: 0;
+        border: none;
+        border-radius: var(--tt-radius-sm);
+        background: transparent;
+        color: var(--tt-color-text-muted);
+        cursor: pointer;
+
+        svg {
+            width: 1rem;
+            height: 1rem;
+            transition: transform 0.15s;
+            transform: rotate(-90deg);
+        }
+
+        &:hover {
+            background: var(--tt-color-bg-hover);
+        }
+    }
+
+    > div {
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+
+    &.is-open > button svg {
+        transform: rotate(0deg);
+    }
+}
+
+.ProseMirror [data-type="details"] summary {
+    font-weight: 600;
+    color: var(--tt-color-heading);
+    list-style: none;
+}
+
+.ProseMirror [data-type="detailsContent"] {
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px dashed var(--tt-color-border);
+
+    > *:first-child {
+        margin-top: 0;
+    }
+
+    > *:last-child {
+        margin-bottom: 0;
+    }
+}

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/tiptap.css
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/tiptap.css
@@ -1289,10 +1289,8 @@
     }
 }
 
-
-
 /* ========================================
-   ACCORDION & TABS — SPECIFIC STYLES
+   ACCORDION & TABS
    ======================================== */
 
 /* Overrides the display:table shared by the maho-* placeholder nodes */

--- a/public/skin/frontend/base/default/css/styles.css
+++ b/public/skin/frontend/base/default/css/styles.css
@@ -7957,6 +7957,105 @@ input[type="datetime-local"]:focus {
 }
 
 /* ============================================ *
+ * WYSIWYG Content - Accordion & Tabs
+ * ============================================ */
+
+[data-type="maho-accordion"] {
+    margin: 1rem 0;
+}
+
+[data-type="maho-accordion"] > details {
+    border: 1px solid var(--maho-color-border);
+    border-radius: 4px;
+    margin-bottom: 0.5rem;
+    background: var(--maho-color-background);
+}
+
+[data-type="maho-accordion"] > details > summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    list-style: none;
+}
+
+[data-type="maho-accordion"] > details > summary::-webkit-details-marker {
+    display: none;
+}
+
+/* Chevron, pointing down when collapsed and up once the panel is open */
+[data-type="maho-accordion"] > details > summary::after {
+    content: '';
+    flex: 0 0 auto;
+    width: 0.5em;
+    height: 0.5em;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    rotate: 45deg;
+    transition: rotate 0.2s;
+}
+
+[data-type="maho-accordion"] > details[open] > summary::after {
+    rotate: -135deg;
+}
+
+[data-type="maho-accordion"] > details > [data-type="detailsContent"] {
+    padding: 0 1rem 1rem;
+}
+
+/* Tabs, once app.js has built the tab strip. Without JS the group keeps its
+   accordion markup and stays usable as one. */
+[data-type="maho-accordion"][data-tabs] > details {
+    border: none;
+    border-radius: 0;
+    margin-bottom: 0;
+}
+
+[data-type="maho-accordion"][data-tabs] > details > summary {
+    display: none;
+}
+
+[data-type="maho-accordion"][data-tabs] > details > [data-type="detailsContent"] {
+    padding: 1rem;
+    border: 1px solid var(--maho-color-border);
+    border-top: none;
+}
+
+.maho-tabs-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    border-bottom: 1px solid var(--maho-color-border);
+}
+
+.maho-tabs-strip button {
+    padding: 0.6rem 1rem;
+    margin-bottom: -1px;
+    border: 1px solid transparent;
+    border-radius: 4px 4px 0 0;
+    background: none;
+    font: inherit;
+    font-weight: 600;
+    color: var(--maho-color-text-secondary);
+    cursor: pointer;
+}
+
+.maho-tabs-strip button:hover {
+    color: var(--maho-color-text-primary);
+    background: var(--maho-color-background-alt);
+}
+
+.maho-tabs-strip button[aria-selected="true"] {
+    border-color: var(--maho-color-border);
+    border-bottom-color: var(--maho-color-background);
+    background: var(--maho-color-background);
+    color: var(--maho-color-text-primary);
+}
+
+/* ============================================ *
  * AJAX Loader Overlay
  * ============================================ */
 

--- a/public/skin/frontend/base/default/js/app.js
+++ b/public/skin/frontend/base/default/js/app.js
@@ -837,3 +837,79 @@ document.addEventListener('DOMContentLoaded', () => {
         updateDots();
     }
 });
+
+/**
+ * Tab groups authored in the WYSIWYG editor
+ *
+ * A group is saved as <details> items inside a wrapper, so it works as an accordion on its
+ * own. The browser cannot lay those out as tabs (display:contents on <details> drops the
+ * open/closed behaviour), so the tab strip is built here, and a group with no JS stays a
+ * usable accordion.
+ */
+function initTabGroups(root = document) {
+    for (const group of root.querySelectorAll('[data-type="maho-accordion"][data-style="tabs"]:not([data-tabs])')) {
+        const items = [...group.querySelectorAll(':scope > details')];
+        if (items.length === 0) {
+            continue;
+        }
+
+        initTabGroups.counter ??= 0;
+        const groupId = `maho-tabs-${++initTabGroups.counter}`;
+
+        const strip = document.createElement('div');
+        strip.className = 'maho-tabs-strip';
+        strip.setAttribute('role', 'tablist');
+
+        const select = (index, focus = false) => {
+            items.forEach((details, i) => details.open = i === index);
+            for (const [i, tab] of tabs.entries()) {
+                tab.setAttribute('aria-selected', String(i === index));
+                tab.tabIndex = i === index ? 0 : -1;
+            }
+            if (focus) {
+                tabs[index].focus();
+            }
+        };
+
+        const tabs = items.map((details, index) => {
+            const panel = details.querySelector(':scope > [data-type="detailsContent"]');
+            const tab = document.createElement('button');
+
+            tab.type = 'button';
+            tab.id = `${groupId}-tab-${index}`;
+            tab.setAttribute('role', 'tab');
+            tab.textContent = details.querySelector(':scope > summary')?.textContent.trim() || `${index + 1}`;
+
+            if (panel) {
+                panel.id = `${groupId}-panel-${index}`;
+                panel.setAttribute('role', 'tabpanel');
+                panel.setAttribute('aria-labelledby', tab.id);
+                tab.setAttribute('aria-controls', panel.id);
+            }
+
+            tab.addEventListener('click', () => select(index));
+            tab.addEventListener('keydown', (event) => {
+                const offset = { ArrowLeft: -1, ArrowRight: 1 }[event.key];
+                if (offset) {
+                    select((index + offset + items.length) % items.length, true);
+                } else if (event.key === 'Home') {
+                    select(0, true);
+                } else if (event.key === 'End') {
+                    select(items.length - 1, true);
+                } else {
+                    return;
+                }
+                event.preventDefault();
+            });
+
+            strip.append(tab);
+            return tab;
+        });
+
+        group.prepend(strip);
+        group.dataset.tabs = '';
+        select(Math.max(items.findIndex((details) => details.open), 0));
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => initTabGroups());

--- a/tests/Backend/Integration/Cms/ContentSanitizationTest.php
+++ b/tests/Backend/Integration/Cms/ContentSanitizationTest.php
@@ -70,6 +70,38 @@ describe('CMS page content sanitization', function () {
 
         $page->delete();
     });
+
+    it('preserves accordion and tabs markup through save', function () {
+        // The WYSIWYG accordion is plain <details> markup, and every part of it carries
+        // meaning on the storefront: `open` picks the visible panel, `name` keeps a tab
+        // group exclusive, and data-style decides accordion or tabs.
+        $content = '<div data-type="maho-accordion" data-style="tabs">'
+            . '<details name="maho-accordion-abc123" open><summary>Description</summary>'
+            . '<div data-type="detailsContent"><p>First panel</p></div></details>'
+            . '<details name="maho-accordion-abc123"><summary>Reviews</summary>'
+            . '<div data-type="detailsContent"><p>Second panel</p></div></details>'
+            . '</div>';
+
+        $page = Mage::getModel('cms/page');
+        $page->setTitle('Accordion Page')
+            ->setIdentifier('accordion-page-' . uniqid())
+            ->setIsActive(1)
+            ->setRootTemplate('one_column')
+            ->setStores([0])
+            ->setContent($content)
+            ->save();
+
+        $loaded = Mage::getModel('cms/page')->load($page->getId());
+
+        expect($loaded->getContent())->toContain('data-type="maho-accordion"')
+            ->and($loaded->getContent())->toContain('data-style="tabs"')
+            ->and($loaded->getContent())->toContain('<summary>Description</summary>')
+            ->and($loaded->getContent())->toContain('data-type="detailsContent"')
+            ->and($loaded->getContent())->toContain('name="maho-accordion-abc123"')
+            ->and($loaded->getContent())->toMatch('/<details[^>]* open/');
+
+        $page->delete();
+    });
 });
 
 describe('CMS block content sanitization', function () {

--- a/tests/Backend/Integration/Cms/ContentSanitizationTest.php
+++ b/tests/Backend/Integration/Cms/ContentSanitizationTest.php
@@ -73,8 +73,8 @@ describe('CMS page content sanitization', function () {
 
     it('preserves accordion and tabs markup through save', function () {
         // The WYSIWYG accordion is plain <details> markup, and every part of it carries
-        // meaning on the storefront: `open` picks the visible panel, `name` keeps a tab
-        // group exclusive, and data-style decides accordion or tabs.
+        // meaning on the storefront: `name` keeps a tab group exclusive, data-style decides
+        // accordion or tabs, and `open` (hand-written only) picks the visible panel.
         $content = '<div data-type="maho-accordion" data-style="tabs">'
             . '<details name="maho-accordion-abc123" open><summary>Description</summary>'
             . '<div data-type="detailsContent"><p>First panel</p></div></details>'

--- a/tests/Browser/CmsAccordionTabsTest.php
+++ b/tests/Browser/CmsAccordionTabsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Tests\Browser\MahoServer;
+use Tests\MahoBrowserTestCase;
+
+uses(MahoBrowserTestCase::class)->group('browser');
+
+const ACCORDION_OPEN_BODY = 'Ships within 48 hours';
+const ACCORDION_CLOSED_BODY = 'Thirty days to change your mind';
+const TABS_FIRST_BODY = 'A description of the product';
+const TABS_SECOND_BODY = 'Weighs exactly one kilogram';
+
+/** A CMS page holding both a WYSIWYG accordion and a WYSIWYG tab group. */
+function createAccordionPage(): string
+{
+    $identifier = 'accordion-tabs-' . uniqid();
+
+    Mage::getModel('cms/page')
+        ->setTitle('Accordion And Tabs')
+        ->setIdentifier($identifier)
+        ->setIsActive(1)
+        ->setRootTemplate('one_column')
+        ->setStores([0])
+        ->setContent(
+            '<div data-type="maho-accordion" data-style="accordion">'
+            . '<details open><summary>Shipping</summary>'
+            . '<div data-type="detailsContent"><p>' . ACCORDION_OPEN_BODY . '</p></div></details>'
+            . '<details><summary>Returns</summary>'
+            . '<div data-type="detailsContent"><p>' . ACCORDION_CLOSED_BODY . '</p></div></details>'
+            . '</div>'
+            . '<div data-type="maho-accordion" data-style="tabs">'
+            . '<details name="tabs-fixture" open><summary>Description</summary>'
+            . '<div data-type="detailsContent"><p>' . TABS_FIRST_BODY . '</p></div></details>'
+            . '<details name="tabs-fixture"><summary>Specifications</summary>'
+            . '<div data-type="detailsContent"><p>' . TABS_SECOND_BODY . '</p></div></details>'
+            . '</div>',
+        )
+        ->save();
+
+    Mage::app()->cleanCache();
+
+    return $identifier;
+}
+
+it('opens an accordion section on the storefront', function () {
+    $page = visit(MahoServer::baseUrl() . '/' . createAccordionPage());
+    waitForPageLoad($page, '[data-style="accordion"]:visible');
+
+    // A closed <details> renders none of its content, so the body text is the signal
+    $page->assertSee(ACCORDION_OPEN_BODY)
+        ->assertDontSee(ACCORDION_CLOSED_BODY);
+
+    $page->click('[data-style="accordion"] > details:nth-of-type(2) > summary')
+        ->assertSee(ACCORDION_CLOSED_BODY)
+        ->assertSee(ACCORDION_OPEN_BODY);
+});
+
+it('switches tabs on the storefront', function () {
+    $page = visit(MahoServer::baseUrl() . '/' . createAccordionPage());
+
+    // The tab strip only exists once app.js has enhanced the group; without it the
+    // group stays an accordion, which is the no-JS fallback rather than a failure
+    waitForPageLoad($page, '.maho-tabs-strip:visible');
+
+    $page->assertSee(TABS_FIRST_BODY)
+        ->assertDontSee(TABS_SECOND_BODY);
+
+    $page->click('.maho-tabs-strip button >> nth=1')
+        ->assertSee(TABS_SECOND_BODY)
+        ->assertDontSee(TABS_FIRST_BODY);
+
+    // The summaries are hidden in tabs mode, so the strip carries the selected state
+    $page->assertAriaAttribute('.maho-tabs-strip button >> nth=1', 'selected', 'true')
+        ->assertAriaAttribute('.maho-tabs-strip button >> nth=0', 'selected', 'false');
+});

--- a/tests/Browser/CmsAccordionTabsTest.php
+++ b/tests/Browser/CmsAccordionTabsTest.php
@@ -17,7 +17,12 @@ const ACCORDION_CLOSED_BODY = 'Thirty days to change your mind';
 const TABS_FIRST_BODY = 'A description of the product';
 const TABS_SECOND_BODY = 'Weighs exactly one kilogram';
 
-/** A CMS page holding both a WYSIWYG accordion and a WYSIWYG tab group. */
+/**
+ * A CMS page holding both a WYSIWYG accordion and a WYSIWYG tab group.
+ *
+ * `open` marks the section the page loads on; the editor never writes it, so this is the
+ * shape of hand-written content.
+ */
 function createAccordionPage(): string
 {
     $identifier = 'accordion-tabs-' . uniqid();


### PR DESCRIPTION
Adds a toolbar entry that inserts a group of `<details>` items, switchable between accordion and tabs from the block's bubble menu (add/delete item, delete group). Saved markup is plain HTML: `<div data-type="maho-accordion" data-style="accordion|tabs">` wrapping `<details>`/`<summary>`/`<div data-type="detailsContent">`, so it degrades to a usable accordion anywhere.

The storefront styles the accordion in CSS alone. Tabs need JS: `display: contents` on `<details>` drops the browser's open/closed behaviour (verified in Chrome), so `app.js` builds an ARIA tablist with arrow/Home/End keys, and a group with no JS stays an accordion. Tab exclusivity is held by a shared `name` on the items, owned by an `appendTransaction` so a paste or a split can't leave an item outside its group.

Expanding an item in the editor is an editing affordance only (`persist: false`): it never writes `open`, so opening every section to type in it doesn't publish the page fully expanded.

Two things ride along:

- TipTap 3.29.2 (from 3.27.1). The `TableRow` parse workaround is still needed — upstream `tableRow` still declares only `{tag: 'tr'}`.
- The columns and bento blocks dropped an author's inline `style`, because their `style` node attribute shadowed the global one that preserves style on every node. Renamed to `gridStyle`, still rendering `data-style`, so stored content is unchanged.

Covered by a CMS sanitization case (the markup survives the malicious-code filter and purifier intact) and a browser test for opening a section and switching tabs on the storefront.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->