### PR TITLE
Cleaned the affected cache tags instead of flagging cache types invalid

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -11371,18 +11371,6 @@ parameters:
 			path: app/code/core/Mage/CatalogRule/Model/Rule.php
 
 		-
-			rawMessage: 'Parameter #1 $product of method Mage_CatalogRule_Model_Resource_Rule::applyAllRules() expects int|Mage_Catalog_Model_Product|null, Mage_Core_Model_Abstract given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/CatalogRule/Model/Rule.php
-
-		-
-			rawMessage: 'Parameter #2 $product of method Mage_CatalogRule_Model_Resource_Rule::applyToProduct() expects Mage_Catalog_Model_Product, Mage_Core_Model_Abstract given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/CatalogRule/Model/Rule.php
-
-		-
 			rawMessage: 'Method Mage_Eav_Model_Entity_Attribute_Source_Interface::getAllOptions() invoked with 1 parameter, 0 required.'
 			identifier: arguments.count
 			count: 1

--- a/app/code/core/Mage/CatalogRule/Model/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule.php
@@ -273,6 +273,7 @@ class Mage_CatalogRule_Model_Rule extends Mage_Rule_Model_Abstract
     public function applyToProduct($product, $websiteIds = null)
     {
         if (is_numeric($product)) {
+            /** @var Mage_Catalog_Model_Product $product */
             $product = $this->_factory->getModel('catalog/product')->load($product);
         }
         if (is_null($websiteIds)) {
@@ -280,11 +281,11 @@ class Mage_CatalogRule_Model_Rule extends Mage_Rule_Model_Abstract
         }
         $this->getResource()->applyToProduct($this, $product, $websiteIds);
         $this->getResource()->applyAllRules($product);
-        $this->_invalidateCache();
+        $this->_cleanProductCache($product);
     }
 
     /**
-     * Apply all price rules, invalidate related cache and refresh price index
+     * Apply all price rules, clean related cache and refresh price index
      *
      * @throws Exception
      */
@@ -292,7 +293,7 @@ class Mage_CatalogRule_Model_Rule extends Mage_Rule_Model_Abstract
     {
         $this->getResourceCollection()->walk([$this->_getResource(), 'updateRuleProductData']);
         $this->_getResource()->applyAllRules();
-        $this->_invalidateCache();
+        $this->_cleanCache();
         $indexProcess = Mage::getSingleton('index/indexer')->getProcessByCode('catalog_product_price');
         if ($indexProcess) {
             $indexProcess->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);
@@ -327,7 +328,7 @@ class Mage_CatalogRule_Model_Rule extends Mage_Rule_Model_Abstract
         }
 
         $this->getResource()->applyAllRules($product);
-        $this->_invalidateCache();
+        $this->_cleanProductCache($product);
 
         Mage::getSingleton('index/indexer')->processEntityAction(
             new \Maho\DataObject(['id' => $product->getId()]),
@@ -416,17 +417,29 @@ class Mage_CatalogRule_Model_Rule extends Mage_Rule_Model_Abstract
     }
 
     /**
-     * Invalidate related cache types
+     * Clean related cache types
      *
      * @return $this
      */
-    protected function _invalidateCache()
+    protected function _cleanCache()
     {
         $types = $this->_config->getNode(self::XML_NODE_RELATED_CACHE);
         if ($types) {
-            $types = $types->asArray();
-            $this->_app->getCache()->invalidateType(array_keys($types));
+            foreach (array_keys($types->asArray()) as $type) {
+                $this->_app->getCache()->cleanType($type);
+            }
         }
+        return $this;
+    }
+
+    /**
+     * Clean the cache holding a single product's prices
+     *
+     * @return $this
+     */
+    protected function _cleanProductCache(Mage_Catalog_Model_Product $product)
+    {
+        $this->_app->cleanCache([Mage_Catalog_Model_Product::CACHE_TAG . '_' . $product->getId()]);
         return $this;
     }
 

--- a/app/code/core/Mage/Cms/Model/Resource/Page.php
+++ b/app/code/core/Mage/Cms/Model/Resource/Page.php
@@ -170,8 +170,8 @@ class Mage_Cms_Model_Resource_Page extends Mage_Core_Model_Resource_Db_Abstract
             $this->_getWriteAdapter()->insertMultiple($table, $data);
         }
 
