### PR TITLE
Fixed composite SKU sent in analytics events for products with custom options

### DIFF
--- a/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Ga.php
@@ -214,7 +214,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                 $_product = $productInCart->getProduct();
                 $productPrice = (float) ($productInCart->getPriceInclTax() ?? $helper->getPriceInclTax($_product));
                 $_item = [
-                    'item_id' => $_product->getSku(),
+                    'item_id' => $helper->getTrackingSku($_product) ?: $productInCart->getSku(),
                     'item_name' => $_product->getName(),
                     'price' => $helper->formatPrice($productPrice),
                     'quantity' => (int) $productInCart->getQty(),
@@ -247,7 +247,7 @@ gtag('set', 'user_id', '{$customer->getId()}');
                     $_product = $productInCart->getProduct();
                     $productPrice = (float) ($productInCart->getPriceInclTax() ?? $helper->getPriceInclTax($_product));
                     $_item = [
-                        'item_id' => $_product->getSku(),
+                        'item_id' => $helper->getTrackingSku($_product) ?: $productInCart->getSku(),
                         'item_name' => $_product->getName(),
                         'price' => $helper->formatPrice($productPrice),
                         'quantity' => (int) $productInCart->getQty(),
@@ -314,8 +314,10 @@ gtag('set', 'user_id', '{$customer->getId()}');
             }
             $_product = $item->getProduct();
             $_item = [
-                // The catalog product SKU, not the order item's composite one, so it matches the merchant feed
-                'item_id' => $_product->getSku() ?: $item->getSku(),
+                // The catalog (or variant) SKU, not the item's composite one, so it matches the merchant feed
+                'item_id' => $item->getProductOptionByCode('simple_sku')
+                    ?: $helper->getTrackingSku($_product)
+                    ?: $item->getSku(),
                 'item_name' => $item->getName(),
                 'quantity' => (int) $item->getQtyOrdered(),
                 'price' => $helper->formatPrice($item->getBasePriceInclTax() ?? $item->getBasePrice()),

--- a/app/code/core/Mage/GoogleAnalytics/Block/Metapixel.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Metapixel.php
@@ -149,7 +149,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
 
                     foreach ($productCollection as $item) {
                         $_product = $item->getProduct();
-                        $productId = $_product->getSku();
+                        $productId = $helper->getTrackingSku($_product) ?: $item->getSku();
                         $contentIds[] = $productId;
                         $itemPrice = (float) ($item->getPriceInclTax() ?? $helper->getPriceInclTax($_product));
                         $contents[] = [
@@ -218,8 +218,10 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
         // Use visible items to avoid double counting configurables, etc.
         /** @var Mage_Sales_Model_Order_Item $item */
         foreach ($order->getAllVisibleItems() as $item) {
-            // The catalog product SKU, not the order item's composite one, so it matches the catalogue feed
-            $productId = $item->getProduct()->getSku() ?: $item->getSku();
+            // The catalog (or variant) SKU, not the item's composite one, so it matches the catalogue feed
+            $productId = $item->getProductOptionByCode('simple_sku')
+                ?: $helper->getTrackingSku($item->getProduct())
+                ?: $item->getSku();
             $contentIds[] = $productId;
             $contents[] = [
                 'id' => $productId,

--- a/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
+++ b/app/code/core/Mage/GoogleAnalytics/Helper/Data.php
@@ -166,6 +166,22 @@ class Mage_GoogleAnalytics_Helper_Data extends Mage_Core_Helper_Abstract
     }
 
     /**
+     * Feed-matching SKU: the raw catalog SKU (the variant's for configurables), never the
+     * composite one getSku() builds on cart products from custom options or bundle selections
+     */
+    public function getTrackingSku(?Mage_Catalog_Model_Product $product): ?string
+    {
+        if (!$product) {
+            return null;
+        }
+        $simpleOption = $product->getCustomOption('simple_product');
+        if ($simpleOption?->getProduct()) {
+            return $simpleOption->getProduct()->getData('sku');
+        }
+        return $product->getData('sku');
+    }
+
+    /**
      * @param int|float|string|null $price
      */
     public function formatPrice($price): string

--- a/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
+++ b/app/code/core/Mage/GoogleAnalytics/Model/Observer.php
@@ -75,7 +75,7 @@ class Mage_GoogleAnalytics_Model_Observer
             $manufacturer = $attribute ? $attribute->getFrontend()->getValue($product) : '';
             $dataForAnalytics = [
                 'id' => $product->getId(),
-                'sku' => $product->getSku(),
+                'sku' => Mage::helper('googleanalytics')->getTrackingSku($product) ?: $item->getSku(),
                 'name' => $product->getName(),
                 'qty' => $addedQty ?: $removedQty,
                 'price' => Mage::helper('googleanalytics')->getPriceInclTax($product),

--- a/tests/Frontend/Unit/GoogleAnalytics/Block/GaTest.php
+++ b/tests/Frontend/Unit/GoogleAnalytics/Block/GaTest.php
@@ -47,6 +47,41 @@ describe('GA4 purchase event', function () {
         expect($orderData['items'][0]['price'])->toBe('122.00');
     });
 
+    it('sends the base SKU when the item product carries SKU-altering custom options', function () {
+        $product = Mage::getModel('catalog/product')
+            ->setSku('basesku123')
+            ->setCategoryIds([]);
+        $option = Mage::getModel('catalog/product_option')
+            ->setId(7)
+            ->setType(Mage_Catalog_Model_Product_Option::OPTION_TYPE_FIELD)
+            ->setSku('mycustom option');
+        $product->addOption($option);
+        $product->addCustomOption('option_ids', '7');
+        $product->addCustomOption('option_7', 'engraved text');
+        $item = Mage::getModel('sales/order_item')
+            ->setSku('basesku123-mycustom option')
+            ->setQtyOrdered(1)
+            ->setBasePriceInclTax(10.00)
+            ->setProduct($product);
+        $order = Mage::getModel('sales/order')->setBaseGrandTotal(10.00);
+        $order->addItem($item);
+
+        expect($this->block->getPurchaseEventData($order)['items'][0]['item_id'])->toBe('basesku123');
+    });
+
+    it('sends the variant SKU for configurable items', function () {
+        $item = Mage::getModel('sales/order_item')
+            ->setSku('TSHIRT-M-mycustom option')
+            ->setQtyOrdered(1)
+            ->setBasePriceInclTax(10.00)
+            ->setProductOptions(['simple_sku' => 'TSHIRT-M'])
+            ->setProduct(Mage::getModel('catalog/product')->setSku('TSHIRT')->setCategoryIds([]));
+        $order = Mage::getModel('sales/order')->setBaseGrandTotal(10.00);
+        $order->addItem($item);
+
+        expect($this->block->getPurchaseEventData($order)['items'][0]['item_id'])->toBe('TSHIRT-M');
+    });
+
     it('falls back to the order item SKU when the product no longer exists', function () {
         $item = Mage::getModel('sales/order_item')
             ->setSku('deleted-sku')

--- a/tests/Frontend/Unit/GoogleAnalytics/Block/MetapixelTest.php
+++ b/tests/Frontend/Unit/GoogleAnalytics/Block/MetapixelTest.php
@@ -192,6 +192,39 @@ describe('Meta Pixel Purchase event', function () {
         expect($eventData['order_id'])->toBe('100000042');
     });
 
+    it('sends the base SKU when the item product carries SKU-altering custom options', function () {
+        $product = Mage::getModel('catalog/product')->setSku('basesku123');
+        $option = Mage::getModel('catalog/product_option')
+            ->setId(7)
+            ->setType(Mage_Catalog_Model_Product_Option::OPTION_TYPE_FIELD)
+            ->setSku('mycustom option');
+        $product->addOption($option);
+        $product->addCustomOption('option_ids', '7');
+        $product->addCustomOption('option_7', 'engraved text');
+        $item = Mage::getModel('sales/order_item')
+            ->setSku('basesku123-mycustom option')
+            ->setQtyOrdered(1)
+            ->setBasePriceInclTax(10.00)
+            ->setProduct($product);
+        $order = Mage::getModel('sales/order')->setBaseGrandTotal(10.00);
+        $order->addItem($item);
+
+        expect($this->block->getPurchaseEventData($order)['content_ids'])->toBe(['basesku123']);
+    });
+
+    it('sends the variant SKU for configurable items', function () {
+        $item = Mage::getModel('sales/order_item')
+            ->setSku('TSHIRT-M-mycustom option')
+            ->setQtyOrdered(1)
+            ->setBasePriceInclTax(10.00)
+            ->setProductOptions(['simple_sku' => 'TSHIRT-M'])
+            ->setProduct(Mage::getModel('catalog/product')->setSku('TSHIRT'));
+        $order = Mage::getModel('sales/order')->setBaseGrandTotal(10.00);
+        $order->addItem($item);
+
+        expect($this->block->getPurchaseEventData($order)['content_ids'])->toBe(['TSHIRT-M']);
+    });
+
     it('falls back to the order item SKU when the product no longer exists', function () {
         $item = Mage::getModel('sales/order_item')
             ->setSku('deleted-sku')

--- a/tests/Frontend/Unit/GoogleAnalytics/Helper/DataTest.php
+++ b/tests/Frontend/Unit/GoogleAnalytics/Helper/DataTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoFrontendTestCase::class);
+
+function gaTrackingSimpleWithSkuOption(): Mage_Catalog_Model_Product
+{
+    $product = Mage::getModel('catalog/product')->setSku('basesku123');
+    gaTrackingAddSkuOption($product);
+    return $product;
+}
+
+function gaTrackingAddSkuOption(Mage_Catalog_Model_Product $product): void
+{
+    $option = Mage::getModel('catalog/product_option')
+        ->setId(7)
+        ->setType(Mage_Catalog_Model_Product_Option::OPTION_TYPE_FIELD)
+        ->setSku('mycustom option');
+    $product->addOption($option);
+    $product->addCustomOption('option_ids', '7');
+    $product->addCustomOption('option_7', 'engraved text');
+}
+
+describe('getTrackingSku', function () {
+    beforeEach(function () {
+        $this->helper = Mage::helper('googleanalytics');
+    });
+
+    it('returns the raw base SKU when custom options make getSku() composite', function () {
+        $product = gaTrackingSimpleWithSkuOption();
+
+        expect($product->getSku())->toBe('basesku123-mycustom option');
+        expect($this->helper->getTrackingSku($product))->toBe('basesku123');
+    });
+
+    it('returns the variant SKU for configurables, without any custom-option suffix', function () {
+        $simple = Mage::getModel('catalog/product')->setId(11)->setSku('TSHIRT-M');
+        $configurable = Mage::getModel('catalog/product')
+            ->setTypeId(Mage_Catalog_Model_Product_Type_Configurable::TYPE_CODE)
+            ->setSku('TSHIRT');
+        $configurable->addCustomOption('simple_product', 11, $simple);
+        gaTrackingAddSkuOption($configurable);
+
+        expect($configurable->getSku())->toBe('TSHIRT-M-mycustom option');
+        expect($this->helper->getTrackingSku($configurable))->toBe('TSHIRT-M');
+    });
+
+    it('returns getSku() for products without custom options', function () {
+        $product = Mage::getModel('catalog/product')->setSku('plain-sku');
+
+        expect($this->helper->getTrackingSku($product))->toBe('plain-sku');
+    });
+
+    it('returns null when there is no product', function () {
+        expect($this->helper->getTrackingSku(null))->toBeNull();
+    });
+});


### PR DESCRIPTION
Follow-up to #1208, fixes the issue reported in https://github.com/MahoCommerce/maho/pull/1208#issuecomment-5164266313.

`Mage_Catalog_Model_Product::getSku()` composes SKUs on cart products: custom options append their SKU suffix (`basesku123-mycustom option`), bundles append selection SKUs, and quote items re-attach custom options to the product, so every quote-based event (`begin_checkout`, `view_cart`, `InitiateCheckout`, add/remove-from-cart) sent composite SKUs; Purchase events sent the parent SKU instead of the variant SKU for configurables.

- Added `Mage_GoogleAnalytics_Helper_Data::getTrackingSku()`: the raw catalog SKU, resolved to the selected variant for configurables, never composed. Used in all SKU call sites of `Ga.php`, `Metapixel.php`, and the cart observer.
- Purchase events prefer the order item's stored `simple_sku` option so configurables report the variant SKU from freshly-loaded order items.
- Tests now build products that actually carry `option_ids` (the #1208 ones didn't, which is why they passed), plus configurable-variant cases and helper coverage.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->