### PR TITLE
Replaced hand-rolled API field stripping, row ownership checks and duplicate permission gates with declarative API Platform security

### DIFF
--- a/app/code/core/Mage/Catalog/Api/CategoryProcessor.php
+++ b/app/code/core/Mage/Catalog/Api/CategoryProcessor.php
@@ -330,8 +330,6 @@ final class CategoryProcessor extends \Maho\ApiPlatform\Processor
             return null;
         }
 
-        $this->requireAdminOrApiUser('Layout updates require admin or API access');
-
         /** @var \Mage_Adminhtml_Model_LayoutUpdate_Validator $validator */
         $validator = Mage::getModel('adminhtml/layoutUpdate_validator');
         try {

--- a/app/code/core/Mage/Catalog/Api/Product.php
+++ b/app/code/core/Mage/Catalog/Api/Product.php
@@ -199,7 +199,7 @@ class Product extends CrudResource
     public ?string $specialToDate = null;
 
     #[Groups(['product:read'])]
-    #[ApiProperty(description: 'Product cost; only returned to admin and API tokens')]
+    #[ApiProperty(description: 'Product cost; only visible to admin and API tokens', security: "is_back_office('products')")]
     public ?float $cost = null;
 
     #[Groups(['product:read'])]
@@ -275,19 +275,19 @@ class Product extends CrudResource
     public ?string $metaRobots = null;
 
     #[Groups(['product:read'])]
-    #[ApiProperty(description: 'Custom design/theme override')]
+    #[ApiProperty(description: 'Custom design/theme override; only visible to admin and API tokens', security: "is_back_office('products')")]
     public ?string $customDesign = null;
 
     #[Groups(['product:read'])]
-    #[ApiProperty(description: 'Custom design active from date (Y-m-d); empty string clears it')]
+    #[ApiProperty(description: 'Custom design active from date (Y-m-d); empty string clears it; only visible to admin and API tokens', security: "is_back_office('products')")]
     public ?string $customDesignFrom = null;
 
     #[Groups(['product:read'])]
-    #[ApiProperty(description: 'Custom design active to date (Y-m-d); empty string clears it')]
+    #[ApiProperty(description: 'Custom design active to date (Y-m-d); empty string clears it; only visible to admin and API tokens', security: "is_back_office('products')")]
     public ?string $customDesignTo = null;
 
     #[Groups(['product:read'])]
-    #[ApiProperty(description: 'Custom layout update XML')]
+    #[ApiProperty(description: 'Custom layout update XML; only visible to admin and API tokens', security: "is_back_office('products')")]
     public ?string $customLayoutUpdate = null;
 
     #[Groups(['product:read'])]
@@ -483,7 +483,7 @@ class Product extends CrudResource
 
     /** @var array<string, mixed>|null User-defined EAV attribute values keyed by attribute_code (read counterpart of customAttributesWrite) */
     #[Groups(['product:detail'])]
-    #[ApiProperty(description: 'User-defined EAV attribute values keyed by attribute_code; only returned to admin and API tokens', writable: false, extraProperties: ['computed' => true])]
+    #[ApiProperty(description: 'User-defined EAV attribute values keyed by attribute_code; only visible to admin and API tokens', writable: false, security: "is_back_office('products')", extraProperties: ['computed' => true])]
     public ?array $customAttributes = null;
 
     /** @var array<string, mixed>|null Full inventory settings keyed by cataloginventory_stock_item column */

--- a/app/code/core/Mage/Catalog/Api/ProductProvider.php
+++ b/app/code/core/Mage/Catalog/Api/ProductProvider.php
@@ -34,21 +34,6 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
 
     private ?bool $backOfficeReader = null;
 
-    /**
-     * Stock item columns that describe back-office inventory policy rather than
-     * anything a shopper can act on: the out-of-stock threshold, the admin
-     * low-stock alert level, the backorder policy and whether stock is tracked
-     * at all. Every `use_config_*` flag joins them, being pure admin config
-     * inheritance metadata.
-     */
-    private const BACK_OFFICE_STOCK_COLUMNS = [
-        'min_qty' => true,
-        'notify_stock_qty' => true,
-        'backorders' => true,
-        'low_stock_date' => true,
-        'manage_stock' => true,
-    ];
-
     private function getMediaConfig(): \Mage_Catalog_Model_Product_Media_Config
     {
         return $this->mediaConfig ??= \Mage::getModel('catalog/product_media_config');
@@ -92,55 +77,6 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
     }
 
     /**
-     * Strip back-office-only fields from a DTO on its way to the response.
-     *
-     * The response cache has no auth dimension (admin, service token and guest
-     * all resolve to customer group 0), so the cached payload must stay the same
-     * for everyone and the filtering has to happen per request, after the cache
-     * is read. Every provider path that can return a cached DTO runs this.
-     */
-    private function filterForCaller(?Product $dto): ?Product
-    {
-        if ($dto !== null && !$this->isBackOfficeReader()) {
-            $this->stripBackOfficeData($dto);
-        }
-        return $dto;
-    }
-
-    /**
-     * @param Product[] $dtos
-     * @return Product[]
-     */
-    private function filterListForCaller(array $dtos): array
-    {
-        if (!$this->isBackOfficeReader()) {
-            foreach ($dtos as $dto) {
-                $this->stripBackOfficeData($dto);
-            }
-        }
-        return $dtos;
-    }
-
-    private function stripBackOfficeData(Product $dto): void
-    {
-        $dto->cost = null;
-        $dto->customAttributes = null;
-        $dto->customDesign = null;
-        $dto->customDesignFrom = null;
-        $dto->customDesignTo = null;
-        $dto->customLayoutUpdate = null;
-
-        if ($dto->stockItem === null) {
-            return;
-        }
-        foreach (array_keys($dto->stockItem) as $column) {
-            if (isset(self::BACK_OFFICE_STOCK_COLUMNS[$column]) || str_starts_with((string) $column, 'use_config_')) {
-                unset($dto->stockItem[$column]);
-            }
-        }
-    }
-
-    /**
      * Display currency the cached prices are converted to.
      */
     private function resolveCurrencyCode(): string
@@ -179,7 +115,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
                 if ($this->isBackOfficeReader()) {
                     $dto = $this->assertBackOfficeProductAccess($dto);
                 }
-                return $this->singleItemPaginator($this->filterForCaller($dto));
+                return $this->singleItemPaginator($dto);
             }
             $barcode = $context['args']['barcode'] ?? null;
             if ($barcode) {
@@ -187,7 +123,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
                 if ($this->isBackOfficeReader()) {
                     $dto = $this->assertBackOfficeProductAccess($dto);
                 }
-                return $this->singleItemPaginator($this->filterForCaller($dto));
+                return $this->singleItemPaginator($dto);
             }
             return $this->getCollection($context);
         }
@@ -201,10 +137,10 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
     private function getItem(int $id): ?Product
     {
         // Back-office readers may load disabled and other-website products (and
-        // raw global values via ?store=admin). Bypass the shared DTO cache both
-        // ways so their unfiltered view never leaks into anonymous reads.
+        // raw global values via ?store=admin), so they bypass the shared DTO
+        // cache, whose key has no auth dimension.
         if ($this->isBackOfficeReader()) {
-            return $this->filterForCaller($this->assertBackOfficeProductAccess($this->loadProductDto($id, visibleOnly: false)));
+            return $this->assertBackOfficeProductAccess($this->loadProductDto($id, visibleOnly: false));
         }
 
         $storeId = StoreContext::getStoreId();
@@ -216,7 +152,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         if ($cached !== false) {
             $data = \Mage::helper('core')->jsonDecode($cached, true);
             if ($data !== null) {
-                return $this->filterForCaller(Product::fromArray($data));
+                return Product::fromArray($data);
             }
         }
 
@@ -232,7 +168,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
             $this->getCacheTtl(),
         );
 
-        return $this->filterForCaller($dto);
+        return $dto;
     }
 
     /**
@@ -366,7 +302,6 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         foreach ($collection as $product) {
             $products[] = $this->toDto($product, forListing: true);
         }
-        $products = $this->filterListForCaller($products);
 
         return new TraversablePaginator(new \ArrayIterator($products), $page, $pageSize, (int) $collection->getSize());
     }
@@ -393,7 +328,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
                 $cachedData = \Mage::helper('core')->jsonDecode($cached, true);
                 if ($cachedData !== null) {
                     // Reconstruct Product DTOs from cached data
-                    $products = $this->filterListForCaller(array_map(fn($data) => Product::fromArray($data), $cachedData['products']));
+                    $products = array_map(fn($data) => Product::fromArray($data), $cachedData['products']);
                     return new TraversablePaginator(new \ArrayIterator($products), $cachedData['page'], $cachedData['pageSize'], $cachedData['total']);
                 }
             }
@@ -601,7 +536,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         }
 
         // Return paginator with total count for proper pagination
-        return new TraversablePaginator(new \ArrayIterator($this->filterListForCaller($products)), $page, $pageSize, (int) $result['total']);
+        return new TraversablePaginator(new \ArrayIterator($products), $page, $pageSize, (int) $result['total']);
     }
 
     /**
@@ -623,7 +558,8 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
      * computed fields (status/visibility enums, prices, image URLs, barcode).
      *
      * Builds the unfiltered DTO, back-office fields included: this is what the
-     * response cache stores, and filterForCaller() strips them per request.
+     * response cache stores. Serialization drops them per request, so the cached
+     * payload can stay the same for every caller.
      */
     private function enrichProduct(
         Product $dto,
@@ -670,7 +606,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
 
         if ($stockData) {
             // Full column set on purpose: this feeds the cache, and
-            // stripBackOfficeData() drops the policy columns per request.
+            // ProductStockItemNormalizer drops the policy columns per request.
             $dto->stockItem = [];
             $columns = ['qty' => 'float', 'is_in_stock' => 'bool', 'manage_stock' => 'bool'] + self::STOCK_ITEM_EXTENDED_COLUMNS;
             foreach ($columns as $column => $type) {

--- a/app/code/core/Mage/Catalog/Api/ProductProvider.php
+++ b/app/code/core/Mage/Catalog/Api/ProductProvider.php
@@ -32,8 +32,6 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
 
     private ?\Mage_Catalog_Model_Product_Media_Config $mediaConfig = null;
 
-    private ?bool $backOfficeReader = null;
-
     private function getMediaConfig(): \Mage_Catalog_Model_Product_Media_Config
     {
         return $this->mediaConfig ??= \Mage::getModel('catalog/product_media_config');
@@ -50,10 +48,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
      */
     private function isBackOfficeReader(): bool
     {
-        return $this->backOfficeReader ??= $this->isAdmin()
-            || ($this->isApiUser()
-                && ($this->getAuthorizedUser()->hasPermission('products/read')
-                    || $this->getAuthorizedUser()->hasPermission('products/write')));
+        return $this->isBackOffice('products');
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Api/ProductStockItemNormalizer.php
+++ b/app/code/core/Mage/Catalog/Api/ProductStockItemNormalizer.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Drops back-office inventory policy columns from a serialized Product.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Mage_Catalog
+ */
+
+declare(strict_types=1);
+
+namespace Mage\Catalog\Api;
+
+use Maho\ApiPlatform\Security\BackOfficeAccess;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * `stockItem` is a column-keyed map rather than a typed sub-resource, so
+ * `#[ApiProperty(security: ...)]` cannot reach the individual columns; this
+ * normalizer applies the same `is_back_office('products')` rule to the keys.
+ *
+ * The columns it removes describe inventory policy, not availability: the
+ * out-of-stock threshold, the admin low-stock alert level, the backorder policy
+ * and whether stock is tracked at all, plus every `use_config_*` flag (pure
+ * admin config-inheritance metadata). Shopper-relevant columns (qty,
+ * is_in_stock, sale quantity bounds, qty increments) stay public.
+ */
+final class ProductStockItemNormalizer implements NormalizerInterface, NormalizerAwareInterface
+{
+    use NormalizerAwareTrait;
+
+    private const ALREADY_CALLED = 'maho_product_stock_item_normalizer';
+
+    private const BACK_OFFICE_COLUMNS = [
+        'min_qty' => true,
+        'notify_stock_qty' => true,
+        'backorders' => true,
+        'low_stock_date' => true,
+        'manage_stock' => true,
+    ];
+
+    public function __construct(private readonly AuthorizationCheckerInterface $authorizationChecker) {}
+
+    #[\Override]
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Product && !isset($context[self::ALREADY_CALLED]);
+    }
+
+    /** @return array<class-string, bool> false: support depends on the context, so the decision is not cacheable */
+    #[\Override]
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Product::class => false];
+    }
+
+    /** @return array<array-key, mixed>|string|int|float|bool|\ArrayObject<array-key, mixed>|null */
+    #[\Override]
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $context[self::ALREADY_CALLED] = true;
+        $data = $this->normalizer->normalize($data, $format, $context);
+
+        if (!is_array($data)
+            || !is_array($data['stockItem'] ?? null)
+            || BackOfficeAccess::isGrantedBy($this->authorizationChecker->isGranted(...), 'products')
+        ) {
+            return $data;
+        }
+
+        foreach (array_keys($data['stockItem']) as $column) {
+            if (isset(self::BACK_OFFICE_COLUMNS[$column]) || str_starts_with((string) $column, 'use_config_')) {
+                unset($data['stockItem'][$column]);
+            }
+        }
+
+        return $data;
+    }
+}

--- a/app/code/core/Mage/Catalog/Api/ProductStockItemNormalizer.php
+++ b/app/code/core/Mage/Catalog/Api/ProductStockItemNormalizer.php
@@ -33,6 +33,8 @@ final class ProductStockItemNormalizer implements NormalizerInterface, Normalize
 {
     use NormalizerAwareTrait;
 
+    // Propagates into nested normalizations: fine while variants/linked
+    // products are plain arrays, not Product DTOs with their own stockItem.
     private const ALREADY_CALLED = 'maho_product_stock_item_normalizer';
 
     private const BACK_OFFICE_COLUMNS = [

--- a/app/code/core/Mage/CatalogInventory/Api/StockUpdateProcessor.php
+++ b/app/code/core/Mage/CatalogInventory/Api/StockUpdateProcessor.php
@@ -28,8 +28,6 @@ final class StockUpdateProcessor extends \Maho\ApiPlatform\Processor
     #[\Override]
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): StockUpdate
     {
-        $this->requireAdminOrApiUser('Stock update requires admin or API access');
-        $this->requireApiPermission('inventory/write');
         $operationName = $operation->getName();
 
         return match ($operationName) {

--- a/app/code/core/Mage/Checkout/Api/CartProvider.php
+++ b/app/code/core/Mage/Checkout/Api/CartProvider.php
@@ -63,11 +63,14 @@ final class CartProvider extends \Maho\ApiPlatform\Provider
             return null;
         }
 
+        // isBackOffice: admin, or a service token holding a carts grant. A bare
+        // api_user token without the grant must NOT bypass cart ownership
+        // (mirrors the write side's isPrivilegedCartActor()).
         $this->cartService->verifyCartAccess(
             $quote,
             $byMasked,
             $this->getAuthenticatedCustomerId(),
-            $this->isPrivilegedCartReader(),
+            $this->isBackOffice('carts'),
         );
 
         // Guest sub-resource endpoints return a bare, focused JSON shape (not the
@@ -83,18 +86,5 @@ final class CartProvider extends \Maho\ApiPlatform\Provider
         }
 
         return $this->cartMapper->mapQuoteToCart($quote);
-    }
-
-    /**
-     * Admin, or an API service account holding carts/read. A bare api_user token
-     * without the grant must NOT bypass cart ownership (mirrors the write side's
-     * isPrivilegedCartActor()).
-     */
-    private function isPrivilegedCartReader(): bool
-    {
-        if ($this->isAdmin()) {
-            return true;
-        }
-        return $this->isApiUser() && $this->getAuthorizedUser()->hasPermission('carts/read');
     }
 }

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -12,7 +12,6 @@ namespace Mage\Checkout\Api;
 
 use Maho\ApiPlatform\Service\StoreContext;
 use Maho\ApiPlatform\Service\StoreDefaults;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -192,9 +191,11 @@ class CartService
     }
 
     /**
-     * Verify the caller has access to this cart.
+     * Verify the caller has access to this cart. Denials are 404, not 403:
+     * cart ids are enumerable ints, so a status that differs from the
+     * missing-cart response would leak which ids exist.
      *
-     * @throws AccessDeniedHttpException
+     * @throws NotFoundHttpException
      */
     public function verifyCartAccess(
         \Mage_Sales_Model_Quote $quote,
@@ -212,7 +213,7 @@ class CartService
         // Customer-owned cart: verify ownership
         if ($cartCustomerId !== null) {
             if ($authenticatedCustomerId === null || $cartCustomerId !== $authenticatedCustomerId) {
-                throw new AccessDeniedHttpException('You can only access your own cart');
+                throw new NotFoundHttpException('Cart not found');
             }
             return;
         }
@@ -221,7 +222,7 @@ class CartService
         // path is enumerable, so even authenticated customers must not see
         // someone else's pre-login cart through it.
         if (!$accessedByMaskedId) {
-            throw new AccessDeniedHttpException('Guest carts must be accessed via masked ID');
+            throw new NotFoundHttpException('Cart not found');
         }
     }
 

--- a/app/code/core/Mage/Cms/Api/CmsPage.php
+++ b/app/code/core/Mage/Cms/Api/CmsPage.php
@@ -96,18 +96,27 @@ class CmsPage extends CrudResource
 
     public ?int $sortOrder = null;
 
+    // Design and layout internals: the layout update is executable markup and
+    // the theme assignment leaks the storefront's internals, while page reads
+    // are public. Back-office callers only, in both directions.
+    #[ApiProperty(security: "is_back_office('cms-pages')")]
     public ?string $layoutUpdateXml = null;
 
+    #[ApiProperty(security: "is_back_office('cms-pages')")]
     public ?string $customTheme = null;
 
+    #[ApiProperty(security: "is_back_office('cms-pages')")]
     public ?string $customRootTemplate = null;
 
+    #[ApiProperty(security: "is_back_office('cms-pages')")]
     public ?string $customLayoutUpdateXml = null;
 
     /** Date string (Y-m-d); empty string clears */
+    #[ApiProperty(security: "is_back_office('cms-pages')")]
     public ?string $customThemeFrom = null;
 
     /** Date string (Y-m-d); empty string clears */
+    #[ApiProperty(security: "is_back_office('cms-pages')")]
     public ?string $customThemeTo = null;
 
     /** One of INDEX,FOLLOW / NOINDEX,FOLLOW / INDEX,NOFOLLOW / NOINDEX,NOFOLLOW; empty string clears */

--- a/app/code/core/Mage/Cms/Api/CmsPageProcessor.php
+++ b/app/code/core/Mage/Cms/Api/CmsPageProcessor.php
@@ -93,8 +93,6 @@ final class CmsPageProcessor extends CrudProcessor
             return null;
         }
 
