### PR TITLE
Fixed `GET /api/rest/v2/stores/currencies` returning 500 once any currency rate is saved

### DIFF
--- a/app/code/core/Mage/Directory/Api/CurrencyProvider.php
+++ b/app/code/core/Mage/Directory/Api/CurrencyProvider.php
@@ -31,7 +31,10 @@ class CurrencyProvider extends \Maho\ApiPlatform\Provider
 
             $dto = Currency::fromModel($currency);
             $dto->symbol = $currency->getCurrencySymbol();
-            $dto->exchangeRate = $rates[$currencyCode] ?? null;
+            // Rates come from a DECIMAL column, so they arrive as strings. Under strict_types
+            // the assignment to ?float would throw for every currency that has a rate row.
+            $rate = $rates[$currencyCode] ?? null;
+            $dto->exchangeRate = $rate === null ? null : (float) $rate;
             $currencies[] = $dto;
         }
 

--- a/app/code/core/Mage/Directory/Api/CurrencyProvider.php
+++ b/app/code/core/Mage/Directory/Api/CurrencyProvider.php
@@ -31,10 +31,9 @@ class CurrencyProvider extends \Maho\ApiPlatform\Provider
 
             $dto = Currency::fromModel($currency);
             $dto->symbol = $currency->getCurrencySymbol();
-            // Rates come from a DECIMAL column, so they arrive as strings. Under strict_types
-            // the assignment to ?float would throw for every currency that has a rate row.
-            $rate = $rates[$currencyCode] ?? null;
-            $dto->exchangeRate = $rate === null ? null : (float) $rate;
+            // MySQL and PostgreSQL return the DECIMAL rate as a string, which strict_types
+            // refuses to assign to ?float. SQLite returns a number, so this never fails locally.
+            $dto->exchangeRate = isset($rates[$currencyCode]) ? (float) $rates[$currencyCode] : null;
             $currencies[] = $dto;
         }
 

--- a/tests/Api/V2/Read/CurrencyTest.php
+++ b/tests/Api/V2/Read/CurrencyTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+/**
+ * API v2 Currency Tests
+ *
+ * Tests for the currency endpoint - PUBLIC ACCESS (no auth required).
+ * All tests are READ-ONLY (safe for synced database).
+ *
+ * @group read
+ */
+
+describe('API v2 Currencies', function (): void {
+
+    describe('public access (no auth)', function (): void {
+
+        // directory_currency_rate is seeded at install (EUR/USD, including the
+        // self-rates), so this collection always carries at least one rate. On
+        // MySQL and PostgreSQL the DECIMAL column comes back as a PHP string,
+        // which used to hit the ?float DTO property and 500 the whole endpoint.
+        it('allows listing currencies without authentication', function (): void {
+            $response = apiGet('/api/rest/v2/stores/currencies');
+
+            expect($response['status'])->toBe(200);
+        });
+
+        it('returns currencies collection', function (): void {
+            $response = apiGet('/api/rest/v2/stores/currencies');
+
+            expect($response['status'])->toBe(200);
+            expect($response['json'])->toBeArray();
+        });
+
+    });
+
+    describe('response format', function (): void {
+
+        it('includes expected currency fields', function (): void {
+            $response = apiGet('/api/rest/v2/stores/currencies');
+            $currencies = $response['json']['member'] ?? $response['json']['hydra:member'] ?? $response['json'] ?? [];
+
+            expect($currencies)->not->toBeEmpty();
+
+            foreach ($currencies as $currency) {
+                expect($currency)->toHaveKey('code');
+                expect($currency)->toHaveKey('symbol');
+                expect($currency)->toHaveKey('exchangeRate');
+            }
+        });
+
+        // Guards both directions: a string rate means the DTO cast was dropped,
+        // and a string in the payload would also mean someone "fixed" the 500
+        // by widening the property to ?string instead.
+        it('exposes the exchange rate as a number, never a string', function (): void {
+            $response = apiGet('/api/rest/v2/stores/currencies');
+            $currencies = $response['json']['member'] ?? $response['json']['hydra:member'] ?? $response['json'] ?? [];
+
+            expect($currencies)->not->toBeEmpty();
+
+            foreach ($currencies as $currency) {
+                if ($currency['exchangeRate'] === null) {
+                    continue;
+                }
+                expect($currency['exchangeRate'])->not->toBeString();
+                expect($currency['exchangeRate'])->toBeNumeric();
+            }
+        });
+
+        it('reports the base currency self-rate as 1', function (): void {
+            $baseCode = \Mage::app()->getStore()->getBaseCurrencyCode();
+
+            $response = apiGet('/api/rest/v2/stores/currencies');
+            $currencies = $response['json']['member'] ?? $response['json']['hydra:member'] ?? $response['json'] ?? [];
+
+            $base = null;
+            foreach ($currencies as $currency) {
+                if ($currency['code'] === $baseCode) {
+                    $base = $currency;
+                    break;
+                }
+            }
+
+            expect($base)->not->toBeNull();
+            expect((float) $base['exchangeRate'])->toBe(1.0);
+        });
+
+    });
+
+});


