### PR TITLE
Closed database connections when the app is reset

### DIFF
--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -330,6 +330,8 @@ jobs:
           API_BASE_URL: http://127.0.0.1:8080
           PAYPAL_SANDBOX_CLIENT_ID: ${{ secrets.PAYPAL_SANDBOX_CLIENT_ID }}
           PAYPAL_SANDBOX_CLIENT_SECRET: ${{ secrets.PAYPAL_SANDBOX_CLIENT_SECRET }}
+          USE_ZEND_ALLOC: 0
+          MALLOC_CHECK_: 3
         run: |
           ulimit -c unlimited
           ./vendor/bin/pest --display-errors --display-warnings
@@ -343,10 +345,9 @@ jobs:
             echo "=================== $core ==================="
             gdb -batch -n \
               -ex "set pagination off" \
-              -ex "info sharedlibrary" \
-              -ex "thread apply all bt full" \
+              -ex "bt 40" \
               -ex quit \
-              "$(which php)" "$core" 2>&1 | tail -300
+              "$(which php)" "$core" 2>&1 | tail -60
           done
 
       - name: Upload browser test failure diagnostics

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -318,12 +318,36 @@ jobs:
           PAYPAL_SANDBOX_CLIENT_ID: ${{ secrets.PAYPAL_SANDBOX_CLIENT_ID }}
           PAYPAL_SANDBOX_CLIENT_SECRET: ${{ secrets.PAYPAL_SANDBOX_CLIENT_SECRET }}
 
+      - name: TEMP DEBUG - enable core dumps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y gdb
+          sudo sysctl -w kernel.core_pattern=/tmp/core.%e.%p
+          sudo sysctl -w fs.suid_dumpable=1
+
       - name: Run Pest Tests
         env:
           API_BASE_URL: http://127.0.0.1:8080
           PAYPAL_SANDBOX_CLIENT_ID: ${{ secrets.PAYPAL_SANDBOX_CLIENT_ID }}
           PAYPAL_SANDBOX_CLIENT_SECRET: ${{ secrets.PAYPAL_SANDBOX_CLIENT_SECRET }}
-        run: ./vendor/bin/pest --display-errors --display-warnings
+        run: |
+          ulimit -c unlimited
+          ./vendor/bin/pest --display-errors --display-warnings
+
+      - name: TEMP DEBUG - backtrace from core dump
+        if: failure()
+        run: |
+          ls -la /tmp/core.* 2>/dev/null || echo "no core files"
+          for core in /tmp/core.*; do
+            [ -f "$core" ] || continue
+            echo "=================== $core ==================="
+            gdb -batch -n \
+              -ex "set pagination off" \
+              -ex "info sharedlibrary" \
+              -ex "thread apply all bt full" \
+              -ex quit \
+              "$(which php)" "$core" 2>&1 | tail -300
+          done
 
       - name: Upload browser test failure diagnostics
         if: failure()

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -330,8 +330,6 @@ jobs:
           API_BASE_URL: http://127.0.0.1:8080
           PAYPAL_SANDBOX_CLIENT_ID: ${{ secrets.PAYPAL_SANDBOX_CLIENT_ID }}
           PAYPAL_SANDBOX_CLIENT_SECRET: ${{ secrets.PAYPAL_SANDBOX_CLIENT_SECRET }}
-          USE_ZEND_ALLOC: 0
-          MALLOC_CHECK_: 3
         run: |
           ulimit -c unlimited
           ./vendor/bin/pest --display-errors --display-warnings

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -318,35 +318,12 @@ jobs:
           PAYPAL_SANDBOX_CLIENT_ID: ${{ secrets.PAYPAL_SANDBOX_CLIENT_ID }}
           PAYPAL_SANDBOX_CLIENT_SECRET: ${{ secrets.PAYPAL_SANDBOX_CLIENT_SECRET }}
 
