### PR TITLE
Fixed cart and product APIs mixing base-currency and quote-currency values in one response

### DIFF
--- a/app/code/core/Mage/Catalog/Api/Product.php
+++ b/app/code/core/Mage/Catalog/Api/Product.php
@@ -88,8 +88,8 @@ use Symfony\Component\Serializer\Attribute\Groups;
             args: [
                 'search' => ['type' => 'String', 'description' => 'Search query'],
                 'categoryId' => ['type' => 'Int', 'description' => 'Filter by category ID'],
-                'priceMin' => ['type' => 'Float', 'description' => 'Minimum price filter'],
-                'priceMax' => ['type' => 'Float', 'description' => 'Maximum price filter'],
+                'priceMin' => ['type' => 'Float', 'description' => 'Minimum price filter, in the same currency as the returned prices'],
+                'priceMax' => ['type' => 'Float', 'description' => 'Maximum price filter, in the same currency as the returned prices'],
                 'sortBy' => ['type' => 'String', 'description' => 'Sort field (name, price, created_at)'],
                 'sortDir' => ['type' => 'String', 'description' => 'Sort direction (asc, desc)'],
                 'pageSize' => ['type' => 'Int', 'description' => 'Items per page (max 100)'],
@@ -183,7 +183,7 @@ class Product extends CrudResource
     public string $stockStatus = 'in_stock';
 
     #[Groups(['product:read'])]
-    #[ApiProperty(description: 'Base price')]
+    #[ApiProperty(description: 'Price in the response currency: display currency for public reads, website base currency for backend tokens and writes')]
     public ?float $price = null;
 
     #[Groups(['product:read'])]

--- a/app/code/core/Mage/Catalog/Api/Product.php
+++ b/app/code/core/Mage/Catalog/Api/Product.php
@@ -231,7 +231,7 @@ class Product extends CrudResource
     public ?float $minimalPrice = null;
 
     #[Groups(['product:read'])]
-    #[ApiProperty(description: 'Currency code for all price fields', writable: false, extraProperties: ['computed' => true])]
+    #[ApiProperty(description: 'Currency code for all price fields except the giftcard amount fields, which stay in the website base currency', writable: false, extraProperties: ['computed' => true])]
     public string $currency = '';
 
     #[Groups(['product:detail'])]
@@ -433,15 +433,15 @@ class Product extends CrudResource
 
     /** @var float[] */
     #[Groups(['product:detail'])]
-    #[ApiProperty(description: 'Preset amounts (giftcard fixed/combined types)', writable: false, extraProperties: ['computed' => true])]
+    #[ApiProperty(description: 'Preset amounts (giftcard fixed/combined types), in website base currency: pass back verbatim as the add-to-cart amount', writable: false, extraProperties: ['computed' => true])]
     public array $giftcardAmounts = [];
 
     #[Groups(['product:detail'])]
-    #[ApiProperty(description: 'Minimum custom amount (giftcard range/combined)', writable: false, extraProperties: ['computed' => true])]
+    #[ApiProperty(description: 'Minimum custom amount (giftcard range/combined), in website base currency', writable: false, extraProperties: ['computed' => true])]
     public ?float $giftcardMinAmount = null;
 
     #[Groups(['product:detail'])]
-    #[ApiProperty(description: 'Maximum custom amount (giftcard range/combined)', writable: false, extraProperties: ['computed' => true])]
+    #[ApiProperty(description: 'Maximum custom amount (giftcard range/combined), in website base currency', writable: false, extraProperties: ['computed' => true])]
     public ?float $giftcardMaxAmount = null;
 
     #[Groups(['product:detail'])]

--- a/app/code/core/Mage/Catalog/Api/ProductProvider.php
+++ b/app/code/core/Mage/Catalog/Api/ProductProvider.php
@@ -73,20 +73,27 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         return StoreContext::getStore()->getCurrentCurrencyCode();
     }
 