-        //Mark layout cache as invalidated
-        Mage::app()->getCache()->invalidateType('layout');
+        // Layout cache is tagged by handle; a page render only contributes `cms_page`.
+        Mage::app()->cleanCache(['cms_page']);
 
         return parent::_afterSave($object);
     }

--- a/app/code/core/Mage/CurrencySymbol/Model/System/Currencysymbol.php
+++ b/app/code/core/Mage/CurrencySymbol/Model/System/Currencysymbol.php
@@ -274,15 +274,14 @@ class Mage_CurrencySymbol_Model_System_Currencysymbol
     }
 
     /**
-     * Clear translate cache
+     * Clear the caches holding the old symbol
      *
      * @return $this
      */
     public function clearCache()
     {
-        // clear cache for frontend
         foreach ($this->_cacheTypes as $cacheType) {
-            Mage::app()->getCache()->invalidateType($cacheType);
+            Mage::app()->getCache()->cleanType($cacheType);
         }
         return $this;
     }

--- a/app/code/core/Mage/Rss/Model/System/Config/Backend/Links.php
+++ b/app/code/core/Mage/Rss/Model/System/Config/Backend/Links.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 class Mage_Rss_Model_System_Config_Backend_Links extends Mage_Core_Model_Config_Data
 {
     /**
-     * Invalidate cache type, when value was changed
+     * Clean the block html holding the old RSS links, when value was changed
      */
     #[\Override]
     protected function _afterSave()
     {
         if ($this->isValueChanged()) {
-            Mage::app()->getCache()->invalidateType(Mage_Core_Block_Abstract::CACHE_GROUP);
+            Mage::app()->getCache()->cleanType(Mage_Core_Block_Abstract::CACHE_GROUP);
         }
         return $this;
     }

--- a/app/code/core/Mage/Widget/Model/Widget/Instance.php
+++ b/app/code/core/Mage/Widget/Model/Widget/Instance.php
@@ -506,40 +506,41 @@ class Mage_Widget_Model_Widget_Instance extends Mage_Core_Model_Abstract
     }
 
     /**
-     * Invalidate related cache types
+     * Clean related cache types
      *
      * @return $this
      */
-    protected function _invalidateCache()
+    protected function _cleanCache()
     {
         $types = Mage::getConfig()->getNode(self::XML_NODE_RELATED_CACHE);
         if ($types) {
-            $types = $types->asArray();
-            Mage::app()->getCache()->invalidateType(array_keys($types));
+            foreach (array_keys($types->asArray()) as $type) {
+                Mage::app()->getCache()->cleanType($type);
+            }
         }
         return $this;
     }
 
     /**
-     * Invalidate related cache if instance contain layout updates
+     * Clean related cache if instance contain layout updates
      */
     #[\Override]
     protected function _afterSave()
     {
         if ($this->dataHasChangedFor('page_groups') || $this->dataHasChangedFor('widget_parameters')) {
-            $this->_invalidateCache();
+            $this->_cleanCache();
         }
         return parent::_afterSave();
     }
 
     /**
-     * Invalidate related cache if instance contain layout updates
+     * Clean related cache if instance contain layout updates
      */
     #[\Override]
     protected function _beforeDelete()
     {
         if ($this->getPageGroups()) {
-            $this->_invalidateCache();
+            $this->_cleanCache();
         }
         return parent::_beforeDelete();
     }