-      - name: TEMP DEBUG - enable core dumps
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y gdb
-          sudo sysctl -w kernel.core_pattern=/tmp/core.%e.%p
-          sudo sysctl -w fs.suid_dumpable=1
-
       - name: Run Pest Tests
         env:
           API_BASE_URL: http://127.0.0.1:8080
           PAYPAL_SANDBOX_CLIENT_ID: ${{ secrets.PAYPAL_SANDBOX_CLIENT_ID }}
           PAYPAL_SANDBOX_CLIENT_SECRET: ${{ secrets.PAYPAL_SANDBOX_CLIENT_SECRET }}
-        run: |
-          ulimit -c unlimited
-          ./vendor/bin/pest --display-errors --display-warnings
-
-      - name: TEMP DEBUG - backtrace from core dump
-        if: failure()
-        run: |
-          ls -la /tmp/core.* 2>/dev/null || echo "no core files"
-          for core in /tmp/core.*; do
-            [ -f "$core" ] || continue
-            echo "=================== $core ==================="
-            gdb -batch -n \
-              -ex "set pagination off" \
-              -ex "bt 40" \
-              -ex quit \
-              "$(which php)" "$core" 2>&1 | tail -60
-          done
+        run: ./vendor/bin/pest --display-errors --display-warnings
 
       - name: Upload browser test failure diagnostics
         if: failure()

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -122,11 +122,7 @@ final class Mage
     {
         $resource = self::$_registry['_singleton/core/resource'] ?? null;
         if ($resource instanceof Mage_Core_Model_Resource) {
-            try {
-                $resource->closeConnections();
-            } catch (\Throwable) {
-                // reset() has to clear state whatever the driver does on close
-            }
+            $resource->closeConnections();
         }
 
         self::$_registry        = [];

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -112,9 +112,19 @@ final class Mage
 
     /**
      * Set all my static data to defaults
+     *
+     * Connections are closed explicitly: dropping the registry only makes an
+     * adapter unreachable, and it holds its connection until PHP's cycle
+     * collector happens to run, so a process that resets repeatedly (the test
+     * suite, once per test) piles up connections until the server refuses more.
      */
     public static function reset()
     {
+        $resource = self::$_registry['_singleton/core/resource'] ?? null;
+        if ($resource instanceof Mage_Core_Model_Resource) {
+            $resource->closeConnections();
+        }
+
         self::$_registry        = [];
         self::$_appRoot         = null;
         self::$_app             = null;

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -122,7 +122,11 @@ final class Mage
     {
         $resource = self::$_registry['_singleton/core/resource'] ?? null;
         if ($resource instanceof Mage_Core_Model_Resource) {
-            $resource->closeConnections();
+            try {
+                $resource->closeConnections();
+            } catch (\Throwable) {
+                // reset() has to clear state whatever the driver does on close
+            }
         }
 
         self::$_registry        = [];

--- a/app/code/core/Mage/Core/Model/Resource.php
+++ b/app/code/core/Mage/Core/Model/Resource.php
@@ -131,7 +131,11 @@ class Mage_Core_Model_Resource
                 continue;
             }
             $closed[$id] = true;
-            $connection->closeConnection();
+            try {
+                $connection->closeConnection();
+            } catch (\Throwable) {
+                // one driver failing to close must not leave the others open
+            }
         }
     }
 

