### PR TITLE
Fixed admin URLs being corrupted when they end in a query string

### DIFF
--- a/app/design/adminhtml/default/default/template/catalog/product/js.phtml
+++ b/app/design/adminhtml/default/default/template/catalog/product/js.phtml
@@ -78,7 +78,7 @@ function recalculateTax() {
 function bindActiveProductTab(event) {
     const storeSwitcher = document.getElementById('store_switcher');
     if (event.tab && event.tab.name && storeSwitcher) {
-        storeSwitcher.switchParams = 'active_tab/'+event.tab.name+'/';
+        storeSwitcher.switchParams = { active_tab: event.tab.name };
     }
 }
 varienGlobalEvents.attachEventHandler('showTab', bindActiveProductTab);
@@ -87,7 +87,7 @@ varienGlobalEvents.attachEventHandler('showTab', bindActiveProductTab);
 <?php if($tabsBlock = $this->getLayout()->getBlock('product_tabs')): ?>
 const storeSwitcher = document.getElementById('store_switcher');
 if (<?= $tabsBlock->getJsObjectName() ?> && <?= $tabsBlock->getJsObjectName() ?>.activeTab && storeSwitcher) {
-    storeSwitcher.switchParams = 'active_tab/'+<?= $tabsBlock->getJsObjectName() ?>.activeTab.name+'/';
+    storeSwitcher.switchParams = { active_tab: <?= $tabsBlock->getJsObjectName() ?>.activeTab.name };
 }
 <?php endif ?>
 </script>

--- a/app/design/adminhtml/default/default/template/dashboard/index.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/index.phtml
@@ -65,10 +65,11 @@ function initDashboardCharts(container) {
 }
 
 function changeDiagramsPeriod(periodObj) {
-    const periodParam = periodObj.value ? 'period/' + periodObj.value + '/' : '';
+    const ajaxBlockUrl = '<?= $this->getUrl('*/*/ajaxBlock', ['_current' => true, 'block' => '', 'period' => '']) ?>';
+    const period = periodObj.value || null;
 
 <?php foreach ($this->getChild('diagrams')->getTabsIds() as $tabId): ?>
-    mahoFetch('<?= $this->getUrl('*/*/ajaxBlock', ['_current' => true, 'block' => '', 'period' => '']) ?>' + 'block/tab_<?= $tabId ?>/' + periodParam, {
+    mahoFetch(setRouteParams(ajaxBlockUrl, { block: 'tab_<?= $tabId ?>', period }), {
         method: 'POST'
     }).then(response => {
         const el = document.getElementById('<?= $this->getChild('diagrams')->getId() ?>_<?= $tabId ?>_content');
@@ -77,7 +78,7 @@ function changeDiagramsPeriod(periodObj) {
     }).catch(e => console.error('Dashboard diagram error:', e));
 <?php endforeach ?>
 
-    mahoFetch('<?= $this->getUrl('*/*/ajaxBlock', ['_current' => true, 'block' => 'totals', 'period' => '']) ?>' + periodParam, {
+    mahoFetch(setRouteParams(ajaxBlockUrl, { block: 'totals', period }), {
         method: 'POST'
     }).then(response => {
         document.getElementById('dashboard_diagram_totals').outerHTML = response;

--- a/app/design/adminhtml/default/default/template/dashboard/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/store/switcher.phtml
@@ -36,24 +36,27 @@
 <script>
 //<![CDATA[
     function switchStore(obj){
-        if (obj.options[obj.selectedIndex].getAttribute('website') == 'true') {
-            var selectionType = 'website';
-        } else if (obj.options[obj.selectedIndex].getAttribute('group') == 'true') {
-            var selectionType = 'group';
-        } else {
-            var selectionType = 'store';
-        }
-        var storeParam = obj.value ? selectionType + '/' + obj.value + '/' : '';
-        if(obj.switchParams){
-            storeParam+= obj.switchParams;
+        const option = obj.options[obj.selectedIndex];
+        const selectionType = option.getAttribute('website') == 'true' ? 'website'
+            : (option.getAttribute('group') == 'true' ? 'group' : 'store');
+
+        // The scope params are read in store/website/group order, so the unselected ones
+        // must be dropped rather than left over from the current URL.
+        const params = { website: null, group: null, store: null };
+        if (obj.value) {
+            params[selectionType] = obj.value;
         }
         if (document.getElementById('diagram_tab_orders_content').style.display != 'none') {
             var select = document.getElementById('order_orders_period');
         } else if (document.getElementById('diagram_tab_amounts_content').style.display != 'none') {
             var select = document.getElementById('order_amounts_period');
         }
-        var periodParam = select.value ? 'period/'+select.value + '/' : '';
-        setLocation('<?= $this->getSwitchUrl() ?>'+storeParam+periodParam);
+        params.period = select.value || null;
+
+        setLocation(setRouteParams('<?= $this->getSwitchUrl() ?>', {
+            ...params,
+            ...parseRouteParams(obj.switchParams),
+        }));
     }
 //]]>
 </script>

--- a/app/design/adminhtml/default/default/template/dashboard/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/dashboard/store/switcher.phtml
@@ -53,10 +53,7 @@
         }
         params.period = select.value || null;
 
-        setLocation(setRouteParams('<?= $this->getSwitchUrl() ?>', {
-            ...params,
-            ...parseRouteParams(obj.switchParams),
-        }));
+        setLocation(setRouteParams('<?= $this->getSwitchUrl() ?>', params));
     }
 //]]>
 </script>

--- a/app/design/adminhtml/default/default/template/report/grid/container.phtml
+++ b/app/design/adminhtml/default/default/template/report/grid/container.phtml
@@ -43,8 +43,7 @@
             });
 
             const params = new URLSearchParams(formData).toString();
-            const encodedParams = btoa(params);
-            setLocation('<?= $this->getFilterUrl() ?>filter/' + encodedParams + '/');
+            setLocation(setRouteParams('<?= $this->getFilterUrl() ?>', { filter: btoa(params) }));
         }
     }
 </script>

--- a/app/design/adminhtml/default/default/template/report/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/report/store/switcher.phtml
@@ -38,18 +38,20 @@
 </p>
 <script>
     function switchStore(obj){
-        if (obj.options[obj.selectedIndex].getAttribute('website') == 'true') {
-            var selectionType = 'website';
-        } else if (obj.options[obj.selectedIndex].getAttribute('group') == 'true') {
-            var selectionType = 'group';
-        } else {
-            var selectionType = 'store';
+        const option = obj.options[obj.selectedIndex];
+        const selectionType = option.getAttribute('website') == 'true' ? 'website'
+            : (option.getAttribute('group') == 'true' ? 'group' : 'store');
+
+        // The scope params are read in store/website/group order, so the unselected ones
+        // must be dropped rather than left over from the current URL.
+        const params = { website: null, group: null, store: null };
+        if (obj.value) {
+            params[selectionType] = obj.value;
         }
-        var storeParam = obj.value ? selectionType + '/' + obj.value + '/' : '';
-        if(obj.switchParams){
-            storeParam+= obj.switchParams;
-        }
-        setLocation('<?= $this->getSwitchUrl() ?>'+storeParam);
+        setLocation(setRouteParams('<?= $this->getSwitchUrl() ?>', {
+            ...params,
+            ...parseRouteParams(obj.switchParams),
+        }));
     }
 </script>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/report/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/report/store/switcher.phtml
@@ -48,10 +48,7 @@
         if (obj.value) {
             params[selectionType] = obj.value;
         }
-        setLocation(setRouteParams('<?= $this->getSwitchUrl() ?>', {
-            ...params,
-            ...parseRouteParams(obj.switchParams),
-        }));
+        setLocation(setRouteParams('<?= $this->getSwitchUrl() ?>', params));
     }
 </script>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/report/store/switcher/enhanced.phtml
+++ b/app/design/adminhtml/default/default/template/report/store/switcher/enhanced.phtml
@@ -37,10 +37,7 @@
 </p>
 <script>
     function switchStore(obj){
-        setLocation(setRouteParams('<?= $this->getSwitchUrl() ?>', {
-            store_ids: obj.value || null,
-            ...parseRouteParams(obj.switchParams),
-        }));
+        setLocation(setRouteParams('<?= $this->getSwitchUrl() ?>', { store_ids: obj.value || null }));
     }
 </script>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/report/store/switcher/enhanced.phtml
+++ b/app/design/adminhtml/default/default/template/report/store/switcher/enhanced.phtml
@@ -37,11 +37,10 @@
 </p>
 <script>
     function switchStore(obj){
-        var storeParam = obj.value ? 'store_ids/' + obj.value + '/' : '';
-        if(obj.switchParams){
-            storeParam+= obj.switchParams;
-        }
-        setLocation('<?= $this->getSwitchUrl() ?>'+storeParam);
+        setLocation(setRouteParams('<?= $this->getSwitchUrl() ?>', {
+            store_ids: obj.value || null,
+            ...parseRouteParams(obj.switchParams),
+        }));
     }
 </script>
 <?php endif ?>

--- a/app/design/adminhtml/default/default/template/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher.phtml
@@ -38,20 +38,20 @@
 </p>
 <script>
     function switchStore(obj) {
-        var storeParam = obj.value ? 'store/' + obj.value + '/' : '';
-        if (obj.switchParams) {
-            storeParam += obj.switchParams;
-        }
+        const url = setRouteParams('<?= $this->getSwitchUrl() ?>', {
+            store: obj.value || null,
+            ...parseRouteParams(obj.switchParams),
+        });
     <?php if ($this->getUseConfirm()): ?>
         if (confirm('<?= $this->jsQuoteEscape($this->__('Please confirm site switching. All data that hasn\'t been saved will be lost.')) ?>')) {
-            setLocation('<?= $this->getSwitchUrl() ?>' + storeParam);
+            setLocation(url);
             return true;
         } else {
             obj.value = '<?= $this->getStoreId() ?>';
         }
         return false;
     <?php else: ?>
-        setLocation('<?= $this->getSwitchUrl() ?>' + storeParam);
+        setLocation(url);
     <?php endif ?>
     }
 </script>

--- a/app/design/adminhtml/default/default/template/store/switcher.phtml
+++ b/app/design/adminhtml/default/default/template/store/switcher.phtml
@@ -40,7 +40,7 @@
     function switchStore(obj) {
         const url = setRouteParams('<?= $this->getSwitchUrl() ?>', {
             store: obj.value || null,
-            ...parseRouteParams(obj.switchParams),
+            ...obj.switchParams,
         });
     <?php if ($this->getUseConfirm()): ?>
         if (confirm('<?= $this->jsQuoteEscape($this->__('Please confirm site switching. All data that hasn\'t been saved will be lost.')) ?>')) {

--- a/public/js/varien/js.js
+++ b/public/js/varien/js.js
@@ -197,6 +197,20 @@ function setRouteParams(url, params = {}) {
 }
 
 /**
+ * Parse Varien type route params, i.e. /id/1/, into an object usable by setRouteParams()
+ *
+ * @param {string} params - route params, with or without surrounding slashes
+ */
+function parseRouteParams(params) {
+    const parts = String(params ?? '').split('/').filter((part) => part !== '');
+    const result = {};
+    for (let i = 0; i < parts.length; i += 2) {
+        result[parts[i]] = parts[i + 1] ?? '';
+    }
+    return result;
+}
+
+/**
  * Set query params, i.e. ?id=1
  *
  * @param {string} url - the base URL

--- a/public/js/varien/js.js
+++ b/public/js/varien/js.js
@@ -197,20 +197,6 @@ function setRouteParams(url, params = {}) {
 }
 
 /**
- * Parse Varien type route params, i.e. /id/1/, into an object usable by setRouteParams()
- *
- * @param {string} params - route params, with or without surrounding slashes
- */
-function parseRouteParams(params) {
-    const parts = String(params ?? '').split('/').filter((part) => part !== '');
-    const result = {};
-    for (let i = 0; i < parts.length; i += 2) {
-        result[parts[i]] = parts[i + 1] ?? '';
-    }
-    return result;
-}
-
-/**
  * Set query params, i.e. ?id=1
  *
  * @param {string} url - the base URL

--- a/tests/Browser/AdminQueryStringUrlsTest.php
+++ b/tests/Browser/AdminQueryStringUrlsTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Tests\Browser\MahoServer;
+use Tests\MahoBrowserTestCase;
+
+uses(MahoBrowserTestCase::class)->group('browser');
+
+/**
+ * Regression for admin screens that append route params to a url built with _current => true.
+ *
+ * setLocation() puts ?form_key=... on every same-origin navigation, so any page reached
+ * through a button carries a query string, and _current copies it into the next url. Code
+ * that then concatenates "key/value/" onto that url writes the segment into the last query
+ * param's value instead of the path, and the param never arrives. Same defect as the store
+ * switcher; these are the two other places that had it.
+ *
+ * Secret keys are turned off for the run so the screens can be addressed directly.
+ */
+
+const QUERY_URLS_ADMIN_USER = 'query-urls-admin';
+const QUERY_URLS_ADMIN_PASSWORD = 'Password123!';
+
+beforeEach(function () {
+    Mage::getModel('core/config')->saveConfig(Mage_Adminhtml_Helper_Data::XML_PATH_ADMINHTML_SECURITY_USE_FORM_KEY, 0);
+    Mage::app()->cleanCache();
+
+    createQueryUrlsAdmin();
+});
+
+afterEach(function () {
+    deleteQueryUrlsAdmin();
+
+    Mage::getModel('core/config')->deleteConfig(Mage_Adminhtml_Helper_Data::XML_PATH_ADMINHTML_SECURITY_USE_FORM_KEY);
+    Mage::app()->getStore()->resetConfig();
+    Mage::app()->cleanCache();
+});
+
+function deleteQueryUrlsAdmin(): void
+{
+    $user = Mage::getModel('admin/user')->loadByUsername(QUERY_URLS_ADMIN_USER);
+    if ($user->getId()) {
+        $user->delete();
+    }
+}
+
+/** A fresh admin with the full-access role, so the password is known and ACL never gets in the way. */
+function createQueryUrlsAdmin(): void
+{
+    deleteQueryUrlsAdmin();
+
+    $user = Mage::getModel('admin/user')
+        ->setUsername(QUERY_URLS_ADMIN_USER)
+        ->setFirstname('Query')
+        ->setLastname('Urls')
+        ->setEmail('query-urls@example.test')
+        ->setPassword(QUERY_URLS_ADMIN_PASSWORD)
+        ->setIsActive(1)
+        ->save();
+
+    $roleId = Mage::getModel('admin/role')->getCollection()
+        ->addFieldToFilter('role_type', Mage_Admin_Model_Acl::ROLE_TYPE_GROUP)
+        ->setPageSize(1)
+        ->getFirstItem()
+        ->getId();
+
+    Mage::getModel('admin/user')->load($user->getId())->setRoleIds([$roleId])->saveRelations();
+}
+
+/** Log in and open an admin page, waiting for one of its elements. */
+function visitAdminPage(string $path, string $selector): object
+{
+    $page = visit(MahoServer::baseUrl() . '/admin')
+        ->fill('#username', QUERY_URLS_ADMIN_USER)
+        ->fill('#login', QUERY_URLS_ADMIN_PASSWORD)
+        ->click('#step1 input[type="submit"]');
+
+    waitForPageLoad($page, '.nav-bar:visible');
+    $page->navigate(MahoServer::baseUrl() . $path);
+
+    return waitForPageLoad($page, $selector);
+}
+
+/**
+ * Run the report for a date range and land on the page it navigates to.
+ *
+ * The filter form is on the page being left too, so no element gate tells the two apart:
+ * the sleep covers the navigation starting, which waitForPageLoad() can't.
+ */
+function submitReportFilter(object $page, string $from, string $to): string
+{
+    $page->fill('#sales_report_from', $from)
+        ->fill('#sales_report_to', $to)
+        ->click('Show Report')
+        ->wait(2);
+
+    return waitForPageLoad($page, '#filter_form')->url();
+}
+
+it('keeps the report filter in the path when the report is run twice', function () {
+    // The first run navigates through setLocation(), so the second one starts from a url
+    // that already carries ?form_key=... - which is where the segment used to land.
+    $page = visitAdminPage('/admin/report_product/viewed', '#filter_form');
+    $first = submitReportFilter($page, '2026-07-01', '2026-07-31');
+    $second = submitReportFilter($page, '2026-06-01', '2026-06-30');
+
+    expect(parse_url($second, PHP_URL_QUERY))->not->toContain('filter')
+        ->and(parse_url($second, PHP_URL_PATH))->toContain('/filter/')
+        ->and(parse_url($second, PHP_URL_PATH))->not->toBe(parse_url($first, PHP_URL_PATH));
+});
+
+it('reloads the dashboard diagram when the period changes on a url with a query string', function () {
+    $page = visitAdminPage('/admin/dashboard/?form_key=PestDashboardFormKey', '#order_orders_period');
+
+    // ajaxBlock answers with an empty body when it gets no block param, which pre-fix is
+    // exactly what happened: "block/tab_orders/" went into the form key's value.
+    $page->select('#order_orders_period', '1y')->wait(2);
+
+    expect(trim((string) $page->page()->locator('#diagram_tab_orders_content')->innerHTML()))->not->toBe('');
+});

--- a/tests/Browser/AdminStoreSwitcherTest.php
+++ b/tests/Browser/AdminStoreSwitcherTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Tests\Browser\MahoServer;
+use Tests\MahoBrowserTestCase;
+
+uses(MahoBrowserTestCase::class)->group('browser');
+
+/**
+ * Regression for the admin store switcher corrupting a url that ends in a query string.
+ *
+ * getSwitchUrl() carries the current query string over, so on a grid reached with one
+ * (?form_key=... in the report) the switcher's "store/<id>/" used to be concatenated onto
+ * the last query param's *value*: the store view never arrived, the form key came back
+ * corrupted, and repeated switches accumulated. Only a browser exercises that js.
+ *
+ * Secret keys are turned off for the run so the grid can be addressed directly; the query
+ * string the switcher has to preserve is therefore supplied by the test itself.
+ */
+
+const STORE_SWITCHER_ADMIN_USER = 'store-switcher-admin';
+const STORE_SWITCHER_ADMIN_PASSWORD = 'Password123!';
+const STORE_SWITCHER_QUERY = 'form_key=PestStoreSwitcherFormKey';
+
+beforeEach(function () {
+    Mage::getModel('core/config')->saveConfig(Mage_Adminhtml_Helper_Data::XML_PATH_ADMINHTML_SECURITY_USE_FORM_KEY, 0);
+    Mage::app()->cleanCache();
+
+    createStoreSwitcherAdmin();
+});
+
+afterEach(function () {
+    deleteStoreSwitcherAdmin();
+
+    Mage::getModel('core/config')->deleteConfig(Mage_Adminhtml_Helper_Data::XML_PATH_ADMINHTML_SECURITY_USE_FORM_KEY);
+    Mage::app()->getStore()->resetConfig();
+    Mage::app()->cleanCache();
+});
+
+function deleteStoreSwitcherAdmin(): void
+{
+    $user = Mage::getModel('admin/user')->loadByUsername(STORE_SWITCHER_ADMIN_USER);
+    if ($user->getId()) {
+        $user->delete();
+    }
+}
+
+/** A fresh admin with the full-access role, so the password is known and ACL never gets in the way. */
+function createStoreSwitcherAdmin(): void
+{
+    deleteStoreSwitcherAdmin();
+
+    $user = Mage::getModel('admin/user')
+        ->setUsername(STORE_SWITCHER_ADMIN_USER)
+        ->setFirstname('Store')
+        ->setLastname('Switcher')
+        ->setEmail('store-switcher@example.test')
+        ->setPassword(STORE_SWITCHER_ADMIN_PASSWORD)
+        ->setIsActive(1)
+        ->save();
+
+    $roleId = Mage::getModel('admin/role')->getCollection()
+        ->addFieldToFilter('role_type', Mage_Admin_Model_Acl::ROLE_TYPE_GROUP)
+        ->setPageSize(1)
+        ->getFirstItem()
+        ->getId();
+
+    Mage::getModel('admin/user')->load($user->getId())->setRoleIds([$roleId])->saveRelations();
+}
+
+/** The first switchable store view. */
+function storeSwitcherStoreId(): int
+{
+    return (int) array_key_first(Mage::app()->getStores());
+}
+
+/** Log in and open the product grid with a query string on it. */
+function visitProductGridWithQuery(): object
+{
+    $page = visit(MahoServer::baseUrl() . '/admin')
+        ->fill('#username', STORE_SWITCHER_ADMIN_USER)
+        ->fill('#login', STORE_SWITCHER_ADMIN_PASSWORD)
+        ->click('#step1 input[type="submit"]');
+
+    waitForPageLoad($page, '.nav-bar:visible');
+    $page->navigate(MahoServer::baseUrl() . '/admin/catalog_product/index/?' . STORE_SWITCHER_QUERY);
+
+    return waitForPageLoad($page, '#store_switcher');
+}
+
+/**
+ * Pick a store view and land on the page it navigates to.
+ *
+ * The switcher is on the page being left too, so no element gate tells the two apart:
+ * the sleep covers the navigation starting, which waitForPageLoad() can't.
+ */
+function switchStoreView(object $page, string $value): object
+{
+    $page->select('#store_switcher', $value)->wait(2);
+
+    return waitForPageLoad($page, '#store_switcher');
+}
+
+it('puts the store view in the path and leaves the query string alone', function () {
+    $storeId = storeSwitcherStoreId();
+
+    $url = switchStoreView(visitProductGridWithQuery(), (string) $storeId)->url();
+
+    // Pre-fix both fail: the segment landed in the query as "?form_key=<key>store/<id>/".
+    expect(parse_url($url, PHP_URL_PATH))->toContain('/store/' . $storeId . '/')
+        ->and(parse_url($url, PHP_URL_QUERY))->toBe(STORE_SWITCHER_QUERY);
+});
+
+it('drops the store view again when switching back to all store views', function () {
+    $page = switchStoreView(visitProductGridWithQuery(), (string) storeSwitcherStoreId());
+
+    // Pre-fix the segments piled up, one per switch, inside the query param's value.
+    $url = switchStoreView($page, '')->url();
+
+    expect(parse_url($url, PHP_URL_PATH))->not->toContain('/store/')
+        ->and(parse_url($url, PHP_URL_QUERY))->toBe(STORE_SWITCHER_QUERY);
+});


### PR DESCRIPTION
Fixes #1202.

`setLocation()` appends `?form_key=...` to every same-origin admin navigation (`addAdminFormKey()`, tools.js, added in 03d2a9a7 / #1036, shipped in 26.7.0), and `getUrl(..., ['_current' => true])` copies the current query string into the URL it builds. Any code that then concatenates `key/value/` onto that URL writes the segment into the last query param's *value* instead of the path: the param never arrives, the form key comes back corrupted, and repeated actions accumulate. The concatenation is inherited M1 code that was harmless until admin URLs started carrying a query string. Three screens did it.

**Store switcher** (the reported one) — all four templates now build the target with `setRouteParams()`, which edits the path and leaves the query alone. `switchParams` (set only by the product edit page, to carry the active tab) is now an object spread into those params instead of an `active_tab/<name>/` string; the dead `switchParams` handling in the dashboard and report switchers, where nothing ever sets it, is gone. Note for extensions: anything assigning the old string form to `store_switcher.switchParams` needs to assign `{ active_tab: '...' }` instead.

While in there: the dashboard and report switchers now null the unselected scope params too. `getSwitchUrl()` only drops `store`, so with `_current` a stale `website/1/` survived, and those blocks read store → website → group in that order, silently ignoring the new selection.

**Report filter** (`report/grid/container.phtml`) — "Show Report" navigates via `setLocation()`, so running a report a second time buried `filter/<base64>/` inside the form key and the report came back unfiltered. All nine `getFilterUrl()` implementations are `_current => true`.

**Dashboard period** (`dashboard/index.phtml`) — after any `setLocation()` navigation (e.g. switching store view), changing the diagram period sent `ajaxBlock` no `block` param, which answers with an empty body and wiped the diagram.

Tests are in the browser suite since all of this is js: `AdminStoreSwitcherTest` (segment lands in the path, query untouched, and switching back to All Store Views drops it again) and `AdminQueryStringUrlsTest` (report run twice, dashboard period change). All fail without the fix.

Checked and left alone: `grid.js::_addVarToUrl` is hand-rolled but correct (splits the query off and re-appends it); the locale switcher, global search and review product link concatenate onto a plain `getUrl()` with no `_current`; the product duplicate URL appends a query param and already picks `?` vs `&`.