### PR TITLE
Sped up catalog_url reindexing by caching ICU transliterator lookups

### DIFF
--- a/app/code/core/Mage/Catalog/Helper/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url.php
@@ -15,7 +15,7 @@ class Mage_Catalog_Helper_Product_Url extends Mage_Core_Helper_Url
     /** @var array<string, bool>|null */
     protected static ?array $_transliteratorIds = null;
 
-    /** @var array<string, Transliterator> */
+    /** @var array<string, Transliterator|null> */
     protected static array $_transliterators = [];
 
     /**
@@ -68,25 +68,22 @@ class Mage_Catalog_Helper_Product_Url extends Mage_Core_Helper_Url
             self::$_transliteratorIds ??= array_fill_keys(transliterator_list_ids() ?: [], true);
             $code = str_replace('_', '-', strtolower($locale)) . '_Latn/BGN';
             if (isset(self::$_transliteratorIds[$code])) {
-                return self::transliterate($code . '; Any-Latin; Latin-ASCII; [^\u001F-\u007f] remove' . ($lower ? '; Lower()' : ''), $string);
+                return static::transliterate($code . '; Any-Latin; Latin-ASCII; [^\u001F-\u007f] remove' . ($lower ? '; Lower()' : ''), $string);
             }
         }
 
-        return self::transliterate('Any-Latin; Latin-ASCII; [^\u001F-\u007f] remove' . ($lower ? '; Lower()' : ''), $string);
+        return static::transliterate('Any-Latin; Latin-ASCII; [^\u001F-\u007f] remove' . ($lower ? '; Lower()' : ''), $string);
     }
 
     protected static function transliterate(string $rules, string $string): string
     {
-        if (!isset(self::$_transliterators[$rules])) {
-            $transliterator = Transliterator::create($rules);
-            if ($transliterator === null) {
-                return $string;
-            }
-            self::$_transliterators[$rules] = $transliterator;
+        // null is cached too, so an unusable rule set is not retried on every call
+        if (!array_key_exists($rules, self::$_transliterators)) {
+            self::$_transliterators[$rules] = Transliterator::create($rules);
         }
 
-        $result = self::$_transliterators[$rules]->transliterate($string);
+        $result = self::$_transliterators[$rules]?->transliterate($string);
 
-        return $result === false ? $string : $result;
+        return is_string($result) ? $result : $string;
     }
 }

--- a/app/code/core/Mage/Catalog/Helper/Product/Url.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Url.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
  * SPDX-FileCopyrightText: 2022-2024 The OpenMage Contributors <https://openmage.org>
  * SPDX-FileCopyrightText: 2006-2020 Magento, Inc. <https://magento.com>
  * SPDX-License-Identifier: OSL-3.0
@@ -10,6 +11,12 @@
 class Mage_Catalog_Helper_Product_Url extends Mage_Core_Helper_Url
 {
     protected $_moduleName = 'Mage_Catalog';
+
+    /** @var array<string, bool>|null */
+    protected static ?array $_transliteratorIds = null;
+
+    /** @var array<string, Transliterator> */
+    protected static array $_transliterators = [];
 
     /**
      * Symbol convert table
@@ -58,13 +65,28 @@ class Mage_Catalog_Helper_Product_Url extends Mage_Core_Helper_Url
         $string = strtr($string, $this->getConvertTable());
 
         if (!empty($locale)) {
-            $opts = transliterator_list_ids();
+            self::$_transliteratorIds ??= array_fill_keys(transliterator_list_ids() ?: [], true);
             $code = str_replace('_', '-', strtolower($locale)) . '_Latn/BGN';
-            if (in_array($code, $opts)) {
-                return transliterator_transliterate($code . '; Any-Latin; Latin-ASCII; [^\u001F-\u007f] remove' . ($lower ? '; Lower()' : ''), $string);
+            if (isset(self::$_transliteratorIds[$code])) {
+                return self::transliterate($code . '; Any-Latin; Latin-ASCII; [^\u001F-\u007f] remove' . ($lower ? '; Lower()' : ''), $string);
             }
         }
 
-        return transliterator_transliterate('Any-Latin; Latin-ASCII; [^\u001F-\u007f] remove' . ($lower ? '; Lower()' : ''), $string);
+        return self::transliterate('Any-Latin; Latin-ASCII; [^\u001F-\u007f] remove' . ($lower ? '; Lower()' : ''), $string);
+    }
+
+    protected static function transliterate(string $rules, string $string): string
+    {
+        if (!isset(self::$_transliterators[$rules])) {
+            $transliterator = Transliterator::create($rules);
+            if ($transliterator === null) {
+                return $string;
+            }
+            self::$_transliterators[$rules] = $transliterator;
+        }
+
+        $result = self::$_transliterators[$rules]->transliterate($string);
+
+        return $result === false ? $string : $result;
     }
 }

--- a/tests/Backend/Unit/Catalog/Helper/ProductUrlFormatTest.php
+++ b/tests/Backend/Unit/Catalog/Helper/ProductUrlFormatTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('Catalog Product Url Helper format()', function () {
+    beforeEach(function () {
+        $this->helper = Mage::helper('catalog/product_url');
+    });
+
+    describe('transliteration without a locale', function () {
+        it('strips accents and lowercases by default', function () {
+            expect($this->helper->format('Ünïcödé Prödüct'))->toBe('unicode product');
+        });
+
+        it('preserves case when $lower is false', function () {
+            expect($this->helper->format('Ünïcödé Prödüct', null, false))->toBe('Unicode Product');
+        });
+
+        it('expands ligatures', function () {
+            expect($this->helper->format('Ægte Å-Vare'))->toBe('aegte a-vare');
+        });
+
+        it('applies the conversion table', function () {
+            expect($this->helper->format('Product © 2026 ®'))->toBe('product c 2026 r');
+        });
+
+        it('returns an empty string for null', function () {
+            expect($this->helper->format(null))->toBe('');
+        });
+
+        it('leaves plain ascii untouched', function () {
+            expect($this->helper->format('0'))->toBe('0');
+            expect($this->helper->format(''))->toBe('');
+        });
+    });
+
+    describe('locale-specific transliteration', function () {
+        it('uses the BGN ruleset for a locale that has one', function () {
+            // Any-Latin renders Ж as z, the Russian BGN ruleset as zh
+            expect($this->helper->format('Жук', 'ru_RU'))->toBe('zhuk');
+            expect($this->helper->format('Жук'))->toBe('zuk');
+        });
+
+        it('honours $lower on the locale branch', function () {
+            expect($this->helper->format('Жук', 'ru_RU', false))->toBe('Zhuk');
+        });
+
+        it('falls back to the generic ruleset for a locale without one', function () {
+            expect($this->helper->format('Жук', 'sv_SE'))->toBe('zuk');
+            expect($this->helper->format('Жук', 'xx_XX'))->toBe('zuk');
+        });
+
+        it('treats an empty locale as no locale', function () {
+            expect($this->helper->format('Жук', ''))->toBe('zuk');
+        });
+    });
+
+    describe('cached transliterators', function () {
+        it('returns the same result when rulesets are interleaved', function () {
+            $first = $this->helper->format('Жук', 'ru_RU');
+            $this->helper->format('Жук');
+            $this->helper->format('Жук', 'ru_RU', false);
+            $this->helper->format('Ünïcödé Prödüct', 'sv_SE');
+
+            expect($this->helper->format('Жук', 'ru_RU'))->toBe($first)->toBe('zhuk');
+        });
+
+        it('keeps each ruleset on its own cache entry', function () {
+            $results = [];
+            foreach ([null, 'ru_RU', 'sv_SE'] as $locale) {
+                foreach ([true, false] as $lower) {
+                    $results[] = $this->helper->format('Жук', $locale, $lower);
+                }
+            }
+
+            expect($results)->toBe(['zuk', 'Zuk', 'zhuk', 'Zhuk', 'zuk', 'Zuk']);
+        });
+
+        it('is not affected by helper instance reuse', function () {
+            $other = Mage::helper('catalog/product_url');
+
+            expect($other->format('Жук', 'ru_RU'))->toBe($this->helper->format('Жук', 'ru_RU'));
+        });
+
+        it('returns the input unchanged for an unusable ruleset and does not retry it', function () {
+            $rules = 'Definitely-Not-A-Real-Transliterator-ID';
+            $transliterate = new ReflectionMethod(Mage_Catalog_Helper_Product_Url::class, 'transliterate');
+
+            expect(@$transliterate->invoke(null, $rules, 'fallback value'))->toBe('fallback value');
+
+            $cache = (new ReflectionProperty(Mage_Catalog_Helper_Product_Url::class, '_transliterators'))->getValue();
+            expect($cache)->toHaveKey($rules);
+            expect($cache[$rules])->toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
## Problem

`Mage_Catalog_Helper_Product_Url::format()` calls `transliterator_list_ids()` on every invocation whenever a locale is passed:

```php
if (!empty($locale)) {
    $opts = transliterator_list_ids();          // ~750 entries, rebuilt every call
    $code = str_replace('_', '-', strtolower($locale)) . '_Latn/BGN';
    if (in_array($code, $opts)) {
```

That call asks ICU to enumerate every registered transliterator and allocates the whole array, just to test membership of a single ID — about **0.9ms per call** (measured: 927ms for 1000 calls, 758 IDs). It is then scanned linearly with `in_array()`.

Separately, `transliterator_transliterate()` re-parses the compound rule string (`Any-Latin; Latin-ASCII; ...`) on every conversion instead of reusing a compiled `Transliterator` (103ms vs 11ms per 1000 calls).

This matters because the `catalog_url` indexer calls `format()` once per rewrite it writes, so the cost scales with products × categories × stores. Every store with a locale configured takes the expensive branch, which is the normal case.

## Impact

Real store: 984 products, 79 categories, 7 non-admin stores, 9,427 rewrite rows → **16,206 `format()` calls** per full `catalog_url` reindex.

Profiled breakdown of a 21.10s reindex:

| | time | share |
|---|---|---|
| `transliterator_list_ids()` | 14.51s | 69% |
| `transliterator_transliterate()` | 1.55s | 7% |

`time` on the reindex shows `16.5s user / 80% CPU`, so it is PHP burning CPU, not waiting on MySQL — the run only issues ~16k queries.

## Fix

- Build the ID list once into a lookup map, so the check is a hash lookup instead of a linear scan over a freshly allocated array.
- Cache compiled `Transliterator` instances per rule string.

Both are needed — measured on the same store, two runs each after a warm-up:

| | run 1 | run 2 | speedup |
|---|---|---|---|
| before | 20.94s | 21.13s | — |
| cache ID list only | 4.00s | 4.01s | 5.1× |
| cache `Transliterator` only | 18.45s | 18.59s | 1.1× |
| **both (this PR)** | **1.44s** | **1.48s** | **~14×** |

## Correctness

The ICU rule strings are untouched (verified by diffing them against `main`). Verified against the same store:

- **12,864 `format()` outputs** — every product and category name × `sv_SE`/`da_DK`/`nb_NO`/`en_GB`/`ru_RU`/`null` × `$lower` true/false, plus edge cases (Cyrillic, CJK, `ÅÄÖ`, `Ægte`, `"0"`, empty, whitespace-only) — **identical** to the current implementation.
- Full `core_url_rewrite` dump (9,428 rows, all columns) after a reindex with this code vs. current code — **identical**.
- All `url_key` attribute values written back to products — **identical**.

`php-cs-fixer check` and `phpstan analyse` both pass clean on the changed file.

## Note on one error path

`transliterator_transliterate()` returns `false` on failure; the new helper returns the input string instead. Previously that `false` flowed into `formatUrlKey()`'s `preg_replace()`, which triggers a PHP 8.1+ deprecation and yields an empty URL key. Returning the unconverted string is both safer and deprecation-free. This path is not reachable with the current static rule strings, since the locale-derived code is validated against the ID list first.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->