--- a/app/code/core/Mage/Core/Model/Resource.php
+++ b/app/code/core/Mage/Core/Model/Resource.php
@@ -116,6 +116,26 @@ class Mage_Core_Model_Resource
     }
 
     /**
+     * Release every open connection, reconnecting on next use. Several names
+     * share one adapter, so each is closed once.
+     */
+    public function closeConnections(): void
+    {
+        $closed = [];
+        foreach ($this->_connections as $connection) {
+            if (!$connection instanceof Maho\Db\Adapter\AdapterInterface) {
+                continue;
+            }
+            $id = spl_object_id($connection);
+            if (isset($closed[$id])) {
+                continue;
+            }
+            $closed[$id] = true;
+            $connection->closeConnection();
+        }
+    }
+
+    /**
      * Determine connection type from config
      *
      * Supports new 'engine' config (mysql, pgsql, sqlite) which derives type as pdo_{engine},

--- a/lib/Maho/Db/Adapter/AbstractPdoAdapter.php
+++ b/lib/Maho/Db/Adapter/AbstractPdoAdapter.php
@@ -214,6 +214,20 @@ abstract class AbstractPdoAdapter implements AdapterInterface
     }
 
     /**
+     * Release the connection, reconnecting on next use. Dropped rather than
+     * just closed so _connect() reapplies _initConnection(): its session
+     * settings don't survive the connection they were set on.
+     */
+    #[\Override]
+    public function closeConnection(): void
+    {
+        $this->_connection?->close();
+        $this->_connection = null;
+        $this->_connectionFlagsSet = false;
+        $this->_transactionLevel = 0;
+    }
+
+    /**
      * Returns the Doctrine DBAL Platform for this connection.
      * Used for platform-agnostic SQL expression generation.
      */

--- a/lib/Maho/Db/Adapter/AbstractPdoAdapter.php
+++ b/lib/Maho/Db/Adapter/AbstractPdoAdapter.php
@@ -221,6 +221,11 @@ abstract class AbstractPdoAdapter implements AdapterInterface
     #[\Override]
     public function closeConnection(): void
     {
+        if ($this->_transactionLevel > 0) {
+            // The destructor's leaked-transaction check never sees this one
+            \Mage::log('Closed a connection with an open transaction, discarding it', \Mage::LOG_WARNING);
+        }
+
         $this->_connection?->close();
         $this->_connection = null;
         $this->_connectionFlagsSet = false;

--- a/lib/Maho/Db/Adapter/AdapterInterface.php
+++ b/lib/Maho/Db/Adapter/AdapterInterface.php
@@ -64,6 +64,11 @@ interface AdapterInterface
     public function getConnection(): \Doctrine\DBAL\Connection;
 
     /**
+     * Release the connection to the database server, reconnecting on next use
+     */
+    public function closeConnection(): void;
+
+    /**
      * Retrieve DDL object for new table
      *
      * @param string|null $tableName the table name

--- a/lib/Maho/Db/Adapter/AdapterInterface.php
+++ b/lib/Maho/Db/Adapter/AdapterInterface.php
@@ -64,7 +64,8 @@ interface AdapterInterface
     public function getConnection(): \Doctrine\DBAL\Connection;
 
     /**
-     * Release the connection to the database server, reconnecting on next use
+     * Release the connection to the database server, reconnecting on next use.
+     * An adapter whose driver has no connection worth releasing may keep it.
      */
     public function closeConnection(): void;
 

--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -281,9 +281,9 @@ class Mysql extends AbstractPdoAdapter
 
     /**
      * Setup state tracks session settings (the relaxed SQL_MODE, the
-     * @OLD_FOREIGN_KEY_CHECKS variable) that die with the connection, so a
-     * close abandons any setup still open rather than restoring it onto a
-     * connection that never had it.
+     * OLD_FOREIGN_KEY_CHECKS session variable) that die with the connection,
+     * so a close abandons any setup still open rather than restoring it onto
+     * a connection that never had it.
      */
     #[\Override]
     public function closeConnection(): void

--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -280,6 +280,20 @@ class Mysql extends AbstractPdoAdapter
     }
 
     /**
+     * Setup state tracks session settings (the relaxed SQL_MODE, the
+     * @OLD_FOREIGN_KEY_CHECKS variable) that die with the connection, so a
+     * close abandons any setup still open rather than restoring it onto a
+     * connection that never had it.
+     */
+    #[\Override]
+    public function closeConnection(): void
+    {
+        parent::closeConnection();
+        $this->_setupNesting = 0;
+        $this->_setupSqlMode = null;
+    }
+
+    /**
      * Run RAW Query
      *
      * @throws \PDOException

--- a/lib/Maho/Db/Adapter/Pdo/Sqlite.php
+++ b/lib/Maho/Db/Adapter/Pdo/Sqlite.php
@@ -122,6 +122,16 @@ class Sqlite extends AbstractPdoAdapter
     }
 
     /**
+     * Keep the connection open. SQLite has no server to run out of connections,
+     * so there is nothing to release, and releasing is not free: pdo_sqlite
+     * frees the PHP callbacks behind the REGEXP/GREATEST/LEAST functions
+     * registered above as it tears the handle down, which corrupts the heap and
+     * segfaults the process later, in an unrelated allocation.
+     */
+    #[\Override]
+    public function closeConnection(): void {}
+
+    /**
      * Register custom SQLite functions for compatibility with MySQL/PostgreSQL
      */
     protected function _registerCustomFunctions(): void