--- a/tests/Backend/Integration/Core/Model/CacheCleaningTest.php
+++ b/tests/Backend/Integration/Core/Model/CacheCleaningTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Tests\MahoBackendTestCase;
+
+uses(MahoBackendTestCase::class);
+
+/*
+ * invalidateType() evicts nothing, it only flags a type so the admin grid asks for a manual
+ * refresh. Saves that know which tags went stale should clean them instead.
+ */
+
+function cacheTypeIsFlaggedInvalid(string $type): bool
+{
+    $flags = Mage::app()->getCache()->load(Mage_Core_Model_Cache::INVALIDATED_TYPES);
+    return is_array($flags) && isset($flags[$type]);
+}
+
+function callProtected(object $object, string $method, array $args = []): mixed
+{
+    return (new ReflectionMethod($object, $method))->invokeArgs($object, $args);
+}
+
+describe('CMS page save', function () {
+    beforeEach(function () {
+        Mage::app()->getCache()->cleanType('layout');
+        Mage::app()->getCache()->cleanType('block_html');
+
+        $this->page = Mage::getModel('cms/page')
+            ->setTitle('Cache cleaning test page')
+            ->setIdentifier('cache-cleaning-test-' . uniqid())
+            ->setStores([0])
+            ->setIsActive(1)
+            ->setContent('<p>before</p>')
+            ->setRootTemplate('one_column')
+            ->save();
+    });
+
+    afterEach(function () {
+        Mage::register('isSecureArea', true, true);
+        $this->page->delete();
+        Mage::unregister('isSecureArea');
+    });
+
+    it('does not flag the layout type', function () {
+        $this->page->setContent('<p>after</p>')->save();
+
+        expect(cacheTypeIsFlaggedInvalid('layout'))->toBeFalse();
+    });
+
+    it('cleans the layout cache entries built from the cms_page handle', function () {
+        $cache = Mage::app()->getCache();
+        $cache->save('cached', 'test_layout_cms_page_handle', ['cms_page', Mage_Core_Model_Layout_Update::LAYOUT_GENERAL_CACHE_TAG]);
+
+        $this->page->setContent('<p>after</p>')->save();
+
+        expect($cache->load('test_layout_cms_page_handle'))->toBeFalse();
+    });
+
+    it('cleans the block html cached for this page', function () {
+        $cache = Mage::app()->getCache();
+        $cache->save('cached', 'test_block_html_cms_page', [Mage_Cms_Model_Page::CACHE_TAG . '_' . $this->page->getId()]);
+
+        $this->page->setContent('<p>after</p>')->save();
+
+        expect($cache->load('test_block_html_cms_page'))->toBeFalse();
+    });
+});
+
+describe('currency symbol save', function () {
+    beforeEach(function () {
+        foreach (['config', 'block_html', 'layout'] as $type) {
+            Mage::app()->getCache()->cleanType($type);
+        }
+    });
+
+    it('does not flag the types it clears', function () {
+        Mage::getSingleton('currencysymbol/system_currencysymbol')->clearCache();
+
+        expect(cacheTypeIsFlaggedInvalid('config'))->toBeFalse();
+        expect(cacheTypeIsFlaggedInvalid('block_html'))->toBeFalse();
+        expect(cacheTypeIsFlaggedInvalid('layout'))->toBeFalse();
+    });
+
+    it('cleans the cached prices rendered with the old symbol', function () {
+        $cache = Mage::app()->getCache();
+        $cache->save('cached', 'test_currency_block_html', [Mage_Core_Block_Abstract::CACHE_GROUP]);
+        $cache->save('cached', 'test_currency_config', [Mage_Core_Model_Config::CACHE_TAG]);
+
+        Mage::getSingleton('currencysymbol/system_currencysymbol')->clearCache();
+
+        expect($cache->load('test_currency_block_html'))->toBeFalse();
+        expect($cache->load('test_currency_config'))->toBeFalse();
+    });
+});
+
+describe('catalog price rule', function () {
+    beforeEach(function () {
+        Mage::app()->getCache()->cleanType('block_html');
+        $this->rule = Mage::getModel('catalogrule/rule');
+    });
+
+    it('cleans its related cache types instead of flagging them', function () {
+        $cache = Mage::app()->getCache();
+        $cache->save('cached', 'test_rule_block_html', [Mage_Core_Block_Abstract::CACHE_GROUP]);
+
+        callProtected($this->rule, '_cleanCache');
+
+        expect($cache->load('test_rule_block_html'))->toBeFalse();
+        expect(cacheTypeIsFlaggedInvalid(Mage_Core_Block_Abstract::CACHE_GROUP))->toBeFalse();
+    });
+
+    it('cleans only the product tag when rules are applied to a single product', function () {
+        // Runs on every admin product save, so it must not flush the whole block html cache.
+        $cache = Mage::app()->getCache();
+        $product = Mage::getModel('catalog/product')->setId(1);
+        $cache->save('cached', 'test_rule_product_block', [Mage_Catalog_Model_Product::CACHE_TAG . '_1']);
+        $cache->save('cached', 'test_rule_unrelated_block', [Mage_Core_Block_Abstract::CACHE_GROUP]);
+
+        callProtected($this->rule, '_cleanProductCache', [$product]);
+
+        expect($cache->load('test_rule_product_block'))->toBeFalse();
+        expect($cache->load('test_rule_unrelated_block'))->toBe('cached');
+    });
+});
+
+describe('widget instance', function () {
+    beforeEach(function () {
+        Mage::app()->getCache()->cleanType('block_html');
+        Mage::app()->getCache()->cleanType('layout');
+        $this->instance = Mage::getModel('widget/widget_instance');
+    });
+
+    it('cleans its related cache types instead of flagging them', function () {
+        $cache = Mage::app()->getCache();
+        $cache->save('cached', 'test_widget_block_html', [Mage_Core_Block_Abstract::CACHE_GROUP]);
+        $cache->save('cached', 'test_widget_layout', [Mage_Core_Model_Layout_Update::LAYOUT_GENERAL_CACHE_TAG]);
+
+        callProtected($this->instance, '_cleanCache');
+
+        expect($cache->load('test_widget_block_html'))->toBeFalse();
+        expect($cache->load('test_widget_layout'))->toBeFalse();
+        expect(cacheTypeIsFlaggedInvalid(Mage_Core_Block_Abstract::CACHE_GROUP))->toBeFalse();
+        expect(cacheTypeIsFlaggedInvalid('layout'))->toBeFalse();
+    });
+});
+
+describe('RSS links config save', function () {
+    beforeEach(function () {
+        Mage::app()->getCache()->cleanType('block_html');
+    });
+
+    it('cleans block html instead of flagging it', function () {
+        $cache = Mage::app()->getCache();
+        $cache->save('cached', 'test_rss_block_html', [Mage_Core_Block_Abstract::CACHE_GROUP]);
+
+        Mage::getModel('rss/system_config_backend_links')
+            ->setPath('rss/config/active')
+            ->setValue('1')
+            ->setOldValue('0')
+            ->save();
+
+        expect($cache->load('test_rss_block_html'))->toBeFalse();
+        expect(cacheTypeIsFlaggedInvalid(Mage_Core_Block_Abstract::CACHE_GROUP))->toBeFalse();
+    });
+});