-        $this->requireAdminOrApiUser('Layout updates require admin or API access');
-
         /** @var \Mage_Adminhtml_Model_LayoutUpdate_Validator $validator */
         $validator = \Mage::getModel('adminhtml/layoutUpdate_validator');
         try {

--- a/app/code/core/Mage/Cms/Api/CmsPageProvider.php
+++ b/app/code/core/Mage/Cms/Api/CmsPageProvider.php
@@ -13,15 +13,14 @@ namespace Mage\Cms\Api;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Operation;
 use Maho\ApiPlatform\CrudProvider;
-use Maho\ApiPlatform\Resource;
 use Maho\ApiPlatform\Service\StoreContext;
 
 /**
  * CMS Page Provider, extends CrudProvider with page-specific filters and named queries.
  *
  * All field mapping and DTO construction is handled by CrudResource/CrudProvider.
- * This class only adds collection filters, identifier-based lookups and the
- * caller-aware gating of the design fields.
+ * This class only adds collection filters and identifier-based lookups; the
+ * design fields gate themselves through their own `#[ApiProperty(security:)]`.
  */
 final class CmsPageProvider extends CrudProvider
 {
@@ -52,29 +51,6 @@ final class CmsPageProvider extends CrudProvider
         }
 
         return parent::provide($operation, $uriVariables, $context);
-    }
-
-    /**
-     * Design and layout internals are back-office data: the layout update is
-     * executable markup and the theme assignment leaks the storefront's internals.
-     * Page reads are public, so only admin and API tokens see them. Every read path
-     * (item by id, item by identifier, collection, GraphQL) builds its DTO here.
-     */
-    #[\Override]
-    public function toDto(object $model): Resource
-    {
-        $dto = parent::toDto($model);
-
-        if ($dto instanceof CmsPage && !$this->isBackOfficeReader()) {
-            $dto->layoutUpdateXml = null;
-            $dto->customLayoutUpdateXml = null;
-            $dto->customTheme = null;
-            $dto->customRootTemplate = null;
-            $dto->customThemeFrom = null;
-            $dto->customThemeTo = null;
-        }
-
-        return $dto;
     }
 
     #[\Override]

--- a/app/code/core/Mage/Cms/Api/MediaProvider.php
+++ b/app/code/core/Mage/Cms/Api/MediaProvider.php
@@ -46,9 +46,6 @@ final class MediaProvider implements ProviderInterface
     #[\Override]
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): array
     {
-        // requireApiPermission() short-circuits for admin tokens (Maho ACL gates those)
-        $this->requireApiPermission('media/read');
-
         return $this->listFiles();
     }
 

--- a/app/code/core/Mage/Customer/Api/Address.php
+++ b/app/code/core/Mage/Customer/Api/Address.php
@@ -23,6 +23,7 @@ use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\GraphQl\Mutation;
 use ApiPlatform\Metadata\GraphQl\DeleteMutation;
 use Maho\ApiPlatform\CrudResource;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 #[ApiResource(
     mahoSection: 'Customers',
