### PR TITLE
Stopped marking the api_data cache type invalidated on every catalog save

### DIFF
--- a/app/code/core/Maho/ApiPlatform/Model/Observer.php
+++ b/app/code/core/Maho/ApiPlatform/Model/Observer.php
@@ -188,7 +188,11 @@ class Maho_ApiPlatform_Model_Observer
     }
 
     /**
-     * Clean API cache by tags and mark the api_data cache type as invalidated
+     * Clean API cache by tags.
+     *
+     * Every api_data consumer caches under one of these tags, so the clean is the
+     * whole job: never invalidate the type here, or ordinary catalog activity would
+     * leave the admin permanently asking for a refresh that has nothing to refresh.
      *
      * @param string[] $tags Cache tags to clean
      */
@@ -196,7 +200,6 @@ class Maho_ApiPlatform_Model_Observer
     {
         try {
             Mage::app()->getCache()->clean($tags);
-            Mage::app()->getCache()->invalidateType('api_data');
         } catch (\Throwable $e) {
             Mage::log('Failed to clean API cache: ' . $e->getMessage(), Mage::LOG_WARNING);
         }

--- a/tests/Backend/Integration/ApiPlatform/CacheInvalidationTest.php
+++ b/tests/Backend/Integration/ApiPlatform/CacheInvalidationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Tests\MahoBackendTestCase;
+
+uses(MahoBackendTestCase::class);
+
+/*
+ * Maho_ApiPlatform_Model_Observer hooks nine everyday events (product, category,
+ * stock, catalog rule, review, config and store saves). Marking the api_data type
+ * invalidated from there means placing a single order re-raises the admin's
+ * "cache types are invalidated" notice, which can then never stay cleared.
+ * Cleaning the tags is enough: every api_data consumer caches under one of them.
+ */
+
+function apiDataIsFlaggedInvalid(): bool
+{
+    $flags = Mage::app()->getCache()->load(Mage_Core_Model_Cache::INVALIDATED_TYPES);
+    return is_array($flags) && isset($flags['api_data']);
+}
+
+function apiPlatformEventObserver(string $key, mixed $object): Maho\Event\Observer
+{
+    $event = new Maho\Event();
+    $event->setData($key, $object);
+
+    $eventObserver = new Maho\Event\Observer();
+    $eventObserver->setEvent($event);
+
+    return $eventObserver;
+}
+
+describe('API platform cache invalidation', function () {
+    beforeEach(function () {
+        Mage::app()->getCache()->cleanType('api_data');
+        $this->observer = new Maho_ApiPlatform_Model_Observer();
+    });
+
+    it('does not flag the api_data type when a stock item save is dispatched', function () {
+        // Placing an order full-saves any item that goes out of stock or drops
+        // below notify_stock_qty, so this event fires on ordinary storefront traffic.
+        Mage::dispatchEvent('cataloginventory_stock_item_save_after', [
+            'item' => Mage::getModel('cataloginventory/stock_item'),
+        ]);
+
+        expect(apiDataIsFlaggedInvalid())->toBeFalse();
+    });
+
+    it('does not flag the api_data type on a product save', function () {
+        $product = Mage::getModel('catalog/product')->setId(1);
+
+        $this->observer->invalidateProductCache(apiPlatformEventObserver('product', $product));
+
+        expect(apiDataIsFlaggedInvalid())->toBeFalse();
+    });
+
+    it('does not flag the api_data type on a config save', function () {
+        $this->observer->invalidateStoreConfigCache(apiPlatformEventObserver('data_object', null));
+
+        expect(apiDataIsFlaggedInvalid())->toBeFalse();
+    });
+
+    it('still cleans the API cache tags it is responsible for', function () {
+        $cache = Mage::app()->getCache();
+        $cache->save('cached', 'test_api_products_entry', ['API_PRODUCTS']);
+        $cache->save('cached', 'test_api_store_config_entry', ['API_STORE_CONFIG']);
+
+        $this->observer->invalidateStockCache(apiPlatformEventObserver('item', null));
+        $this->observer->invalidateStoreConfigCache(apiPlatformEventObserver('data_object', null));
+
+        expect($cache->load('test_api_products_entry'))->toBeFalse();
+        expect($cache->load('test_api_store_config_entry'))->toBeFalse();
+    });
+});


### PR DESCRIPTION
`Maho_ApiPlatform_Model_Observer::cleanApiCache()` called `invalidateType('api_data')` after cleaning the tags, and it's wired to product, category, stock item, catalog rule, review, config and store saves. Placing an order is enough to trigger it: `Stock::registerProductsSale()` collects items that go out of stock or drop below `notify_stock_qty`, and `reindexQuoteInventory()` full-saves them, firing `cataloginventory_stock_item_save_after`. So the admin notice "One or more of the Cache Types are invalidated: API Data" came back right after every refresh, including on stores with no API protocol enabled.

Dropped the `invalidateType()` call. The tag clean is the whole job: every `api_data` consumer (`ProductProvider`, `LayeredFilterProvider`, `StoreConfigProvider`, `CountryProvider`, `ReviewProvider`) caches under one of the type's tags, so nothing stale is left for the operator to refresh.

Fixes #1197

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->