### PR DESCRIPTION
The built-in `Currency` API resource returns HTTP 500 as soon as `directory_currency_rate` holds a
row for any allowed currency.

**The exchange rate is a string. The DTO property it is assigned to is a float.**

`Mage_Directory_Model_Resource_Currency::_getRatesByCode()`
(`app/code/core/Mage/Directory/Model/Resource/Currency.php:212-230`) returns the `rate` column
verbatim, with no cast. It is a `DECIMAL`, and the driver hands `DECIMAL` back as a PHP string:

```php
foreach ($rowSet as $row) {
    $result[$row['currency_to']] = $row['rate'];   // DECIMAL column → PHP string
}
```

So `getCurrencyRates()` returns quoted strings, not numbers — here on a store with base `USD` and
allowed `AUD,CAD,EUR,USD`:

```json
{ "AUD": "1.377220000000", "CAD": "1.323100000000", "EUR": "0.875880000000", "USD": "1.000000000000" }
```

`Mage\Directory\Api\Currency::$exchangeRate` is declared `?float`, and both files declare
`strict_types=1`, so no coercion happens. `CurrencyProvider::provide()` assigns the string
straight into the float property:

```php
// app/code/core/Mage/Directory/Api/CurrencyProvider.php:34
$dto->exchangeRate = $rates[$currencyCode] ?? null;   // string → ?float
```

```
TypeError: Cannot assign string to property Mage\Directory\Api\Currency::$exchangeRate
of type ?float
```

 The ?? null guard only covers the case where no rate row exists for that currency code. That state does not exist after a normal install: Mage/Directory/data/directory_setup/data-install-1.6.0.0.php:293 seeds EUR→EUR, EUR→USD, USD→EUR, USD→USD, and the shipped defaults are currency/options/base = USD, currency/options/allow = USD,EUR (Mage/Directory/etc/config.xml:117). Both allowed currencies therefore carry a rate row out of the box, so the endpoint returns 500 on a fresh install with no admin action at all. Saving rates in admin is not a prerequisite; the Reproduce steps below just make the failure explicit.

The 500 carries no detail, because `public/rest.php` boots the kernel with `debug=false`:

```json
{"error":"internal_server_error","message":"An internal error occurred","code":500}
```

### Reproduce

Tested on:

| | |
| --- | --- |
| Maho | `main` at `76327c891` (26.9.0) |
| PHP | 8.5.7 |
| MySQL | 8.4.9 |
| DB adapter | `Maho\Db\Adapter\Pdo\Mysql` — `pdo_mysql` + `mysqlnd`, `doctrine/dbal` 4.4.4 |

Only that combination was tested, but nothing in it looks load-bearing: `pdo_mysql` surfaces
`DECIMAL` as a PHP string to preserve precision, independently of emulated prepares, so any
install with a saved currency rate should hit this.

Prerequisite for both cases below: REST v2 is opt-in, so set `apiplatform/protocols/rest_v2 = 1`.
With it off, `ProtocolToggleListener` answers 404 `{"error":"protocol_disabled"}` before the
provider ever runs, which masks the bug.

Multi-currency:

1. `currency/options/base = USD`, `currency/options/allow = USD,EUR`.
2. Save rates in Admin → System → Currency Rates, so `directory_currency_rate` has `USD → EUR`.
3. `curl -s https://<host>/api/rest/v2/stores/currencies` → HTTP 500.

Single currency — same result:

1. `currency/options/base = USD`, `currency/options/allow = USD`.
2. Save rates once, so the self-rate row `USD → USD = 1.000000000000` exists.
3. Same call → HTTP 500.

The call returns 200 only while no row in `directory_currency_rate` matches an allowed currency
code — `$exchangeRate` is then never assigned a non-null value.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->