### PR TITLE
Stopped putting the admin form key in every navigation URL

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Edit/Form.php
@@ -203,7 +203,7 @@ class Mage_Adminhtml_Block_Catalog_Category_Edit_Form extends Mage_Adminhtml_Blo
      */
     public function getDeleteUrl(array $args = [])
     {
-        return $this->getUrl('*/*/delete', [
+        return $this->getUrlSecure('*/*/delete', [
             '_current' => true, '_query' => false, ...$args,
         ]);
     }

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Attributes.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Category/Tab/Attributes.php
@@ -159,10 +159,9 @@ class Mage_Adminhtml_Block_Catalog_Category_Tab_Attributes extends Mage_Adminhtm
             if ($this->getCategory() && $this->getCategory()->getId()) {
                 // Runs the rules synchronously in this request, evaluating every product in the catalog,
                 // so confirm before starting rather than letting a large catalog look like a hung page
-                $refreshUrl = $this->getUrl('*/*/processDynamic', [
+                $refreshUrl = $this->getUrlSecure('*/*/processDynamic', [
                     'id' => $this->getCategory()->getId(),
                     'store' => $this->getRequest()->getParam('store'),
-                    'form_key' => Mage::getSingleton('core/session')->getFormKey(),
                 ]);
                 $fieldset->addField('dynamic_refresh_button', 'note', [
                     'text' => $this->getLayout()->createBlock('adminhtml/widget_button')

--- a/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Group/Edit.php
@@ -27,22 +27,6 @@ class Mage_Adminhtml_Block_Customer_Group_Edit extends Mage_Adminhtml_Block_Widg
 
     /**
      * @return string
-     * @throws Exception
-     */
-    #[\Override]
-    public function getDeleteUrl()
-    {
-        if (!Mage::getSingleton('adminhtml/url')->useSecretKey()) {
-            return $this->getUrl('*/*/delete', [
-                $this->_objectId => $this->getRequest()->getParam($this->_objectId),
-                'form_key' => Mage::getSingleton('core/session')->getFormKey(),
-            ]);
-        }
-        return parent::getDeleteUrl();
-    }
-
-    /**
-     * @return string
      */
     #[\Override]
     public function getHeaderText()

--- a/app/code/core/Mage/Adminhtml/Block/Review/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Review/Edit.php
@@ -55,7 +55,7 @@ class Mage_Adminhtml_Block_Review_Edit extends Mage_Adminhtml_Block_Widget_Form_
                 'delete',
                 'onclick',
                 Mage::helper('core/js')->getDeleteConfirmJs(
-                    $this->getUrl('*/*/delete', [
+                    $this->getUrlSecure('*/*/delete', [
                         $this->_objectId => $this->getRequest()->getParam($this->_objectId),
                         'ret' => 'pending',
                     ]),

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Creditmemo/View.php
@@ -139,7 +139,7 @@ class Mage_Adminhtml_Block_Sales_Order_Creditmemo_View extends Mage_Adminhtml_Bl
      */
     public function getVoidUrl()
     {
-        return $this->getUrl('*/*/void', ['creditmemo_id' => $this->getCreditmemo()->getId()]);
+        return $this->getUrlSecure('*/*/void', ['creditmemo_id' => $this->getCreditmemo()->getId()]);
     }
 
     /**
@@ -149,7 +149,7 @@ class Mage_Adminhtml_Block_Sales_Order_Creditmemo_View extends Mage_Adminhtml_Bl
      */
     public function getCancelUrl()
     {
-        return $this->getUrl('*/*/cancel', ['creditmemo_id' => $this->getCreditmemo()->getId()]);
+        return $this->getUrlSecure('*/*/cancel', ['creditmemo_id' => $this->getCreditmemo()->getId()]);
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Invoice/View.php
@@ -149,7 +149,7 @@ class Mage_Adminhtml_Block_Sales_Order_Invoice_View extends Mage_Adminhtml_Block
      */
     public function getCaptureUrl()
     {
-        return $this->getUrl('*/*/capture', ['invoice_id' => $this->getInvoice()->getId()]);
+        return $this->getUrlSecure('*/*/capture', ['invoice_id' => $this->getInvoice()->getId()]);
     }
 
     /**
@@ -157,7 +157,7 @@ class Mage_Adminhtml_Block_Sales_Order_Invoice_View extends Mage_Adminhtml_Block
      */
     public function getVoidUrl()
     {
-        return $this->getUrl('*/*/void', ['invoice_id' => $this->getInvoice()->getId()]);
+        return $this->getUrlSecure('*/*/void', ['invoice_id' => $this->getInvoice()->getId()]);
     }
 
     /**
@@ -165,7 +165,7 @@ class Mage_Adminhtml_Block_Sales_Order_Invoice_View extends Mage_Adminhtml_Block
      */
     public function getCancelUrl()
     {
-        return $this->getUrl('*/*/cancel', ['invoice_id' => $this->getInvoice()->getId()]);
+        return $this->getUrlSecure('*/*/cancel', ['invoice_id' => $this->getInvoice()->getId()]);
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Shipment/View.php
@@ -123,7 +123,7 @@ class Mage_Adminhtml_Block_Sales_Order_Shipment_View extends Mage_Adminhtml_Bloc
 
     public function getCancelUrl(): string
     {
-        return $this->getUrl('*/*/cancel', ['shipment_id' => $this->getShipment()->getId()]);
+        return $this->getUrlSecure('*/*/cancel', ['shipment_id' => $this->getShipment()->getId()]);
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View.php
@@ -284,7 +284,7 @@ class Mage_Adminhtml_Block_Sales_Order_View extends Mage_Adminhtml_Block_Widget_
      */
     public function getHoldUrl()
     {
-        return $this->getUrl('*/*/hold');
+        return $this->getUrlSecure('*/*/hold');
     }
 
     /**
@@ -292,7 +292,7 @@ class Mage_Adminhtml_Block_Sales_Order_View extends Mage_Adminhtml_Block_Widget_
      */
     public function getUnholdUrl()
     {
-        return $this->getUrl('*/*/unhold');
+        return $this->getUrlSecure('*/*/unhold');
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/System/Design/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Design/Edit.php
@@ -63,10 +63,7 @@ class Mage_Adminhtml_Block_System_Design_Edit extends Mage_Adminhtml_Block_Widge
      */
     public function getDeleteUrl()
     {
-        return $this->getUrlSecure('*/*/delete', [
-            'id' => $this->getDesignChangeId(),
-            Mage_Core_Model_Url::FORM_KEY => $this->getFormKey(),
-        ]);
+        return $this->getUrlSecure('*/*/delete', ['id' => $this->getDesignChangeId()]);
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Block/System/Store/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Store/Edit.php
@@ -89,12 +89,9 @@ class Mage_Adminhtml_Block_System_Store_Edit extends Mage_Adminhtml_Block_Widget
         if ($backupAvailable) {
             $deleteUrl   = $this->getUrl('*/*/delete' . $storeType, ['item_id' => Mage::registry('store_data')->getId()]);
         } else {
-            $deleteUrl   = $this->getUrl(
+            $deleteUrl   = $this->getUrlSecure(
                 '*/*/delete' . $storeType . 'Post',
-                [
-                    'item_id' => Mage::registry('store_data')->getId(),
-                    'form_key' => Mage::getSingleton('core/session')->getFormKey(),
-                ],
+                ['item_id' => Mage::registry('store_data')->getId()],
             );
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Urlrewrite/Edit.php
@@ -133,7 +133,7 @@ class Mage_Adminhtml_Block_Urlrewrite_Edit extends Mage_Adminhtml_Block_Widget_C
                         Mage::helper('adminhtml')->__('Are you sure you want to do this?'),
                     )
                     . '\', \''
-                    . Mage::helper('adminhtml')->getUrl('*/*/delete', ['id' => $this->getUrlrewriteId()])
+                    . $this->getUrlSecure('*/*/delete', ['id' => $this->getUrlrewriteId()])
                     . '\')',
                 'class'   => 'scalable delete',
                 'level'   => -1,

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Form/Container.php
@@ -135,9 +135,8 @@ class Mage_Adminhtml_Block_Widget_Form_Container extends Mage_Adminhtml_Block_Wi
      */
     public function getDeleteUrl()
     {
-        return $this->getUrl('*/*/delete', [
+        return $this->getUrlSecure('*/*/delete', [
             $this->_objectId => $this->getRequest()->getParam($this->_objectId),
-            Mage_Core_Model_Url::FORM_KEY => $this->getFormKey(),
         ]);
     }
 

--- a/app/code/core/Mage/Adminhtml/Controller/Action.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Action.php
@@ -180,7 +180,7 @@ class Mage_Adminhtml_Controller_Action extends Mage_Core_Controller_Varien_Actio
         if (!$isValidFormKey || !$isValidSecretKey) {
             $this->setFlag('', self::FLAG_NO_DISPATCH, true);
             $this->setFlag('', self::FLAG_NO_POST_DISPATCH, true);
-            if ($this->getRequest()->getQuery('isAjax', false) || $this->getRequest()->getQuery('ajax', false)) {
+            if ($this->getRequest()->getParam('isAjax', false) || $this->getRequest()->getParam('ajax', false)) {
                 $this->getResponse()->setBody(Mage::helper('core')->jsonEncode([
                     'error' => true,
                     'message' => $keyErrorMsg,

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
@@ -10,6 +10,13 @@
 
 class Mage_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Controller_Sales_Creditmemo
 {
+    #[\Override]
+    public function preDispatch()
+    {
+        $this->_setForcedFormKeyActions(['cancel', 'void']);
+        return parent::preDispatch();
+    }
+
     /**
      * Get requested items qtys and return to stock flags
      */

--- a/app/code/core/Mage/Core/Block/Abstract.php
+++ b/app/code/core/Mage/Core/Block/Abstract.php
@@ -998,10 +998,20 @@ abstract class Mage_Core_Block_Abstract extends \Maho\DataObject
      */
     public function getUrlSecure($route = '', $params = [])
     {
+        return $this->getUrl($route, $this->getUrlSecureParams($params));
+    }
+
+    /**
+     * Same rule as getUrlSecure() for callers that build the url themselves, e.g. grid action
+     * columns. The form key is the root the per-action secret key is derived from, so it may
+     * only travel in a url when it is itself the token being checked.
+     */
+    public function getUrlSecureParams(array $params = []): array
+    {
         if (!Mage::helper('adminhtml')->isEnabledSecurityKeyUrl()) {
             $params[Mage_Core_Model_Url::FORM_KEY] = $this->getFormKey();
         }
-        return $this->getUrl($route, $params);
+        return $params;
     }
 
     /**

--- a/app/code/core/Mage/Core/Controller/Varien/Action.php
+++ b/app/code/core/Mage/Core/Controller/Varien/Action.php
@@ -812,12 +812,11 @@ abstract class Mage_Core_Controller_Varien_Action
      */
     protected function _validateFormKey()
     {
-        if (!($formKey = $this->getRequest()->getParam('form_key'))
-            || $formKey != Mage::getSingleton('core/session')->getFormKey()
-        ) {
+        $formKey = $this->getRequest()->getParam('form_key');
+        if (!is_string($formKey) || $formKey === '') {
             return false;
         }
-        return true;
+        return hash_equals(Mage::getSingleton('core/session')->getFormKey(), $formKey);
     }
 
     /**

--- a/app/code/core/Mage/Core/Model/Session.php
+++ b/app/code/core/Mage/Core/Model/Session.php
@@ -59,7 +59,7 @@ class Mage_Core_Model_Session extends Mage_Core_Model_Session_Abstract
      */
     public function validateFormKey($formKey)
     {
-        return ($formKey === $this->getFormKey());
+        return is_string($formKey) && hash_equals($this->getFormKey(), $formKey);
     }
 
     public function getOrderIds(bool $clear = false): array

--- a/app/code/core/Mage/Cron/Block/Adminhtml/System/Tools/Cronjobs.php
+++ b/app/code/core/Mage/Cron/Block/Adminhtml/System/Tools/Cronjobs.php
@@ -18,7 +18,7 @@ class Mage_Cron_Block_Adminhtml_System_Tools_Cronjobs extends Mage_Adminhtml_Blo
 
         $this->_addButton('clear_history', [
             'label' => Mage::helper('cron')->__('Clear History'),
-            'onclick' => "setLocation('{$this->getUrl('*/*/clearHistory')}')",
+            'onclick' => "setLocation('{$this->getUrlSecure('*/*/clearHistory')}')",
             'class' => 'delete',
         ]);
     }

--- a/app/code/core/Mage/Directory/Block/Adminhtml/Country/Grid.php
+++ b/app/code/core/Mage/Directory/Block/Adminhtml/Country/Grid.php
@@ -76,7 +76,7 @@ class Mage_Directory_Block_Adminhtml_Country_Grid extends Mage_Adminhtml_Block_W
                 ],
                 [
                     'caption' => Mage::helper('adminhtml')->__('Delete'),
-                    'url' => ['base' => '*/*/delete', 'params' => [Mage_Core_Model_Url::FORM_KEY => $this->getFormKey()]],
+                    'url' => ['base' => '*/*/delete', 'params' => $this->getUrlSecureParams()],
                     'field' => 'id',
                     'confirm' => Mage::helper('directory')->__('Are you sure you want to delete this country?'),
                 ],

--- a/app/code/core/Mage/Directory/Block/Adminhtml/Region/Grid.php
+++ b/app/code/core/Mage/Directory/Block/Adminhtml/Region/Grid.php
@@ -75,7 +75,7 @@ class Mage_Directory_Block_Adminhtml_Region_Grid extends Mage_Adminhtml_Block_Wi
                 ],
                 [
                     'caption' => Mage::helper('adminhtml')->__('Delete'),
-                    'url' => ['base' => '*/*/delete', 'params' => [Mage_Core_Model_Url::FORM_KEY => $this->getFormKey()]],
+                    'url' => ['base' => '*/*/delete', 'params' => $this->getUrlSecureParams()],
                     'field' => 'id',
                     'confirm' => Mage::helper('directory')->__('Are you sure you want to delete this region?'),
                 ],

--- a/app/code/core/Maho/ContentVersion/Block/Adminhtml/Version/Grid.php
+++ b/app/code/core/Maho/ContentVersion/Block/Adminhtml/Version/Grid.php
@@ -74,7 +74,7 @@ class Maho_ContentVersion_Block_Adminhtml_Version_Grid extends Mage_Adminhtml_Bl
                 [
                     'caption' => Mage::helper('contentversion')->__('Restore'),
                     'confirm' => Mage::helper('contentversion')->__('Are you sure you want to restore this version? The current content will be saved as a new version first.'),
-                    'url' => ['base' => 'adminhtml/contentversion/restore', 'params' => ['form_key' => Mage::getSingleton('core/session')->getFormKey()]],
+                    'url' => ['base' => 'adminhtml/contentversion/restore', 'params' => $this->getUrlSecureParams()],
                     'field' => 'version_id',
                 ],
             ],

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Destination/Grid.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Destination/Grid.php
@@ -106,7 +106,7 @@ class Maho_FeedManager_Block_Adminhtml_Destination_Grid extends Mage_Adminhtml_B
                 ],
                 [
                     'caption' => $this->__('Test'),
-                    'url' => ['base' => '*/*/test'],
+                    'url' => ['base' => '*/*/test', 'params' => $this->getUrlSecureParams()],
                     'field' => 'id',
                 ],
             ],

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit.php
@@ -38,7 +38,7 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit extends Mage_Adminhtml_Block_Wi
         if ($this->_getFeed()->getId()) {
             $this->_addButton('duplicate', [
                 'label' => $this->__('Duplicate'),
-                'onclick' => "setLocation('" . $this->getUrl('*/*/duplicate', ['id' => $this->_getFeed()->getId()]) . "')",
+                'onclick' => "setLocation('" . $this->getUrlSecure('*/*/duplicate', ['id' => $this->_getFeed()->getId()]) . "')",
                 'class' => 'add',
             ], -95);
 

--- a/app/code/core/Maho/MediaCleaner/Block/Adminhtml/Mediacleaner.php
+++ b/app/code/core/Maho/MediaCleaner/Block/Adminhtml/Mediacleaner.php
@@ -67,8 +67,6 @@ class Maho_MediaCleaner_Block_Adminhtml_Mediacleaner extends Mage_Adminhtml_Bloc
 
     protected function getActionUrl(string $action): string
     {
-        return $this->getUrl('*/*/' . $action, [
-            'form_key' => Mage::getSingleton('core/session')->getFormKey(),
-        ]);
+        return $this->getUrlSecure('*/*/' . $action);
     }
 }

--- a/app/code/core/Maho/MediaCleaner/Block/Adminhtml/Mediacleaner/Grid/Renderer/Actions.php
+++ b/app/code/core/Maho/MediaCleaner/Block/Adminhtml/Mediacleaner/Grid/Renderer/Actions.php
@@ -23,10 +23,7 @@ class Maho_MediaCleaner_Block_Adminhtml_Mediacleaner_Grid_Renderer_Actions exten
 
         $links[] = sprintf(
             '<a href="%s" onclick="return confirm(\'%s\')">%s</a>',
-            $this->getUrl('*/*/delete', [
-                'image_id' => $row->getId(),
-                'form_key' => Mage::getSingleton('core/session')->getFormKey(),
-            ]),
+            $this->getUrlSecure('*/*/delete', ['image_id' => $row->getId()]),
             $this->jsQuoteEscape($this->__('Are you sure?')),
             $this->__('Delete'),
         );

--- a/app/code/core/Maho/Queue/Block/Adminhtml/Message/View.php
+++ b/app/code/core/Maho/Queue/Block/Adminhtml/Message/View.php
@@ -22,18 +22,12 @@ class Maho_Queue_Block_Adminhtml_Message_View extends Mage_Adminhtml_Block_Widge
 
     public function getRetryUrl(): string
     {
-        return $this->getUrl('*/*/retry', [
-            'id' => $this->getMessage()?->getId(),
-            'form_key' => Mage::getSingleton('core/session')->getFormKey(),
-        ]);
+        return $this->getUrlSecure('*/*/retry', ['id' => $this->getMessage()?->getId()]);
     }
 
     public function getDiscardUrl(): string
     {
-        return $this->getUrl('*/*/discard', [
-            'id' => $this->getMessage()?->getId(),
-            'form_key' => Mage::getSingleton('core/session')->getFormKey(),
-        ]);
+        return $this->getUrlSecure('*/*/discard', ['id' => $this->getMessage()?->getId()]);
     }
 
     public function isRetryable(): bool

--- a/app/code/core/Maho/Revocation/Block/Adminhtml/Request/View.php
+++ b/app/code/core/Maho/Revocation/Block/Adminhtml/Request/View.php
@@ -80,7 +80,7 @@ class Maho_Revocation_Block_Adminhtml_Request_View extends Mage_Adminhtml_Block_
 
     public function getResendUrl(): string
     {
-        return $this->getUrl('*/*/resend', ['id' => $this->getRevocationRequest()?->getId(), 'form_key' => Mage::getSingleton('core/session')->getFormKey()]);
+        return $this->getUrlSecure('*/*/resend', ['id' => $this->getRevocationRequest()?->getId()]);
     }
 
     public function getOrderViewUrl(Mage_Sales_Model_Order $order): string

--- a/app/design/adminhtml/default/default/template/contentversion/preview.phtml
+++ b/app/design/adminhtml/default/default/template/contentversion/preview.phtml
@@ -17,7 +17,7 @@ $typeLabels = [
     'cms_block' => $this->__('CMS Block'),
     'blog_post' => $this->__('Blog Post'),
 ];
-$restoreUrl = $this->getUrl('adminhtml/contentversion/restore', ['version_id' => $versionId]);
+$restoreUrl = $this->getUrlSecure('adminhtml/contentversion/restore', ['version_id' => $versionId]);
 $confirmMsg = $this->jsQuoteEscape(
     $this->__('Are you sure you want to restore this version? The current content will be saved as a new version first.'),
 );

--- a/public/js/mage/adminhtml/catalog/category.js
+++ b/public/js/mage/adminhtml/catalog/category.js
@@ -254,7 +254,7 @@ class CategoryEditForm {
             return;
         }
         if (!this.config.useAjax) {
-            return setLocation(setRouteParams(url, { form_key: FORM_KEY }));
+            return setLocation(url);
         }
         try {
             const result = await mahoFetch(url, { method: 'POST' });

--- a/public/js/mage/adminhtml/tools.js
+++ b/public/js/mage/adminhtml/tools.js
@@ -3,24 +3,7 @@
 // SPDX-FileCopyrightText: 2006-2020 Magento, Inc. <https://magento.com>
 // SPDX-License-Identifier: AFL-3.0
 function setLocation(url){
-    window.location.href = addAdminFormKey(url);
-}
-
-// Append the admin form key to same-origin navigations so state-changing GET
-// actions guarded by _setForcedFormKeyActions() pass server-side CSRF validation.
-function addAdminFormKey(url){
-    if (typeof FORM_KEY === 'undefined' || !FORM_KEY) {
-        return encodeURI(url);
-    }
-    try {
-        const target = new URL(url, window.location.href);
-        if (target.origin === window.location.origin && !target.searchParams.has('form_key')) {
-            target.searchParams.set('form_key', FORM_KEY);
-        }
-        return target.href;
-    } catch (e) {
-        return encodeURI(url);
-    }
+    window.location.href = encodeURI(url);
 }
 
 function confirmSetLocation(message, url){

--- a/tests/Backend/Integration/Adminhtml/AdminUrlFormKeyTest.php
+++ b/tests/Backend/Integration/Adminhtml/AdminUrlFormKeyTest.php
@@ -33,6 +33,7 @@ function adminUrlBlock(): Mage_Adminhtml_Block_Template
 
 afterEach(function () {
     Mage::app()->getStore()->resetConfig();
+    Mage::unregister('current_creditmemo');
 });
 
 it('keeps the form key out of admin urls when secret keys are on', function () {
@@ -102,6 +103,45 @@ it('carries the form key on buttons that build their own forced-action url', fun
     'queue discard' => ['queue/adminhtml_message_view', 'getDiscardUrl'],
     'revocation resend' => ['revocation/adminhtml_request_view', 'getResendUrl'],
 ]);
+
+/**
+ * Cancel and void on a credit memo are the same shape as their invoice counterparts: a plain GET
+ * navigation into a forced-form-key action. The state keeps every button branch in the constructor
+ * from touching an order that isn't there; only the urls are under test.
+ */
+it('carries the form key on the credit memo cancel and void urls', function (string $method) {
+    Mage::register('current_creditmemo', Mage::getModel('sales/order_creditmemo')
+        ->setId(1)
+        ->setState(Mage_Sales_Model_Order_Creditmemo::STATE_CANCELED));
+
+    $block = Mage::app()->getLayout()->createBlock('adminhtml/sales_order_creditmemo_view');
+
+    adminUrlSetSecretKey(false);
+    expect($block->{$method}())->toContain('form_key/' . Mage::getSingleton('core/session')->getFormKey());
+
+    adminUrlSetSecretKey(true);
+    expect($block->{$method}())->not->toContain('form_key');
+})->with(['getCancelUrl', 'getVoidUrl']);
+
+/**
+ * A grid action column builds its own href and navigates through setLocation(), so an action on the
+ * forced-form-key list has to put the key in the column config itself.
+ */
+it('carries the form key on the feed destination grid test action', function () {
+    $testAction = function (): array {
+        $block = Mage::app()->getLayout()->createBlock('feedmanager/adminhtml_destination_grid');
+        Closure::bind(fn() => $this->_prepareColumns(), $block, $block::class)();
+        $actions = $block->getColumn('action')->getActions();
+        return array_values(array_filter($actions, fn(array $a) => $a['url']['base'] === '*/*/test'))[0];
+    };
+
+    adminUrlSetSecretKey(false);
+    expect($testAction()['url']['params'])
+        ->toBe([Mage_Core_Model_Url::FORM_KEY => Mage::getSingleton('core/session')->getFormKey()]);
+
+    adminUrlSetSecretKey(true);
+    expect($testAction()['url']['params'])->toBe([]);
+});
 
 /**
  * Instantiated directly because _prepareLayout() needs a registered category; only the url

--- a/tests/Backend/Integration/Adminhtml/AdminUrlFormKeyTest.php
+++ b/tests/Backend/Integration/Adminhtml/AdminUrlFormKeyTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * The form key is the session-wide CSRF root the per-action secret key is derived from, so it
+ * must never ride in an admin url that doesn't need it. Only getUrlSecure() may emit it, and
+ * only when secret keys are off, which is the sole config where _setForcedFormKeyActions()
+ * arms itself. With secret keys on nothing reads it, so no url should contain it.
+ */
+
+function adminUrlSetSecretKey(bool $enabled): void
+{
+    Mage::app()->getStore()->setConfig(
+        Mage_Adminhtml_Helper_Data::XML_PATH_ADMINHTML_SECURITY_USE_FORM_KEY,
+        $enabled ? 1 : 0,
+    );
+}
+
+function adminUrlBlock(): Mage_Adminhtml_Block_Template
+{
+    /** @var Mage_Adminhtml_Block_Template $block */
+    $block = Mage::app()->getLayout()->createBlock('adminhtml/template');
+    return $block;
+}
+
+afterEach(function () {
+    Mage::app()->getStore()->resetConfig();
+});
+
+it('keeps the form key out of admin urls when secret keys are on', function () {
+    adminUrlSetSecretKey(true);
+    $block = adminUrlBlock();
+    $plain = $block->getUrl('adminhtml/sales_order/view', ['order_id' => 1]);
+
+    expect($plain)->not->toContain('form_key')
+        ->and($plain)->toContain('/key/')
+        ->and($block->getUrlSecure('adminhtml/sales_order/hold', ['order_id' => 1]))->not->toContain('form_key');
+});
+
+it('emits the form key only from getUrlSecure when secret keys are off', function () {
+    adminUrlSetSecretKey(false);
+    $block = adminUrlBlock();
+    $plain = $block->getUrl('adminhtml/sales_order/view', ['order_id' => 1]);
+
+    expect($plain)->not->toContain('form_key')
+        ->and($plain)->not->toContain('/key/')
+        ->and($block->getUrlSecure('adminhtml/sales_order/hold', ['order_id' => 1]))
+        ->toContain('form_key/' . Mage::getSingleton('core/session')->getFormKey());
+});

--- a/tests/Backend/Integration/Adminhtml/AdminUrlFormKeyTest.php
+++ b/tests/Backend/Integration/Adminhtml/AdminUrlFormKeyTest.php
@@ -55,3 +55,66 @@ it('emits the form key only from getUrlSecure when secret keys are off', functio
         ->and($block->getUrlSecure('adminhtml/sales_order/hold', ['order_id' => 1]))
         ->toContain('form_key/' . Mage::getSingleton('core/session')->getFormKey());
 });
+
+it('builds grid action params with the same form key rule as urls', function () {
+    adminUrlSetSecretKey(true);
+    expect(adminUrlBlock()->getUrlSecureParams())->toBe([]);
+
+    adminUrlSetSecretKey(false);
+    expect(adminUrlBlock()->getUrlSecureParams(['id' => 7]))
+        ->toBe(['id' => 7, 'form_key' => Mage::getSingleton('core/session')->getFormKey()]);
+});
+
+/**
+ * Every delete button on a form container is a plain GET navigation, and the delete action is on
+ * the forced-form-key list of most admin controllers, so the url has to carry the key when secret
+ * keys are off and must not leak it when they're on.
+ */
+it('scopes the form key on the shared form container delete url', function () {
+    /** @var Mage_Adminhtml_Block_Widget_Form_Container $block */
+    $block = Mage::app()->getLayout()->createBlock('adminhtml/widget_form_container');
+
+    adminUrlSetSecretKey(true);
+    expect($block->getDeleteUrl())->not->toContain('form_key');
+
+    adminUrlSetSecretKey(false);
+    expect($block->getDeleteUrl())
+        ->toContain('form_key/' . Mage::getSingleton('core/session')->getFormKey());
+});
+
+/**
+ * These buttons build their own url instead of going through the container, so each one has to
+ * opt into getUrlSecure() by hand. setLocation() used to paper over a miss by appending the key
+ * to every navigation; without it a miss is a dead button.
+ */
+it('carries the form key on buttons that build their own forced-action url', function (string $blockAlias, string $method) {
+    adminUrlSetSecretKey(false);
+    $formKey = Mage::getSingleton('core/session')->getFormKey();
+
+    $block = Mage::app()->getLayout()->createBlock($blockAlias);
+
+    expect($block->{$method}())->toContain('form_key/' . $formKey);
+
+    adminUrlSetSecretKey(true);
+    expect(Mage::app()->getLayout()->createBlock($blockAlias)->{$method}())->not->toContain('form_key');
+})->with([
+    'queue retry' => ['queue/adminhtml_message_view', 'getRetryUrl'],
+    'queue discard' => ['queue/adminhtml_message_view', 'getDiscardUrl'],
+    'revocation resend' => ['revocation/adminhtml_request_view', 'getResendUrl'],
+]);
+
+/**
+ * Instantiated directly because _prepareLayout() needs a registered category; only the url
+ * matters here. The tree's delete button is the one navigation category.js no longer patches
+ * the key onto, so the block has to supply it.
+ */
+it('carries the form key on the category tree delete url', function () {
+    $block = new Mage_Adminhtml_Block_Catalog_Category_Edit_Form();
+
+    adminUrlSetSecretKey(false);
+    expect($block->getDeleteUrl())
+        ->toContain('form_key/' . Mage::getSingleton('core/session')->getFormKey());
+
+    adminUrlSetSecretKey(true);
+    expect($block->getDeleteUrl())->not->toContain('form_key');
+});

--- a/tests/Browser/AdminQueryStringUrlsTest.php
+++ b/tests/Browser/AdminQueryStringUrlsTest.php
@@ -15,17 +15,18 @@ uses(MahoBrowserTestCase::class)->group('browser');
 /**
  * Regression for admin screens that append route params to a url built with _current => true.
  *
- * setLocation() puts ?form_key=... on every same-origin navigation, so any page reached
- * through a button carries a query string, and _current copies it into the next url. Code
- * that then concatenates "key/value/" onto that url writes the segment into the last query
- * param's value instead of the path, and the param never arrives. Same defect as the store
- * switcher; these are the two other places that had it.
+ * _current copies the current query string into the next url. Code that then concatenates
+ * "key/value/" onto that url writes the segment into the last query param's value instead of
+ * the path, and the param never arrives. Same defect as the store switcher; these are the two
+ * other places that had it.
  *
- * Secret keys are turned off for the run so the screens can be addressed directly.
+ * Secret keys are turned off for the run so the screens can be addressed directly; the query
+ * string the screens have to survive is therefore supplied by the test itself.
  */
 
 const QUERY_URLS_ADMIN_USER = 'query-urls-admin';
 const QUERY_URLS_ADMIN_PASSWORD = 'Password123!';
+const QUERY_URLS_QUERY = 'pest_query=PestQueryStringUrls';
 
 beforeEach(function () {
     Mage::getModel('core/config')->saveConfig(Mage_Adminhtml_Helper_Data::XML_PATH_ADMINHTML_SECURITY_USE_FORM_KEY, 0);
@@ -104,9 +105,9 @@ function submitReportFilter(object $page, string $from, string $to): string
 }
 
 it('keeps the report filter in the path when the report is run twice', function () {
-    // The first run navigates through setLocation(), so the second one starts from a url
-    // that already carries ?form_key=... - which is where the segment used to land.
-    $page = visitAdminPage('/admin/report_product/viewed', '#filter_form');
+    // _current carries the query string into the url the first run navigates to, so the
+    // second one starts from a url that ends in one - which is where the segment used to land.
+    $page = visitAdminPage('/admin/report_product/viewed?' . QUERY_URLS_QUERY, '#filter_form');
     $first = submitReportFilter($page, '2026-07-01', '2026-07-31');
     $second = submitReportFilter($page, '2026-06-01', '2026-06-30');
 
@@ -116,10 +117,10 @@ it('keeps the report filter in the path when the report is run twice', function 
 });
 
 it('reloads the dashboard diagram when the period changes on a url with a query string', function () {
-    $page = visitAdminPage('/admin/dashboard/?form_key=PestDashboardFormKey', '#order_orders_period');
+    $page = visitAdminPage('/admin/dashboard/?' . QUERY_URLS_QUERY, '#order_orders_period');
 
     // ajaxBlock answers with an empty body when it gets no block param, which pre-fix is
-    // exactly what happened: "block/tab_orders/" went into the form key's value.
+    // exactly what happened: "block/tab_orders/" went into the last query param's value.
     $page->select('#order_orders_period', '1y')->wait(2);
 
     expect(trim((string) $page->page()->locator('#diagram_tab_orders_content')->innerHTML()))->not->toBe('');


### PR DESCRIPTION
Fixes #1241.

`setLocation()` appended `?form_key=...` to every same-origin admin URL (added in 03d2a9a71, first released in 26.7.0, which matches when the reporter first saw it). Grid row clicks and edit-screen buttons all route through it, while menu links are plain anchors, which is exactly the contrast in the issue. `Mage_Adminhtml_Block_Widget_Form_Container` is not involved; those screens are just the ones you normally reach by clicking a row or a button.

Not cosmetic. `preDispatch()` validates POSTs against the form key alone and never the secret key, so a form key scraped from an address bar, a Referer header, a screenshot or an access log was enough to forge a POST to any admin action.

The six state-changing GET actions that were relying on the append now build their links with `getUrlSecure()`: order `hold`/`unhold`, invoice `capture`/`void`/`cancel`, shipment `cancel`. That emits the form key only when secret keys are off, which is the sole config where `_setForcedFormKeyActions()` arms itself, so the hardening in 03d2a9a71 is preserved without publishing the token in the default setup.

Two adjacent fixes in the same code path: form keys are now compared with `hash_equals()` instead of a loose, non-constant-time check (`Mage_Core_Model_Session::validateFormKey()` is called on the unauthenticated admin login POST), and the admin AJAX error branch reads `isAjax` via `getParam()` so an AJAX POST with an invalid key gets the JSON error instead of an HTML redirect.

`AdminQueryStringUrlsTest` supplied its query string via the append, so it now seeds its own param.

Worth backporting to 26.7 on the CSRF grounds above.

Every other admin link pointing at a forced-form-key action is now routed through `getUrlSecure()` / `getUrlSecureParams()` too, including ones that predate 03d2a9a71 and were never protected: category and urlrewrite `delete`, `contentversion/restore`, plus the design, store, review, cron, country/region, queue, revocation, feed and media-cleaner screens. Attribute-set delete needed nothing: it is a POST form submit, which already carries the key.

Credit memo `cancel`/`void` are handled too, and they needed more than a link change: `Mage_Adminhtml_Sales_Order_CreditmemoController` declared no `_setForcedFormKeyActions()` at all, so those two state-changing GETs had no token check of any kind. The controller now arms them like `InvoiceController` does, and the buttons build their urls with `getUrlSecure()`.
