### PR TITLE
Fix gift card admin ACL resource

### DIFF
--- a/app/code/core/Maho/Giftcard/controllers/Adminhtml/Giftcard/HistoryController.php
+++ b/app/code/core/Maho/Giftcard/controllers/Adminhtml/Giftcard/HistoryController.php
@@ -45,10 +45,4 @@ class Maho_Giftcard_Adminhtml_Giftcard_HistoryController extends Mage_Adminhtml_
         $this->loadLayout();
         $this->renderLayout();
     }
-
-    #[\Override]
-    protected function _isAllowed(): bool
-    {
-        return Mage::getSingleton('admin/session')->isAllowed('sales/giftcard/history');
-    }
 }

--- a/app/code/core/Maho/Giftcard/controllers/Adminhtml/Giftcard/PrintController.php
+++ b/app/code/core/Maho/Giftcard/controllers/Adminhtml/Giftcard/PrintController.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 class Maho_Giftcard_Adminhtml_Giftcard_PrintController extends Mage_Adminhtml_Controller_Action
 {
-    public const ADMIN_RESOURCE = 'giftcard/manage';
+    public const ADMIN_RESOURCE = 'sales/giftcard/manage';
 
     /**
      * Print gift card as PDF
@@ -131,6 +131,6 @@ class Maho_Giftcard_Adminhtml_Giftcard_PrintController extends Mage_Adminhtml_Co
     #[\Override]
     protected function _isAllowed(): bool
     {
-        return Mage::getSingleton('admin/session')->isAllowed('giftcard/manage');
+        return Mage::getSingleton('admin/session')->isAllowed('sales/giftcard/manage');
     }
 }

--- a/app/code/core/Maho/Giftcard/controllers/Adminhtml/Giftcard/PrintController.php
+++ b/app/code/core/Maho/Giftcard/controllers/Adminhtml/Giftcard/PrintController.php
@@ -127,10 +127,4 @@ class Maho_Giftcard_Adminhtml_Giftcard_PrintController extends Mage_Adminhtml_Co
             $this->_redirect('*/giftcard/edit', ['id' => $id]);
         }
     }
-
-    #[\Override]
-    protected function _isAllowed(): bool
-    {
-        return Mage::getSingleton('admin/session')->isAllowed('sales/giftcard/manage');
-    }
 }

--- a/app/code/core/Maho/Giftcard/controllers/Adminhtml/Giftcard/ProductController.php
+++ b/app/code/core/Maho/Giftcard/controllers/Adminhtml/Giftcard/ProductController.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 class Maho_Giftcard_Adminhtml_Giftcard_ProductController extends Mage_Adminhtml_Controller_Action
 {
-    public const ADMIN_RESOURCE = 'giftcard/manage';
+    public const ADMIN_RESOURCE = 'sales/giftcard/manage';
 
     /**
      * Create gift card product(s) action
@@ -176,6 +176,6 @@ class Maho_Giftcard_Adminhtml_Giftcard_ProductController extends Mage_Adminhtml_
     #[\Override]
     protected function _isAllowed(): bool
     {
-        return Mage::getSingleton('admin/session')->isAllowed('giftcard/manage');
+        return Mage::getSingleton('admin/session')->isAllowed('sales/giftcard/manage');
     }
 }

--- a/app/code/core/Maho/Giftcard/controllers/Adminhtml/Giftcard/ProductController.php
+++ b/app/code/core/Maho/Giftcard/controllers/Adminhtml/Giftcard/ProductController.php
@@ -172,10 +172,4 @@ class Maho_Giftcard_Adminhtml_Giftcard_ProductController extends Mage_Adminhtml_
 
         return $product;
     }
-
-    #[\Override]
-    protected function _isAllowed(): bool
-    {
-        return Mage::getSingleton('admin/session')->isAllowed('sales/giftcard/manage');
-    }
 }

--- a/app/code/core/Maho/Giftcard/controllers/Adminhtml/GiftcardController.php
+++ b/app/code/core/Maho/Giftcard/controllers/Adminhtml/GiftcardController.php
@@ -300,10 +300,4 @@ class Maho_Giftcard_Adminhtml_GiftcardController extends Mage_Adminhtml_Controll
             'expires_at' => $giftcard->getExpiresAt(),
         ]));
     }
-
-    #[\Override]
-    protected function _isAllowed(): bool
-    {
-        return Mage::getSingleton('admin/session')->isAllowed('sales/giftcard/manage');
-    }
 }


### PR DESCRIPTION
# Problem

`Maho_Giftcard_Adminhtml_Giftcard_PrintController` and `ProductController` check the ACL resource `giftcard/manage`, but `Maho/Giftcard/etc/adminhtml.xml` declares `admin/sales/giftcard/manage` (already used correctly by `GiftcardController` and `HistoryController`).

For an undeclared resource the Laminas ACL throws, and `Mage_Admin_Model_Session::isAllowed()` falls back to `$acl->isAllowed($role, null)`, the role's root rule. Administrators have `all => allow` there and never notice; every restricted role has `all => deny` and is denied, no matter which gift card permissions it was granted.

So a non-admin user with full gift card rights can edit gift cards but gets "Access denied" on:

- gift card PDF print (`giftcard_print/pdf`)
- mass PDF print (`giftcard_print/massPdf`)
- gift card email (`giftcard_print/email`)
- gift card product creation (`giftcard_product/create`, `.../save`)

# Fix

Use the declared resource `sales/giftcard/manage` in both controllers, in `ADMIN_RESOURCE` and in `_isAllowed()`.

# Verification

ACL loaded from the DB (`Mage::getResourceModel('admin/acl')->loadAcl()`):

```
admin/giftcard/manage        hasResource=false  -> throws, falls back to root rule
admin/sales/giftcard/manage  hasResource=true   -> admin=true, restricted role inheriting admin/sales=true
```

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->