--- a/tests/Backend/Integration/Db/ConnectionLifecycleTest.php
+++ b/tests/Backend/Integration/Db/ConnectionLifecycleTest.php
@@ -49,6 +49,21 @@ it('abandons open setup state when the connection is closed', function () {
     $adapter->endSetup();
 });
 
+it('discards an open transaction when the connection is closed', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    $adapter->beginTransaction();
+    $adapter->closeConnection();
+
+    expect($adapter->getTransactionLevel())->toBe(0);
+    expect($adapter->isTransaction())->toBeFalse();
+
+    $adapter->beginTransaction();
+    expect($adapter->getTransactionLevel())->toBe(1);
+    $adapter->rollBack();
+
+    expect((int) $adapter->fetchOne('SELECT 1'))->toBe(1);
+});
+
 it('leaves no connection open behind Mage::reset()', function () {
     $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
     $adapter->fetchOne('SELECT 1');

--- a/tests/Backend/Integration/Db/ConnectionLifecycleTest.php
+++ b/tests/Backend/Integration/Db/ConnectionLifecycleTest.php
@@ -9,9 +9,21 @@ declare(strict_types=1);
 
 uses(Tests\MahoBackendTestCase::class);
 
+/**
+ * SQLite deliberately keeps its connection open (see Maho\Db\Adapter\Pdo\Sqlite),
+ * so the tests that assert a connection actually went away don't apply to it.
+ */
+function skipOnSqlite(Maho\Db\Adapter\AdapterInterface $adapter): void
+{
+    if ($adapter instanceof Maho\Db\Adapter\Pdo\Sqlite) {
+        test()->markTestSkipped('SQLite connections are never closed');
+    }
+}
+
 it('closes every open connection', function () {
     $resource = Mage::getSingleton('core/resource');
     $adapter = $resource->getConnection('core_write');
+    skipOnSqlite($adapter);
     $adapter->fetchOne('SELECT 1');
 
     // Captured up front: asking the adapter for it again would reconnect.
@@ -51,6 +63,7 @@ it('abandons open setup state when the connection is closed', function () {
 
 it('discards an open transaction when the connection is closed', function () {
     $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    skipOnSqlite($adapter);
     $adapter->beginTransaction();
     $adapter->closeConnection();
 
@@ -66,6 +79,7 @@ it('discards an open transaction when the connection is closed', function () {
 
 it('leaves no connection open behind Mage::reset()', function () {
     $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    skipOnSqlite($adapter);
     $adapter->fetchOne('SELECT 1');
     $dbal = $adapter->getConnection();
 

--- a/tests/Backend/Integration/Db/ConnectionLifecycleTest.php
+++ b/tests/Backend/Integration/Db/ConnectionLifecycleTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+it('closes every open connection', function () {
+    $resource = Mage::getSingleton('core/resource');
+    $adapter = $resource->getConnection('core_write');
+    $adapter->fetchOne('SELECT 1');
+
+    // Captured up front: asking the adapter for it again would reconnect.
+    $dbal = $adapter->getConnection();
+    expect($dbal->isConnected())->toBeTrue();
+
+    $resource->closeConnections();
+
+    expect($dbal->isConnected())->toBeFalse();
+});
+
+it('reconnects on demand after a close', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    $adapter->fetchOne('SELECT 1');
+    $adapter->closeConnection();
+
+    expect((int) $adapter->fetchOne('SELECT 1'))->toBe(1);
+});
+
+it('leaves no connection open behind Mage::reset()', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    $adapter->fetchOne('SELECT 1');
+    $dbal = $adapter->getConnection();
+
+    Mage::reset();
+
+    expect($dbal->isConnected())->toBeFalse();
+});

--- a/tests/Backend/Integration/Db/ConnectionLifecycleTest.php
+++ b/tests/Backend/Integration/Db/ConnectionLifecycleTest.php
@@ -31,6 +31,24 @@ it('reconnects on demand after a close', function () {
     expect((int) $adapter->fetchOne('SELECT 1'))->toBe(1);
 });
 
+it('abandons open setup state when the connection is closed', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    if (!$adapter instanceof Maho\Db\Adapter\Pdo\Mysql) {
+        $this->markTestSkipped('Setup session state is MySQL-specific');
+    }
+
+    $adapter->startSetup();
+    $adapter->closeConnection();
+
+    expect((new ReflectionProperty($adapter, '_setupNesting'))->getValue($adapter))->toBe(0);
+
+    // The relaxed SQL_MODE died with the connection, so this has to count as a
+    // fresh setup and relax it again rather than nest inside the closed one.
+    $adapter->startSetup();
+    expect((string) $adapter->fetchOne('SELECT @@SESSION.sql_mode'))->not->toContain('NO_ZERO_DATE');
+    $adapter->endSetup();
+});
+
 it('leaves no connection open behind Mage::reset()', function () {
     $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
     $adapter->fetchOne('SELECT 1');


### PR DESCRIPTION
`Mage::reset()` dropped the registry without closing the connections behind it. An unreachable adapter still holds its connection (it sits in a reference cycle until PHP's cycle collector happens to run), so a process that resets repeatedly accumulates connections.

The test suite resets once per test, which works out to one open connection per test file. PostgreSQL allows 100 by default and the suite was sitting at 96 of them, one short of the wall:

| run | test files booted before the failure point | result |
|---|---|---|
| `cb541b2d` | 96 | pass |
| `00c517d2` (#1240) | 97 | fail |

#1240 added `tests/Backend/Integration/Db/Schema/StatusTest.php`, which sorts before `ImportExport/` and boots the app like every other integration test. That was the 97th, and the Backend suite started failing with `SQLSTATE[08006] ... sorry, too many clients already` — every pgsql job breaking at the same unrelated test and recovering ~2s later when GC fired. MySQL and MariaDB allow 151 and SQLite has no limit, so only pgsql broke.

Adds `closeConnection()` to the adapter and `closeConnections()` to `Mage_Core_Model_Resource`, called from `Mage::reset()`. The adapter is dropped rather than just closed so the next connect reapplies `_initConnection()`, whose session settings (encoding, time zone) don't survive the connection they were set on.

Fixes pgsql CI on `main`, and takes the ceiling off so the next integration test file added doesn't break it again.

SQLite is the one adapter that does not close: `Sqlite::closeConnection()` is a documented no-op. Closing a pdo_sqlite handle that carries the `REGEXP` / `GREATEST` / `LEAST` callbacks registered in `_initConnection()` corrupts the heap, and the process then segfaults at some later, unrelated allocation. The sqlite job died with exit 139 (`_emalloc` under `json_decode`), and moved to a different suite minutes earlier once the run was put on glibc's allocator (`tcache_get`), which is what a corrupted heap looks like. There is nothing to gain by closing anyway: SQLite is a file, with no server-side connections to exhaust. The three `ConnectionLifecycleTest` cases that assert a connection actually went away skip on sqlite; "reconnects on demand after a close" still runs on every backend.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->