@@ -36,7 +37,10 @@ use Maho\ApiPlatform\CrudResource;
         new Get(
             uriTemplate: '/addresses/{id}',
             description: 'Get a specific address by ID',
-            security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('addresses/read')",
+            // Row-level: post-read ownership, denial maps to 404 so a foreign
+            // id is indistinguishable from a missing one.
+            security: "is_back_office('addresses') or is_owner(object, 'customerId')",
+            exceptionToStatus: [AccessDeniedException::class => 404],
         ),
         new Put(
             uriTemplate: '/addresses/{id}',
@@ -76,7 +80,8 @@ use Maho\ApiPlatform\CrudResource;
             name: 'get_me_address',
             uriTemplate: '/customers/me/addresses/{id}',
             description: 'Get an address for the authenticated customer',
-            security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('addresses/read')",
+            security: "is_back_office('addresses') or is_owner(object, 'customerId')",
+            exceptionToStatus: [AccessDeniedException::class => 404],
         ),
         new Put(
             name: 'update_me_address',
@@ -110,7 +115,8 @@ use Maho\ApiPlatform\CrudResource;
         ),
     ],
     graphQlOperations: [
-        new Query(name: 'item_query', description: 'Get an address by ID', security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('addresses/read')"),
+        // Row-level denial is converted to a null result by OwnershipDenialProvider.
+        new Query(name: 'item_query', description: 'Get an address by ID', security: "is_back_office('addresses') or is_owner(object, 'customerId')"),
         new QueryCollection(name: 'collection_query', description: 'Get addresses', security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('addresses/read')"),
         // Named 'my' → field `myAddresses` (not `myAddressesAddresses`).
         new QueryCollection(

--- a/app/code/core/Mage/Customer/Api/AddressProcessor.php
+++ b/app/code/core/Mage/Customer/Api/AddressProcessor.php
@@ -18,7 +18,6 @@ use Maho\ApiPlatform\Service\StoreContext;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
  * Address State Processor - Handles address mutations.
@@ -159,9 +158,10 @@ final class AddressProcessor extends \Maho\ApiPlatform\Processor
             throw new NotFoundHttpException('Address not found');
         }
 
-        // Verify address belongs to the customer
+        // Another customer's address is reported exactly like a missing one: a
+        // 403 here and a 404 there would make the endpoint an address-id oracle.
         if ((int) $address->getCustomerId() !== (int) $customer->getId()) {
-            throw new AccessDeniedHttpException('Address does not belong to this customer');
+            throw new NotFoundHttpException('Address not found');
         }
 
         $this->validateAddress($data);
@@ -217,9 +217,10 @@ final class AddressProcessor extends \Maho\ApiPlatform\Processor
             throw new NotFoundHttpException('Address not found');
         }
 
-        // Verify address belongs to the customer
+        // Another customer's address is reported exactly like a missing one: a
+        // 403 here and a 404 there would make the endpoint an address-id oracle.
         if ((int) $address->getCustomerId() !== (int) $customer->getId()) {
-            throw new AccessDeniedHttpException('Address does not belong to this customer');
+            throw new NotFoundHttpException('Address not found');
         }
 
         try {

--- a/app/code/core/Mage/Customer/Api/AddressProvider.php
+++ b/app/code/core/Mage/Customer/Api/AddressProvider.php
@@ -55,65 +55,51 @@ final class AddressProvider extends \Maho\ApiPlatform\Provider
             return $this->getCollection($customer);
         }
 
-        $customerId = (int) ($uriVariables['customerId'] ?? 0);
-        $addressId = (int) ($uriVariables['id'] ?? 0);
-
-        // Check if this is a /customers/me/* route (uses authenticated customer)
-        $isMeRoute = str_contains($operationName, '_me_') || str_starts_with($operationName, 'get_me') || str_starts_with($operationName, 'get_my');
-
-        // For simple /addresses/{id} routes - load address first to get customerId.
-        // The owner is derived from an id the caller supplied, so an address
-        // belonging to someone else must be reported exactly like a missing one;
-        // deferring to authorizeCustomerAccess() below would answer 403 and
-        // confirm the id exists.
-        if (!$customerId && $addressId && !$isMeRoute) {
-            $address = \Mage::getModel('customer/address')->load($addressId);
-            if (!$address->getId() || !$this->canAccessCustomer((int) $address->getCustomerId())) {
-                throw new NotFoundHttpException('Address not found');
-            }
-            $customerId = (int) $address->getCustomerId();
+        // Item lookups: ownership is not checked here. The read operations'
+        // `is_owner(object, 'customerId')` expression denies post-read (and maps
+        // to 404), and the write processor re-verifies ownership itself.
+        if (!$operation instanceof CollectionOperationInterface) {
+            return $this->getItem((int) ($uriVariables['id'] ?? 0));
         }
 
-        // For /addresses or /customers/me/addresses routes - use authenticated customer
-        if (!$customerId && ($operation instanceof CollectionOperationInterface || $isMeRoute)) {
-            $customerId = $this->getAuthenticatedCustomerId();
+        // Collections: derive the target customer and verify access, which is
+        // their only guard (a paginator can't be ownership-checked post-read).
+        $customerId = (int) ($uriVariables['customerId'] ?? 0);
+        if (!$customerId) {
+            $customerId = (int) $this->getAuthenticatedCustomerId();
         }
 
         if (!$customerId) {
             throw new NotFoundHttpException('Customer ID is required');
         }
 
-        // SECURITY: Verify the user can access this customer's addresses
         $this->authorizeCustomerAccess($customerId);
 
-        // Load customer to verify they exist
         $customer = \Mage::getModel('customer/customer')->load($customerId);
         if (!$customer->getId()) {
             throw new NotFoundHttpException('Customer not found');
         }
 
-        if ($operation instanceof CollectionOperationInterface) {
-            return $this->getCollection($customer);
-        }
-
-        return $this->getItem($customer, $addressId);
+        return $this->getCollection($customer);
     }
 
     /**
      * Get a single address by ID
      */
-    private function getItem(\Mage_Customer_Model_Customer $customer, int $addressId): ?Address
+    private function getItem(int $addressId): ?Address
     {
-        $address = \Mage::getModel('customer/address')->load($addressId);
+        if (!$addressId) {
+            return null;
+        }
 
+        $address = \Mage::getModel('customer/address')->load($addressId);
         if (!$address->getId()) {
             return null;
         }
 
-        // Another customer's address is reported exactly like a missing one: a
-        // 403 here and a 404 there would make the endpoint an address-id oracle.
-        if ((int) $address->getCustomerId() !== (int) $customer->getId()) {
-            throw new NotFoundHttpException('Address not found');
+        $customer = \Mage::getModel('customer/customer')->load((int) $address->getCustomerId());
+        if (!$customer->getId()) {
+            return null;
         }
 
         return $this->mapToDto($address, $customer);

--- a/app/code/core/Mage/Customer/Api/AddressProvider.php
+++ b/app/code/core/Mage/Customer/Api/AddressProvider.php
@@ -15,7 +15,6 @@ use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\State\Pagination\TraversablePaginator;
 use Maho\ApiPlatform\Service\StoreContext;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
  * Address State Provider - Fetches customer address data.
@@ -62,10 +61,14 @@ final class AddressProvider extends \Maho\ApiPlatform\Provider
         // Check if this is a /customers/me/* route (uses authenticated customer)
         $isMeRoute = str_contains($operationName, '_me_') || str_starts_with($operationName, 'get_me') || str_starts_with($operationName, 'get_my');
 
-        // For simple /addresses/{id} routes - load address first to get customerId
+        // For simple /addresses/{id} routes - load address first to get customerId.
+        // The owner is derived from an id the caller supplied, so an address
+        // belonging to someone else must be reported exactly like a missing one;
+        // deferring to authorizeCustomerAccess() below would answer 403 and
+        // confirm the id exists.
         if (!$customerId && $addressId && !$isMeRoute) {
             $address = \Mage::getModel('customer/address')->load($addressId);
-            if (!$address->getId()) {
+            if (!$address->getId() || !$this->canAccessCustomer((int) $address->getCustomerId())) {
                 throw new NotFoundHttpException('Address not found');
             }
             $customerId = (int) $address->getCustomerId();
@@ -107,9 +110,10 @@ final class AddressProvider extends \Maho\ApiPlatform\Provider
             return null;
         }
 
-        // Verify address belongs to the customer
+        // Another customer's address is reported exactly like a missing one: a
+        // 403 here and a 404 there would make the endpoint an address-id oracle.
         if ((int) $address->getCustomerId() !== (int) $customer->getId()) {
-            throw new AccessDeniedHttpException('Address does not belong to this customer');
+            throw new NotFoundHttpException('Address not found');
         }
 
         return $this->mapToDto($address, $customer);

--- a/app/code/core/Mage/Customer/Api/Customer.php
+++ b/app/code/core/Mage/Customer/Api/Customer.php
@@ -206,7 +206,7 @@ class Customer extends CrudResource
     #[ApiProperty(description: 'Date of birth as Y-m-d; empty string clears')]
     public ?string $dob = null;
 
-    #[ApiProperty(description: 'Tax/VAT number; admin or service token only')]
+    #[ApiProperty(description: 'Tax/VAT number; admin or service token only', securityPostDenormalize: "is_granted('ROLE_ADMIN') or is_granted('customers/create') or is_granted('customers/write')")]
     public ?string $taxvat = null;
 
     #[ApiProperty(writable: false, extraProperties: ['computed' => true])]
@@ -215,13 +215,13 @@ class Customer extends CrudResource
     #[ApiProperty(writable: false, extraProperties: ['computed' => true])]
     public bool $isSubscribed = false;
 
-    #[ApiProperty(description: 'Customer group id; admin or service token only')]
+    #[ApiProperty(description: 'Customer group id; admin or service token only', securityPostDenormalize: "is_granted('ROLE_ADMIN') or is_granted('customers/create') or is_granted('customers/write')")]
     public ?int $groupId = null;
 
-    #[ApiProperty(description: 'Account enabled flag; admin or service token only')]
+    #[ApiProperty(description: 'Account enabled flag; admin or service token only', securityPostDenormalize: "is_granted('ROLE_ADMIN') or is_granted('customers/create') or is_granted('customers/write')")]
     public ?bool $isActive = null;
 
-    #[ApiProperty(description: 'Website id; admin or service token, settable on create only')]
+    #[ApiProperty(description: 'Website id; admin or service token, settable on create only', securityPostDenormalize: "is_granted('ROLE_ADMIN') or is_granted('customers/create') or is_granted('customers/write')")]
     public ?int $websiteId = null;
 
     #[ApiProperty(writable: false)]
@@ -230,7 +230,7 @@ class Customer extends CrudResource
     #[ApiProperty(writable: false)]
     public ?string $createdIn = null;
 
-    #[ApiProperty(description: 'Exclude from automatic (VAT) group changes; admin or service token only')]
+    #[ApiProperty(description: 'Exclude from automatic (VAT) group changes; admin or service token only', securityPostDenormalize: "is_granted('ROLE_ADMIN') or is_granted('customers/create') or is_granted('customers/write')")]
     public ?bool $disableAutoGroupChange = null;
 
     /** True when the account needs no (or has completed) email confirmation */

--- a/app/code/core/Mage/Customer/Api/CustomerProcessor.php
+++ b/app/code/core/Mage/Customer/Api/CustomerProcessor.php
@@ -457,16 +457,10 @@ final class CustomerProcessor extends \Maho\ApiPlatform\Processor
 
     /**
      * Update any customer as an admin or a service token holding customers/write.
-     * The route security already excludes customer tokens; this re-checks in depth.
+     * The operation's security already excludes customer tokens.
      */
     private function updateCustomerAdmin(int $customerId, Customer $data): Customer
     {
-        if ($this->isApiUser()) {
-            $this->requireApiPermission('customers/write');
-        } else {
-            $this->requireAdmin();
-        }
-
         $customer = $this->customerService->getCustomerById($customerId);
         if (!$customer) {
             throw new NotFoundHttpException('Customer not found');

--- a/app/code/core/Mage/Customer/Api/CustomerProcessor.php
+++ b/app/code/core/Mage/Customer/Api/CustomerProcessor.php
@@ -154,12 +154,11 @@ final class CustomerProcessor extends \Maho\ApiPlatform\Processor
     {
         StoreContext::ensureStore();
 
-        // POST /customers is public (registration). Admin-only fields are accepted
-        // only from an admin or a service token holding customers/create; anyone
-        // else supplying them is rejected before the rate limiter records a hit.
+        // POST /customers is public (registration); the admin-only fields carry
+        // their own securityPostDenormalize gate, which has already reset them
+        // to their defaults for an unprivileged caller by the time we get here.
         $isPrivileged = $this->canWriteAdminFields('customers/create');
         if (!$isPrivileged) {
-            $this->assertNoAdminOnlyFields($data);
             $this->checkRateLimitByIp('create_customer', 'customer_register', 3600);
         }
 
@@ -182,7 +181,7 @@ final class CustomerProcessor extends \Maho\ApiPlatform\Processor
             if ($defaultStore) {
                 $storeId = (int) $defaultStore->getId();
             }
-            // Only privileged callers reach here (assertNoAdminOnlyFields above),
+            // websiteId only survives denormalization for a privileged caller,
             // so the authenticated ApiUser is guaranteed to exist.
             $this->assertWebsiteAllowed($websiteId, $this->getAuthorizedUser(), 'customer');
         }
@@ -516,23 +515,6 @@ final class CustomerProcessor extends \Maho\ApiPlatform\Processor
 
         $user = $this->security?->getUser();
         return $user instanceof ApiUser && $user->isApiUser() && $user->hasPermission($permission);
-    }
-
-    /** @throws AccessDeniedHttpException when a non-privileged caller supplies an admin-only field */
-    private function assertNoAdminOnlyFields(Customer $data): void
-    {
-        $adminOnly = [
-            'groupId' => $data->groupId,
-            'isActive' => $data->isActive,
-            'websiteId' => $data->websiteId,
-            'taxvat' => $data->taxvat,
-            'disableAutoGroupChange' => $data->disableAutoGroupChange,
-        ];
-        foreach ($adminOnly as $field => $value) {
-            if ($value !== null) {
-                throw new AccessDeniedHttpException("Field {$field} requires an admin or service token");
-            }
-        }
     }
 
     /**

--- a/app/code/core/Mage/Customer/Api/CustomerProvider.php
+++ b/app/code/core/Mage/Customer/Api/CustomerProvider.php
@@ -55,28 +55,15 @@ final class CustomerProvider extends \Maho\ApiPlatform\Provider
 
 
         if ($operation instanceof CollectionOperationInterface) {
-            // SECURITY: Only admins and API users with customers/read can list customers
-            if (!$this->isAdmin()) {
-                if ($this->isApiUser()) {
-                    $this->requireApiPermission('customers/read');
-                } else {
-                    $this->requireAdmin('Listing all customers requires admin or API user access');
-                }
-            }
             return $this->getCollection($context);
         }
 
-        // Single customer lookup. Admin tokens can read any customer (admins
-        // are gated by Maho ACL anyway). API-user tokens must hold the
-        // explicit customers/read permission to cross customer boundaries,
-        // otherwise a bare service-account token would let any client_credentials
-        // key dump every customer's profile + addresses. ROLE_CUSTOMER (a
-        // customer's own token) falls through to authorizeCustomerAccess(),
-        // which enforces self-only.
+        // Single customer lookup. The operation's security already limited this
+        // to admin tokens, API-user tokens holding customers/read, and a
+        // customer's own token; only the last needs a row-level check, since
+        // ROLE_CUSTOMER says nothing about *which* customer is being read.
         $requestedId = (int) ($uriVariables['id'] ?? 0);
-        if ($this->isApiUser()) {
-            $this->requireApiPermission('customers/read');
-        } elseif (!$this->isAdmin()) {
+        if (!$this->isAdmin() && !$this->isApiUser()) {
             $this->authorizeCustomerAccess($requestedId);
         }
 

--- a/app/code/core/Mage/Review/Api/Review.php
+++ b/app/code/core/Mage/Review/Api/Review.php
@@ -142,7 +142,7 @@ class Review extends CrudResource
     public int $rating = 5;
 
     /** approved | pending | not_approved. Writable through the moderation Put only; submit always forces pending. */
-    #[ApiProperty(extraProperties: ['computed' => true])]
+    #[ApiProperty(securityPostDenormalize: "is_granted('ROLE_ADMIN') or is_granted('reviews/write')", extraProperties: ['computed' => true])]
     public ?string $status = null;
 
     #[ApiProperty(writable: false)]
@@ -163,7 +163,7 @@ class Review extends CrudResource
      *
      * @var array<int|string>|null
      */
-    #[ApiProperty(extraProperties: ['computed' => true])]
+    #[ApiProperty(securityPostDenormalize: "is_granted('ROLE_ADMIN') or is_granted('reviews/write')", extraProperties: ['computed' => true])]
     public ?array $stores = null;
 
     // Not serialized in responses: the author's internal customer id has no

--- a/app/code/core/Mage/Review/Api/ReviewProcessor.php
+++ b/app/code/core/Mage/Review/Api/ReviewProcessor.php
@@ -72,16 +72,12 @@ final class ReviewProcessor extends \Maho\ApiPlatform\Processor
     }
 
     /**
-     * Moderation is admin/service-token only. The route security already excludes
-     * customer tokens (no ROLE_CUSTOMER, and the permission voter never grants
-     * 'reviews/write' to non-API-key users); this re-checks in the processor so
-     * the gate holds even if the operation metadata is ever loosened.
+     * Moderation is admin/service-token only, enforced by the operation's own
+     * `security:` expression: no ROLE_CUSTOMER, and the permission voter never
+     * grants 'reviews/write' to a non-API-key token.
      */
     private function moderateReview(int $reviewId, Review $data): Review
     {
-        $this->requireAdminOrApiUser('Review moderation requires admin or API access');
-        $this->requireApiPermission('reviews/write');
-
         if ($data->status === null && ($data->stores === null || $data->stores === [])) {
             throw new BadRequestHttpException('Provide a status and/or stores to moderate');
         }

--- a/app/code/core/Mage/Review/Api/ReviewProvider.php
+++ b/app/code/core/Mage/Review/Api/ReviewProvider.php
@@ -70,7 +70,7 @@ final class ReviewProvider extends CrudProvider
                 ['page' => $page, 'pageSize' => $pageSize] = $this->extractPagination($context, 10, 100);
                 return $this->getProductReviews($productId, $page, $pageSize);
             }
-            if ($this->isAdmin() || $this->canReadModerationQueue()) {
+            if ($this->isBackOffice('reviews')) {
                 ['page' => $page, 'pageSize' => $pageSize] = $this->extractPagination($context, 10, 100);
                 return $this->getModerationQueue($context, $page, $pageSize);
             }
@@ -280,8 +280,7 @@ final class ReviewProvider extends CrudProvider
         // service tokens scoped for moderation; everyone else gets 404.
         if ($checkVisibility
             && (int) $review->getStatusId() !== \Mage_Review_Model_Review::STATUS_APPROVED
-            && !$this->isAdmin()
-            && !$this->canReadModerationQueue()
+            && !$this->isBackOffice('reviews')
         ) {
             $customerId = $this->getAuthenticatedCustomerId();
             if (!$customerId || (int) $review->getCustomerId() !== $customerId) {
@@ -296,15 +295,6 @@ final class ReviewProvider extends CrudProvider
         $dto->productName = $productNames[$dto->productId] ?? null;
 
         return $dto;
-    }
-
-    /**
-     * A service token sees pending/rejected content only when scoped for it:
-     * an unrelated scope (say newsletter/read) must not read the queue.
-     */
-    private function canReadModerationQueue(): bool
-    {
-        return $this->isApiUser() && $this->getAuthorizedUser()->hasPermission('reviews/read');
     }
 
     /**

--- a/app/code/core/Mage/Sales/Api/CreditMemoProcessor.php
+++ b/app/code/core/Mage/Sales/Api/CreditMemoProcessor.php
@@ -23,8 +23,6 @@ final class CreditMemoProcessor extends \Maho\ApiPlatform\Processor
     #[\Override]
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): CreditMemo
     {
-        $this->requireAdminOrApiUser('Credit memo creation requires admin or API access');
-        $this->requireApiPermission('credit-memos/create');
         $operationName = $operation->getName();
 
         return match ($operationName) {

--- a/app/code/core/Mage/Sales/Api/CreditMemoProvider.php
+++ b/app/code/core/Mage/Sales/Api/CreditMemoProvider.php
@@ -21,7 +21,6 @@ final class CreditMemoProvider extends CrudProvider
     #[\Override]
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): CreditMemo|TraversablePaginator|null
     {
-        $this->requireAdminOrApiUser('Credit memo access requires admin or API access');
         $this->resourceClass = $operation->getClass();
         $this->modelAlias = 'sales/order_creditmemo';
 

--- a/app/code/core/Mage/Sales/Api/InvoiceProcessor.php
+++ b/app/code/core/Mage/Sales/Api/InvoiceProcessor.php
@@ -28,7 +28,6 @@ final class InvoiceProcessor extends \Maho\ApiPlatform\Processor
     #[\Override]
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Invoice
     {
-        $this->requireAdminOrApiUser('Invoice management requires admin or API access');
         $operationName = $operation->getName();
 
         $this->normalizeGraphQlInput($context);
@@ -43,8 +42,6 @@ final class InvoiceProcessor extends \Maho\ApiPlatform\Processor
 
     private function createInvoice(array $uriVariables, array $context): Invoice
     {
-        $this->requireApiPermission('invoices/create');
-
         $orderId = (int) ($uriVariables['orderId'] ?? 0);
         if (!$orderId) {
             throw new BadRequestHttpException('Order ID is required');
@@ -194,8 +191,6 @@ final class InvoiceProcessor extends \Maho\ApiPlatform\Processor
      */
     private function executeLifecycleAction(string $action, array $uriVariables): Invoice
     {
-        $this->requireApiPermission('invoices/write');
-
         $invoiceId = (int) ($uriVariables['id'] ?? 0);
         if (!$invoiceId) {
             throw new BadRequestHttpException('Invoice ID is required');

--- a/app/code/core/Mage/Sales/Api/InvoiceProvider.php
+++ b/app/code/core/Mage/Sales/Api/InvoiceProvider.php
@@ -141,9 +141,8 @@ class InvoiceProvider extends \Maho\ApiPlatform\Provider
         } else {
             // Admins and API users (permission already enforced upstream by the
             // operation's `security:` expression) may access any order's
-            // invoices within their store allowlist, matching
-            // OrderProvider::canAccessOrder(). Customers are limited to their
-            // own orders.
+            // invoices within their store allowlist. Customers are limited to
+            // their own orders.
             if ($this->isAdmin() || $this->isApiUser()) {
                 $this->assertStoreAllowed($order->getStoreId(), $this->getAuthorizedUser(), 'order');
             } else {

--- a/app/code/core/Mage/Sales/Api/Order.php
+++ b/app/code/core/Mage/Sales/Api/Order.php
@@ -387,10 +387,12 @@ class Order extends CrudResource
     #[ApiProperty(writable: false, description: 'Order status before it was put on hold')]
     public ?string $holdBeforeStatus = null;
 
-    #[ApiProperty(writable: false, description: 'Client IP the order was placed from (admin/API readers only)', extraProperties: ['computed' => true])]
+    // Fraud-relevant request metadata, never echoed to a customer or
+    // guest-token reader.
+    #[ApiProperty(writable: false, description: 'Client IP the order was placed from (admin/API readers only)', security: "is_back_office('orders')", extraProperties: ['computed' => true])]
     public ?string $remoteIp = null;
 
-    #[ApiProperty(writable: false, description: 'X-Forwarded-For header at placement (admin/API readers only)', extraProperties: ['computed' => true])]
+    #[ApiProperty(writable: false, description: 'X-Forwarded-For header at placement (admin/API readers only)', security: "is_back_office('orders')", extraProperties: ['computed' => true])]
     public ?string $xForwardedFor = null;
 
     #[ApiProperty(writable: false, description: 'Total number of distinct items')]

--- a/app/code/core/Mage/Sales/Api/Order.php
+++ b/app/code/core/Mage/Sales/Api/Order.php
@@ -23,6 +23,7 @@ use ApiPlatform\Metadata\GraphQl\Mutation;
 use Maho\ApiPlatform\CrudResource;
 use Maho\ApiPlatform\GraphQl\CustomQueryResolver;
 use Mage\Customer\Api\Address;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 #[ApiResource(
     mahoOperations: ['read' => 'View', 'create' => 'Place', 'write' => 'Manage'],
@@ -34,7 +35,11 @@ use Mage\Customer\Api\Address;
     operations: [
         new Get(
             uriTemplate: '/orders/{id}',
-            security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('orders/read')",
+            // Row-level: the object clause defers evaluation to post-read, and a
+            // denial maps to 404 so a foreign id is indistinguishable from a
+            // missing one.
+            security: "is_back_office('orders') or is_owner(object, 'customerId')",
+            exceptionToStatus: [AccessDeniedException::class => 404],
             description: 'Get an order by ID',
         ),
         new GetCollection(
@@ -143,7 +148,9 @@ use Mage\Customer\Api\Address;
         new Query(
             name: 'item_query',
             description: 'Get an order by ID',
-            security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('orders/read')",
+            // Row-level denial is converted to a null result by
+            // OwnershipDenialProvider, matching the missing-row shape.
+            security: "is_back_office('orders') or is_owner(object, 'customerId')",
         ),
         new QueryCollection(
             name: 'collection_query',

--- a/app/code/core/Mage/Sales/Api/OrderProvider.php
+++ b/app/code/core/Mage/Sales/Api/OrderProvider.php
@@ -336,12 +336,9 @@ final class OrderProvider extends \Maho\ApiPlatform\Provider
         $dto->appliedRuleIds = $this->parseAppliedRuleIds($order->getAppliedRuleIds());
         $dto->giftcardCodes = $this->parseGiftcardCodes($order->getData('giftcard_codes'));
 
-        // Fraud-relevant request metadata is for back-office eyes only, never
-        // echoed to customer or guest-token readers.
-        if ($this->isAdmin() || $this->isApiUser()) {
-            $dto->remoteIp = $order->getRemoteIp();
-            $dto->xForwardedFor = $order->getXForwardedFor();
-        }
+        // Back-office only; the DTO properties carry the gate.
+        $dto->remoteIp = $order->getRemoteIp();
+        $dto->xForwardedFor = $order->getXForwardedFor();
 
         // Set access token for guest orders
         if ($accessToken) {

--- a/app/code/core/Mage/Sales/Api/OrderProvider.php
+++ b/app/code/core/Mage/Sales/Api/OrderProvider.php
@@ -274,8 +274,6 @@ final class OrderProvider extends \Maho\ApiPlatform\Provider
      */
     private function getCollection(array $context): TraversablePaginator
     {
-        $this->requireAdminOrApiUser('Order listing requires admin or API access');
-
         ['page' => $page, 'pageSize' => $pageSize] = $this->extractPagination($context);
         $result = $this->orderService->getAllOrders(
             $page,

--- a/app/code/core/Mage/Sales/Api/OrderProvider.php
+++ b/app/code/core/Mage/Sales/Api/OrderProvider.php
@@ -189,56 +189,16 @@ final class OrderProvider extends \Maho\ApiPlatform\Provider
             return null;
         }
 
-        // Verify access to this order
-        // - Admins can access any order
-        // - API users with orders/read permission can access any order (for integrations)
-        // - Customers can only access their own orders
-        if (!$this->canAccessOrder($order)) {
-            return null;
-        }
+        // Ownership is not checked here: the operation's
+        // `is_owner(object, 'customerId')` expression does the denying post-read.
 
         // Store allowlist enforcement for back-office tokens; customer tokens
-        // are identity-bound above and stay untouched.
+        // are identity-bound by the ownership expression and stay untouched.
         if ($this->isAdmin() || $this->isApiUser()) {
             $this->assertStoreAllowed($order->getStoreId(), $this->getAuthorizedUser(), 'order');
         }
 
         return $this->mapToDto($order);
-    }
-
-    /**
-     * Check if current user can access the given order
-     *
-     * - Admins: full access
-     * - API service accounts: full access (permission already checked by the operation security expression)
-     * - Customers: own orders only
-     */
-    private function canAccessOrder(\Mage_Sales_Model_Order $order): bool
-    {
-        // Admins can access any order
-        if ($this->isAdmin()) {
-            return true;
-        }
-
-        // API users with orders/read permission can access any order. The
-        // granular orders/read check is enforced upstream by the operation's
-        // `security: is_granted('orders/read')` expression (via ApiUserVoter)
-        // before this runs, so by the time we get here the key is already
-        // authorized to read orders.
-        $user = $this->security->getUser();
-        if ($user instanceof \Maho\ApiPlatform\Security\ApiUser && $user->isApiUser()) {
-            return true;
-        }
-
-        // Customers can only access their own orders
-        $authenticatedCustomerId = $this->getAuthenticatedCustomerId();
-        if ($authenticatedCustomerId !== null) {
-            $orderCustomerId = $order->getCustomerId();
-            return $orderCustomerId && (int) $orderCustomerId === $authenticatedCustomerId;
-        }
-
-        // No valid authentication context
-        return false;
     }
 
     /**

--- a/app/code/core/Mage/Sales/Api/ShipmentProcessor.php
+++ b/app/code/core/Mage/Sales/Api/ShipmentProcessor.php
@@ -23,8 +23,6 @@ final class ShipmentProcessor extends \Maho\ApiPlatform\Processor
     #[\Override]
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Shipment
     {
-        $this->requireAdminOrApiUser('Shipment creation requires admin or API access');
-        $this->requireApiPermission('shipments/create');
         $operationName = $operation->getName();
 
         // Bridge the raw REST body into $context['args']['input'] so the track /

--- a/app/code/core/Mage/Sales/Api/ShipmentProvider.php
+++ b/app/code/core/Mage/Sales/Api/ShipmentProvider.php
@@ -59,8 +59,6 @@ final class ShipmentProvider extends CrudProvider
 
     private function getShipmentById(int $id): Shipment
     {
-        $this->requireAdminOrApiUser('Shipment access requires admin or API access');
-
         $shipment = \Mage::getModel('sales/order_shipment')->load($id);
         if (!$shipment->getId()) {
             throw new NotFoundHttpException('Shipment not found');
@@ -76,8 +74,6 @@ final class ShipmentProvider extends CrudProvider
      */
     private function getShipmentsForOrder(int $orderId): ArrayPaginator
     {
-        $this->requireAdminOrApiUser('Shipment access requires admin or API access');
-
         $order = \Mage::getModel('sales/order')->load($orderId);
         if (!$order->getId()) {
             throw new NotFoundHttpException('Order not found');
@@ -102,8 +98,6 @@ final class ShipmentProvider extends CrudProvider
      */
     private function getAllShipments(array $context): TraversablePaginator
     {
-        $this->requireAdminOrApiUser('Shipment listing requires admin or API access');
-
         ['page' => $page, 'pageSize' => $perPage] = $this->extractPagination($context);
 
         $collection = \Mage::getResourceModel('sales/order_shipment_collection');

--- a/app/code/core/Mage/SalesRule/Api/CouponProcessor.php
+++ b/app/code/core/Mage/SalesRule/Api/CouponProcessor.php
@@ -49,14 +49,12 @@ final class CouponProcessor extends \Maho\ApiPlatform\Processor
 
     private function createFromGraphQl(array $context): Coupon
     {
-        $this->requireAdminOrApiUser('Coupon creation requires admin or API access');
         $args = $context['args']['input'] ?? [];
         return $this->doCreate($args);
     }
 
     private function updateFromGraphQl(array $context): Coupon
     {
-        $this->requireAdminOrApiUser('Coupon update requires admin or API access');
         $args = $context['args']['input'] ?? [];
         $id = (int) ($args['id'] ?? 0);
         if (!$id) {
@@ -67,7 +65,6 @@ final class CouponProcessor extends \Maho\ApiPlatform\Processor
 
     private function deleteFromGraphQl(array $context): null
     {
-        $this->requireAdminOrApiUser('Coupon deletion requires admin or API access');
         $id = (int) ($context['args']['input']['id'] ?? 0);
         return $this->doDelete($id);
     }
@@ -92,9 +89,6 @@ final class CouponProcessor extends \Maho\ApiPlatform\Processor
 
     private function doCreate(array $data): Coupon
     {
-        $this->requireAdminOrApiUser('Coupon creation requires admin or API access');
-        $this->requireApiPermission('coupons/create');
-
         $code = $data['code'] ?? '';
         $this->validateCouponCode($code);
 
@@ -181,9 +175,6 @@ final class CouponProcessor extends \Maho\ApiPlatform\Processor
 
     private function doUpdate(int $id, array $data): Coupon
     {
-        $this->requireAdminOrApiUser('Coupon update requires admin or API access');
-        $this->requireApiPermission('coupons/write');
-
         /** @var \Mage_SalesRule_Model_Coupon $coupon */
         $coupon = \Mage::getModel('salesrule/coupon');
         $coupon->load($id);
@@ -317,9 +308,6 @@ final class CouponProcessor extends \Maho\ApiPlatform\Processor
 
     private function doDelete(int $id): null
     {
-        $this->requireAdminOrApiUser('Coupon deletion requires admin or API access');
-        $this->requireApiPermission('coupons/delete');
-
         if (!$id) {
             throw new BadRequestHttpException('Coupon ID is required');
         }

--- a/app/code/core/Mage/SalesRule/Api/CouponProvider.php
+++ b/app/code/core/Mage/SalesRule/Api/CouponProvider.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace Mage\SalesRule\Api;
 
-use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\Pagination\TraversablePaginator;
 use Maho\ApiPlatform\Resource;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -22,13 +21,6 @@ final class CouponProvider extends \Maho\ApiPlatform\Provider
 {
     protected ?string $modelAlias = 'salesrule/coupon';
     protected array $defaultSort = ['coupon_id' => 'DESC'];
-
-    #[\Override]
-    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
-    {
-        $this->requireAdminOrApiUser('Coupon access requires admin or API access');
-        return parent::provide($operation, $uriVariables, $context);
-    }
 
     #[\Override]
     protected function provideItem(int|string $id): Resource

--- a/app/code/core/Mage/Wishlist/Api/WishlistItem.php
+++ b/app/code/core/Mage/Wishlist/Api/WishlistItem.php
@@ -61,7 +61,8 @@ use Maho\ApiPlatform\CrudResource;
         ),
     ],
     graphQlOperations: [
-        new Query(name: 'item_query', description: 'Get a wishlist item by ID', security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('wishlists/read')"),
+        // Row-level denial is converted to a null result by OwnershipDenialProvider.
+        new Query(name: 'item_query', description: 'Get a wishlist item by ID', security: "is_back_office('wishlists') or is_owner(object, 'customerId')"),
         new QueryCollection(name: 'collection_query', description: 'Get wishlist items', security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('wishlists/read')"),
         new QueryCollection(
             name: 'my',
@@ -111,6 +112,12 @@ class WishlistItem extends CrudResource
 
     #[ApiProperty(identifier: true, writable: false)]
     public ?int $id = null;
+
+    // Owner of the parent wishlist, set by WishlistProvider from the wishlist it
+    // already holds (wishlist_item has no customer_id column). Never serialized;
+    // exists for the is_owner(object, 'customerId') security expression.
+    #[ApiProperty(readable: false, writable: false)]
+    public ?int $customerId = null;
 
     public ?int $productId = null;
 

--- a/app/code/core/Mage/Wishlist/Api/WishlistProcessor.php
+++ b/app/code/core/Mage/Wishlist/Api/WishlistProcessor.php
@@ -17,7 +17,6 @@ use Mage\Checkout\Api\CartService;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
  * Wishlist State Processor.
@@ -207,8 +206,10 @@ final class WishlistProcessor extends \Maho\ApiPlatform\Processor
         $wishlistId = $item->getWishlistId();
         /** @var \Mage_Wishlist_Model_Wishlist $wishlist */
         $wishlist = \Mage::getModel('wishlist/wishlist')->load($wishlistId);
+        // Reported as missing rather than forbidden, so the endpoint cannot be
+        // used to probe which wishlist item ids exist.
         if (!$wishlist->getId() || (int) $wishlist->getCustomerId() !== $customerId) {
-            throw new AccessDeniedHttpException('Access denied to this wishlist item');
+            throw new NotFoundHttpException('Wishlist item not found');
         }
 
         $item->delete();
@@ -236,8 +237,10 @@ final class WishlistProcessor extends \Maho\ApiPlatform\Processor
         $wishlistId = $item->getWishlistId();
         /** @var \Mage_Wishlist_Model_Wishlist $wishlist */
         $wishlist = \Mage::getModel('wishlist/wishlist')->load($wishlistId);
+        // Reported as missing rather than forbidden, so the endpoint cannot be
+        // used to probe which wishlist item ids exist.
         if (!$wishlist->getId() || (int) $wishlist->getCustomerId() !== $customerId) {
-            throw new AccessDeniedHttpException('Access denied to this wishlist item');
+            throw new NotFoundHttpException('Wishlist item not found');
         }
 
         $product = $item->getProduct();

--- a/app/code/core/Mage/Wishlist/Api/WishlistProvider.php
+++ b/app/code/core/Mage/Wishlist/Api/WishlistProvider.php
@@ -100,7 +100,9 @@ final class WishlistProvider extends \Maho\ApiPlatform\Provider
                 continue;
             }
 
-            $items[] = WishlistItem::fromModel($item);
+            $dto = WishlistItem::fromModel($item);
+            $dto->customerId = $customerId;
+            $items[] = $dto;
         }
 
         \Mage::app()->getCache()->save(
@@ -114,12 +116,12 @@ final class WishlistProvider extends \Maho\ApiPlatform\Provider
     }
 
     /**
-     * Get single wishlist item
+     * Get single wishlist item. Ownership is not checked here: the parent
+     * wishlist's customer id is set on the DTO and the operation's
+     * `is_owner(object, 'customerId')` expression does the denying post-read.
      */
     private function getItem(int $itemId): WishlistItem
     {
-        $customerId = $this->requireAuthentication();
-
         /** @var \Mage_Wishlist_Model_Item $item */
         $item = \Mage::getModel('wishlist/item')->load($itemId);
 
@@ -127,17 +129,16 @@ final class WishlistProvider extends \Maho\ApiPlatform\Provider
             throw new NotFoundHttpException('Wishlist item not found');
         }
 
-        // Verify ownership - load wishlist explicitly
-        $wishlistId = $item->getWishlistId();
         /** @var \Mage_Wishlist_Model_Wishlist $wishlist */
-        $wishlist = \Mage::getModel('wishlist/wishlist')->load($wishlistId);
-        // Reported as missing rather than forbidden, so the endpoint cannot be
-        // used to probe which wishlist item ids exist.
-        if (!$wishlist->getId() || (int) $wishlist->getCustomerId() !== $customerId) {
+        $wishlist = \Mage::getModel('wishlist/wishlist')->load($item->getWishlistId());
+        if (!$wishlist->getId()) {
             throw new NotFoundHttpException('Wishlist item not found');
         }
 
-        return WishlistItem::fromModel($item);
+        $dto = WishlistItem::fromModel($item);
+        $dto->customerId = $wishlist->getCustomerId() ? (int) $wishlist->getCustomerId() : null;
+
+        return $dto;
     }
 
     /**
@@ -147,6 +148,7 @@ final class WishlistProvider extends \Maho\ApiPlatform\Provider
     {
         return [
             'id' => $item->id,
+            'customerId' => $item->customerId,
             'productId' => $item->productId,
             'productName' => $item->productName,
             'productSku' => $item->productSku,
@@ -166,6 +168,7 @@ final class WishlistProvider extends \Maho\ApiPlatform\Provider
     {
         $item = new WishlistItem();
         $item->id = (int) $data['id'];
+        $item->customerId = isset($data['customerId']) ? (int) $data['customerId'] : null;
         $item->productId = (int) $data['productId'];
         $item->productName = $data['productName'];
         $item->productSku = $data['productSku'];

--- a/app/code/core/Mage/Wishlist/Api/WishlistProvider.php
+++ b/app/code/core/Mage/Wishlist/Api/WishlistProvider.php
@@ -15,7 +15,6 @@ use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\State\Pagination\TraversablePaginator;
 use Maho\ApiPlatform\Service\StoreContext;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
  * Wishlist State Provider.
@@ -132,8 +131,10 @@ final class WishlistProvider extends \Maho\ApiPlatform\Provider
         $wishlistId = $item->getWishlistId();
         /** @var \Mage_Wishlist_Model_Wishlist $wishlist */
         $wishlist = \Mage::getModel('wishlist/wishlist')->load($wishlistId);
+        // Reported as missing rather than forbidden, so the endpoint cannot be
+        // used to probe which wishlist item ids exist.
         if (!$wishlist->getId() || (int) $wishlist->getCustomerId() !== $customerId) {
-            throw new AccessDeniedHttpException('Access denied to this wishlist item');
+            throw new NotFoundHttpException('Wishlist item not found');
         }
 
         return WishlistItem::fromModel($item);

--- a/app/code/core/Maho/ApiPlatform/symfony/Controller/AdminGraphQlController.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Controller/AdminGraphQlController.php
@@ -26,6 +26,18 @@ use Symfony\Component\Routing\Attribute\Route;
  *
  * Handles GraphQL requests for authenticated admin users.
  * Uses handler-based resolution for clean separation of concerns.
+ *
+ * Deliberately a separate authorization surface from REST and storefront
+ * GraphQL. Dispatch is a hand-rolled match table rather than API Platform
+ * operations, so nothing here evaluates an operation `security:` expression,
+ * and the handlers hand-serialize with `$dto->toArray()` rather than going
+ * through the serializer, so per-property `#[ApiProperty(security: …)]` gates
+ * do not apply either. What gates it instead: the firewall admits only
+ * fully-authenticated admin sessions, and every dispatched handler method calls
+ * `AdminAcl::checkResource()` against the same ADMIN_RESOURCE constant
+ * AdminAclListener enforces on the REST surface, which is what makes
+ * back-office field visibility correct here (every caller holds the resource's
+ * admin ACL). AdminGraphQlAclCoverageTest keeps that per-handler check honest.
  */
 #[Route('/api/admin/graphql', name: 'api_admin_graphql', methods: ['GET', 'POST'])]
 class AdminGraphQlController

--- a/app/code/core/Maho/ApiPlatform/symfony/CrudProvider.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/CrudProvider.php
@@ -39,8 +39,6 @@ class CrudProvider extends Provider
     /** Whether this resource supports the back-office `scope=all` collection filter. */
     protected bool $supportsScopeAll = false;
 
-    private ?bool $backOfficeReader = null;
-
     /**
      * Permission resource id (e.g. 'cms-pages') whose read or write grant makes
      * an API-user token a back-office reader: drafts/disabled rows, cross-store
@@ -69,11 +67,8 @@ class CrudProvider extends Provider
 
     protected function isBackOfficeReader(): bool
     {
-        return $this->backOfficeReader ??= $this->isAdmin()
-            || ($this->isApiUser()
-                && $this->backOfficeResource !== null
-                && ($this->getAuthorizedUser()->hasPermission($this->backOfficeResource . '/read')
-                    || $this->getAuthorizedUser()->hasPermission($this->backOfficeResource . '/write')));
+        return $this->isAdmin()
+            || ($this->backOfficeResource !== null && $this->isBackOffice($this->backOfficeResource));
     }
 
     /**

--- a/app/code/core/Maho/ApiPlatform/symfony/EventListener/ApiExceptionListener.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/EventListener/ApiExceptionListener.php
@@ -142,9 +142,11 @@ class ApiExceptionListener implements EventSubscriberInterface
                 if ($operation instanceof HttpOperation) {
                     foreach ($operation->getExceptionToStatus() ?? [] as $class => $mappedStatus) {
                         if (is_a($exception::class, $class, true)) {
+                            // A 404-mapped denial must match a missing row's body
+                            // (ReadProvider's 'Not Found') or the masking leaks.
                             return new JsonResponse([
                                 'error' => $this->getErrorCodeFromStatusCode($mappedStatus),
-                                'message' => $this->getDefaultMessageForStatusCode($mappedStatus),
+                                'message' => $mappedStatus === 404 ? 'Not Found' : $this->getDefaultMessageForStatusCode($mappedStatus),
                                 'code' => $mappedStatus,
                             ], $mappedStatus);
                         }

--- a/app/code/core/Maho/ApiPlatform/symfony/EventListener/ApiExceptionListener.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/EventListener/ApiExceptionListener.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Maho\ApiPlatform\EventListener;
 
+use ApiPlatform\Metadata\HttpOperation;
 use Maho\ApiPlatform\Exception\ApiException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -128,6 +129,29 @@ class ApiExceptionListener implements EventSubscriberInterface
             // InsufficientAuthenticationException as the `previous`.
             $isNotAuthenticated = $exception->getPrevious() instanceof InsufficientAuthenticationException
                 || !$hasBearerToken;
+
+            // Honor the operation's exceptionToStatus mapping (e.g. row-level
+            // ownership denials mapped to 404 so a foreign id is
+            // indistinguishable from a missing one), but only for authenticated
+            // callers: an unauthenticated caller must keep the 401 +
+            // WWW-Authenticate affordance below. is_a() matching mirrors API
+            // Platform's own ErrorListener; the security stage throws a subclass
+            // of the mapped Symfony AccessDeniedException.
+            if (!$isNotAuthenticated) {
+                $operation = $request?->attributes->get('_api_operation');
+                if ($operation instanceof HttpOperation) {
+                    foreach ($operation->getExceptionToStatus() ?? [] as $class => $mappedStatus) {
+                        if (is_a($exception::class, $class, true)) {
+                            return new JsonResponse([
+                                'error' => $this->getErrorCodeFromStatusCode($mappedStatus),
+                                'message' => $this->getDefaultMessageForStatusCode($mappedStatus),
+                                'code' => $mappedStatus,
+                            ], $mappedStatus);
+                        }
+                    }
+                }
+            }
+
             $statusCode = $isNotAuthenticated ? 401 : 403;
             $error = $isNotAuthenticated ? 'unauthorized' : 'forbidden';
             $message = $isNotAuthenticated ? 'Authentication required' : 'Access denied';

--- a/app/code/core/Maho/ApiPlatform/symfony/GraphQl/OwnershipDenialProvider.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/GraphQl/OwnershipDenialProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Maho_ApiPlatform
+ */
+
+declare(strict_types=1);
+
+namespace Maho\ApiPlatform\GraphQl;
+
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Decorates the GraphQL ReadProvider chain to convert row-level ownership
+ * denials on item queries into null results.
+ *
+ * GraphQL operations have no `exceptionToStatus`, so without this a foreign row
+ * surfaces as an "Access Denied." entry in `errors[]` while a missing row yields
+ * `data: null`, an id oracle over enumerable ids (the REST counterpart is the
+ * `AccessDeniedException => 404` mapping honored by ApiExceptionListener). The
+ * conversion is deliberately scoped to item Queries whose security expression
+ * references `object`, i.e. exactly the post-read row-level case: role/grant
+ * denials on admin-locked queries keep their explicit "Access Denied." error,
+ * where no existence is leaked and the affordance helps the caller.
+ *
+ * @implements ProviderInterface<object>
+ */
+final class OwnershipDenialProvider implements ProviderInterface
+{
+    /**
+     * @param ProviderInterface<object> $inner
+     */
+    public function __construct(private readonly ProviderInterface $inner) {}
+
+    #[\Override]
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        try {
+            return $this->inner->provide($operation, $uriVariables, $context);
+        } catch (AccessDeniedHttpException $e) {
+            if (
+                $operation instanceof Query
+                && !$operation instanceof QueryCollection
+                && str_contains($operation->getSecurity() ?? '', 'object')
+            ) {
+                return null;
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/app/code/core/Maho/ApiPlatform/symfony/GraphQl/OwnershipDenialProvider.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/GraphQl/OwnershipDenialProvider.php
@@ -27,7 +27,10 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
  * conversion is deliberately scoped to item Queries whose security expression
  * references `object`, i.e. exactly the post-read row-level case: role/grant
  * denials on admin-locked queries keep their explicit "Access Denied." error,
- * where no existence is leaked and the affordance helps the caller.
+ * where no existence is leaked and the affordance helps the caller. The catch
+ * is by exception type, so imperative denials from the provider chain (e.g.
+ * the store-allowlist check) are masked too; they are equally row-scoped, so
+ * null is the right answer there as well.
  *
  * @implements ProviderInterface<object>
  */

--- a/app/code/core/Maho/ApiPlatform/symfony/Kernel.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Kernel.php
@@ -408,6 +408,11 @@ class Kernel extends BaseKernel
         $services->set(Security\BackOfficeAccess::class)
             ->tag('security.expression_language_provider');
 
+        // Row-level counterpart: is_owner(object, '<property>') for the item
+        // operations of mahoCustomerScoped resources.
+        $services->set(Security\CustomerOwnership::class)
+            ->tag('security.expression_language_provider');
+
         $services->set(GraphQl\CustomQueryResolver::class)
             ->arg('$providerLocator', tagged_locator('maho.api.state_provider'))
             ->tag('api_platform.graphql.query_resolver');
@@ -428,6 +433,16 @@ class Kernel extends BaseKernel
         $services->set(GraphQl\IriToleranceProvider::class)
             ->decorate('api_platform.graphql.state_provider.read')
             ->arg('$inner', new Reference(GraphQl\IriToleranceProvider::class . '.inner'));
+
+        // Convert row-level ownership denials on item queries into null results
+        // (see the class docblock). Priority -10: decoration priority is
+        // higher-is-innermost, and this MUST wrap the vendor
+        // AccessCheckerProvider (priority 0 on the same service) to catch what
+        // it throws; at 0 the registration-order tie-break would nest it inside,
+        // like IriToleranceProvider above.
+        $services->set(GraphQl\OwnershipDenialProvider::class)
+            ->decorate('api_platform.graphql.state_provider.read', null, -10)
+            ->arg('$inner', new Reference(GraphQl\OwnershipDenialProvider::class . '.inner'));
 
         // DefaultDenyListener is wired via its #[AsEventListener(priority: 5)]
         // attribute (autoconfigured by the services loader above) so it runs

--- a/app/code/core/Maho/ApiPlatform/symfony/Kernel.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Kernel.php
@@ -400,6 +400,14 @@ class Kernel extends BaseKernel
             ->arg('$debug', '%kernel.debug%')
             ->tag('kernel.event_subscriber');
 
+        // Publishes is_back_office('<resource>') to every security expression,
+        // including the per-property ones the serializer evaluates. Tagged by
+        // hand: FrameworkBundle autoconfigures ExpressionFunctionProviderInterface
+        // onto the generic `expression_language_provider` tag, which the security
+        // expression language does not read.
+        $services->set(Security\BackOfficeAccess::class)
+            ->tag('security.expression_language_provider');
+
         $services->set(GraphQl\CustomQueryResolver::class)
             ->arg('$providerLocator', tagged_locator('maho.api.state_provider'))
             ->tag('api_platform.graphql.query_resolver');

--- a/app/code/core/Maho/ApiPlatform/symfony/Security/ApiUser.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Security/ApiUser.php
@@ -133,14 +133,21 @@ class ApiUser implements UserInterface
     }
 
     /**
-     * Check if user has a specific permission
+     * Whether the user holds a `resource/operation` grant, directly or through
+     * the `resource/all` or global `all` wildcards. Same rule ApiUserVoter
+     * applies to `is_granted()`, so a direct call here and an operation's
+     * `security:` expression can never disagree about the same grant.
      */
     public function hasPermission(string $permission): bool
     {
-        if (in_array('all', $this->permissions, true)) {
+        if (in_array('all', $this->permissions, true)
+            || in_array($permission, $this->permissions, true)
+        ) {
             return true;
         }
-        return in_array($permission, $this->permissions, true);
+
+        [$resource] = explode('/', $permission, 2);
+        return $resource !== $permission && in_array($resource . '/all', $this->permissions, true);
     }
 
     /**

--- a/app/code/core/Maho/ApiPlatform/symfony/Security/ApiUserVoter.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Security/ApiUserVoter.php
@@ -53,14 +53,7 @@ class ApiUserVoter extends Voter
             return false;
         }
 
-        // "all" grants unrestricted access.
-        if ($user->hasPermission('all')) {
-            return true;
-        }
-
-        [$resource] = explode('/', $attribute, 2);
-
-        return $user->hasPermission($attribute)
-            || $user->hasPermission($resource . '/all');
+        // hasPermission() resolves the `all` and `resource/all` wildcards.
+        return $user->hasPermission($attribute);
     }
 }

--- a/app/code/core/Maho/ApiPlatform/symfony/Security/BackOfficeAccess.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Security/BackOfficeAccess.php
@@ -23,8 +23,8 @@ use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
  *
  * Registering this as a `security.expression_language_provider` publishes the rule
  * as an `is_back_office('<resource>')` function usable anywhere API Platform
- * evaluates a security expression: operation `security:`, and — the reason it
- * exists — per-property `#[ApiProperty(security: ...)]`, which the serializer
+ * evaluates a security expression: operation `security:`, and (the reason it
+ * exists) per-property `#[ApiProperty(security: ...)]`, which the serializer
  * enforces for REST, GraphQL and MCP alike. Field visibility therefore lives on
  * the field instead of in a per-provider stripping routine.
  */

--- a/app/code/core/Maho/ApiPlatform/symfony/Security/BackOfficeAccess.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Security/BackOfficeAccess.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Single definition of what "back-office caller" means for an API resource.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Maho_ApiPlatform
+ */
+
+declare(strict_types=1);
+
+namespace Maho\ApiPlatform\Security;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+/**
+ * A back-office caller is an admin token (gated separately by the Maho admin ACL
+ * through AdminAclListener) or a service token that actually holds a grant on the
+ * resource. Write counts as well as read, so an integration can read back the
+ * draft it just created.
+ *
+ * Registering this as a `security.expression_language_provider` publishes the rule
+ * as an `is_back_office('<resource>')` function usable anywhere API Platform
+ * evaluates a security expression: operation `security:`, and — the reason it
+ * exists — per-property `#[ApiProperty(security: ...)]`, which the serializer
+ * enforces for REST, GraphQL and MCP alike. Field visibility therefore lives on
+ * the field instead of in a per-provider stripping routine.
+ */
+final class BackOfficeAccess implements ExpressionFunctionProviderInterface
+{
+    /**
+     * @param callable(string): bool $isGranted attribute checker, e.g. `$security->isGranted(...)`
+     */
+    public static function isGrantedBy(callable $isGranted, string $resourceId): bool
+    {
+        return $isGranted('ROLE_ADMIN')
+            || $isGranted($resourceId . '/read')
+            || $isGranted($resourceId . '/write');
+    }
+
+    /** @return list<ExpressionFunction> */
+    #[\Override]
+    public function getFunctions(): array
+    {
+        return [
+            new ExpressionFunction(
+                'is_back_office',
+                static fn(string $resourceId): string => sprintf(
+                    '\%s::isGrantedBy($auth_checker->isGranted(...), %s)',
+                    self::class,
+                    $resourceId,
+                ),
+                static fn(array $variables, string $resourceId): bool => self::isGrantedBy(
+                    $variables['auth_checker']->isGranted(...),
+                    $resourceId,
+                ),
+            ),
+        ];
+    }
+}

--- a/app/code/core/Maho/ApiPlatform/symfony/Security/CustomerOwnership.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Security/CustomerOwnership.php
@@ -32,15 +32,14 @@ use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
  * - integer property (customer id): strict compare; 0/null means a guest row,
  *   owned by nobody.
  * - string property (email): case-insensitive compare against the caller's
- *   email, resolved once per customer with a single-column read.
+ *   email, resolved with a single-column read. Deliberately uncached: a stale
+ *   email after an account change must not decide ownership, and the lookup
+ *   runs at most once per item read.
  * - property missing on the object: deny and log, so a renamed DTO field can
  *   never fail open.
  */
 final class CustomerOwnership implements ExpressionFunctionProviderInterface
 {
-    /** @var array<int, ?string> */
-    private static array $emailByCustomerId = [];
-
     public static function isOwner(mixed $user, mixed $object, string $property): bool
     {
         if ($object === null) {
@@ -76,10 +75,6 @@ final class CustomerOwnership implements ExpressionFunctionProviderInterface
 
     private static function resolveCustomerEmail(int $customerId): ?string
     {
-        if (array_key_exists($customerId, self::$emailByCustomerId)) {
-            return self::$emailByCustomerId[$customerId];
-        }
-
         $resource = \Mage::getSingleton('core/resource');
         $read = $resource->getConnection('core_read');
         $select = $read->select()
@@ -88,7 +83,7 @@ final class CustomerOwnership implements ExpressionFunctionProviderInterface
             ->limit(1);
         $email = $read->fetchOne($select);
 
-        return self::$emailByCustomerId[$customerId] = is_string($email) && $email !== '' ? $email : null;
+        return is_string($email) && $email !== '' ? $email : null;
     }
 
     /** @return list<ExpressionFunction> */

--- a/app/code/core/Maho/ApiPlatform/symfony/Security/CustomerOwnership.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Security/CustomerOwnership.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Single definition of "the caller owns this row" for customer-scoped API resources.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Maho_ApiPlatform
+ */
+
+declare(strict_types=1);
+
+namespace Maho\ApiPlatform\Security;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+/**
+ * Publishes `is_owner(object, '<property>')` to every security expression, the
+ * row-level counterpart of `is_back_office()`. Used on item read operations of
+ * `mahoCustomerScoped` resources as
+ * `security: "is_back_office('<resource>') or is_owner(object, 'customerId')"`,
+ * evaluated by API Platform's AccessCheckerProvider after the provider has
+ * loaded the row (the literal `object` token in the expression is what defers
+ * evaluation to post-read, so never wrap or alias it).
+ *
+ * Semantics, fail-closed on anything unexpected:
+ * - `object` null: allow. Nothing was loaded, the 404/null path stands (only
+ *   reachable on GraphQL; REST's ReadProvider throws 404 before security runs).
+ * - caller without a customer identity: deny. Admin and service tokens are
+ *   decided by the `is_back_office()` clause, never by ownership.
+ * - integer property (customer id): strict compare; 0/null means a guest row,
+ *   owned by nobody.
+ * - string property (email): case-insensitive compare against the caller's
+ *   email, resolved once per customer with a single-column read.
+ * - property missing on the object: deny and log, so a renamed DTO field can
+ *   never fail open.
+ */
+final class CustomerOwnership implements ExpressionFunctionProviderInterface
+{
+    /** @var array<int, ?string> */
+    private static array $emailByCustomerId = [];
+
+    public static function isOwner(mixed $user, mixed $object, string $property): bool
+    {
+        if ($object === null) {
+            return true;
+        }
+
+        if (!is_object($object) || !$user instanceof ApiUser || $user->getCustomerId() === null) {
+            return false;
+        }
+
+        if (!property_exists($object, $property)) {
+            \Mage::log(
+                sprintf('is_owner: property "%s" does not exist on %s, denying', $property, $object::class),
+                \Mage::LOG_WARNING,
+                'api.log',
+            );
+            return false;
+        }
+
+        $value = $object->{$property} ?? null;
+
+        if (is_int($value)) {
+            return $value !== 0 && $value === $user->getCustomerId();
+        }
+
+        if (is_string($value)) {
+            $email = self::resolveCustomerEmail($user->getCustomerId());
+            return $value !== '' && $email !== null && strcasecmp($value, $email) === 0;
+        }
+
+        return false;
+    }
+
+    private static function resolveCustomerEmail(int $customerId): ?string
+    {
+        if (array_key_exists($customerId, self::$emailByCustomerId)) {
+            return self::$emailByCustomerId[$customerId];
+        }
+
+        $resource = \Mage::getSingleton('core/resource');
+        $read = $resource->getConnection('core_read');
+        $select = $read->select()
+            ->from($resource->getTableName('customer/entity'), ['email'])
+            ->where('entity_id = ?', $customerId)
+            ->limit(1);
+        $email = $read->fetchOne($select);
+
+        return self::$emailByCustomerId[$customerId] = is_string($email) && $email !== '' ? $email : null;
+    }
+
+    /** @return list<ExpressionFunction> */
+    #[\Override]
+    public function getFunctions(): array
+    {
+        return [
+            new ExpressionFunction(
+                'is_owner',
+                static fn(string $object, string $property): string => sprintf(
+                    '\%s::isOwner($user, %s, %s)',
+                    self::class,
+                    $object,
+                    $property,
+                ),
+                static fn(array $variables, mixed $object, string $property): bool => self::isOwner(
+                    $variables['user'],
+                    $object,
+                    $property,
+                ),
+            ),
+        ];
+    }
+}

--- a/app/code/core/Maho/ApiPlatform/symfony/State/McpDispatchProvider.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/State/McpDispatchProvider.php
@@ -22,6 +22,8 @@ use Maho\ApiPlatform\Mcp\OperationRequestFactory;
 use Maho\ApiPlatform\Mcp\SourceOperationResolver;
 use Maho\ApiPlatform\Security\OperationAccessChecker;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\InsufficientAuthenticationException;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -94,7 +96,24 @@ final class McpDispatchProvider implements ProviderInterface
             $context['request'] = $substituted;
         }
 
-        $data = $this->decorated->provide($operation, $uriVariables, $context);
+        try {
+            $data = $this->decorated->provide($operation, $uriVariables, $context);
+        } catch (AccessDeniedException $e) {
+            // MCP errors never reach kernel.exception (the MCP server answers
+            // from its own request loop), so the operation's exceptionToStatus
+            // mapping is honored here instead of in ApiExceptionListener. A
+            // row-level denial mapped to 404 must be byte-identical to what
+            // ReadProvider throws for a genuinely missing row.
+            if ($operation instanceof HttpOperation) {
+                foreach ($operation->getExceptionToStatus() ?? [] as $class => $status) {
+                    if ($status === 404 && is_a($e::class, $class, true)) {
+                        throw new NotFoundHttpException('Not Found', $e);
+                    }
+                }
+            }
+
+            throw $e;
+        }
 
         if ($substituted !== null && $original instanceof Request) {
             // The read stage wrote these onto the request it was handed; the MCP handler

--- a/app/code/core/Maho/ApiPlatform/symfony/Trait/AuthenticationTrait.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Trait/AuthenticationTrait.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Maho\ApiPlatform\Trait;
 
 use Maho\ApiPlatform\Security\ApiUser;
+use Maho\ApiPlatform\Security\BackOfficeAccess;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
@@ -90,6 +91,18 @@ trait AuthenticationTrait
     protected function isAdmin(): bool
     {
         return $this->security !== null && $this->security->isGranted('ROLE_ADMIN');
+    }
+
+    /**
+     * Whether the caller may see this resource's back-office view: drafts and
+     * disabled rows, cross-store items, admin-only columns. Delegates to the
+     * same rule `is_back_office('<resource>')` applies inside a security
+     * expression, so a provider and a property gate can never disagree.
+     */
+    protected function isBackOffice(string $resourceId): bool
+    {
+        return $this->security !== null
+            && BackOfficeAccess::isGrantedBy($this->security->isGranted(...), $resourceId);
     }
 
     protected function isApiUser(): bool

--- a/app/code/core/Maho/ApiPlatform/symfony/Trait/ProductLoaderTrait.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Trait/ProductLoaderTrait.php
@@ -92,10 +92,7 @@ trait ProductLoaderTrait
      */
     protected function canReadBackOfficeProducts(): bool
     {
-        return $this->isAdmin()
-            || ($this->isApiUser()
-                && ($this->getAuthorizedUser()->hasPermission('products/read')
-                    || $this->getAuthorizedUser()->hasPermission('products/write')));
+        return $this->isBackOffice('products');
     }
 
     /**

--- a/app/code/core/Maho/Giftcard/Api/GiftCardProcessor.php
+++ b/app/code/core/Maho/Giftcard/Api/GiftCardProcessor.php
@@ -178,8 +178,6 @@ final class GiftCardProcessor extends \Maho\ApiPlatform\CrudProcessor
 
     private function createGiftcardFromGraphQl(array $context): GiftCard
     {
-        $this->requireAdminOrApiUser('Gift card management requires admin or API access');
-        $this->requireApiPermission('giftcards/create');
         $args = $context['args']['input'] ?? [];
 
         $this->assertValidGiftcard(
@@ -239,8 +237,6 @@ final class GiftCardProcessor extends \Maho\ApiPlatform\CrudProcessor
 
     private function adjustBalance(array $context): GiftCard
     {
-        $this->requireAdminOrApiUser('Gift card management requires admin or API access');
-        $this->requireApiPermission('giftcards/write');
         $args = $context['args']['input'] ?? [];
 
         $code = trim((string) ($args['code'] ?? ''));

--- a/app/code/core/Maho/Revocation/Api/RevocationRequest.php
+++ b/app/code/core/Maho/Revocation/Api/RevocationRequest.php
@@ -20,6 +20,7 @@ use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
 use Maho\ApiPlatform\Resource;
 use Maho\Config\ApiResource;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 #[ApiResource(
     mahoSection: 'Sales',
@@ -44,7 +45,11 @@ use Maho\Config\ApiResource;
         ),
         new Get(
             uriTemplate: '/revocation-requests/{id}',
-            security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('revocation-requests/read')",
+            // Row-level: ownership is the email on the declaration (guest
+            // submissions have no customer id). Denial maps to 404 so a foreign
+            // id is indistinguishable from a missing one.
+            security: "is_back_office('revocation-requests') or is_owner(object, 'email')",
+            exceptionToStatus: [AccessDeniedException::class => 404],
             requirements: ['id' => '\d+'],
             description: 'Get a single revocation request (own request for customers, any for admins)',
         ),
@@ -65,7 +70,9 @@ use Maho\Config\ApiResource;
         new Query(
             name: 'item_query',
             description: 'Get a revocation request by ID',
-            security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('revocation-requests/read')",
+            // Row-level denial is converted to a null result by
+            // OwnershipDenialProvider.
+            security: "is_back_office('revocation-requests') or is_owner(object, 'email')",
         ),
         new QueryCollection(
             name: 'collection_query',
@@ -136,13 +143,13 @@ class RevocationRequest extends Resource
     #[ApiProperty(description: 'When the declaration was processed (UTC)', writable: false)]
     public ?string $processedAt = null;
 
-    #[ApiProperty(description: 'Internal admin note (admin only)', writable: true)]
+    #[ApiProperty(description: 'Internal admin note (admin only)', writable: true, security: "is_back_office('revocation-requests')")]
     public ?string $adminNote = null;
 
-    #[ApiProperty(description: 'IP address the declaration was submitted from (admin only)', writable: false)]
+    #[ApiProperty(description: 'IP address the declaration was submitted from (admin only)', writable: false, security: "is_back_office('revocation-requests')")]
     public ?string $ip = null;
 
-    #[ApiProperty(description: 'User agent the declaration was submitted from (admin only)', writable: false)]
+    #[ApiProperty(description: 'User agent the declaration was submitted from (admin only)', writable: false, security: "is_back_office('revocation-requests')")]
     public ?string $userAgent = null;
 
     #[ApiProperty(description: 'When the customer receipt email was suppressed (UTC), if any', writable: false)]
@@ -151,11 +158,7 @@ class RevocationRequest extends Resource
     #[ApiProperty(description: 'Reason the customer receipt email was suppressed, if any', writable: false)]
     public ?string $suppressedReason = null;
 
-    /**
-     * Build a DTO from a revocation request model. Internal-only fields
-     * (admin note, IP, user agent) are populated only for the admin view.
-     */
-    public static function fromModel(object $model, bool $adminView = false): self
+    public static function fromModel(object $model): self
     {
         $dto = new self();
         $dto->id = (int) $model->getId();
@@ -171,12 +174,9 @@ class RevocationRequest extends Resource
         $dto->processedAt = $model->getProcessedAt();
         $dto->suppressedAt = $model->getSuppressedAt();
         $dto->suppressedReason = $model->getSuppressedReason();
-
-        if ($adminView) {
-            $dto->adminNote = $model->getAdminNote();
-            $dto->ip = $model->getIp();
-            $dto->userAgent = $model->getUserAgent();
-        }
+        $dto->adminNote = $model->getAdminNote();
+        $dto->ip = $model->getIp();
+        $dto->userAgent = $model->getUserAgent();
 
         return $dto;
     }

--- a/app/code/core/Maho/Revocation/Api/RevocationRequestProcessor.php
+++ b/app/code/core/Maho/Revocation/Api/RevocationRequestProcessor.php
@@ -155,6 +155,6 @@ final class RevocationRequestProcessor extends Processor
 
         $model->save();
 
-        return RevocationRequest::fromModel($model, adminView: true);
+        return RevocationRequest::fromModel($model);
     }
 }

--- a/app/code/core/Maho/Revocation/Api/RevocationRequestProcessor.php
+++ b/app/code/core/Maho/Revocation/Api/RevocationRequestProcessor.php
@@ -133,16 +133,6 @@ final class RevocationRequestProcessor extends Processor
 
     private function processAdminUpdate(int $id, mixed $data): RevocationRequest
     {
-        $this->requireAdminOrApiUser();
-
-        // Admin tokens are gated by ROLE_ADMIN; API-user tokens must hold the
-        // granular write permission rather than passing on role alone, so a
-        // read-only API key cannot change processing status or admin notes.
-        $user = $this->getAuthorizedUser();
-        if ($user->isApiUser()) {
-            $this->requirePermission($user, 'revocation-requests/write');
-        }
-
         $model = \Mage::getModel('revocation/request')->load($id);
         if (!$model->getId()) {
             throw new NotFoundHttpException('Revocation request not found');

--- a/app/code/core/Maho/Revocation/Api/RevocationRequestProvider.php
+++ b/app/code/core/Maho/Revocation/Api/RevocationRequestProvider.php
@@ -20,9 +20,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 /**
  * Reads revocation requests for the owning customer and for admins.
  *
- * Customer-facing operations are scoped to the authenticated account email
- * (the declaration's natural key); admins see every request and the
- * internal-only fields (admin note, IP, user agent).
+ * Item reads are ownership-gated by the operation's `is_owner(object, 'email')`
+ * expression (the declaration's natural key); the customer collection is scoped
+ * to the authenticated account email at the query. Internal-only fields (admin
+ * note, IP, user agent) are gated per-property by `is_back_office()`.
  */
 final class RevocationRequestProvider extends Provider
 {
@@ -41,7 +42,6 @@ final class RevocationRequestProvider extends Provider
         }
 
         if ($operation instanceof CollectionOperationInterface) {
-            $this->requireAdminView();
             return $this->provideAdminCollection($context);
         }
 
@@ -55,7 +55,7 @@ final class RevocationRequestProvider extends Provider
         $collection = \Mage::getModel($this->modelAlias)->getCollection()
             ->addFieldToFilter('email', $email);
 
-        return $this->paginate($collection, $context, adminView: false);
+        return $this->paginate($collection, $context);
     }
 
     private function provideAdminCollection(array $context): TraversablePaginator
@@ -76,7 +76,7 @@ final class RevocationRequestProvider extends Provider
             $collection->addFieldToFilter('order_id', (int) $filters['orderId']);
         }
 
-        return $this->paginate($collection, $context, adminView: true);
+        return $this->paginate($collection, $context);
     }
 
     private function provideSingle(int $id): ?RevocationRequest
@@ -90,20 +90,12 @@ final class RevocationRequestProvider extends Provider
             return null;
         }
 
-        if ($this->isAdminView()) {
-            return RevocationRequest::fromModel($model, adminView: true);
-        }
-
-        // Customer path: only the owner (matched by account email) may read it.
-        $email = $this->requireCustomerEmail();
-        if (strcasecmp((string) $model->getEmail(), $email) !== 0) {
-            throw new NotFoundHttpException('Revocation request not found');
-        }
-
-        return RevocationRequest::fromModel($model, adminView: false);
+        // Ownership is enforced by the operation's `is_owner(object, 'email')`
+        // expression post-read; a denial maps to 404 / null.
+        return RevocationRequest::fromModel($model);
     }
 
-    private function paginate(object $collection, array $context, bool $adminView): TraversablePaginator
+    private function paginate(object $collection, array $context): TraversablePaginator
     {
         foreach ($this->defaultSort as $field => $dir) {
             $collection->setOrder($field, $dir);
@@ -121,23 +113,10 @@ final class RevocationRequestProvider extends Provider
 
         $items = [];
         foreach ($collection as $model) {
-            $items[] = RevocationRequest::fromModel($model, $adminView);
+            $items[] = RevocationRequest::fromModel($model);
         }
 
         return new TraversablePaginator(new \ArrayIterator($items), $page, $pageSize, $total);
-    }
-
-    /** Admins and API users see every request and the internal-only fields. */
-    private function isAdminView(): bool
-    {
-        return $this->isAdmin() || $this->isApiUser();
-    }
-
-    private function requireAdminView(): void
-    {
-        if (!$this->isAdminView()) {
-            throw new \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException('Admin access required');
-        }
     }
 
     private function requireCustomerEmail(): string

--- a/tests/Api/V2/Mcp/McpTest.php
+++ b/tests/Api/V2/Mcp/McpTest.php
@@ -458,6 +458,27 @@ describe('MCP tool dispatch', function (): void {
         expect($response['json']['error'] ?? null)->not->toBeNull();
     });
 
+    it('reports a foreign customer order exactly like a missing one', function (): void {
+        // The ownership denial from the security stage is remapped to Not Found
+        // inside McpDispatchProvider (MCP errors bypass ApiExceptionListener, so
+        // the operation's exceptionToStatus is honored there). Any difference
+        // between the two replies would make the tool an order-id oracle.
+        $orderId = fixtures('other_customer_order_id');
+        if (!$orderId) {
+            $this->markTestSkipped('No other_customer_order_id configured in fixtures');
+        }
+
+        $token = customerToken();
+        $session = mcpSession($token);
+        $foreign = mcpTool('sales_orders_get', ['id' => (int) $orderId], $token, $session);
+        $missing = mcpTool('sales_orders_get', ['id' => 99999999], $token, $session);
+
+        $foreignError = $foreign['json']['error']['message'] ?? null;
+        expect($foreignError)->not->toBeNull();
+        expect($foreignError)->not->toContain('Access Denied');
+        expect($foreignError)->toBe($missing['json']['error']['message'] ?? null);
+    });
+
     it('applies admin ACL to admin tokens', function (): void {
         // A role granting catalog only must not reach a sales tool: the request
         // attributes AdminAclListener keys off are absent under MCP, so this

--- a/tests/Api/V2/Read/AddressTest.php
+++ b/tests/Api/V2/Read/AddressTest.php
@@ -111,14 +111,17 @@ describe('API v2 Customer Addresses', function (): void {
             }
             $addressId = (int) $create['json']['id'];
 
-            // Customer B must not read A's address by id (AddressProvider loads
-            // the address, then authorizeCustomerAccess() denies the non-owner).
+            // Customer B must not read A's address by id. 404, not 403: a
+            // distinguishable response would turn this into an address-id oracle.
             $read = apiGet("/api/rest/v2/addresses/{$addressId}", customerToken($intruderId));
-            expect($read['status'])->toBeIn([403, 404]);
+            expect($read['status'])->toBe(404);
+            expect(apiGet('/api/rest/v2/addresses/99999999', customerToken($intruderId))['status'])
+                ->toBe($read['status']);
 
-            // Customer B must not delete A's address.
+            // Customer B must not delete A's address, and again cannot tell it apart
+            // from an address that does not exist.
             $delete = apiDelete("/api/rest/v2/customers/me/addresses/{$addressId}", customerToken($intruderId));
-            expect($delete['status'])->toBeIn([403, 404]);
+            expect($delete['status'])->toBe(404);
 
             // Owner removes their own address (no tracked-cleanup type for addresses).
             apiDelete("/api/rest/v2/customers/me/addresses/{$addressId}", customerToken($ownerId));

--- a/tests/Api/V2/Read/AddressTest.php
+++ b/tests/Api/V2/Read/AddressTest.php
@@ -111,6 +111,11 @@ describe('API v2 Customer Addresses', function (): void {
             }
             $addressId = (int) $create['json']['id'];
 
+            // The owner reads their own address: proves the ownership gate lets
+            // owners through (a fail-closed misconfiguration would 404 here).
+            $ownerRead = apiGet("/api/rest/v2/addresses/{$addressId}", customerToken($ownerId));
+            expect($ownerRead['status'])->toBe(200);
+
             // Customer B must not read A's address by id. 404, not 403: a
             // distinguishable response would turn this into an address-id oracle.
             $read = apiGet("/api/rest/v2/addresses/{$addressId}", customerToken($intruderId));

--- a/tests/Api/V2/Read/AddressTest.php
+++ b/tests/Api/V2/Read/AddressTest.php
@@ -118,10 +118,13 @@ describe('API v2 Customer Addresses', function (): void {
 
             // Customer B must not read A's address by id. 404, not 403: a
             // distinguishable response would turn this into an address-id oracle.
+            // The body must match too, or the oracle survives at the message level.
             $read = apiGet("/api/rest/v2/addresses/{$addressId}", customerToken($intruderId));
             expect($read['status'])->toBe(404);
-            expect(apiGet('/api/rest/v2/addresses/99999999', customerToken($intruderId))['status'])
-                ->toBe($read['status']);
+            $missingRead = apiGet('/api/rest/v2/addresses/99999999', customerToken($intruderId));
+            expect($missingRead['status'])->toBe($read['status']);
+            expect($read['json']['error'] ?? null)->toBe($missingRead['json']['error'] ?? null);
+            expect($read['json']['message'] ?? null)->toBe($missingRead['json']['message'] ?? null);
 
             // Customer B must not delete A's address, and again cannot tell it apart
             // from an address that does not exist.

--- a/tests/Api/V2/Read/OrderTest.php
+++ b/tests/Api/V2/Read/OrderTest.php
@@ -78,10 +78,13 @@ describe('GET /api/rest/v2/orders', function (): void {
         $response = apiGet("/api/rest/v2/orders/{$orderId}", customerToken());
 
         // 404 and not 403: a status differing from the missing-id response
-        // would make the endpoint an order-id oracle.
+        // would make the endpoint an order-id oracle. The body must match too,
+        // or the oracle survives at the message level.
         expect($response['status'])->toBe(404);
         $missing = apiGet('/api/rest/v2/orders/99999999', customerToken());
         expect($missing['status'])->toBe($response['status']);
+        expect($response['json']['error'] ?? null)->toBe($missing['json']['error'] ?? null);
+        expect($response['json']['message'] ?? null)->toBe($missing['json']['message'] ?? null);
     });
 
     it('still answers 401 with WWW-Authenticate on an unauthenticated item read', function (): void {

--- a/tests/Api/V2/Read/OrderTest.php
+++ b/tests/Api/V2/Read/OrderTest.php
@@ -77,7 +77,39 @@ describe('GET /api/rest/v2/orders', function (): void {
 
         $response = apiGet("/api/rest/v2/orders/{$orderId}", customerToken());
 
-        expect($response['status'])->toBeIn([403, 404]);
+        // 404 and not 403: a status differing from the missing-id response
+        // would make the endpoint an order-id oracle.
+        expect($response['status'])->toBe(404);
+        $missing = apiGet('/api/rest/v2/orders/99999999', customerToken());
+        expect($missing['status'])->toBe($response['status']);
+    });
+
+    it('still answers 401 with WWW-Authenticate on an unauthenticated item read', function (): void {
+        // The ownership clause is evaluated post-read, so this 401 rests solely
+        // on the listener's missing-Bearer check; pin the affordance.
+        $response = apiGetRaw('/api/rest/v2/orders/1');
+
+        expect($response['status'])->toBe(401);
+        expect($response['headers']['www-authenticate'][0] ?? '')->toContain('Bearer');
+    });
+
+    it('returns null (not an Access Denied error) for a foreign order via GraphQL', function (): void {
+        $orderId = fixtures('other_customer_order_id');
+        if (!$orderId) {
+            $this->markTestSkipped('No other_customer_order_id configured in fixtures');
+        }
+
+        $foreign = gqlQuery("{ order(id: \"/api/rest/v2/orders/{$orderId}\") { _id } }", [], customerToken());
+        $missing = gqlQuery('{ order(id: "/api/rest/v2/orders/99999999") { _id } }', [], customerToken());
+
+        // Foreign row and nonexistent id must be indistinguishable: data.order
+        // null in both, and no errors[] entry disclosing "Access Denied".
+        foreach ([$foreign, $missing] as $response) {
+            expect($response['status'])->toBe(200);
+            expect($response['json'])->not->toHaveKey('errors');
+            expect($response['json']['data'] ?? [])->toHaveKey('order');
+            expect($response['json']['data']['order'])->toBeNull();
+        }
     });
 
 });

--- a/tests/Api/V2/Read/WishlistTest.php
+++ b/tests/Api/V2/Read/WishlistTest.php
@@ -118,9 +118,12 @@ describe('API v2 Wishlist - cross-tenant isolation', function (): void {
         );
         expect($intruderIds)->not->toContain($itemId);
 
-        // Customer B must not be able to delete A's item.
+        // Customer B must not be able to delete A's item, and cannot tell it apart
+        // from an item id that does not exist at all.
         $delete = apiDelete("/api/rest/v2/customers/me/wishlist/{$itemId}", customerToken($intruderId));
-        expect($delete['status'])->toBeIn([403, 404]);
+        expect($delete['status'])->toBe(404);
+        expect(apiDelete('/api/rest/v2/customers/me/wishlist/99999999', customerToken($intruderId))['status'])
+            ->toBe($delete['status']);
 
         // The item must still exist for its owner.
         $ownerList = apiGet('/api/rest/v2/customers/me/wishlist', customerToken($ownerId));

--- a/tests/Api/V2/Write/CustomerWriteTest.php
+++ b/tests/Api/V2/Write/CustomerWriteTest.php
@@ -83,17 +83,25 @@ describe('POST /api/rest/v2/customers (extended fields)', function (): void {
         expect($customer)->not->toHaveKey('confirmation');
     });
 
-    it('rejects admin-only fields on anonymous registration', function (): void {
+    it('ignores admin-only fields on anonymous registration', function (): void {
+        $email = CUSTOMER_WRITE_EMAIL_PREFIX . uniqid() . '@example.test';
         $response = apiPost('/api/rest/v2/customers', [
-            'email' => CUSTOMER_WRITE_EMAIL_PREFIX . uniqid() . '@example.test',
+            'email' => $email,
             'password' => 'PestWrite1234!',
             'firstname' => 'Anon',
             'lastname' => 'User',
             'groupId' => 2,
+            'taxvat' => 'IT12345678901',
         ]);
 
-        // AccessDenied surfaces as 401 for tokenless callers, 403 for tokened ones
-        expect($response['status'])->toBeIn([401, 403]);
+        // The admin-only properties carry a securityPostDenormalize gate, so an
+        // unprivileged caller's values are reset before the processor sees them:
+        // registration succeeds, on the default group, with no tax id.
+        expect($response['status'])->toBeSuccessful();
+
+        $read = apiGet('/api/rest/v2/customers/' . (int) $response['json']['id'], adminToken());
+        expect($read['json']['groupId'])->toBe(1)
+            ->and($read['json']['taxvat'])->toBeNull();
     });
 
     it('rejects a non-existent groupId', function (): void {

--- a/tests/Api/V2/Write/SecurityHardeningTest.php
+++ b/tests/Api/V2/Write/SecurityHardeningTest.php
@@ -87,7 +87,9 @@ describe('Wishlist move-to-cart ownership (IDOR)', function (): void {
             'cartId' => $victimQuoteId,
         ], customerToken());
 
-        expect($move['status'])->toBeForbidden();
+        // 404, not 403: cart ids are enumerable, so a foreign cart is reported
+        // exactly like a missing one (CartService::verifyCartAccess).
+        expect($move['status'])->toBeNotFound();
 
         // The victim's cart must remain empty.
         $reloaded = Mage::getModel('sales/quote')->loadByIdWithoutStore($victimQuoteId);

--- a/tests/Backend/Integration/ApiPlatform/AdminGraphQlAclCoverageTest.php
+++ b/tests/Backend/Integration/ApiPlatform/AdminGraphQlAclCoverageTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Maho\ApiPlatform\Controller\AdminGraphQlController;
+use Tests\MahoBackendTestCase;
+
+uses(MahoBackendTestCase::class);
+
+/*
+ * Authorization-coverage guard for /api/admin/graphql.
+ *
+ * This endpoint is a separate surface from the REST and storefront-GraphQL one.
+ * It does not go through API Platform's state providers, so nothing there
+ * evaluates an operation `security:` expression or a property one: the handlers
+ * hand-serialize with $dto->toArray(). What gates it instead is
+ * AdminAcl::checkResource(), once per handler method, against the same
+ * ADMIN_RESOURCE constant AdminAclListener uses on the REST surface.
+ *
+ * That makes the per-handler call the only gate, and forgetting one on a new
+ * operation is invisible in review. These tests walk the controller's own
+ * dispatch table, so a handler method reachable from a GraphQL operation name
+ * has to carry the check.
+ */
+
+/**
+ * Handler methods the controller can dispatch a GraphQL operation to, read out
+ * of resolveOperation()'s match table.
+ *
+ * @return list<string>
+ */
+function adminGraphQlDispatchedMethods(): array
+{
+    $method = new ReflectionMethod(AdminGraphQlController::class, 'resolveOperation');
+    $source = implode('', array_slice(
+        file($method->getFileName()),
+        $method->getStartLine(),
+        $method->getEndLine() - $method->getStartLine(),
+    ));
+
+    preg_match_all('/\$this->(\w+)->(\w+)\(/', $source, $matches, PREG_SET_ORDER);
+
+    $methods = [];
+    foreach ($matches as [, $handlerProperty, $handlerMethod]) {
+        $type = (new ReflectionProperty(AdminGraphQlController::class, $handlerProperty))->getType();
+        $methods[] = ((string) $type) . '::' . $handlerMethod;
+    }
+
+    return array_values(array_unique($methods));
+}
+
+/** Source of one method, so the assertions can look for the gate inside it. */
+function adminGraphQlMethodSource(string $class, string $method): string
+{
+    $reflection = new ReflectionMethod($class, $method);
+
+    return implode('', array_slice(
+        file($reflection->getFileName()),
+        $reflection->getStartLine(),
+        $reflection->getEndLine() - $reflection->getStartLine(),
+    ));
+}
+
+it('dispatches to a non-trivial number of handler methods', function (): void {
+    // Guards against the regex silently matching nothing after a refactor,
+    // which would make the coverage assertion below vacuously pass.
+    expect(count(adminGraphQlDispatchedMethods()))->toBeGreaterThan(20);
+});
+
+it('checks the admin ACL in every handler method the admin GraphQL endpoint dispatches to', function (): void {
+    $ungated = [];
+
+    foreach (adminGraphQlDispatchedMethods() as $target) {
+        [$class, $method] = explode('::', $target, 2);
+        if (!str_contains(adminGraphQlMethodSource($class, $method), 'AdminAcl::checkResource(')) {
+            $ungated[] = (new ReflectionClass($class))->getShortName() . "::{$method}()";
+        }
+    }
+
+    expect($ungated)->toBe(
+        [],
+        'Admin GraphQL operations reachable without an ADMIN_RESOURCE check: ' . implode(', ', $ungated),
+    );
+});
+
+it('names a resource class that declares ADMIN_RESOURCE in every check', function (): void {
+    $undeclared = [];
+
+    foreach (adminGraphQlDispatchedMethods() as $target) {
+        [$class, $method] = explode('::', $target, 2);
+        $source = adminGraphQlMethodSource($class, $method);
+
+        preg_match_all('/AdminAcl::checkResource\(\s*([\\\\\w]+)::class\s*\)/', $source, $matches);
+        foreach ($matches[1] as $shortRef) {
+            // The handlers import their resource classes, so resolve the
+            // reference through the handler's own use statements.
+            $resourceClass = adminGraphQlResolveClassRef($class, $shortRef);
+            if ($resourceClass === null || !defined($resourceClass . '::ADMIN_RESOURCE')) {
+                $undeclared[] = (new ReflectionClass($class))->getShortName() . "::{$method}() -> {$shortRef}";
+            }
+        }
+    }
+
+    expect($undeclared)->toBe(
+        [],
+        'AdminAcl::checkResource() called with a class that declares no ADMIN_RESOURCE, '
+        . 'which default-denies the operation outright: ' . implode(', ', $undeclared),
+    );
+});
+
+/** Resolve a `Foo::class` reference written inside $context's file to its FQCN. */
+function adminGraphQlResolveClassRef(string $context, string $reference): ?string
+{
+    $reference = ltrim($reference, '\\');
+    if (class_exists($reference)) {
+        return $reference;
+    }
+
+    $source = (string) file_get_contents((new ReflectionClass($context))->getFileName());
+    preg_match_all('/^use\s+([\\\\\w]+);/m', $source, $matches, PREG_SET_ORDER);
+
+    foreach ($matches as [, $imported]) {
+        if (str_ends_with($imported, '\\' . $reference) && class_exists($imported)) {
+            return $imported;
+        }
+    }
+
+    return null;
+}

--- a/tests/Backend/Integration/ApiPlatform/CustomerScopeCoverageTest.php
+++ b/tests/Backend/Integration/ApiPlatform/CustomerScopeCoverageTest.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+use Maho\ApiPlatform\Kernel;
+use Maho\Config\ApiResource as MahoApiResource;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Tests\MahoBackendTestCase;
+
+uses(MahoBackendTestCase::class);
+
+/*
+ * Row-scoping coverage guard for customer-scoped API resources (issue #1212).
+ *
+ * Ownership of a row is enforced declaratively: every item read operation a
+ * plain customer can reach on a `mahoCustomerScoped` resource must carry an
+ * `is_owner(object, '<property>')` clause in its security expression. The
+ * clause defers evaluation to after the provider has loaded the row, and the
+ * denial is shaped like a missing row (REST/MCP: the operation's
+ * `AccessDeniedException => 404` mapping; GraphQL: OwnershipDenialProvider
+ * converts it to a null result). This test makes the pattern mandatory: a new
+ * customer-reachable item read without the clause, the 404 mapping, or a
+ * matching DTO property fails the build.
+ */
+
+final class CustomerScopeKernel extends Kernel
+{
+    #[\Override]
+    protected function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new class implements CompilerPassInterface {
+            #[\Override]
+            public function process(ContainerBuilder $container): void
+            {
+                $expose = [
+                    ResourceNameCollectionFactoryInterface::class,
+                    ResourceMetadataCollectionFactoryInterface::class,
+                ];
+                foreach ($expose as $id) {
+                    if ($container->hasAlias($id)) {
+                        $container->getAlias($id)->setPublic(true);
+                    } elseif ($container->hasDefinition($id)) {
+                        $container->getDefinition($id)->setPublic(true);
+                    }
+                }
+            }
+        });
+    }
+}
+
+function customerScopeContainer(): \Psr\Container\ContainerInterface
+{
+    static $container = null;
+    if ($container === null) {
+        Mage::app();
+        $kernel = new CustomerScopeKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer();
+    }
+    return $container;
+}
+
+/**
+ * Every read ITEM operation on a mahoCustomerScoped resource that a plain
+ * customer can reach, i.e. whose security expression is not the public 'true'.
+ * Collections are excluded by design: they are identity-scoped at the query
+ * (post-read filtering of a paginator would corrupt totalItems).
+ *
+ * @return list<array{label: string, resourceClass: class-string, operation: object, security: string}>
+ */
+function customerScopeItemReads(): array
+{
+    static $rows = null;
+    if ($rows !== null) {
+        return $rows;
+    }
+
+    $container = customerScopeContainer();
+    /** @var ResourceNameCollectionFactoryInterface $nameFactory */
+    $nameFactory = $container->get(ResourceNameCollectionFactoryInterface::class);
+    /** @var ResourceMetadataCollectionFactoryInterface $metadataFactory */
+    $metadataFactory = $container->get(ResourceMetadataCollectionFactoryInterface::class);
+
+    $rows = [];
+    foreach ($nameFactory->create() as $resourceClass) {
+        if (str_starts_with($resourceClass, 'ApiPlatform\\')) {
+            continue;
+        }
+
+        foreach ($metadataFactory->create($resourceClass) as $metadata) {
+            if (!$metadata instanceof MahoApiResource || !$metadata->mahoCustomerScoped) {
+                continue;
+            }
+            $shortName = $metadata->getShortName() ?? $resourceClass;
+
+            // Cart is exempt as a whole: its item reads resolve guest carts by
+            // masked id and are ownership-gated inside
+            // CartService::verifyCartAccess() (shared with the write
+            // processors), which already answers 404 for foreign rows.
+            if ($shortName === 'Cart') {
+                continue;
+            }
+
+            $operations = [];
+            foreach ($metadata->getOperations() ?? [] as $name => $operation) {
+                if ($operation instanceof Get) {
+                    $operations["REST {$shortName}::{$name}"] = $operation;
+                }
+            }
+            foreach ($metadata->getGraphQlOperations() ?? [] as $name => $operation) {
+                if ($operation instanceof Query && !$operation instanceof QueryCollection) {
+                    $operations["GraphQL {$shortName}::{$name}"] = $operation;
+                }
+            }
+
+            foreach ($operations as $label => $operation) {
+                $security = trim((string) $operation->getSecurity());
+
+                // 'true' marks the guest/public surface (masked ids, one-time
+                // tokens, public reviews) - another party's row is the contract.
+                if ($security === '' || $security === 'true') {
+                    continue;
+                }
+
+                // Admin/service-locked operations have no customer to scope to.
+                if (!str_contains($security, 'ROLE_CUSTOMER') && !str_contains($security, 'is_owner')) {
+                    continue;
+                }
+
+                // Newsletter status reads accept no identifier: the subscriber
+                // is derived from the JWT inside the provider, so there is no
+                // id to probe and nothing for is_owner to compare.
+                if (in_array($operation->getName(), ['status', 'status_rest'], true)) {
+                    continue;
+                }
+
+                $rows[] = [
+                    'label' => $label,
+                    'resourceClass' => $resourceClass,
+                    'operation' => $operation,
+                    'security' => $security,
+                ];
+            }
+        }
+    }
+
+    return $rows;
+}
+
+it('finds the customer-reachable item reads (vacuous-pass guard)', function (): void {
+    // Order (REST+GraphQL), Address (2 REST + GraphQL), WishlistItem (GraphQL),
+    // RevocationRequest (REST+GraphQL) = 8 today. Growth is fine; silence is not.
+    expect(count(customerScopeItemReads()))->toBeGreaterThanOrEqual(8);
+});
+
+it('carries an is_owner clause on every customer-reachable item read', function (): void {
+    $missing = [];
+    foreach (customerScopeItemReads() as $row) {
+        if (!preg_match("/is_owner\\(object,\\s*'[A-Za-z0-9_]+'\\)/", $row['security'])) {
+            $missing[] = "{$row['label']} -> {$row['security']}";
+        }
+    }
+
+    expect($missing)->toBe(
+        [],
+        'Customer-reachable item reads without a row-ownership clause (any customer can read any row): '
+        . implode(', ', $missing),
+    );
+});
+
+it('maps the ownership denial to 404 on every REST item read carrying the clause', function (): void {
+    // The security stage throws ApiPlatform's AccessDeniedException subclass;
+    // the mapping must catch it (ApiExceptionListener matches with is_a()).
+    $thrownClass = \ApiPlatform\Symfony\Security\Exception\AccessDeniedException::class;
+
+    $unmapped = [];
+    foreach (customerScopeItemReads() as $row) {
+        $operation = $row['operation'];
+        if (!$operation instanceof HttpOperation || !str_contains($row['security'], 'is_owner')) {
+            continue;
+        }
+
+        $mapsTo404 = false;
+        foreach ($operation->getExceptionToStatus() ?? [] as $class => $status) {
+            if ($status === 404 && is_a($thrownClass, $class, true)) {
+                $mapsTo404 = true;
+                break;
+            }
+        }
+        if (!$mapsTo404) {
+            $unmapped[] = $row['label'];
+        }
+    }
+
+    expect($unmapped)->toBe(
+        [],
+        'REST item reads whose ownership denial answers 403 instead of 404 (id oracle): ' . implode(', ', $unmapped),
+    );
+});
+
+it('names an existing DTO property in every is_owner clause', function (): void {
+    $broken = [];
+    foreach (customerScopeItemReads() as $row) {
+        if (!preg_match("/is_owner\\(object,\\s*'([A-Za-z0-9_]+)'\\)/", $row['security'], $m)) {
+            continue;
+        }
+        $property = $m[1];
+        if (!(new ReflectionClass($row['resourceClass']))->hasProperty($property)) {
+            $broken[] = "{$row['label']} -> {$property}";
+        }
+    }
+
+    expect($broken)->toBe(
+        [],
+        'is_owner clauses naming a property the DTO does not have (is_owner fails closed, the owner is locked out too): '
+        . implode(', ', $broken),
+    );
+});

--- a/tests/Backend/Integration/ApiPlatform/PropertyAuthorizationTest.php
+++ b/tests/Backend/Integration/ApiPlatform/PropertyAuthorizationTest.php
@@ -25,7 +25,7 @@ uses(MahoBackendTestCase::class);
  *
  * Which fields a caller sees is decided by API Platform's per-property
  * `security:` / `securityPostDenormalize:` expressions, evaluated by
- * AbstractItemNormalizer — so one declaration covers REST, GraphQL and MCP,
+ * AbstractItemNormalizer, so one declaration covers REST, GraphQL and MCP,
  * in both directions. Nothing strips fields in a provider any more, which
  * makes these expressions the only gate and worth pinning down:
  *

--- a/tests/Backend/Integration/ApiPlatform/PropertyAuthorizationTest.php
+++ b/tests/Backend/Integration/ApiPlatform/PropertyAuthorizationTest.php
@@ -1,0 +1,423 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+use Maho\ApiPlatform\Kernel;
+use Maho\ApiPlatform\Security\ApiUser;
+use Maho\ApiPlatform\Security\ApiPermissionRegistry;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Tests\MahoBackendTestCase;
+
+uses(MahoBackendTestCase::class);
+
+/*
+ * Field-visibility regression guard.
+ *
+ * Which fields a caller sees is decided by API Platform's per-property
+ * `security:` / `securityPostDenormalize:` expressions, evaluated by
+ * AbstractItemNormalizer — so one declaration covers REST, GraphQL and MCP,
+ * in both directions. Nothing strips fields in a provider any more, which
+ * makes these expressions the only gate and worth pinning down:
+ *
+ *   1. `is_back_office('<resource>')` resolves the way the grant model says it
+ *      should, wildcards included.
+ *   2. Round-tripping a DTO through the real serializer actually drops the
+ *      gated fields, including the stockItem policy columns a property
+ *      expression cannot reach.
+ *   3. Write-side gates reset an unprivileged caller's admin-only input.
+ *   4. Every referenced permission is real (a typo would silently always-deny).
+ *   5. The set of fields an unauthenticated caller can read matches the
+ *      committed snapshot, so a newly added property cannot join the public
+ *      surface without someone editing that file on purpose.
+ */
+
+/**
+ * Test kernel that publishes the (private) services these assertions drive.
+ * The production container is untouched.
+ */
+final class PropertyAuthzKernel extends Kernel
+{
+    private const EXPOSE = [
+        'api_platform.serializer',
+        'api_platform.security.resource_access_checker',
+        'security.token_storage',
+        ResourceNameCollectionFactoryInterface::class,
+        PropertyNameCollectionFactoryInterface::class,
+        PropertyMetadataFactoryInterface::class,
+    ];
+
+    #[\Override]
+    protected function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new class implements CompilerPassInterface {
+            #[\Override]
+            public function process(ContainerBuilder $container): void
+            {
+                foreach (PropertyAuthzKernel::exposedServiceIds() as $id) {
+                    if ($container->hasAlias($id)) {
+                        $container->getAlias($id)->setPublic(true);
+                    } elseif ($container->hasDefinition($id)) {
+                        $container->getDefinition($id)->setPublic(true);
+                    }
+                }
+            }
+        });
+    }
+
+    /** @return list<string> */
+    public static function exposedServiceIds(): array
+    {
+        return self::EXPOSE;
+    }
+}
+
+function propertyAuthzContainer(): \Psr\Container\ContainerInterface
+{
+    static $container = null;
+    if ($container === null) {
+        Mage::app();
+        $kernel = new PropertyAuthzKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer();
+    }
+    return $container;
+}
+
+/**
+ * Authenticate the container as the given caller for the duration of one
+ * assertion. Null clears the token (unauthenticated).
+ *
+ * @param list<string> $permissions
+ */
+function propertyAuthzAuthenticate(?string $kind, array $permissions = []): void
+{
+    $storage = propertyAuthzContainer()->get('security.token_storage');
+
+    if ($kind === null) {
+        $storage->setToken(null);
+        return;
+    }
+
+    $user = match ($kind) {
+        'admin' => new ApiUser('admin', ['ROLE_ADMIN'], null, 1),
+        'customer' => new ApiUser('customer', ['ROLE_CUSTOMER'], 1),
+        'api' => new ApiUser('service', ['ROLE_API_USER'], null, null, 1, $permissions),
+    };
+
+    $storage->setToken(new UsernamePasswordToken($user, 'api', $user->getRoles()));
+}
+
+/** Evaluate a security expression as the currently authenticated caller. */
+function propertyAuthzEvaluate(string $expression): bool
+{
+    return propertyAuthzContainer()
+        ->get('api_platform.security.resource_access_checker')
+        ->isGranted(Mage\Catalog\Api\Product::class, $expression);
+}
+
+/**
+ * Normalize a DTO through the real API Platform serializer.
+ *
+ * @return array<string, mixed>
+ */
+function propertyAuthzNormalize(object $dto, array $groups = []): array
+{
+    $context = ['resource_class' => $dto::class];
+    if ($groups !== []) {
+        $context['groups'] = $groups;
+    }
+
+    /** @var array<string, mixed> */
+    return propertyAuthzContainer()->get('api_platform.serializer')->normalize($dto, 'json', $context);
+}
+
+afterEach(function (): void {
+    propertyAuthzAuthenticate(null);
+});
+
+it('grants is_back_office to admins and to service tokens holding the resource', function (): void {
+    $cases = [
+        'unauthenticated' => [null, [], false],
+        'admin' => ['admin', [], true],
+        'customer' => ['customer', [], false],
+        'service token with products/read' => ['api', ['products/read'], true],
+        'service token with products/write' => ['api', ['products/write'], true],
+        'service token with products/all' => ['api', ['products/all'], true],
+        'service token with the global all' => ['api', ['all'], true],
+        'service token with only products/delete' => ['api', ['products/delete'], false],
+        'service token for another resource' => ['api', ['orders/read'], false],
+    ];
+
+    foreach ($cases as $label => [$kind, $permissions, $expected]) {
+        propertyAuthzAuthenticate($kind, $permissions);
+        expect(propertyAuthzEvaluate("is_back_office('products')"))
+            ->toBe($expected, "is_back_office('products') for {$label}");
+    }
+});
+
+it('omits back-office product fields for a caller without a products grant', function (): void {
+    $product = new Mage\Catalog\Api\Product();
+    $product->id = 1;
+    $product->sku = 'SKU-1';
+    $product->cost = 12.34;
+    $product->customDesign = 'default/modern';
+    $product->customLayoutUpdate = '<reference name="content"/>';
+    $product->customAttributes = ['internal_note' => 'do not show'];
+
+    $groups = ['product:read', 'product:detail'];
+    $gated = ['cost', 'customDesign', 'customLayoutUpdate', 'customAttributes'];
+
+    propertyAuthzAuthenticate(null);
+    expect(array_keys(propertyAuthzNormalize($product, $groups)))
+        ->not->toContain(...$gated)
+        ->toContain('sku');
+
+    propertyAuthzAuthenticate('api', ['orders/read']);
+    expect(array_keys(propertyAuthzNormalize($product, $groups)))->not->toContain(...$gated);
+
+    propertyAuthzAuthenticate('api', ['products/read']);
+    expect(array_keys(propertyAuthzNormalize($product, $groups)))->toContain(...$gated);
+
+    propertyAuthzAuthenticate('admin');
+    expect(array_keys(propertyAuthzNormalize($product, $groups)))->toContain(...$gated);
+});
+
+it('omits inventory policy columns from stockItem for a caller without a products grant', function (): void {
+    $product = new Mage\Catalog\Api\Product();
+    $product->id = 1;
+    $product->sku = 'SKU-1';
+    $product->stockItem = [
+        'qty' => 5.0,
+        'is_in_stock' => true,
+        'min_sale_qty' => 1.0,
+        'min_qty' => 2.0,
+        'backorders' => 1,
+        'manage_stock' => true,
+        'notify_stock_qty' => 3.0,
+        'use_config_min_qty' => true,
+    ];
+
+    $groups = ['product:read', 'product:detail'];
+    $policy = ['min_qty', 'backorders', 'manage_stock', 'notify_stock_qty', 'use_config_min_qty'];
+    $public = ['qty', 'is_in_stock', 'min_sale_qty'];
+
+    propertyAuthzAuthenticate(null);
+    $columns = array_keys(propertyAuthzNormalize($product, $groups)['stockItem']);
+    expect($columns)->not->toContain(...$policy)->toContain(...$public);
+
+    propertyAuthzAuthenticate('api', ['products/write']);
+    $columns = array_keys(propertyAuthzNormalize($product, $groups)['stockItem']);
+    expect($columns)->toContain(...$policy)->toContain(...$public);
+});
+
+it('omits back-office fields on other resources for unprivileged callers', function (): void {
+    $page = new Mage\Cms\Api\CmsPage();
+    $page->id = 1;
+    $page->title = 'Home';
+    $page->layoutUpdateXml = '<reference name="content"/>';
+    $page->customTheme = 'default/modern';
+
+    propertyAuthzAuthenticate(null);
+    expect(array_keys(propertyAuthzNormalize($page)))
+        ->not->toContain('layoutUpdateXml', 'customTheme')
+        ->toContain('title');
+
+    propertyAuthzAuthenticate('api', ['cms-pages/read']);
+    expect(array_keys(propertyAuthzNormalize($page)))->toContain('layoutUpdateXml', 'customTheme');
+
+    $order = new Mage\Sales\Api\Order();
+    $order->id = 1;
+    $order->remoteIp = '203.0.113.7';
+    $order->xForwardedFor = '198.51.100.4';
+
+    propertyAuthzAuthenticate('customer');
+    expect(array_keys(propertyAuthzNormalize($order)))->not->toContain('remoteIp', 'xForwardedFor');
+
+    propertyAuthzAuthenticate('api', ['orders/read']);
+    expect(array_keys(propertyAuthzNormalize($order)))->toContain('remoteIp', 'xForwardedFor');
+});
+
+it('resets admin-only customer fields submitted by an unprivileged caller', function (): void {
+    $payload = (string) Mage::helper('core')->jsonEncode([
+        'email' => 'shopper@example.com',
+        'firstname' => 'Shopper',
+        'groupId' => 3,
+        'isActive' => true,
+        'taxvat' => 'IT12345678901',
+        'disableAutoGroupChange' => true,
+    ]);
+
+    $deserialize = static fn(): Mage\Customer\Api\Customer => propertyAuthzContainer()
+        ->get('api_platform.serializer')
+        ->deserialize($payload, Mage\Customer\Api\Customer::class, 'json', [
+            'resource_class' => Mage\Customer\Api\Customer::class,
+        ]);
+
+    // Public registration: the profile fields land, the admin-only ones do not.
+    propertyAuthzAuthenticate(null);
+    $customer = $deserialize();
+    expect($customer->email)->toBe('shopper@example.com')
+        ->and($customer->firstname)->toBe('Shopper')
+        ->and($customer->groupId)->toBeNull()
+        ->and($customer->isActive)->toBeNull()
+        ->and($customer->taxvat)->toBeNull()
+        ->and($customer->disableAutoGroupChange)->toBeNull();
+
+    // A customer's own token is no more privileged than an anonymous one here.
+    propertyAuthzAuthenticate('customer');
+    expect($deserialize()->groupId)->toBeNull();
+
+    propertyAuthzAuthenticate('api', ['customers/create']);
+    $customer = $deserialize();
+    expect($customer->groupId)->toBe(3)
+        ->and($customer->isActive)->toBeTrue()
+        ->and($customer->taxvat)->toBe('IT12345678901');
+
+    propertyAuthzAuthenticate('admin');
+    expect($deserialize()->groupId)->toBe(3);
+});
+
+it('references only real, grantable permissions in every property security expression', function (): void {
+    $valid = (new ApiPermissionRegistry())->getPermissionIds();
+    $phantom = [];
+
+    foreach (propertyAuthzSecuredProperties() as $label => $expression) {
+        // `is_granted('resource/op')` and `is_back_office('resource')` both name a
+        // resource that has to exist; a typo in either is silently always-denied.
+        preg_match_all("/is_granted\\(\\s*['\"]([^'\"]+)['\"]/", $expression, $granted);
+        foreach (array_filter($granted[1], static fn(string $a): bool => str_contains($a, '/')) as $permission) {
+            if (!in_array($permission, $valid, true)) {
+                $phantom[] = "{$label} -> {$permission}";
+            }
+        }
+
+        preg_match_all("/is_back_office\\(\\s*['\"]([^'\"]+)['\"]/", $expression, $backOffice);
+        foreach ($backOffice[1] as $resourceId) {
+            if (!in_array($resourceId . '/read', $valid, true) && !in_array($resourceId . '/write', $valid, true)) {
+                $phantom[] = "{$label} -> is_back_office({$resourceId})";
+            }
+        }
+    }
+
+    expect($phantom)->toBe(
+        [],
+        'Property security expressions naming a permission that cannot be granted: ' . implode(', ', $phantom),
+    );
+});
+
+it('exposes exactly the snapshotted set of fields to an unauthenticated caller', function (): void {
+    $snapshotFile = __DIR__ . '/public-api-fields.php';
+    $expected = require $snapshotFile;
+    $actual = propertyAuthzPublicFields();
+
+    // Reported per resource so the failure names the field that changed rather
+    // than dumping the whole surface.
+    foreach ($actual as $shortName => $fields) {
+        expect($fields)->toBe(
+            $expected[$shortName] ?? [],
+            "Fields readable without authentication changed for {$shortName}. If the change is "
+            . 'intended, update ' . basename($snapshotFile) . '; if not, gate the new property with '
+            . "#[ApiProperty(security: \"is_back_office('…')\")].",
+        );
+    }
+
+    expect(array_keys($actual))->toBe(array_keys($expected), 'The set of API resources changed.');
+});
+
+/**
+ * Every property carrying a security expression, keyed by `ShortName::property`.
+ *
+ * @return array<string, string>
+ */
+function propertyAuthzSecuredProperties(): array
+{
+    $secured = [];
+    foreach (propertyAuthzResourceProperties() as $resourceClass => $properties) {
+        $shortName = (new ReflectionClass($resourceClass))->getShortName();
+        foreach ($properties as $property => $metadata) {
+            foreach (['security' => $metadata->getSecurity(), 'securityPostDenormalize' => $metadata->getSecurityPostDenormalize()] as $kind => $expression) {
+                if (is_string($expression) && trim($expression) !== '') {
+                    $secured["{$shortName}::{$property} ({$kind})"] = $expression;
+                }
+            }
+        }
+    }
+    return $secured;
+}
+
+/**
+ * Readable properties per resource that survive an unauthenticated read, keyed
+ * by short name and sorted, i.e. the public API surface.
+ *
+ * @return array<string, list<string>>
+ */
+function propertyAuthzPublicFields(): array
+{
+    propertyAuthzAuthenticate(null);
+    $checker = propertyAuthzContainer()->get('api_platform.security.resource_access_checker');
+
+    $public = [];
+    foreach (propertyAuthzResourceProperties() as $resourceClass => $properties) {
+        $fields = [];
+        foreach ($properties as $property => $metadata) {
+            if ($metadata->isReadable() === false) {
+                continue;
+            }
+            $security = $metadata->getSecurity();
+            if (is_string($security) && !$checker->isGranted($resourceClass, $security)) {
+                continue;
+            }
+            $fields[] = $property;
+        }
+        sort($fields);
+        $public[(new ReflectionClass($resourceClass))->getShortName()] = $fields;
+    }
+
+    ksort($public);
+    return $public;
+}
+
+/**
+ * Property metadata for every Maho API resource, keyed by class then property.
+ *
+ * @return array<class-string, array<string, ApiPlatform\Metadata\ApiProperty>>
+ */
+function propertyAuthzResourceProperties(): array
+{
+    static $properties = null;
+    if ($properties !== null) {
+        return $properties;
+    }
+
+    $container = propertyAuthzContainer();
+    $nameFactory = $container->get(ResourceNameCollectionFactoryInterface::class);
+    $propertyNames = $container->get(PropertyNameCollectionFactoryInterface::class);
+    $propertyMetadata = $container->get(PropertyMetadataFactoryInterface::class);
+
+    $properties = [];
+    foreach ($nameFactory->create() as $resourceClass) {
+        // API Platform's own Error/ConstraintViolation resources model response
+        // shapes, not Maho data.
+        if (str_starts_with($resourceClass, 'ApiPlatform\\')) {
+            continue;
+        }
+
+        foreach ($propertyNames->create($resourceClass) as $property) {
+            $properties[$resourceClass][$property] = $propertyMetadata->create($resourceClass, $property);
+        }
+    }
+
+    return $properties;
+}

--- a/tests/Backend/Integration/ApiPlatform/public-api-fields.php
+++ b/tests/Backend/Integration/ApiPlatform/public-api-fields.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Snapshot of every field the API serializes for an unauthenticated caller.
+ * Snapshot of every readable API field carrying no property-level security gate.
  *
  * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
  * SPDX-License-Identifier: OSL-3.0
@@ -11,9 +11,11 @@ declare(strict_types=1);
 
 /*
  * PropertyAuthorizationTest compares the live surface against this file. A
- * property with no `#[ApiProperty(security: ...)]` is public, so adding one to a
- * DTO widens the public API by default; this snapshot turns that into a failing
- * test until someone either gates the property or records it here on purpose.
+ * property with no `#[ApiProperty(security: ...)]` is visible to every caller
+ * the operation-level gates let through (for publicly readable resources, that
+ * is anyone), so adding one to a DTO widens the exposed surface by default;
+ * this snapshot turns that into a failing test until someone either gates the
+ * property or records it here on purpose.
  *
  * Regenerate deliberately, never to silence a failure you have not read.
  */

--- a/tests/Backend/Integration/ApiPlatform/public-api-fields.php
+++ b/tests/Backend/Integration/ApiPlatform/public-api-fields.php
@@ -195,9 +195,9 @@ return [
         'ratings', 'status', 'stores', 'title',
     ],
     'RevocationRequest' => [
-        'adminNote', 'customerName', 'email', 'extensions', 'id', 'ip', 'orderId', 'orderReference',
+        'customerName', 'email', 'extensions', 'id', 'orderId', 'orderReference',
         'processedAt', 'processedStatus', 'reason', 'receivedAt', 'storeId', 'suppressedAt',
-        'suppressedReason', 'userAgent', 'verified',
+        'suppressedReason', 'verified',
     ],
     'Shipment' => [
         'comments', 'createdAt', 'emailSent', 'extensions', 'id', 'incrementId', 'items', 'orderId',

--- a/tests/Backend/Integration/ApiPlatform/public-api-fields.php
+++ b/tests/Backend/Integration/ApiPlatform/public-api-fields.php
@@ -1,0 +1,243 @@
+<?php
+
+/**
+ * Snapshot of every field the API serializes for an unauthenticated caller.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+/*
+ * PropertyAuthorizationTest compares the live surface against this file. A
+ * property with no `#[ApiProperty(security: ...)]` is public, so adding one to a
+ * DTO widens the public API by default; this snapshot turns that into a failing
+ * test until someone either gates the property or records it here on purpose.
+ *
+ * Regenerate deliberately, never to silence a failure you have not read.
+ */
+
+return [
+    'Address' => [
+        'addressType', 'city', 'company', 'countryId', 'createdAt', 'customerAddressId', 'customerId',
+        'email', 'extensions', 'fax', 'firstname', 'id', 'isDefaultBilling', 'isDefaultShipping',
+        'lastname', 'middlename', 'postcode', 'prefix', 'region', 'regionId', 'street', 'suffix',
+        'telephone', 'updatedAt', 'vatId',
+    ],
+    'AttributeSet' => [
+        'attributeCodes', 'attributeSetName', 'extensions', 'groups', 'id',
+    ],
+    'AuthToken' => [
+        'apiUser', 'cartId', 'cartItemsQty', 'cartMaskedId', 'customer', 'expiresIn', 'extensions',
+        'id', 'message', 'permissions', 'success', 'token', 'tokenType',
+    ],
+    'BlogCategory' => [
+        'createdAt', 'extensions', 'id', 'isActive', 'level', 'metaDescription', 'metaKeywords',
+        'metaRobots', 'metaTitle', 'name', 'parentId', 'path', 'position', 'stores', 'updatedAt',
+        'urlKey',
+    ],
+    'BlogPost' => [
+        'categoryIds', 'content', 'createdAt', 'excerpt', 'extensions', 'id', 'image', 'imageUrl',
+        'isActive', 'metaDescription', 'metaKeywords', 'metaRobots', 'metaTitle', 'publishDate',
+        'shortContent', 'status', 'stores', 'title', 'updatedAt', 'urlKey',
+    ],
+    'BundleOption' => [
+        'extensions', 'id', 'position', 'required', 'selections', 'title', 'type',
+    ],
+    'Cart' => [
+        'appliedCoupon', 'appliedGiftcards', 'availablePaymentMethods', 'availableShippingMethods',
+        'billingAddress', 'cartRecreated', 'createdAt', 'currency', 'customerEmail', 'customerId',
+        'customerNote', 'extensions', 'giftMessage', 'id', 'isActive', 'items', 'itemsCount',
+        'itemsQty', 'maskedId', 'prices', 'reservedOrderId', 'selectedPaymentMethod',
+        'selectedShippingMethod', 'shippingAddress', 'storeId', 'updatedAt',
+    ],
+    'Category' => [
+        'availableSortBy', 'children', 'childrenCount', 'childrenIds', 'cmsBlock', 'createdAt',
+        'customApplyToProducts', 'customDesign', 'customDesignFrom', 'customDesignTo',
+        'customLayoutUpdate', 'customUseParentSettings', 'defaultSortBy', 'description', 'displayMode',
+        'extensions', 'filterPriceRange', 'id', 'image', 'includeInMenu', 'isActive', 'isAnchor',
+        'landingPageId', 'level', 'metaDescription', 'metaKeywords', 'metaRobots', 'metaTitle', 'name',
+        'pageLayout', 'parentId', 'path', 'position', 'productCount', 'updatedAt', 'urlKey', 'urlPath',
+    ],
+    'CmsBlock' => [
+        'content', 'createdAt', 'extensions', 'id', 'identifier', 'isActive', 'status', 'stores',
+        'title', 'updatedAt',
+    ],
+    'CmsPage' => [
+        'content', 'contentHeading', 'createdAt', 'extensions', 'id', 'identifier', 'isActive',
+        'metaDescription', 'metaKeywords', 'metaRobots', 'pageLayout', 'sortOrder', 'status', 'stores',
+        'title', 'updatedAt',
+    ],
+    'ConfigurableSetup' => [
+        'childProductIds', 'extensions', 'id', 'superAttributes',
+    ],
+    'ContactForm' => [
+        'captchaProvider', 'captchaSiteKey', 'enabled', 'extensions', 'honeypotField', 'id', 'message',
+        'success',
+    ],
+    'Country' => [
+        'availableRegions', 'extensions', 'id', 'iso2Code', 'iso3Code', 'name',
+    ],
+    'Coupon' => [
+        'applyToShipping', 'code', 'createdAt', 'customerGroupIds', 'description', 'discountAmount',
+        'discountPreview', 'discountQty', 'discountStep', 'discountType', 'expirationDate',
+        'extensions', 'fromDate', 'id', 'isActive', 'isPrimary', 'isValid', 'minimumSubtotal',
+        'ruleId', 'ruleName', 'simpleFreeShipping', 'sortOrder', 'stopRulesProcessing', 'timesUsed',
+        'toDate', 'type', 'usageLimit', 'usagePerCustomer', 'validationMessage', 'websiteIds',
+    ],
+    'CreditMemo' => [
+        'adjustment', 'adjustmentNegative', 'adjustmentPositive', 'baseAdjustment', 'baseCurrencyCode',
+        'baseDiscountAmount', 'baseGrandTotal', 'baseShippingAmount', 'baseSubtotal', 'baseTaxAmount',
+        'comment', 'comments', 'createdAt', 'creditmemoStatus', 'currency', 'discountAmount',
+        'discountDescription', 'emailSent', 'extensions', 'grandTotal', 'hiddenTaxAmount', 'id',
+        'incrementId', 'invoiceId', 'items', 'orderCurrencyCode', 'orderId', 'orderIncrementId',
+        'shippingAmount', 'shippingInclTax', 'shippingTaxAmount', 'state', 'storeId', 'subtotal',
+        'subtotalInclTax', 'taxAmount', 'transactionId', 'updatedAt',
+    ],
+    'Currency' => [
+        'code', 'exchangeRate', 'extensions', 'symbol',
+    ],
+    'Customer' => [
+        'addresses', 'createdAt', 'createdIn', 'defaultBillingAddress', 'defaultShippingAddress',
+        'disableAutoGroupChange', 'dob', 'email', 'extensions', 'firstname', 'fullName', 'gender',
+        'groupId', 'id', 'isActive', 'isConfirmed', 'isSubscribed', 'lastname', 'middlename', 'prefix',
+        'storeId', 'suffix', 'taxvat', 'updatedAt', 'websiteId',
+    ],
+    'CustomerGroup' => [
+        'code', 'extensions', 'id', 'taxClassId', 'taxClassName',
+    ],
+    'DownloadableLink' => [
+        'extensions', 'id', 'isShareable', 'linkType', 'linkUrl', 'numberOfDownloads', 'price',
+        'sampleType', 'sampleUrl', 'sortOrder', 'title',
+    ],
+    'GiftCard' => [
+        'balance', 'code', 'createdAt', 'currencyCode', 'emailScheduledAt', 'emailSentAt', 'expiresAt',
+        'extensions', 'history', 'id', 'initialBalance', 'message', 'purchaseOrderId',
+        'purchaseOrderItemId', 'recipientEmail', 'recipientName', 'senderEmail', 'senderName',
+        'status', 'updatedAt', 'websiteId',
+    ],
+    'GroupedProductLink' => [
+        'childProductId', 'childProductName', 'childProductSku', 'extensions', 'id', 'position', 'qty',
+    ],
+    'Invoice' => [
+        'baseDiscountAmount', 'baseGrandTotal', 'baseShippingAmount', 'baseSubtotal', 'baseTaxAmount',
+        'canVoidFlag', 'comments', 'createdAt', 'currency', 'discountAmount', 'discountDescription',
+        'emailSent', 'extensions', 'grandTotal', 'id', 'incrementId', 'isUsedForRefund', 'items',
+        'orderId', 'orderIncrementId', 'pdfUrl', 'shippingAmount', 'shippingInclTax', 'state',
+        'stateName', 'storeId', 'subtotal', 'subtotalInclTax', 'taxAmount', 'totalQty',
+        'transactionId', 'updatedAt',
+    ],
+    'LayeredFilter' => [
+        'code', 'extensions', 'label', 'multiple', 'options', 'position', 'type',
+    ],
+    'Media' => [
+        'dimensions', 'directive', 'extensions', 'filename', 'path', 'size', 'url',
+    ],
+    'NewsletterSubscription' => [
+        'changeStatusAt', 'confirmationRequired', 'customerId', 'email', 'extensions', 'isSubscribed',
+        'message', 'status', 'storeId', 'subscriberId',
+    ],
+    'Order' => [
+        'accessToken', 'accountToken', 'appliedRuleIds', 'baseCurrencyCode', 'billingAddress',
+        'changeAmount', 'couponCode', 'couponRuleName', 'createdAt', 'currency', 'customerDob',
+        'customerEmail', 'customerFirstname', 'customerGender', 'customerGroupId', 'customerId',
+        'customerIsGuest', 'customerLastname', 'customerMiddlename', 'customerNote', 'customerPrefix',
+        'customerSuffix', 'customerTaxvat', 'discountDescription', 'emailSent', 'extCustomerId',
+        'extOrderId', 'extensions', 'giftcardCodes', 'globalCurrencyCode', 'holdBeforeState',
+        'holdBeforeStatus', 'id', 'incrementId', 'isVirtual', 'items', 'paymentMethod',
+        'paymentMethodTitle', 'prices', 'quoteId', 'shipments', 'shippingAddress',
+        'shippingDescription', 'shippingMethod', 'state', 'status', 'statusHistory', 'storeId',
+        'storeName', 'totalItemCount', 'totalQtyOrdered', 'updatedAt', 'weight',
+    ],
+    'Product' => [
+        'additionalAttributes', 'attributeSetId', 'averageRating', 'barcode', 'bundleOptions',
+        'categoryIds', 'configurableOptions', 'countryOfManufacture', 'createdAt', 'crosssellProducts',
+        'currency', 'customOptions', 'description', 'downloadableLinks', 'extensions', 'finalPrice',
+        'giftMessageAvailable', 'giftcardAmounts', 'giftcardIsMessageAllowed', 'giftcardMaxAmount',
+        'giftcardMinAmount', 'giftcardType', 'groupedProducts', 'gtin', 'hasRequiredOptions', 'id',
+        'imageLabel', 'imageUrl', 'isActive', 'linksPurchasedSeparately', 'linksTitle', 'mediaGallery',
+        'metaDescription', 'metaKeywords', 'metaRobots', 'metaTitle', 'minimalPrice', 'mpn', 'msrp',
+        'msrpDisplayActualPriceType', 'msrpEnabled', 'name', 'newsFromDate', 'newsToDate',
+        'optionsContainer', 'pageLayout', 'price', 'priceType', 'priceView', 'relatedProducts',
+        'reviewCount', 'samplesTitle', 'shipmentType', 'shortDescription', 'sku', 'skuType',
+        'smallImageLabel', 'smallImageUrl', 'specialFromDate', 'specialPrice', 'specialToDate',
+        'status', 'stockItem', 'stockQty', 'stockStatus', 'taxClassId', 'thumbnailLabel',
+        'thumbnailUrl', 'tierPrices', 'type', 'updatedAt', 'upsellProducts', 'urlKey', 'urlPath',
+        'variants', 'visibility', 'websiteIds', 'weight', 'weightType',
+    ],
+    'ProductAttribute' => [
+        'applyTo', 'attributeCode', 'backendType', 'defaultValue', 'extensions', 'frontendClass',
+        'frontendInput', 'frontendLabel', 'id', 'isComparable', 'isConfigurable', 'isFilterable',
+        'isFilterableInSearch', 'isGlobal', 'isHtmlAllowedOnFront', 'isRequired', 'isSearchable',
+        'isUnique', 'isUsedForPriceRules', 'isUserDefined', 'isVisibleInAdvancedSearch',
+        'isVisibleOnFront', 'isWysiwygEnabled', 'note', 'options', 'position', 'scope',
+        'usedForSortBy', 'usedInProductListing',
+    ],
+    'ProductCustomOption' => [
+        'extensions', 'fileExtensions', 'id', 'imageSizeX', 'imageSizeY', 'maxCharacters', 'price',
+        'priceType', 'required', 'sku', 'sortOrder', 'title', 'type', 'values',
+    ],
+    'ProductGroupPrice' => [
+        'customerGroupId', 'extensions', 'id', 'price', 'websiteId',
+    ],
+    'ProductLink' => [
+        'extensions', 'id', 'linkedProductId', 'linkedProductName', 'linkedProductSku', 'position',
+    ],
+    'ProductMedia' => [
+        'disabled', 'extensions', 'file', 'id', 'label', 'position', 'types', 'url',
+    ],
+    'ProductTierPrice' => [
+        'customerGroupId', 'extensions', 'id', 'price', 'qty', 'websiteId',
+    ],
+    'Review' => [
+        'createdAt', 'detail', 'extensions', 'id', 'nickname', 'productId', 'productName', 'rating',
+        'ratings', 'status', 'stores', 'title',
+    ],
+    'RevocationRequest' => [
+        'adminNote', 'customerName', 'email', 'extensions', 'id', 'ip', 'orderId', 'orderReference',
+        'processedAt', 'processedStatus', 'reason', 'receivedAt', 'storeId', 'suppressedAt',
+        'suppressedReason', 'userAgent', 'verified',
+    ],
+    'Shipment' => [
+        'comments', 'createdAt', 'emailSent', 'extensions', 'id', 'incrementId', 'items', 'orderId',
+        'orderIncrementId', 'packages', 'shipmentStatus', 'storeId', 'totalQty', 'totalWeight',
+        'tracks', 'updatedAt',
+    ],
+    'StockUpdate' => [
+        'backorders', 'enableQtyIncrements', 'extensions', 'isInStock', 'isQtyDecimal', 'manageStock',
+        'maxSaleQty', 'minQty', 'minSaleQty', 'notifyStockQty', 'previousQty', 'qty', 'qtyIncrements',
+        'results', 'sku', 'success', 'useConfigBackorders', 'useConfigEnableQtyInc',
+        'useConfigManageStock', 'useConfigMaxSaleQty', 'useConfigMinQty', 'useConfigMinSaleQty',
+        'useConfigNotifyStockQty', 'useConfigQtyIncrements',
+    ],
+    'Store' => [
+        'baseLinkUrl', 'baseMediaUrl', 'baseUrl', 'code', 'currency', 'extensions', 'groupId',
+        'groupName', 'id', 'isActive', 'locale', 'name', 'rootCategoryId', 'success', 'websiteId',
+    ],
+    'StoreConfig' => [
+        'allowedCountries', 'baseCurrencyCode', 'baseMediaUrl', 'baseUrl', 'cmsHomePage',
+        'defaultDescription', 'defaultDisplayCurrencyCode', 'defaultTitle', 'extensions', 'id',
+        'isGuestCheckoutAllowed', 'locale', 'logoAlt', 'logoUrl', 'newsletterEnabled',
+        'reviewsEnabled', 'storeCode', 'storeName', 'timezone', 'weightUnit', 'wishlistEnabled',
+    ],
+    'TaxClass' => [
+        'className', 'classType', 'extensions', 'id',
+    ],
+    'TaxRate' => [
+        'code', 'extensions', 'id', 'rate', 'taxCountryId', 'taxPostcode', 'taxRegionId', 'titles',
+        'zipFrom', 'zipIsRange', 'zipTo',
+    ],
+    'TaxRule' => [
+        'calculateSubtotal', 'code', 'customerTaxClassIds', 'extensions', 'id', 'position', 'priority',
+        'productTaxClassIds', 'taxRateIds',
+    ],
+    'UrlResolveResult' => [
+        'extensions', 'id', 'identifier', 'redirectType', 'redirectUrl', 'type',
+    ],
+    'WishlistItem' => [
+        'addedAt', 'description', 'extensions', 'id', 'inStock', 'productFinalPrice', 'productId',
+        'productImageUrl', 'productName', 'productPrice', 'productSku', 'productType', 'productUrl',
+        'qty',
+    ],
+];


### PR DESCRIPTION
Refs #1212.

API Platform 4.3 has native per-property authorization (`#[ApiProperty(security:)]` / `securityPostDenormalize:`), evaluated by `AbstractItemNormalizer`, and native row-level authorization (`security:` expressions referencing `object`, evaluated post-read by `AccessCheckerProvider`). One declaration on the property or operation covers REST, GraphQL and MCP, which replaces both the serialization-groups plan and the provider-hook row-scoping plan in the issue.

**Phase 1.** Deleted the per-resource permission re-checks that duplicate the operation's `security:` expression. They were also subtly stricter than the gate they duplicated: `ApiUser::hasPermission()` didn't understand the `resource/all` wildcard that `ApiUserVoter` grants, so a role holding `coupons/all` passed the operation gate and was then rejected by the processor. `hasPermission()` now resolves both wildcards and the voter defers to it.

**Phase 3.** `BackOfficeAccess` publishes the grant rule as an `is_back_office('<resource>')` expression function; product cost / design / layout / raw EAV, CMS design fields and order fraud metadata are gated on the property, and the admin-only customer fields on `securityPostDenormalize`. `stripBackOfficeData()`, the `CmsPageProvider::toDto()` override, the `OrderProvider` branch and `assertNoAdminOnlyFields()` are gone. Not fail-closed, so `tests/.../public-api-fields.php` snapshots the field set an unauthenticated caller can read and fails when a new property joins it.

**Phase 2.** Row scoping is now declarative too. A new `is_owner(object, '<property>')` expression function (the row-level counterpart of `is_back_office`) sits on every item read a plain customer can reach on the customer-scoped resources, REST and GraphQL alike:

```php
security: "is_back_office('orders') or is_owner(object, 'customerId')",
exceptionToStatus: [AccessDeniedException::class => 404],
```

The hand-rolled read-side ownership checks in `OrderProvider`, `AddressProvider`, `WishlistProvider` and `RevocationRequestProvider` are deleted. A denied row is indistinguishable from a missing one on all three protocols: `ApiExceptionListener` honors the operation's `exceptionToStatus` for authenticated callers (unauthenticated keeps 401 + `WWW-Authenticate`); GraphQL operations have no `exceptionToStatus` upstream, so `OwnershipDenialProvider` converts item-query ownership denials to `data: null`; MCP errors bypass `kernel.exception`, so `McpDispatchProvider` remaps the denial to the same `NotFoundHttpException` a missing row produces. `CustomerScopeCoverageTest` walks both `getOperations()` and `getGraphQlOperations()` and fails the build when a customer-reachable item read lacks the clause, the 404 mapping, or a real DTO owner property. Verified fail-closed by probe: with a deliberately wrong property name the owner is locked out too, nothing leaks.

Exempt by design, documented in the coverage test: Cart (ownership lives in `CartService::verifyCartAccess()`, shared with the write processors and masked-id guest flow, though its denials are now 404 instead of 403 since cart ids are enumerable), Review (public item reads), Newsletter status (no identifier accepted). Folded in: `RevocationRequest` internal fields (`adminNote`, `ip`, `userAgent`) moved from a caller-threaded `adminView` flag to per-property `is_back_office()` security, closing a hole where any service token saw them regardless of scope; the remaining bespoke privileged-reader predicates consolidated onto `isBackOffice()`.

**Phase 4.** Took the issue's second option. `/api/admin/graphql` dispatches through a hand-rolled match table and hand-serializes, so neither operation nor property expressions run there; `AdminAcl::checkResource()` per handler is the only gate, and every reachable handler already had one. `AdminGraphQlAclCoverageTest` walks the controller's own dispatch table so a new operation can't ship without it (verified by removing a gate and watching it fail).

**Behavior changes**, all main-only: an unprivileged caller sending an admin-only customer field gets it reset rather than a 403; gated fields are absent rather than null; foreign-row reads are 404 rather than 403 everywhere (REST, GraphQL null, MCP), including cart writes; a service token holding the resource grant can now read any row by id, which is what the operation gates already declared (the providers were stricter than the gate, the same defect class phase 1 removed); an authenticated caller without the grant probing an item id gets 404 instead of 403, hiding existence.

Not done here: write-path ownership. Processors keep their imperative checks; the native follow-up is `securityPostDenormalize` with `previous_object`, a separate pass.

Net +151 lines in `app/` + `lib/`: the ~2,100 lines of caller-dependent, per-resource security code lose their field-visibility, double-gating and read-side ownership share, replaced by one-time shared infrastructure; a new scoped resource now costs one clause and one property, enforced by coverage tests. `composer lint` clean; Api (794) + Backend (2835) + Frontend green.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->