### PR TITLE
Fixed product save silently failing and redirecting to the dashboard on validation errors

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/ProductController.php
@@ -521,8 +521,19 @@ class Mage_Adminhtml_Catalog_ProductController extends Mage_Adminhtml_Controller
 
         try {
             $productData = $this->getRequest()->getPost('product');
+            if (empty($productData)) {
+                Mage::log(sprintf(
+                    'Product validate request for product ID %s contained no product data, POST keys received: %s',
+                    $this->getRequest()->getParam('id'),
+                    implode(', ', array_keys($this->getRequest()->getPost())),
+                ), Mage::LOG_WARNING);
+                $response->setError(true);
+                $response->setMessage($this->__('No product data was received, the page may not have fully loaded yet. Please try saving again.'));
+                $this->getResponse()->setBodyJson($response);
+                return;
+            }
 
-            if ($productData && !isset($productData['stock_data']['use_config_manage_stock'])) {
+            if (!isset($productData['stock_data']['use_config_manage_stock'])) {
                 $productData['stock_data']['use_config_manage_stock'] = 0;
             }
             /** @var Mage_Catalog_Model_Product $product */
@@ -744,6 +755,20 @@ class Mage_Adminhtml_Catalog_ProductController extends Mage_Adminhtml_Controller
 
         $data = $this->getRequest()->getPost();
         if ($data) {
+            if (empty($data['product'])) {
+                Mage::log(sprintf(
+                    'Product save request for product ID %s contained no product data, POST keys received: %s',
+                    $productId,
+                    implode(', ', array_keys($data)),
+                ), Mage::LOG_WARNING);
+                $this->_getSession()->addError($this->__('No product data was received, the page may not have fully loaded yet. Please try saving again.'));
+                $this->_redirect('*/*/edit', [
+                    'id' => $productId,
+                    '_current' => true,
+                ]);
+                return;
+            }
+
             $this->_filterStockData($data['product']['stock_data']);
 
             $product = $this->_initProductSave();

--- a/app/locale/en_US/Mage_Adminhtml.csv
+++ b/app/locale/en_US/Mage_Adminhtml.csv
@@ -621,6 +621,7 @@
 "No customer id defined.","No customer id defined."
 "No Data Found","No Data Found"
 "No information available.","No information available."
+"No product data was received, the page may not have fully loaded yet. Please try saving again.","No product data was received, the page may not have fully loaded yet. Please try saving again."
 "None","None"
 "No Passkey Created","No Passkey Created"
 "No profile loaded...","No profile loaded..."

--- a/public/js/mage/adminhtml/form.js
+++ b/public/js/mage/adminhtml/form.js
@@ -62,7 +62,12 @@ class varienForm {
             this._processValidationResult(data);
         })
         .catch(error => {
-            this._processFailure();
+            // show server-side validation errors, only redirect on genuine fetch failures
+            if (error?.response?.error) {
+                this._processValidationResult(error.response);
+            } else {
+                this._processFailure();
+            }
         });
     }
 

--- a/public/js/mage/adminhtml/tabs.js
+++ b/public/js/mage/adminhtml/tabs.js
@@ -43,7 +43,12 @@ class varienTabs {
         });
 
         this.displayFirst = activeTabId;
-        window.addEventListener('load', () => this.moveTabContentInDest());
+        // move tab contents at DOMContentLoaded, waiting for window load would leave the form submittable while still empty
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => this.moveTabContentInDest());
+        } else {
+            this.moveTabContentInDest();
+        }
     }
 
     setSkipDisplayFirstTab() {

--- a/public/js/varien/js.js
+++ b/public/js/varien/js.js
@@ -67,7 +67,9 @@ async function mahoFetch(url, options) {
         if (typeof result === 'object' && result !== null) {
             if (result.error) {
                 const message = result.message ?? result.error;
-                throw new MahoError(typeof message === 'string' ? message : 'An error occurred.');
+                const error = new MahoError(typeof message === 'string' ? message : 'An error occurred.');
+                error.response = result;
+                throw error;
             } else if (result.ajaxExpired && result.ajaxRedirect) {
                 setLocation(result.ajaxRedirect);
                 await new Promise((resolve) => {});


### PR DESCRIPTION
## Symptom

Saving certain products from the admin edit page silently fails: the admin is redirected to the dashboard, no error is shown, and nothing is saved. It is deterministic per product, and the "Update attributes" mass action still works for the affected products. Reported by a merchant and reproduced on a live store.

## Root cause

Clicking Save first posts the form to `catalog_product/validate` via AJAX. When the server rejects the data it responds `{error: true, message: "..."}`, but `mahoFetch()` throws a `MahoError` on any `error: true` JSON response, so in `varienForm._validate()` the response never reaches `_processValidationResult()` (the code that displays the message). It lands in the `.catch()` handler instead, which calls `_processFailure()`, and that is `location.href = BASE_URL`. Every server-side validation error therefore becomes a silent redirect to the dashboard. This is a regression from the prototype.js to fetch migration, and it affects any `varienForm` with a validation URL.

A second, contributing defect: `varienTabs` only moves the tab contents into the `<form>` on window `load`, after every asset has finished downloading. On a slow page the Save button works before that, and clicking it submits a form containing only the form key. The controller then "saves" the unchanged product, reports success, and redirects to the grid, silently discarding the changes.

## Fix

- `mahoFetch()` attaches the parsed JSON response to the thrown `MahoError` (`error.response`). No behavior change for existing callers.
- `varienForm._validate()` routes error responses back to `_processValidationResult()`, restoring the inline error display. Only genuine failures (network error, non-JSON response) still go to `_processFailure()`.
- `varienTabs` moves tab contents into the destination form at `DOMContentLoaded` instead of window `load`. This also makes the edit page content appear earlier.
- `ProductController::validateAction()` / `saveAction()` reject a POST with a missing `product` payload with an explicit error message instead of a fake success, and log a warning with the product ID and the POST keys that were actually received, so it is visible in the logs what data produced the error.

## Testing

- Reproduced both failure modes by submitting the product edit form in its pre-load state (only the form key inside the form): previously a fake "The product has been saved." plus redirect, and a forced validation error previously redirected to the dashboard with no message.
- After the fix the same submission shows the error inline and stays on the edit page, and normal saves persist correctly.
- `php-cs-fixer` and `phpstan` pass on the touched PHP file.