### PR TITLE
Fixed a media stat failure throwing a TypeError instead of reporting a null size

### DIFF
--- a/app/code/core/Mage/Cms/Api/MediaProcessor.php
+++ b/app/code/core/Mage/Cms/Api/MediaProcessor.php
@@ -161,9 +161,8 @@ final class MediaProcessor implements ProcessorInterface
         $media = new Media();
         $media->url = Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA) . $relativePath;
         $media->directive = sprintf('{{media url="%s"}}', $relativePath);
-        // filesize() returns false if the file is removed between the save above and this stat,
-        // which strict_types refuses to assign to ?int. The save itself already threw on failure.
-        $media->size = is_int($size = filesize($targetPath)) ? $size : null;
+        $size = filesize($targetPath);
+        $media->size = $size === false ? null : $size;
         $media->dimensions = $imageSize ? ['width' => $imageSize[0], 'height' => $imageSize[1]] : null;
         $media->filename = $targetFilename;
         $media->path = $relativePath;

--- a/app/code/core/Mage/Cms/Api/MediaProcessor.php
+++ b/app/code/core/Mage/Cms/Api/MediaProcessor.php
@@ -161,7 +161,8 @@ final class MediaProcessor implements ProcessorInterface
         $media = new Media();
         $media->url = Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA) . $relativePath;
         $media->directive = sprintf('{{media url="%s"}}', $relativePath);
-        $media->size = filesize($targetPath);
+        $size = filesize($targetPath);
+        $media->size = $size === false ? null : $size;
         $media->dimensions = $imageSize ? ['width' => $imageSize[0], 'height' => $imageSize[1]] : null;
         $media->filename = $targetFilename;
         $media->path = $relativePath;

--- a/app/code/core/Mage/Cms/Api/MediaProcessor.php
+++ b/app/code/core/Mage/Cms/Api/MediaProcessor.php
@@ -161,8 +161,9 @@ final class MediaProcessor implements ProcessorInterface
         $media = new Media();
         $media->url = Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA) . $relativePath;
         $media->directive = sprintf('{{media url="%s"}}', $relativePath);
-        $size = filesize($targetPath);
-        $media->size = $size === false ? null : $size;
+        // filesize() returns false if the file is removed between the save above and this stat,
+        // which strict_types refuses to assign to ?int. The save itself already threw on failure.
+        $media->size = is_int($size = filesize($targetPath)) ? $size : null;
         $media->dimensions = $imageSize ? ['width' => $imageSize[0], 'height' => $imageSize[1]] : null;
         $media->filename = $targetFilename;
         $media->path = $relativePath;

--- a/app/code/core/Mage/Cms/Api/MediaProvider.php
+++ b/app/code/core/Mage/Cms/Api/MediaProvider.php
@@ -134,7 +134,8 @@ final class MediaProvider implements ProviderInterface
             $media = new Media();
             $media->url = $fileUrl;
             $media->directive = $directive;
-            $media->size = is_int($size = filesize($fullPath)) ? $size : null;
+            $size = filesize($fullPath);
+            $media->size = $size === false ? null : $size;
             $media->dimensions = $dimensions;
             $media->filename = $filename;
             $media->path = $relativePath;

--- a/app/code/core/Mage/Cms/Api/MediaProvider.php
+++ b/app/code/core/Mage/Cms/Api/MediaProvider.php
@@ -134,7 +134,7 @@ final class MediaProvider implements ProviderInterface
             $media = new Media();
             $media->url = $fileUrl;
             $media->directive = $directive;
-            $media->size = (int) filesize($fullPath);
+            $media->size = is_int($size = filesize($fullPath)) ? $size : null;
             $media->dimensions = $dimensions;
             $media->filename = $filename;
             $media->path = $relativePath;

--- a/tests/Api/V2/Write/MediaTest.php
+++ b/tests/Api/V2/Write/MediaTest.php
@@ -98,9 +98,6 @@ describe('Media Upload (REST)', function (): void {
         expect($response['json']['dimensions'])->toHaveKey('height');
     });
 
-    // The size comes from filesize(), which is int|false, assigned to a ?int DTO property.
-    // Nothing can make the stat fail here on demand, so this pins the successful direction:
-    // an int, never null and never 0, so the null branch cannot be widened into the happy path.
     it('reports the upload size as a positive integer', function (): void {
         $tmpFile = tempnam(sys_get_temp_dir(), 'pest_media_') . '.png';
         $img = imagecreatetruecolor(8, 8);

--- a/tests/Api/V2/Write/MediaTest.php
+++ b/tests/Api/V2/Write/MediaTest.php
@@ -98,6 +98,29 @@ describe('Media Upload (REST)', function (): void {
         expect($response['json']['dimensions'])->toHaveKey('height');
     });
 
+    // The size comes from filesize(), which is int|false, assigned to a ?int DTO property.
+    // Nothing can make the stat fail here on demand, so this pins the successful direction:
+    // an int, never null and never 0, so the null branch cannot be widened into the happy path.
+    it('reports the upload size as a positive integer', function (): void {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'pest_media_') . '.png';
+        $img = imagecreatetruecolor(8, 8);
+        imagefill($img, 0, 0, imagecolorallocate($img, 0, 128, 255));
+        imagepng($img, $tmpFile);
+
+        $token = serviceToken(['media/write']);
+        $response = apiPostMultipart(
+            '/api/rest/v2/media',
+            ['folder' => 'test', 'filename' => 'pest-size-check'],
+            ['file' => $tmpFile],
+            $token,
+        );
+        unlink($tmpFile);
+
+        expect($response['status'])->toBeIn([200, 201]);
+        expect($response['json']['size'])->toBeInt();
+        expect($response['json']['size'])->toBeGreaterThan(0);
+    });
+
     it('uploads with custom folder', function (): void {
         $tmpFile = tempnam(sys_get_temp_dir(), 'pest_media_') . '.png';
         $img = imagecreatetruecolor(1, 1);


### PR DESCRIPTION
`MediaProcessor::handleUpload()` assigns `filesize()` (`int|false`) straight into `Media::$size`, which is declared `?int` (`Mage/Cms/Api/Media.php:96`), in a file with `strict_types=1`:

```php
// app/code/core/Mage/Cms/Api/MediaProcessor.php:164
$media->size = filesize($targetPath);
```

A failed stat is therefore a `TypeError`, not a null size.

Null rather than `(int)`, because `0 bytes` is indistinguishable from a genuinely empty file, and `$media->dimensions` alongside it already nulls on the same failure.

`MediaProvider.php:137` had the same assignment behind an `is_file()` guard, which does not close the window: `getImageSize()` at line 125 runs inside it and already nulls, while the `(int)` cast there turned a vanished file into `0 bytes`. Aligned both call sites. That endpoint never returned null in practice before, so it is a small contract change for anyone reading the size.

`MediaTest.php` gains a case pinning the upload size to a positive `int`. Nothing can go red against the unfixed code, since reaching the null branch needs the file to vanish between two adjacent statements, so it guards only the other direction.

Follow-up to #1230 (1e80b1791), where this was noted as a separate leftover.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->