-    /** Set by displayCurrencyRate(); <= 0 means no conversion. */
+    private ?bool $backendProductsAccess = null;
+
+    /** Memoized per request; hasBackendAccess() runs security voters on every call. */
+    private function backendProductsAccess(): bool
+    {
+        return $this->backendProductsAccess ??= $this->hasBackendAccess('products');
+    }
+
+    private bool $displayRateResolved = false;
     private ?float $displayRate = null;
 
     /**
      * Forward base-to-display rate, or null when prices stay in base currency:
      * backend tokens (lossless read-modify-write), display equals base, or no
-     * imported rate for the display code. Memoized, hasBackendAccess() runs
-     * security voters on every call.
+     * imported rate for the display code.
      */
     private function displayCurrencyRate(): ?float
     {
-        if ($this->displayRate === null) {
-            $this->displayRate = -1.0;
-            if (!$this->hasBackendAccess('products')) {
+        if (!$this->displayRateResolved) {
+            $this->displayRateResolved = true;
+            if (!$this->backendProductsAccess()) {
                 $store = StoreContext::getStore();
                 $currencyCode = $store->getCurrentCurrencyCode();
                 if ($currencyCode !== $store->getBaseCurrencyCode()) {
@@ -97,7 +104,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
                 }
             }
         }
-        return $this->displayRate > 0 ? $this->displayRate : null;
+        return $this->displayRate;
     }
 
     /**
@@ -116,25 +123,31 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
     {
         $store = StoreContext::getStore();
 
-        if ($this->displayCurrencyRate() === null) {
+        $rate = $this->displayCurrencyRate();
+        if ($rate === null) {
             $dto->currency = $store->getBaseCurrencyCode();
             return;
         }
 
-        $convert = fn(float|int|null $value): ?float => $value === null
+        $convert = fn(?float $value): ?float => $value === null
             ? null
-            : (float) $store->roundPrice($store->convertPrice((float) $value, false));
+            : (float) $store->roundPrice($value * $rate);
 
         $dto->price = $convert($dto->price);
-        $dto->specialPrice = $convert($dto->specialPrice);
         $dto->finalPrice = $convert($dto->finalPrice);
         $dto->minimalPrice = $convert($dto->minimalPrice);
         $dto->msrp = $convert($dto->msrp);
 
-        foreach ($dto->tierPrices as &$tier) {
-            $tier['price'] = $convert((float) $tier['price']);
+        // Bundle special_price and tier price rows are percent discounts
+        // (Mage_Bundle_Model_Product_Price applies them as finalPrice * pct/100),
+        // not amounts, so multiplying them by the rate would corrupt them.
+        if ($dto->type !== \Mage_Catalog_Model_Product_Type::TYPE_BUNDLE) {
+            $dto->specialPrice = $convert($dto->specialPrice);
+            foreach ($dto->tierPrices as &$tier) {
+                $tier['price'] = $convert((float) $tier['price']);
+            }
+            unset($tier);
         }
-        unset($tier);
 
         foreach ($dto->variants as &$variant) {
             $variant['price'] = $convert((float) $variant['price']);
@@ -205,7 +218,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         }
 
         if ($operation instanceof CollectionOperationInterface) {
-            $backend = $this->hasBackendAccess('products');
+            $backend = $this->backendProductsAccess();
             $sku = $context['args']['sku'] ?? null;
             if ($sku) {
                 $dto = $this->getProductBySku($sku, !$backend);
@@ -236,7 +249,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         // Backend readers may load disabled and other-website products (and
         // raw global values via ?store=admin), so they bypass the shared DTO
         // cache, whose key has no auth dimension.
-        if ($this->hasBackendAccess('products')) {
+        if ($this->backendProductsAccess()) {
             return $this->assertBackendProductAccess($this->loadProductDto($id, visibleOnly: false));
         }
 
@@ -363,7 +376,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         // Backend readers get unconverted base-currency DTOs, so they must not
         // share cached entries with public readers of the same store/currency.
         $scope = StoreContext::getStoreId() . '_' . $this->getCustomerGroupId() . '_' . $this->resolveCurrencyCode()
-            . ($this->hasBackendAccess('products') ? '_backend' : '');
+            . ($this->backendProductsAccess() ? '_backend' : '');
         return 'api_products_' . md5(\Mage::helper('core')->jsonEncode($keyData) . '_' . $scope);
     }
 

--- a/app/code/core/Mage/Catalog/Api/ProductProvider.php
+++ b/app/code/core/Mage/Catalog/Api/ProductProvider.php
@@ -74,6 +74,100 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
     }
 
     /**
+     * Whether outgoing DTO prices must be converted to the store display
+     * currency. Public reads only: backend tokens read the raw base-currency
+     * values they write, so admin read-modify-write round trips stay lossless.
+     */
+    private function shouldConvertPrices(): bool
+    {
+        if ($this->hasBackendAccess('products')) {
+            return false;
+        }
+        $store = StoreContext::getStore();
+        return $store->getCurrentCurrencyCode() !== $store->getBaseCurrencyCode();
+    }
+
+    /**
+     * Make every money field agree with the DTO's single `currency` label.
+     *
+     * Public reads convert from website base currency to the store display
+     * currency (the storefront does the same before rendering); backend reads
+     * keep base values and relabel `currency` to the base code. Two deliberate
+     * exceptions stay in base currency: `cost` (backend-only, never converted)
+     * and the gift card amount fields, which are buy-request values validated
+     * against the stored base amounts on add-to-cart, so converting them would
+     * break the round trip. Linked-product summaries are converted by their own
+     * enrichment pass and are not touched here.
+     */
+    private function applyDisplayCurrency(Product $dto): void
+    {
+        $store = StoreContext::getStore();
+
+        if (!$this->shouldConvertPrices()) {
+            $dto->currency = $store->getBaseCurrencyCode();
+            return;
+        }
+
+        $convert = fn(float|int|null $value): ?float => $value === null
+            ? null
+            : (float) $store->roundPrice($store->convertPrice((float) $value, false));
+
+        $dto->price = $convert($dto->price);
+        $dto->specialPrice = $convert($dto->specialPrice);
+        $dto->finalPrice = $convert($dto->finalPrice);
+        $dto->minimalPrice = $convert($dto->minimalPrice);
+        $dto->msrp = $convert($dto->msrp);
+
+        foreach ($dto->tierPrices as &$tier) {
+            $tier['price'] = $convert((float) $tier['price']);
+        }
+        unset($tier);
+
+        foreach ($dto->variants as &$variant) {
+            $variant['price'] = $convert((float) $variant['price']);
+            $variant['finalPrice'] = $convert((float) $variant['finalPrice']);
+        }
+        unset($variant);
+
+        foreach ($dto->groupedProducts as &$child) {
+            $child['price'] = $convert((float) $child['price']);
+            $child['finalPrice'] = $convert((float) $child['finalPrice']);
+        }
+        unset($child);
+
+        foreach ($dto->customOptions as &$option) {
+            foreach ($option['values'] as &$value) {
+                if (($value['priceType'] ?? 'fixed') !== 'percent') {
+                    $value['price'] = $convert((float) $value['price']);
+                }
+            }
+            unset($value);
+        }
+        unset($option);
+
+        // Dynamic bundles price selections off the child product, so the value
+        // is an amount regardless of the stored selection price type.
+        $bundleIsDynamic = ($dto->priceType ?? 1) === 0;
+        foreach ($dto->bundleOptions as &$bundleOption) {
+            foreach ($bundleOption['selections'] as &$selection) {
+                if ($bundleIsDynamic || ($selection['priceType'] ?? 'fixed') !== 'percent') {
+                    $selection['price'] = $convert((float) $selection['price']);
+                }
+                foreach ($selection['tierPrices'] ?? [] as $i => $tier) {
+                    $selection['tierPrices'][$i]['price'] = $convert((float) $tier['price']);
+                }
+            }
+            unset($selection);
+        }
+        unset($bundleOption);
+
+        foreach ($dto->downloadableLinks as &$link) {
+            $link['price'] = $convert((float) $link['price']);
+        }
+        unset($link);
+    }
+
+    /**
      * Provide product data based on operation type
      *
      * @return TraversablePaginator<Product>|Product|null
@@ -253,7 +347,10 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
     {
         $keyData = array_filter($filters, fn($v) => $v !== '' && $v !== null);
         ksort($keyData);
-        $scope = StoreContext::getStoreId() . '_' . $this->getCustomerGroupId() . '_' . $this->resolveCurrencyCode();
+        // Backend readers get unconverted base-currency DTOs, so they must not
+        // share cached entries with public readers of the same store/currency.
+        $scope = StoreContext::getStoreId() . '_' . $this->getCustomerGroupId() . '_' . $this->resolveCurrencyCode()
+            . ($this->hasBackendAccess('products') ? '_backend' : '');
         return 'api_products_' . md5(\Mage::helper('core')->jsonEncode($keyData) . '_' . $scope);
     }
 
@@ -382,11 +479,22 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         // reports index min_price as `price` for products whose own EAV price is
         // 0 (configurable/bundle/grouped). Filtering the EAV attribute would drop
         // every such product and mismatch the value the client sees.
+        //
+        // The bounds arrive in the same display currency the DTO prices are
+        // reported in; the index stores base amounts, so translate the bounds
+        // back to base before filtering or filters and output would disagree.
+        $priceRate = 1.0;
+        if ($this->shouldConvertPrices()) {
+            $currentRate = (float) StoreContext::getStore()->getCurrentCurrencyRate();
+            if ($currentRate > 0) {
+                $priceRate = $currentRate;
+            }
+        }
         if (!empty($requestFilters['priceMin'])) {
-            $collection->getSelect()->where('price_index.min_price >= ?', (float) $requestFilters['priceMin']);
+            $collection->getSelect()->where('price_index.min_price >= ?', (float) $requestFilters['priceMin'] / $priceRate);
         }
         if (!empty($requestFilters['priceMax'])) {
-            $collection->getSelect()->where('price_index.min_price <= ?', (float) $requestFilters['priceMax']);
+            $collection->getSelect()->where('price_index.min_price <= ?', (float) $requestFilters['priceMax'] / $priceRate);
         }
 
         // Extract attribute filters, REST uses attr_ prefix, GraphQL uses JSON string
@@ -587,6 +695,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         }
 
         if ($forListing) {
+            $this->applyDisplayCurrency($dto);
             \Mage::dispatchEvent('api_product_dto_build', ['product' => $product, 'for_listing' => true, 'dto' => $dto, 'customer_group_id' => $this->getCustomerGroupId()]);
             return;
         }
@@ -852,15 +961,16 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         if ($typeId === \Mage_Downloadable_Model_Product_Type::TYPE_DOWNLOADABLE) {
             /** @var \Mage_Downloadable_Model_Product_Type $typeInstance */
             $links = $typeInstance->getLinks($product);
-            $store = \Mage::app()->getStore();
-            $dto->downloadableLinks = $links ? array_values(array_map(function ($link) use ($store) {
+            // Base currency like every other price here; applyDisplayCurrency()
+            // converts the whole DTO in one place.
+            $dto->downloadableLinks = $links ? array_values(array_map(function ($link) {
                 $sampleUrl = $link->getSampleFile()
                     ? \Mage::getUrl('downloadable/download/linkSample', ['link_id' => $link->getId()])
                     : ($link->getSampleUrl() ?: null);
                 return [
                     'id' => (int) $link->getId(),
                     'title' => $link->getStoreTitle() ?: $link->getTitle(),
-                    'price' => (float) $store->convertPrice($link->getPrice(), false),
+                    'price' => (float) $link->getPrice(),
                     'sortOrder' => (int) $link->getSortOrder(),
                     'numberOfDownloads' => (int) $link->getNumberOfDownloads(),
                     'sampleUrl' => $sampleUrl,
@@ -917,6 +1027,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
             ];
         }
 
+        $this->applyDisplayCurrency($dto);
         \Mage::dispatchEvent('api_product_dto_build', ['product' => $product, 'for_listing' => false, 'dto' => $dto, 'customer_group_id' => $this->getCustomerGroupId()]);
     }
 

--- a/app/code/core/Mage/Catalog/Api/ProductProvider.php
+++ b/app/code/core/Mage/Catalog/Api/ProductProvider.php
@@ -73,18 +73,40 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         return StoreContext::getStore()->getCurrentCurrencyCode();
     }
 
+    /** Set by displayCurrencyRate(); <= 0 means no conversion. */
+    private ?float $displayRate = null;
+
+    /**
+     * Forward base-to-display rate, or null when prices stay in base currency:
+     * backend tokens (lossless read-modify-write), display equals base, or no
+     * imported rate for the display code. Memoized, hasBackendAccess() runs
+     * security voters on every call.
+     */
+    private function displayCurrencyRate(): ?float
+    {
+        if ($this->displayRate === null) {
+            $this->displayRate = -1.0;
+            if (!$this->hasBackendAccess('products')) {
+                $store = StoreContext::getStore();
+                $currencyCode = $store->getCurrentCurrencyCode();
+                if ($currencyCode !== $store->getBaseCurrencyCode()) {
+                    $rate = (float) $store->getBaseCurrency()->getRate($currencyCode);
+                    if ($rate > 0) {
+                        $this->displayRate = $rate;
+                    }
+                }
+            }
+        }
+        return $this->displayRate > 0 ? $this->displayRate : null;
+    }
+
     /**
      * Whether outgoing DTO prices must be converted to the store display
-     * currency. Public reads only: backend tokens read the raw base-currency
-     * values they write, so admin read-modify-write round trips stay lossless.
+     * currency.
      */
     private function shouldConvertPrices(): bool
     {
-        if ($this->hasBackendAccess('products')) {
-            return false;
-        }
-        $store = StoreContext::getStore();
-        return $store->getCurrentCurrencyCode() !== $store->getBaseCurrencyCode();
+        return $this->displayCurrencyRate() !== null;
     }
 
     /**
@@ -483,18 +505,17 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         // The bounds arrive in the same display currency the DTO prices are
         // reported in; the index stores base amounts, so translate the bounds
         // back to base before filtering or filters and output would disagree.
-        $priceRate = 1.0;
-        if ($this->shouldConvertPrices()) {
-            $currentRate = (float) StoreContext::getStore()->getCurrentCurrencyRate();
-            if ($currentRate > 0) {
-                $priceRate = $currentRate;
-            }
+        // Display prices round to 2dp after conversion, so widen each bound by
+        // half a cent; zero is a meaningful bound (priceMax=0 means free).
+        $priceRate = $this->displayCurrencyRate() ?? 1.0;
+        $boundEpsilon = $priceRate === 1.0 ? 0.0 : 0.005;
+        $priceMin = $requestFilters['priceMin'] ?? null;
+        $priceMax = $requestFilters['priceMax'] ?? null;
+        if ($priceMin !== null && $priceMin !== '') {
+            $collection->getSelect()->where('price_index.min_price >= ?', ((float) $priceMin - $boundEpsilon) / $priceRate);
         }
-        if (!empty($requestFilters['priceMin'])) {
-            $collection->getSelect()->where('price_index.min_price >= ?', (float) $requestFilters['priceMin'] / $priceRate);
-        }
-        if (!empty($requestFilters['priceMax'])) {
-            $collection->getSelect()->where('price_index.min_price <= ?', (float) $requestFilters['priceMax'] / $priceRate);
+        if ($priceMax !== null && $priceMax !== '') {
+            $collection->getSelect()->where('price_index.min_price <= ?', ((float) $priceMax + $boundEpsilon) / $priceRate);
         }
 
         // Extract attribute filters, REST uses attr_ prefix, GraphQL uses JSON string
@@ -695,8 +716,9 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         }
 
         if ($forListing) {
-            $this->applyDisplayCurrency($dto);
+            // Event before conversion, so listeners see base-currency DTO values.
             \Mage::dispatchEvent('api_product_dto_build', ['product' => $product, 'for_listing' => true, 'dto' => $dto, 'customer_group_id' => $this->getCustomerGroupId()]);
+            $this->applyDisplayCurrency($dto);
             return;
         }
 
@@ -1027,8 +1049,9 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
             ];
         }
 
-        $this->applyDisplayCurrency($dto);
+        // Event before conversion, so listeners see base-currency DTO values.
         \Mage::dispatchEvent('api_product_dto_build', ['product' => $product, 'for_listing' => false, 'dto' => $dto, 'customer_group_id' => $this->getCustomerGroupId()]);
+        $this->applyDisplayCurrency($dto);
     }
 
     /**

--- a/app/code/core/Mage/Catalog/Api/ProductProvider.php
+++ b/app/code/core/Mage/Catalog/Api/ProductProvider.php
@@ -101,15 +101,6 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
     }
 
     /**
-     * Whether outgoing DTO prices must be converted to the store display
-     * currency.
-     */
-    private function shouldConvertPrices(): bool
-    {
-        return $this->displayCurrencyRate() !== null;
-    }
-
-    /**
      * Make every money field agree with the DTO's single `currency` label.
      *
      * Public reads convert from website base currency to the store display
@@ -125,7 +116,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
     {
         $store = StoreContext::getStore();
 
-        if (!$this->shouldConvertPrices()) {
+        if ($this->displayCurrencyRate() === null) {
             $dto->currency = $store->getBaseCurrencyCode();
             return;
         }
@@ -506,9 +497,11 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         // reported in; the index stores base amounts, so translate the bounds
         // back to base before filtering or filters and output would disagree.
         // Display prices round to 2dp after conversion, so widen each bound by
-        // half a cent; zero is a meaningful bound (priceMax=0 means free).
-        $priceRate = $this->displayCurrencyRate() ?? 1.0;
-        $boundEpsilon = $priceRate === 1.0 ? 0.0 : 0.005;
+        // half a cent whenever conversion runs (a parity rate of exactly 1.0
+        // still rounds); zero is a meaningful bound (priceMax=0 means free).
+        $displayRate = $this->displayCurrencyRate();
+        $boundEpsilon = $displayRate === null ? 0.0 : 0.005;
+        $priceRate = $displayRate ?? 1.0;
         $priceMin = $requestFilters['priceMin'] ?? null;
         $priceMax = $requestFilters['priceMax'] ?? null;
         if ($priceMin !== null && $priceMin !== '') {

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -115,13 +115,12 @@ class CartMapper
         if ($giftcardCodesJson) {
             $giftcardCodes = \Mage::helper('core')->jsonDecode($giftcardCodesJson, true);
             if (is_array($giftcardCodes)) {
-                // giftcard_codes stores {code: applied_amount} in the quote's
-                // base currency. Skip cards the total collector skips (wrong
-                // website, expired, drained), then convert both fields exactly
-                // like the collector converts the discount, so the element
-                // agrees with prices['giftcardAmount']. Single source for
-                // applied gift cards: the GraphQL cart handler maps through
-                // here too.
+                // giftcard_codes stores {code: applied_amount} in base
+                // currency; the collector prunes invalid cards on collect,
+                // skip any lingering in a not-yet-collected quote. Convert
+                // both fields like the collector converts the discount so the
+                // element agrees with prices['giftcardAmount']. The GraphQL
+                // cart handler maps through here too.
                 $store = $quote->getStore();
                 $websiteId = (int) $store->getWebsiteId();
                 foreach ($giftcardCodes as $code => $appliedAmount) {
@@ -130,7 +129,10 @@ class CartMapper
                     if (!$giftcard->getId() || !$giftcard->isValidForWebsite($websiteId)) {
                         continue;
                     }
-                    $balance = $giftcard->getBalance($store->getBaseCurrencyCode());
+                    // isValidForWebsite() ensures the card belongs to this
+                    // website, so its raw balance is already base currency;
+                    // the bare call cannot throw on a missing rate row.
+                    $balance = $giftcard->getBalance();
                     $cart->appliedGiftcards[] = [
                         'code' => (string) $code,
                         'balance' => (float) $store->roundPrice($store->convertPrice($balance, false)),
@@ -167,7 +169,9 @@ class CartMapper
         // getPrice() is website base currency; getCalculationPrice() is the
         // converted (or custom) unit price the totals pipeline multiplies, and
         // calcRowTotal() rounds it first, so round here to keep price * qty
-        // equal to rowTotal.
+        // equal to rowTotal. Tax-inclusive Row/Total calculation derives the
+        // unit price from an already-rounded row total, so there the two can
+        // still differ by up to one cent.
         $dto->price = (float) $item->getStore()->roundPrice($item->getCalculationPrice());
         $dto->priceInclTax = (float) $item->getPriceInclTax();
         $dto->rowTotal = (float) $item->getRowTotal();

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -115,16 +115,20 @@ class CartMapper
         if ($giftcardCodesJson) {
             $giftcardCodes = \Mage::helper('core')->jsonDecode($giftcardCodesJson, true);
             if (is_array($giftcardCodes)) {
-                // giftcard_codes stores {code: applied_amount} in the website
-                // base currency (the total collector owns that format), and the
-                // card balance is stored in the issuing website's base currency
-                // too. Convert both to quote currency: everything non-base* in
-                // this response is quote currency. The live card balance must be
-                // loaded from the model. This is the single source for applied
-                // gift cards: the GraphQL cart handler maps through here too,
-                // so REST and GraphQL return identical values.
-                $quoteCurrency = $cart->currency;
+                // giftcard_codes stores {code: applied_amount} in base currency,
+                // and the live card balance is base currency too. Convert both
+                // with the same guarded forward rate so the two fields of one
+                // element can never disagree (getBalance($currency) throws on a
+                // missing rate row). Single source for applied gift cards: the
+                // GraphQL cart handler maps through here too.
                 $store = $quote->getStore();
+                $rate = 1.0;
+                if ($store->getCurrentCurrencyCode() !== $store->getBaseCurrencyCode()) {
+                    $currentRate = (float) $store->getCurrentCurrencyRate();
+                    if ($currentRate > 0) {
+                        $rate = $currentRate;
+                    }
+                }
                 foreach ($giftcardCodes as $code => $appliedAmount) {
                     /** @var \Maho_Giftcard_Model_Giftcard $giftcard */
                     $giftcard = \Mage::getModel('giftcard/giftcard')->loadByCode((string) $code);
@@ -133,8 +137,8 @@ class CartMapper
                     }
                     $cart->appliedGiftcards[] = [
                         'code' => (string) $code,
-                        'balance' => (float) $giftcard->getBalance($quoteCurrency),
-                        'appliedAmount' => (float) $store->convertPrice((float) $appliedAmount, false),
+                        'balance' => (float) $store->roundPrice($giftcard->getBalance() * $rate),
+                        'appliedAmount' => (float) $store->roundPrice((float) $appliedAmount * $rate),
                     ];
                 }
             }

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -115,10 +115,16 @@ class CartMapper
         if ($giftcardCodesJson) {
             $giftcardCodes = \Mage::helper('core')->jsonDecode($giftcardCodesJson, true);
             if (is_array($giftcardCodes)) {
-                // giftcard_codes stores {code: applied_amount}. The live card
-                // balance must be loaded from the model. This is the single
-                // source for applied gift cards: the GraphQL cart handler maps
-                // through here too, so REST and GraphQL return identical values.
+                // giftcard_codes stores {code: applied_amount} in the website
+                // base currency (the total collector owns that format), and the
+                // card balance is stored in the issuing website's base currency
+                // too. Convert both to quote currency: everything non-base* in
+                // this response is quote currency. The live card balance must be
+                // loaded from the model. This is the single source for applied
+                // gift cards: the GraphQL cart handler maps through here too,
+                // so REST and GraphQL return identical values.
+                $quoteCurrency = $cart->currency;
+                $store = $quote->getStore();
                 foreach ($giftcardCodes as $code => $appliedAmount) {
                     /** @var \Maho_Giftcard_Model_Giftcard $giftcard */
                     $giftcard = \Mage::getModel('giftcard/giftcard')->loadByCode((string) $code);
@@ -127,8 +133,8 @@ class CartMapper
                     }
                     $cart->appliedGiftcards[] = [
                         'code' => (string) $code,
-                        'balance' => (float) $giftcard->getBalance(),
-                        'appliedAmount' => (float) $appliedAmount,
+                        'balance' => (float) $giftcard->getBalance($quoteCurrency),
+                        'appliedAmount' => (float) $store->convertPrice((float) $appliedAmount, false),
                     ];
                 }
             }
@@ -157,7 +163,12 @@ class CartMapper
         $dto->sku = $item->getSku();
         $dto->name = $item->getName() ?? '';
         $dto->qty = (float) $item->getQty();
-        $dto->price = (float) $item->getPrice();
+        // Quote currency, like every other non-base money field in the response.
+        // getPrice() is website base currency; getCalculationPrice() is the
+        // converted (or custom) unit price the totals pipeline multiplies, and
+        // calcRowTotal() rounds it first, so round here to keep price * qty
+        // equal to rowTotal.
+        $dto->price = (float) $item->getStore()->roundPrice($item->getCalculationPrice());
         $dto->priceInclTax = (float) $item->getPriceInclTax();
         $dto->rowTotal = (float) $item->getRowTotal();
         $dto->rowTotalInclTax = (float) $item->getRowTotalInclTax();
@@ -352,6 +363,11 @@ class CartMapper
         try {
             $address->collectShippingRates();
 
+            // Rate prices are website base currency; the shipping total collector
+            // converts the selected one into shipping_amount, so convert here too
+            // or the same method would change price once selected.
+            $store = $address->getQuote()->getStore();
+
             foreach ($address->getAllShippingRates() as $rate) {
                 $carrierCode = (string) $rate->getCarrier();
                 $methodCode = (string) $rate->getMethod();
@@ -367,7 +383,7 @@ class CartMapper
                     'methodCode' => $methodCode,
                     'carrierTitle' => $carrierTitle,
                     'methodTitle' => $methodTitle,
-                    'price' => (float) $rate->getPrice(),
+                    'price' => (float) $store->convertPrice((float) $rate->getPrice(), false),
                 ];
             }
         } catch (\Exception $e) {

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -115,30 +115,26 @@ class CartMapper
         if ($giftcardCodesJson) {
             $giftcardCodes = \Mage::helper('core')->jsonDecode($giftcardCodesJson, true);
             if (is_array($giftcardCodes)) {
-                // giftcard_codes stores {code: applied_amount} in base currency,
-                // and the live card balance is base currency too. Convert both
-                // with the same guarded forward rate so the two fields of one
-                // element can never disagree (getBalance($currency) throws on a
-                // missing rate row). Single source for applied gift cards: the
-                // GraphQL cart handler maps through here too.
+                // giftcard_codes stores {code: applied_amount} in the quote's
+                // base currency. Skip cards the total collector skips (wrong
+                // website, expired, drained), then convert both fields exactly
+                // like the collector converts the discount, so the element
+                // agrees with prices['giftcardAmount']. Single source for
+                // applied gift cards: the GraphQL cart handler maps through
+                // here too.
                 $store = $quote->getStore();
-                $rate = 1.0;
-                if ($store->getCurrentCurrencyCode() !== $store->getBaseCurrencyCode()) {
-                    $currentRate = (float) $store->getCurrentCurrencyRate();
-                    if ($currentRate > 0) {
-                        $rate = $currentRate;
-                    }
-                }
+                $websiteId = (int) $store->getWebsiteId();
                 foreach ($giftcardCodes as $code => $appliedAmount) {
                     /** @var \Maho_Giftcard_Model_Giftcard $giftcard */
                     $giftcard = \Mage::getModel('giftcard/giftcard')->loadByCode((string) $code);
-                    if (!$giftcard->getId()) {
+                    if (!$giftcard->getId() || !$giftcard->isValidForWebsite($websiteId)) {
                         continue;
                     }
+                    $balance = $giftcard->getBalance($store->getBaseCurrencyCode());
                     $cart->appliedGiftcards[] = [
                         'code' => (string) $code,
-                        'balance' => (float) $store->roundPrice($giftcard->getBalance() * $rate),
-                        'appliedAmount' => (float) $store->roundPrice((float) $appliedAmount * $rate),
+                        'balance' => (float) $store->roundPrice($store->convertPrice($balance, false)),
+                        'appliedAmount' => (float) $store->roundPrice($store->convertPrice((float) $appliedAmount, false)),
                     ];
                 }
             }

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -631,12 +631,17 @@ class CartService
         // is a base-currency map (the total collector rewrites it in base on
         // every collectTotals()), so snapshot in base too; the requested amount
         // arrives in quote currency, what the client sees, and is converted
-        // first. revalidateGiftcards() re-checks at placement, but the capped
-        // value here keeps quote totals and pre-auth correct in the meantime.
+        // first, dividing by the forward rate (rate imports only maintain
+        // base-to-allowed rows, so a quote-to-base lookup would throw). The
+        // collector ignores the stored amount and applies the full balance,
+        // so the cap only bounds the snapshot.
         $baseCurrency = $quote->getBaseCurrencyCode() ?: $quote->getStore()->getBaseCurrencyCode();
         $quoteCurrency = $quote->getQuoteCurrencyCode() ?: $quote->getStore()->getCurrentCurrencyCode();
         if ($amount !== null && $quoteCurrency !== $baseCurrency) {
-            $amount = (float) \Mage::helper('directory')->currencyConvert($amount, $quoteCurrency, $baseCurrency);
+            $rate = (float) $quote->getStore()->getBaseCurrency()->getRate($quoteCurrency);
+            if ($rate > 0) {
+                $amount /= $rate;
+            }
         }
         $balance = (float) $giftcard->getBalance($baseCurrency);
         $appliedCodes[$giftcardCode] = $amount === null ? $balance : min($amount, $balance);

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -626,16 +626,14 @@ class CartService
             throw new BadRequestHttpException('Gift card "' . $giftcardCode . '" is already applied');
         }
 
-        // Apply gift card - store the requested amount capped at the live
-        // balance, or the full balance when no amount is given. giftcard_codes
-        // is a base-currency map (the total collector rewrites it in base on
-        // every collectTotals()), so snapshot in base too; the requested amount
-        // arrives in quote currency, what the client sees, and is converted
-        // first, dividing by the forward rate (rate imports only maintain
-        // base-to-allowed rows, so a quote-to-base lookup would throw). The
-        // collector ignores the stored amount and applies the full balance,
-        // so the cap only bounds the snapshot.
-        $baseCurrency = $quote->getBaseCurrencyCode() ?: $quote->getStore()->getBaseCurrencyCode();
+        // giftcard_codes is a base-currency map (the total collector rewrites
+        // it in base whenever a discount applies), so snapshot in base too; the
+        // requested amount arrives in quote currency, what the client sees, and
+        // is converted first, dividing by the forward rate (rate imports only
+        // maintain base-to-allowed rows, so a quote-to-base lookup would
+        // throw). The collector ignores the stored amount and applies the full
+        // balance, so the cap only bounds the snapshot.
+        $baseCurrency = $quote->getStore()->getBaseCurrencyCode();
         $quoteCurrency = $quote->getQuoteCurrencyCode() ?: $quote->getStore()->getCurrentCurrencyCode();
         if ($amount !== null && $quoteCurrency !== $baseCurrency) {
             $rate = (float) $quote->getStore()->getBaseCurrency()->getRate($quoteCurrency);
@@ -673,7 +671,7 @@ class CartService
 
         $changed = false;
         // The snapshot map is base currency; compare live balances in base too.
-        $baseCurrency = $quote->getBaseCurrencyCode() ?: $quote->getStore()->getBaseCurrencyCode();
+        $baseCurrency = $quote->getStore()->getBaseCurrencyCode();
         $websiteId = (int) $quote->getStore()->getWebsiteId();
 
         foreach ($applied as $code => $snapshotBalance) {

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -637,9 +637,12 @@ class CartService
         $quoteCurrency = $quote->getQuoteCurrencyCode() ?: $quote->getStore()->getCurrentCurrencyCode();
         if ($amount !== null && $quoteCurrency !== $baseCurrency) {
             $rate = (float) $quote->getStore()->getBaseCurrency()->getRate($quoteCurrency);
-            if ($rate > 0) {
-                $amount /= $rate;
+            // Fail loudly like the totals pipeline would: silently skipping the
+            // division would store a quote-currency number as a base snapshot.
+            if ($rate <= 0) {
+                throw new BadRequestHttpException('No exchange rate available for "' . $quoteCurrency . '"');
             }
+            $amount /= $rate;
         }
         $balance = (float) $giftcard->getBalance($baseCurrency);
         $appliedCodes[$giftcardCode] = $amount === null ? $balance : min($amount, $balance);

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -627,11 +627,18 @@ class CartService
         }
 
         // Apply gift card - store the requested amount capped at the live
-        // balance (in quote currency), or the full balance when no amount is
-        // given. revalidateGiftcards() re-checks at placement, but the capped
+        // balance, or the full balance when no amount is given. giftcard_codes
+        // is a base-currency map (the total collector rewrites it in base on
+        // every collectTotals()), so snapshot in base too; the requested amount
+        // arrives in quote currency, what the client sees, and is converted
+        // first. revalidateGiftcards() re-checks at placement, but the capped
         // value here keeps quote totals and pre-auth correct in the meantime.
-        $quoteCurrency = $quote->getQuoteCurrencyCode();
-        $balance = (float) $giftcard->getBalance($quoteCurrency);
+        $baseCurrency = $quote->getBaseCurrencyCode() ?: $quote->getStore()->getBaseCurrencyCode();
+        $quoteCurrency = $quote->getQuoteCurrencyCode() ?: $quote->getStore()->getCurrentCurrencyCode();
+        if ($amount !== null && $quoteCurrency !== $baseCurrency) {
+            $amount = (float) \Mage::helper('directory')->currencyConvert($amount, $quoteCurrency, $baseCurrency);
+        }
+        $balance = (float) $giftcard->getBalance($baseCurrency);
         $appliedCodes[$giftcardCode] = $amount === null ? $balance : min($amount, $balance);
 
         $quote->setGiftcardCodes(\Mage::helper('core')->jsonEncode($appliedCodes));
@@ -660,7 +667,8 @@ class CartService
         }
 
         $changed = false;
-        $quoteCurrency = $quote->getQuoteCurrencyCode();
+        // The snapshot map is base currency; compare live balances in base too.
+        $baseCurrency = $quote->getBaseCurrencyCode() ?: $quote->getStore()->getBaseCurrencyCode();
         $websiteId = (int) $quote->getStore()->getWebsiteId();
 
         foreach ($applied as $code => $snapshotBalance) {
@@ -669,7 +677,7 @@ class CartService
                 throw new BadRequestHttpException('Gift card "' . $code . '" is no longer valid');
             }
 
-            $live = (float) $card->getBalance($quoteCurrency);
+            $live = (float) $card->getBalance($baseCurrency);
             if ($live <= 0) {
                 throw new BadRequestHttpException('Gift card "' . $code . '" has no remaining balance');
             }

--- a/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
+++ b/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
@@ -248,10 +248,12 @@ class CartMutationHandler
         if (!$giftcard->getId()) {
             throw NotFoundException::giftCard($code);
         }
+        // getBalance() with no argument returns the issuing website's base currency.
+        $currencyCode = \Mage::app()->getStore()->getCurrentCurrencyCode();
         return ['checkGiftCardBalance' => [
             'code' => $giftcard->getCode(),
-            'currency' => \Mage::app()->getStore()->getCurrentCurrencyCode(),
-            'balance' => (float) $giftcard->getBalance(),
+            'currency' => $currencyCode,
+            'balance' => (float) $giftcard->getBalance($currencyCode),
             'status' => $giftcard->getStatus(),
             'isValid' => $giftcard->isValid(),
             'expiresAt' => $giftcard->getExpiresAt(),

--- a/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
+++ b/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
@@ -362,6 +362,7 @@ class CartMutationHandler
         $shippingAddress->collectShippingRates();
         $rates = $shippingAddress->getGroupedAllShippingRates();
         $currency = $quote->getQuoteCurrencyCode();
+        $store = $quote->getStore();
 
         $methods = [];
         foreach ($rates as $carrierRates) {
@@ -371,7 +372,9 @@ class CartMutationHandler
                     'carrierTitle' => $rate->getCarrierTitle(),
                     'methodCode' => $rate->getMethod(),
                     'methodTitle' => $rate->getMethodTitle(),
-                    'amount' => (float) $rate->getPrice(),
+                    // Rate prices are base currency; the advertised currency is
+                    // the quote currency, so convert like the shipping collector.
+                    'amount' => (float) $store->convertPrice((float) $rate->getPrice(), false),
                     'currency' => $currency,
                     'available' => !$rate->getErrorMessage(),
                     'errorMessage' => $rate->getErrorMessage(),

--- a/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
+++ b/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
@@ -248,12 +248,21 @@ class CartMutationHandler
         if (!$giftcard->getId()) {
             throw NotFoundException::giftCard($code);
         }
-        // getBalance() with no argument returns the issuing website's base currency.
+        // Report in the current display currency when a rate exists; the card
+        // is priced in its issuing website's base currency and no card-to-store
+        // rate row may exist (rate imports only maintain base-to-allowed rows),
+        // so fall back to the card's own currency instead of failing the query.
         $currencyCode = \Mage::app()->getStore()->getCurrentCurrencyCode();
+        try {
+            $balance = (float) $giftcard->getBalance($currencyCode);
+        } catch (\Exception) {
+            $currencyCode = $giftcard->getCurrencyCode();
+            $balance = (float) $giftcard->getBalance();
+        }
         return ['checkGiftCardBalance' => [
             'code' => $giftcard->getCode(),
             'currency' => $currencyCode,
-            'balance' => (float) $giftcard->getBalance($currencyCode),
+            'balance' => $balance,
             'status' => $giftcard->getStatus(),
             'isValid' => $giftcard->isValid(),
             'expiresAt' => $giftcard->getExpiresAt(),

--- a/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
+++ b/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
@@ -252,13 +252,18 @@ class CartMutationHandler
         // is priced in its issuing website's base currency and no card-to-store
         // rate row may exist (rate imports only maintain base-to-allowed rows),
         // so fall back to the card's own currency instead of failing the query.
-        $currencyCode = \Mage::app()->getStore()->getCurrentCurrencyCode();
-        try {
-            $balance = (float) $giftcard->getBalance($currencyCode);
-        } catch (\Exception) {
-            $currencyCode = $giftcard->getCurrencyCode();
-            $balance = (float) $giftcard->getBalance();
+        // Probe the rate instead of catching: getBalance() throws a bare
+        // \Exception on a missing rate, and catching it would also swallow
+        // genuine failures. Round like the cart mapper so both APIs agree.
+        $store = \Mage::app()->getStore();
+        $currencyCode = $store->getCurrentCurrencyCode();
+        $cardCurrency = $giftcard->getCurrencyCode();
+        if ($currencyCode !== $cardCurrency
+            && (float) \Mage::getModel('directory/currency')->load($cardCurrency)->getRate($currencyCode) <= 0
+        ) {
+            $currencyCode = $cardCurrency;
         }
+        $balance = (float) $store->roundPrice($giftcard->getBalance($currencyCode));
         return ['checkGiftCardBalance' => [
             'code' => $giftcard->getCode(),
             'currency' => $currencyCode,

--- a/app/code/core/Mage/Directory/Model/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Currency.php
@@ -337,6 +337,7 @@ class Mage_Directory_Model_Currency extends Mage_Core_Model_Abstract
     public function saveRates($rates)
     {
         $this->_getResource()->saveRates($rates);
+        Mage::dispatchEvent('directory_currency_rates_save_after', ['rates' => $rates]);
         return $this;
     }
 }

--- a/app/code/core/Maho/ApiPlatform/Model/Observer.php
+++ b/app/code/core/Maho/ApiPlatform/Model/Observer.php
@@ -134,6 +134,17 @@ class Maho_ApiPlatform_Model_Observer
     }
 
     /**
+     * Cached product DTOs carry prices converted at the rate current when they
+     * were built, so a rate change must flush them or the API serves the old
+     * rate until the TTL lapses.
+     */
+    #[Maho\Config\Observer('directory_currency_rates_save_after')]
+    public function invalidateCurrencyRateCache(\Maho\Event\Observer $_observer): void
+    {
+        $this->cleanApiCache(['API_PRODUCTS']);
+    }
+
+    /**
      * Invalidate API reviews cache when a review is saved/approved
      */
     #[Maho\Config\Observer('review_save_after')]

--- a/app/code/core/Maho/Giftcard/Model/Giftcard.php
+++ b/app/code/core/Maho/Giftcard/Model/Giftcard.php
@@ -178,7 +178,8 @@ class Maho_Giftcard_Model_Giftcard extends Mage_Core_Model_Abstract
             $expires = new DateTime($this->getExpiresAt(), new DateTimeZone('UTC'));
 
             if ($now > $expires) {
-                $this->setStatus(self::STATUS_EXPIRED)->save();
+                // In-memory only; the cron job persists the flip
+                $this->setStatus(self::STATUS_EXPIRED);
                 return false;
             }
         }

--- a/app/code/core/Maho/Giftcard/Model/Total/Quote.php
+++ b/app/code/core/Maho/Giftcard/Model/Total/Quote.php
@@ -91,14 +91,15 @@ class Maho_Giftcard_Model_Total_Quote extends Mage_Sales_Model_Quote_Address_Tot
             $giftcard = Mage::getModel('giftcard/giftcard')->loadByCode($code);
 
             if (!$giftcard->getId() || !$giftcard->isValidForWebsite($websiteId)) {
-                continue; // Skip invalid cards or cards from different website
+                continue; // Drop invalid cards or cards from different website
             }
 
-            // Calculate how much can be applied
-            $remainingTotal = $baseGrandTotal - $baseTotalDiscount;
+            // A valid card stays applied even when nothing is left to pay
+            $validCodes[$code] = 0;
 
+            $remainingTotal = $baseGrandTotal - $baseTotalDiscount;
             if ($remainingTotal <= 0) {
-                break; // Nothing left to pay
+                continue;
             }
 
             // Get gift card balance converted to quote's base currency
@@ -114,12 +115,13 @@ class Maho_Giftcard_Model_Total_Quote extends Mage_Sales_Model_Quote_Address_Tot
             }
         }
 
+        // Rewrite the map so invalid cards are removed from the quote
+        $validCodesJson = $validCodes === [] ? null : json_encode($validCodes);
+        $quote->setGiftcardCodes($validCodesJson);
+
         if ($baseTotalDiscount > 0) {
             // Store gift card codes on address for display
-            $address->setGiftcardCodes(json_encode($validCodes));
-
-            // Update valid codes (remove invalid ones)
-            $quote->setGiftcardCodes(json_encode($validCodes));
+            $address->setGiftcardCodes($validCodesJson);
 
             // Reset total amounts before setting (to prevent accumulation from multiple calls)
             $address->setTotalAmount($this->getCode(), 0);
@@ -136,7 +138,11 @@ class Maho_Giftcard_Model_Total_Quote extends Mage_Sales_Model_Quote_Address_Tot
             $address->setBaseGiftcardAmount($baseTotalDiscount);
             $address->setGiftcardAmount($totalDiscount);
         } else {
-            // No gift card discount - reset amounts
+            // No gift card discount - reset amounts, quote-level too, or a
+            // previously collected amount survives on the quote and readers
+            // (cart API prices) report a discount that no longer applies
+            $quote->setBaseGiftcardAmount(0);
+            $quote->setGiftcardAmount(0);
             $address->setBaseGiftcardAmount(0);
             $address->setGiftcardAmount(0);
             $address->setTotalAmount($this->getCode(), 0);

--- a/tests/Backend/Integration/Catalog/Api/ProductDisplayCurrencyTest.php
+++ b/tests/Backend/Integration/Catalog/Api/ProductDisplayCurrencyTest.php
@@ -19,31 +19,6 @@ uses(Tests\MahoBackendTestCase::class);
  * so filters and output agree.
  */
 
-/** Switch store 1 to EUR display currency in-memory and return the USD→EUR rate. */
-function catalogUseEurDisplayCurrency(): float
-{
-    $store = Mage::app()->getStore(1);
-
-    if ($store->getBaseCurrencyCode() !== 'USD') {
-        test()->markTestSkipped('Test expects USD base currency on store 1');
-    }
-
-    $store->setConfig(Mage_Directory_Model_Currency::XML_PATH_CURRENCY_ALLOW, 'USD,EUR');
-    $store->setConfig(Mage_Directory_Model_Currency::XML_PATH_CURRENCY_DEFAULT, 'EUR');
-    foreach (['available_currency_codes', 'disallowed_base_currency_code_index', 'current_currency', 'default_currency', 'base_currency'] as $memo) {
-        $store->unsetData($memo);
-    }
-
-    $rate = (float) $store->getBaseCurrency()->getRate('EUR');
-    if ($rate <= 0 || $rate == 1.0) {
-        test()->markTestSkipped('USD→EUR rate not available or trivially 1');
-    }
-
-    expect($store->getCurrentCurrencyCode())->toBe('EUR');
-
-    return $rate;
-}
-
 /** A visible enabled simple product without special pricing, plus its base final price. */
 function catalogPickPlainSimpleProduct(): Mage_Catalog_Model_Product
 {
@@ -69,7 +44,7 @@ describe('Product API display-currency conversion (issue #1238)', function (): v
 
     beforeEach(function (): void {
         StoreContext::ensureStore(1);
-        $this->rate = catalogUseEurDisplayCurrency();
+        $this->rate = useEurDisplayCurrency();
         $this->provider = new ProductProvider(null);
         Mage::app()->getCache()->clean(['API_PRODUCTS']);
     });

--- a/tests/Backend/Integration/Catalog/Api/ProductDisplayCurrencyTest.php
+++ b/tests/Backend/Integration/Catalog/Api/ProductDisplayCurrencyTest.php
@@ -120,6 +120,48 @@ describe('Product API display-currency conversion (issue #1238)', function (): v
         expect($found->price)->toBeLessThanOrEqual($eurPrice + 0.51);
     });
 
+    test('a price band equal to the rounded display price keeps the product', function (): void {
+        $product = catalogPickPlainSimpleProduct();
+        $eurPrice = round((float) $product->getFinalPrice() * $this->rate, 2);
+
+        $method = new ReflectionMethod(ProductProvider::class, 'getCollection');
+        $paginator = $method->invoke($this->provider, [
+            'filters' => [
+                'priceMin' => $eurPrice,
+                'priceMax' => $eurPrice,
+                'pageSize' => 50,
+            ],
+        ]);
+
+        $found = false;
+        foreach ($paginator as $dto) {
+            if ($dto->id === (int) $product->getId()) {
+                $found = true;
+            }
+        }
+
+        // The display price is rounded after conversion, so a band placed
+        // exactly on it must not exclude the product it was read from.
+        expect($found)->toBeTrue();
+    });
+
+    test('priceMax=0 filters to free products instead of being ignored', function (): void {
+        $product = catalogPickPlainSimpleProduct();
+
+        $method = new ReflectionMethod(ProductProvider::class, 'getCollection');
+        $paginator = $method->invoke($this->provider, [
+            'filters' => ['priceMax' => 0, 'pageSize' => 50],
+        ]);
+
+        $ids = [];
+        foreach ($paginator as $dto) {
+            $ids[] = $dto->id;
+        }
+
+        // Zero is a meaningful bound: a priced product must not come back.
+        expect($ids)->not->toContain((int) $product->getId());
+    });
+
     test('listing DTOs convert prices to the display currency', function (): void {
         $product = catalogPickPlainSimpleProduct();
         $expected = round((float) $product->getPrice() * $this->rate, 2);

--- a/tests/Backend/Integration/Catalog/Api/ProductDisplayCurrencyTest.php
+++ b/tests/Backend/Integration/Catalog/Api/ProductDisplayCurrencyTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Mage\Catalog\Api\ProductProvider;
+use Maho\ApiPlatform\Service\StoreContext;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Regression tests for issue #1238: public product reads must return prices
+ * converted to the store display currency (the `currency` field already claims
+ * they are), and priceMin/priceMax must be interpreted in that same currency
+ * so filters and output agree.
+ */
+
+/** Switch store 1 to EUR display currency in-memory and return the USD→EUR rate. */
+function catalogUseEurDisplayCurrency(): float
+{
+    $store = Mage::app()->getStore(1);
+
+    if ($store->getBaseCurrencyCode() !== 'USD') {
+        test()->markTestSkipped('Test expects USD base currency on store 1');
+    }
+
+    $store->setConfig(Mage_Directory_Model_Currency::XML_PATH_CURRENCY_ALLOW, 'USD,EUR');
+    $store->setConfig(Mage_Directory_Model_Currency::XML_PATH_CURRENCY_DEFAULT, 'EUR');
+    foreach (['available_currency_codes', 'disallowed_base_currency_code_index', 'current_currency', 'default_currency', 'base_currency'] as $memo) {
+        $store->unsetData($memo);
+    }
+
+    $rate = (float) $store->getBaseCurrency()->getRate('EUR');
+    if ($rate <= 0 || $rate == 1.0) {
+        test()->markTestSkipped('USD→EUR rate not available or trivially 1');
+    }
+
+    expect($store->getCurrentCurrencyCode())->toBe('EUR');
+
+    return $rate;
+}
+
+/** A visible enabled simple product without special pricing, plus its base final price. */
+function catalogPickPlainSimpleProduct(): Mage_Catalog_Model_Product
+{
+    $collection = Mage::getResourceModel('catalog/product_collection')
+        ->addWebsiteFilter([1])
+        ->addAttributeToSelect(['price', 'special_price'])
+        ->addAttributeToFilter('type_id', 'simple')
+        ->addAttributeToFilter('status', Mage_Catalog_Model_Product_Status::STATUS_ENABLED)
+        ->addAttributeToFilter('price', ['gt' => 0])
+        ->setVisibility(Mage::getSingleton('catalog/product_visibility')->getVisibleInCatalogIds())
+        ->setPageSize(20);
+
+    foreach ($collection as $candidate) {
+        if (!$candidate->getSpecialPrice()) {
+            return Mage::getModel('catalog/product')->setStoreId(1)->load((int) $candidate->getId());
+        }
+    }
+
+    test()->markTestSkipped('No plain-priced visible simple product available');
+}
+
+describe('Product API display-currency conversion (issue #1238)', function (): void {
+
+    beforeEach(function (): void {
+        StoreContext::ensureStore(1);
+        $this->rate = catalogUseEurDisplayCurrency();
+        $this->provider = new ProductProvider(null);
+        Mage::app()->getCache()->clean(['API_PRODUCTS']);
+    });
+
+    test('public single-product read converts prices to the display currency', function (): void {
+        $product = catalogPickPlainSimpleProduct();
+        $basePrice = (float) $product->getPrice();
+
+        $dto = $this->provider->loadProductDto((int) $product->getId());
+
+        expect($dto)->not->toBeNull();
+        expect($dto->currency)->toBe('EUR');
+
+        $expected = round($basePrice * $this->rate, 2);
+        expect($dto->price)->toEqualWithDelta($expected, 0.011);
+        expect($dto->finalPrice)->toEqualWithDelta($expected, 0.011);
+
+        if ($dto->minimalPrice !== null) {
+            expect($dto->minimalPrice)->toBeLessThan($basePrice);
+        }
+    });
+
+    test('priceMin and priceMax are interpreted in the display currency', function (): void {
+        $product = catalogPickPlainSimpleProduct();
+        $eurPrice = round((float) $product->getFinalPrice() * $this->rate, 2);
+
+        $method = new ReflectionMethod(ProductProvider::class, 'getCollection');
+        $paginator = $method->invoke($this->provider, [
+            'filters' => [
+                'priceMin' => max(0.01, $eurPrice - 0.5),
+                'priceMax' => $eurPrice + 0.5,
+                'pageSize' => 50,
+            ],
+        ]);
+
+        $found = null;
+        foreach ($paginator as $dto) {
+            if ($dto->id === (int) $product->getId()) {
+                $found = $dto;
+            }
+        }
+
+        // The product whose display price sits inside the display-currency
+        // bounds must be in the result set, and the price the client sees
+        // must itself sit inside the bounds it filtered by.
+        expect($found)->not->toBeNull();
+        expect($found->price)->toBeGreaterThanOrEqual($eurPrice - 0.51);
+        expect($found->price)->toBeLessThanOrEqual($eurPrice + 0.51);
+    });
+
+    test('listing DTOs convert prices to the display currency', function (): void {
+        $product = catalogPickPlainSimpleProduct();
+        $expected = round((float) $product->getPrice() * $this->rate, 2);
+
+        $method = new ReflectionMethod(ProductProvider::class, 'getCollection');
+        $paginator = $method->invoke($this->provider, [
+            'filters' => ['attr_sku' => $product->getSku(), 'pageSize' => 10],
+        ]);
+
+        $dto = null;
+        foreach ($paginator as $candidate) {
+            if ($candidate->id === (int) $product->getId()) {
+                $dto = $candidate;
+            }
+        }
+
+        expect($dto)->not->toBeNull();
+        expect($dto->currency)->toBe('EUR');
+        expect($dto->price)->toEqualWithDelta($expected, 0.011);
+    });
+
+});

--- a/tests/Backend/Integration/Checkout/Api/CartCurrencyConsistencyTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartCurrencyConsistencyTest.php
@@ -17,32 +17,8 @@ uses(Tests\MahoBackendTestCase::class);
  * from the website base currency, every non-base* money field in the cart API
  * response must be in quote currency. Store 1 is switched to EUR display
  * in-memory (base stays USD); the USD→EUR rate is seeded at install.
+ * useEurDisplayCurrency() lives in tests/Pest.php.
  */
-
-/** Switch store 1 to EUR display currency in-memory and return the USD→EUR rate. */
-function useEurDisplayCurrency(): float
-{
-    $store = Mage::app()->getStore(1);
-
-    if ($store->getBaseCurrencyCode() !== 'USD') {
-        test()->markTestSkipped('Test expects USD base currency on store 1');
-    }
-
-    $store->setConfig(Mage_Directory_Model_Currency::XML_PATH_CURRENCY_ALLOW, 'USD,EUR');
-    $store->setConfig(Mage_Directory_Model_Currency::XML_PATH_CURRENCY_DEFAULT, 'EUR');
-    foreach (['available_currency_codes', 'disallowed_base_currency_code_index', 'current_currency', 'default_currency', 'base_currency'] as $memo) {
-        $store->unsetData($memo);
-    }
-
-    $rate = (float) $store->getBaseCurrency()->getRate('EUR');
-    if ($rate <= 0 || $rate == 1.0) {
-        test()->markTestSkipped('USD→EUR rate not available or trivially 1');
-    }
-
-    expect($store->getCurrentCurrencyCode())->toBe('EUR');
-
-    return $rate;
-}
 
 function loadSimplePricedProduct(): Mage_Catalog_Model_Product
 {

--- a/tests/Backend/Integration/Checkout/Api/CartCurrencyConsistencyTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartCurrencyConsistencyTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Mage\Checkout\Api\CartMapper;
+use Mage\Checkout\Api\CartService;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Regression tests for issue #1238: on a store whose display currency differs
+ * from the website base currency, every non-base* money field in the cart API
+ * response must be in quote currency. Store 1 is switched to EUR display
+ * in-memory (base stays USD); the USD→EUR rate is seeded at install.
+ */
+
+/** Switch store 1 to EUR display currency in-memory and return the USD→EUR rate. */
+function useEurDisplayCurrency(): float
+{
+    $store = Mage::app()->getStore(1);
+
+    if ($store->getBaseCurrencyCode() !== 'USD') {
+        test()->markTestSkipped('Test expects USD base currency on store 1');
+    }
+
+    $store->setConfig(Mage_Directory_Model_Currency::XML_PATH_CURRENCY_ALLOW, 'USD,EUR');
+    $store->setConfig(Mage_Directory_Model_Currency::XML_PATH_CURRENCY_DEFAULT, 'EUR');
+    foreach (['available_currency_codes', 'disallowed_base_currency_code_index', 'current_currency', 'default_currency', 'base_currency'] as $memo) {
+        $store->unsetData($memo);
+    }
+
+    $rate = (float) $store->getBaseCurrency()->getRate('EUR');
+    if ($rate <= 0 || $rate == 1.0) {
+        test()->markTestSkipped('USD→EUR rate not available or trivially 1');
+    }
+
+    expect($store->getCurrentCurrencyCode())->toBe('EUR');
+
+    return $rate;
+}
+
+function loadSimplePricedProduct(): Mage_Catalog_Model_Product
+{
+    // Price >= 10 so ten units always exceed the 50.00 gift card balance and
+    // the full balance applies regardless of which sample product is first.
+    $productId = Mage::getResourceModel('catalog/product_collection')
+        ->addWebsiteFilter([1])
+        ->addAttributeToFilter('type_id', 'simple')
+        ->addAttributeToFilter('status', Mage_Catalog_Model_Product_Status::STATUS_ENABLED)
+        ->addAttributeToFilter('price', ['gteq' => 10])
+        ->setPageSize(1)
+        ->getFirstItem()
+        ->getId();
+
+    if (!$productId) {
+        test()->markTestSkipped('No priced simple product available');
+    }
+
+    return Mage::getModel('catalog/product')->setStoreId(1)->load($productId);
+}
+
+function createEurQuoteWithProduct(Mage_Catalog_Model_Product $product, int $qty = 2): Mage_Sales_Model_Quote
+{
+    $quote = Mage::getModel('sales/quote');
+    $quote->setStoreId(1);
+    $quote->addProduct($product, $qty);
+    $quote->getShippingAddress()
+        ->setCountryId('US')
+        ->setRegionId(12)
+        ->setPostcode('90210')
+        ->setCollectShippingRates(true);
+    $quote->collectTotals();
+    $quote->save();
+
+    return $quote;
+}
+
+describe('Cart API quote-currency consistency (issue #1238)', function (): void {
+
+    beforeEach(function (): void {
+        $this->rate = useEurDisplayCurrency();
+        $this->product = loadSimplePricedProduct();
+        $this->mapper = new CartMapper();
+    });
+
+    test('item price is in quote currency and consistent with rowTotal', function (): void {
+        $quote = createEurQuoteWithProduct($this->product, 2);
+        $cart = $this->mapper->mapQuoteToCart($quote, false);
+
+        expect($cart->currency)->toBe('EUR');
+        expect($cart->items)->not->toBeEmpty();
+
+        $item = $cart->items[0];
+        $basePrice = (float) $this->product->getFinalPrice();
+        $expectedUnitPrice = round($basePrice * $this->rate, 2);
+
+        expect($item->price)->toEqualWithDelta($expectedUnitPrice, 0.011);
+
+        // Unit price times qty must land on the row total: one currency per response.
+        expect($item->price * $item->qty)->toEqualWithDelta($item->rowTotal, 0.011);
+
+        // The quote-level pair must keep its meaning: base* is base, plain is quote.
+        expect($cart->prices['baseSubtotal'])->toEqualWithDelta($basePrice * 2, 0.011);
+        expect($cart->prices['subtotal'])->toEqualWithDelta($expectedUnitPrice * 2, 0.011);
+    });
+
+    test('available shipping method price matches the selected shipping amount', function (): void {
+        $quote = createEurQuoteWithProduct($this->product, 2);
+        $quote->getShippingAddress()->setShippingMethod('flatrate_flatrate');
+        $quote->setTotalsCollectedFlag(false);
+        $quote->collectTotals();
+
+        $cart = $this->mapper->mapQuoteToCart($quote, false);
+
+        $flatrate = null;
+        foreach ($cart->availableShippingMethods as $method) {
+            if ($method['code'] === 'flatrate_flatrate') {
+                $flatrate = $method;
+            }
+        }
+
+        if ($flatrate === null || $cart->prices['shippingAmount'] === null) {
+            test()->markTestSkipped('Flat rate shipping not available in this environment');
+        }
+
+        // The same method must not change price between the list and selection.
+        expect($flatrate['price'])->toEqualWithDelta($cart->prices['shippingAmount'], 0.011);
+        expect($cart->selectedShippingMethod['price'])->toEqualWithDelta($cart->prices['shippingAmount'], 0.011);
+
+        // And the quote-currency amount differs from base when the rate does.
+        expect($cart->prices['baseShippingAmount'])->not->toBeNull();
+        expect($flatrate['price'])->toEqualWithDelta($cart->prices['baseShippingAmount'] * $this->rate, 0.011);
+    });
+
+    test('applied gift card balance and amount are in quote currency', function (): void {
+        $giftcard = Mage::getModel('giftcard/giftcard');
+        $giftcard->setCode(Mage::helper('giftcard')->generateCode());
+        $giftcard->setStatus(Maho_Giftcard_Model_Giftcard::STATUS_ACTIVE);
+        $giftcard->setWebsiteId(1);
+        $giftcard->setBalance(50.00);
+        $giftcard->setInitialBalance(50.00);
+        $giftcard->save();
+
+        // A large enough cart that the full balance applies.
+        $quote = createEurQuoteWithProduct($this->product, 10);
+
+        $service = new CartService();
+        $service->applyGiftcard($quote, $giftcard->getCode());
+
+        // The stored snapshot is base currency: the total collector owns the format.
+        $storedCodes = Mage::helper('core')->jsonDecode($quote->getGiftcardCodes(), true);
+        expect((float) $storedCodes[$giftcard->getCode()])->toEqualWithDelta(50.00, 0.011);
+
+        $cart = (new CartMapper())->mapQuoteToCart($quote, false);
+
+        expect($cart->appliedGiftcards)->toHaveCount(1);
+        $applied = $cart->appliedGiftcards[0];
+
+        $expectedEur = round(50.00 * $this->rate, 2);
+
+        expect((float) $applied['balance'])->toEqualWithDelta($expectedEur, 0.011);
+        expect((float) $applied['appliedAmount'])->toEqualWithDelta($expectedEur, 0.011);
+        expect((float) $cart->prices['giftcardAmount'])->toEqualWithDelta($expectedEur, 0.011);
+
+        // appliedAmount must agree with the amount actually subtracted from totals.
+        expect((float) $applied['appliedAmount'])->toEqualWithDelta((float) $cart->prices['giftcardAmount'], 0.011);
+    });
+
+});

--- a/tests/Backend/Integration/Giftcard/InvalidCardRemovalTest.php
+++ b/tests/Backend/Integration/Giftcard/InvalidCardRemovalTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('Invalid gift card removal on totals collection', function (): void {
+
+    beforeEach(function (): void {
+        $product = Mage::getResourceModel('catalog/product_collection')
+            ->addAttributeToFilter('type_id', 'simple')
+            ->addAttributeToFilter('status', 1)
+            ->addAttributeToSelect(['price', 'name'])
+            ->setPageSize(1)
+            ->getFirstItem();
+
+        if (!$product->getId()) {
+            $this->markTestSkipped('No simple product available for testing');
+        }
+        $this->product = $product;
+
+        $this->makeQuote = function (): Mage_Sales_Model_Quote {
+            $quote = Mage::getModel('sales/quote');
+            $quote->setStoreId(1);
+            $quote->addProduct($this->product, 1);
+
+            $addressData = [
+                'country_id' => 'US',
+                'region_id' => 12,
+                'postcode' => '90210',
+                'firstname' => 'Test',
+                'lastname' => 'Customer',
+                'street' => '123 Test St',
+                'city' => 'Beverly Hills',
+                'telephone' => '555-1234',
+                'email' => 'test@example.com',
+            ];
+            $quote->getBillingAddress()->addData($addressData);
+            $quote->getShippingAddress()->addData($addressData)
+                ->setCollectShippingRates(true)
+                ->setShippingMethod('flatrate_flatrate');
+
+            return $quote;
+        };
+
+        $this->makeCard = function (string $status, ?string $expiresAt = null): Maho_Giftcard_Model_Giftcard {
+            $giftcard = Mage::getModel('giftcard/giftcard');
+            $giftcard->setCode(Mage::helper('giftcard')->generateCode());
+            $giftcard->setStatus($status);
+            $giftcard->setWebsiteId(1);
+            $giftcard->setBalance(50.00);
+            $giftcard->setInitialBalance(50.00);
+            if ($expiresAt !== null) {
+                $giftcard->setExpiresAt($expiresAt);
+            }
+            $giftcard->save();
+
+            return $giftcard;
+        };
+    });
+
+    test('collect drops invalid cards and keeps valid ones', function (): void {
+        $valid = ($this->makeCard)(Maho_Giftcard_Model_Giftcard::STATUS_ACTIVE);
+        $disabled = ($this->makeCard)(Maho_Giftcard_Model_Giftcard::STATUS_DISABLED);
+
+        $quote = ($this->makeQuote)();
+        $quote->setGiftcardCodes(json_encode([
+            $disabled->getCode() => 50.00,
+            $valid->getCode() => 50.00,
+        ]));
+        $quote->collectTotals();
+
+        $storedCodes = json_decode((string) $quote->getGiftcardCodes(), true);
+        expect($storedCodes)->toHaveKey($valid->getCode());
+        expect($storedCodes)->not->toHaveKey($disabled->getCode());
+        expect((float) $quote->getBaseGiftcardAmount())->toBeGreaterThan(0.0);
+    });
+
+    test('collect clears the code map when every card is invalid', function (): void {
+        $pastDate = (new DateTime('-1 day', new DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+        $expired = ($this->makeCard)(Maho_Giftcard_Model_Giftcard::STATUS_ACTIVE, $pastDate);
+        $disabled = ($this->makeCard)(Maho_Giftcard_Model_Giftcard::STATUS_DISABLED);
+
+        $quote = ($this->makeQuote)();
+        $quote->setGiftcardCodes(json_encode([
+            $expired->getCode() => 50.00,
+            $disabled->getCode() => 50.00,
+        ]));
+        $quote->collectTotals();
+
+        expect($quote->getGiftcardCodes())->toBeNull();
+        expect((float) $quote->getBaseGiftcardAmount())->toBe(0.0);
+        expect((float) $quote->getGiftcardAmount())->toBe(0.0);
+    });
+});

--- a/tests/Backend/Integration/Giftcard/Model/GiftcardCrudTest.php
+++ b/tests/Backend/Integration/Giftcard/Model/GiftcardCrudTest.php
@@ -329,7 +329,7 @@ describe('Giftcard Balance Operations with Database', function () {
 });
 
 describe('Giftcard Expiration Validation', function () {
-    test('isValid() returns false for expired card and updates status', function () {
+    test('isValid() returns false for expired card without persisting the status', function () {
         $helper = Mage::helper('giftcard');
         $code = $helper->generateCode();
 
@@ -345,12 +345,13 @@ describe('Giftcard Expiration Validation', function () {
         $giftcard->setExpiresAt($pastDate);
         $giftcard->save();
 
-        // isValid should return false and update status
+        // isValid reports the card expired in memory so callers can message it
         expect($giftcard->isValid())->toBeFalse();
+        expect($giftcard->getStatus())->toBe(Maho_Giftcard_Model_Giftcard::STATUS_EXPIRED);
 
-        // Reload and check status was updated
+        // A validity check is a read; the persisted flip belongs to the cron job
         $reloaded = Mage::getModel('giftcard/giftcard')->load($giftcard->getId());
-        expect($reloaded->getStatus())->toBe(Maho_Giftcard_Model_Giftcard::STATUS_EXPIRED);
+        expect($reloaded->getStatus())->toBe(Maho_Giftcard_Model_Giftcard::STATUS_ACTIVE);
     });
 
     test('isValid() returns true for card with future expiration', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -477,6 +477,41 @@ function agoUtc(int $seconds): string
     return gmdate(Mage_Core_Model_Locale::DATETIME_FORMAT, time() - $seconds);
 }
 
+/*
+|--------------------------------------------------------------------------
+| Display Currency Helpers
+|--------------------------------------------------------------------------
+|
+| Shared by the display-currency regression tests (issue #1238) in
+| tests/Backend/Integration/.
+|
+*/
+
+/** Switch a store to EUR display currency in-memory and return the USD→EUR rate. */
+function useEurDisplayCurrency(int $storeId = 1): float
+{
+    $store = Mage::app()->getStore($storeId);
+
+    if ($store->getBaseCurrencyCode() !== 'USD') {
+        test()->markTestSkipped('Test expects USD base currency on store ' . $storeId);
+    }
+
+    $store->setConfig(Mage_Directory_Model_Currency::XML_PATH_CURRENCY_ALLOW, 'USD,EUR');
+    $store->setConfig(Mage_Directory_Model_Currency::XML_PATH_CURRENCY_DEFAULT, 'EUR');
+    foreach (['available_currency_codes', 'disallowed_base_currency_code_index', 'current_currency', 'default_currency', 'base_currency'] as $memo) {
+        $store->unsetData($memo);
+    }
+
+    $rate = (float) $store->getBaseCurrency()->getRate('EUR');
+    if ($rate <= 0 || $rate == 1.0) {
+        test()->markTestSkipped('USD→EUR rate not available or trivially 1');
+    }
+
+    expect($store->getCurrentCurrencyCode())->toBe('EUR');
+
+    return $rate;
+}
+
 /**
  * Merge extra queue config the way another module's config.xml would, run the
  * assertions, then restore the original config exactly (a snapshot, so merging


### PR DESCRIPTION
Fixes #1238.

On a store whose display currency differs from the website base currency, every non-`base*` money field in the cart response is now quote currency:

- Cart item `price` now uses the rounded calculation price, so `price * qty` equals `rowTotal` and matches `priceInclTax`.
- `availableShippingMethods[].price` is converted like the shipping total collector converts the selected rate, so a method no longer changes price once selected. The POS GraphQL handler had the same defect on its shipping `amount` and is fixed too.
- Applied gift card `balance` and `appliedAmount` are converted to quote currency and now agree with `prices.giftcardAmount`. `CartService` now snapshots `giftcard_codes` in base currency, the format the total collector rewrites on every `collectTotals()`, and `revalidateGiftcards()` compares balances in base currency.

The products endpoint now converts for public reads: all money fields (price, specialPrice, finalPrice, minimalPrice, msrp, tier prices, variants, grouped children, bundle selections, fixed custom option values, downloadable links) are returned in the store display currency, and `priceMin`/`priceMax` are interpreted in that same currency before filtering the base-currency price index, so filters and output agree. Backend tokens keep raw base values (their `currency` field now reports the base code), so admin read-modify-write round trips stay lossless; the collection cache key gains a backend dimension so the two reader classes never share entries.

Two fields deliberately stay in base currency: `cost` (backend-only) and the gift card amount fields, which are buy-request values validated against the stored base amounts on add-to-cart.

Backend integration tests cover the cart mapping and the product conversion/filter behavior against an EUR-display store on a USD-base website.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->