### PR DESCRIPTION
`invalidateType()` evicts nothing: it only records a flag so the admin cache grid asks for a manual refresh, and the storefront keeps serving stale output until someone clicks it. #1198 removed the ApiPlatform caller; this removes the rest. Every one of them knew which tags had gone stale, so they now clean them:

- `Cms/Model/Resource/Page.php` flagged the whole `layout` type. Layout entries are tagged by handle and a page's own `layout_update_xml` is merged after the cached load (`Mage_Cms_Helper_Page::_renderPage`), so it never reaches the cache at all. Cleans the `cms_page` handle instead.
- `CurrencySymbol/.../Currencysymbol.php` and `Rss/.../Backend/Links.php` swap `invalidateType()` for `cleanType()`, which also clears any flag left by an older release.
- `Widget/Model/Widget/Instance.php` same swap over its related cache types.
- `CatalogRule/Model/Rule.php` splits: `applyAll()` keeps the full `block_html` clean, but the per-product paths clean only `catalog_product_<id>`. `applyAllRulesToProduct()` is wired to `catalog_product_save_commit_after`, so a full-type clean there would flush the whole block cache on every admin product save.

`invalidateType()` itself stays, for cases where the blast radius really is an operator decision. It just has no callers now.

Two things worth flagging: the protected `_invalidateCache()` → `_cleanCache()` rename breaks any third-party subclass overriding it, and `applyToProduct()` gained a `@var` narrowing that let two entries drop out of the phpstan baseline.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->