### PR TITLE
Fixed REST shipment creation never persisting qty_shipped

### DIFF
--- a/app/code/core/Mage/Sales/Api/Shipment.php
+++ b/app/code/core/Mage/Sales/Api/Shipment.php
@@ -20,6 +20,8 @@ use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\GraphQl\Query;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\OpenApi\Model\RequestBody;
 use Maho\ApiPlatform\CrudResource;
 
 #[ApiResource(
@@ -48,6 +50,49 @@ use Maho\ApiPlatform\CrudResource;
             ],
             security: "is_granted('ROLE_ADMIN') or is_granted('shipments/create')",
             description: 'Create a shipment for an order',
+            // The processor reads the raw body, so none of it maps to a writable
+            // DTO property: without this the spec advertises no request body at all.
+            openapi: new OpenApiOperation(
+                summary: 'Create a shipment for an order (full or partial)',
+                requestBody: new RequestBody(
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'items' => [
+                                        'type' => 'array',
+                                        'description' => 'Items to ship. Ships every remaining item if omitted.',
+                                        'items' => [
+                                            'type' => 'object',
+                                            'properties' => [
+                                                'orderItemId' => ['type' => 'integer'],
+                                                'qty' => ['type' => 'number'],
+                                            ],
+                                            'required' => ['orderItemId', 'qty'],
+                                        ],
+                                    ],
+                                    'tracks' => [
+                                        'type' => 'array',
+                                        'description' => 'Tracking entries to attach to the new shipment.',
+                                        'items' => [
+                                            'type' => 'object',
+                                            'properties' => [
+                                                'carrierCode' => ['type' => 'string', 'default' => 'custom'],
+                                                'title' => ['type' => 'string'],
+                                                'trackNumber' => ['type' => 'string'],
+                                            ],
+                                            'required' => ['trackNumber'],
+                                        ],
+                                    ],
+                                    'comment' => ['type' => 'string'],
+                                    'notifyCustomer' => ['type' => 'boolean', 'default' => false],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+            ),
         ),
         new Post(
             uriTemplate: '/shipments/{id}/tracks',
@@ -55,6 +100,23 @@ use Maho\ApiPlatform\CrudResource;
             requirements: ['id' => '\d+'],
             security: "is_granted('ROLE_ADMIN') or is_granted('shipments/create')",
             description: 'Add a tracking number to an existing shipment',
+            openapi: new OpenApiOperation(
+                requestBody: new RequestBody(
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'carrierCode' => ['type' => 'string', 'default' => 'custom'],
+                                    'title' => ['type' => 'string'],
+                                    'trackNumber' => ['type' => 'string'],
+                                ],
+                                'required' => ['trackNumber'],
+                            ],
+                        ],
+                    ]),
+                ),
+            ),
         ),
         new Delete(
             uriTemplate: '/shipments/{id}/tracks/{trackId}',
@@ -68,7 +130,24 @@ use Maho\ApiPlatform\CrudResource;
             name: 'shipment_add_comment',
             requirements: ['id' => '\d+'],
             security: "is_granted('ROLE_ADMIN') or is_granted('shipments/create')",
-            description: 'Add a comment to an existing shipment. Body: comment (required), notifyCustomer, visibleOnFront',
+            description: 'Add a comment to an existing shipment',
+            openapi: new OpenApiOperation(
+                requestBody: new RequestBody(
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'comment' => ['type' => 'string'],
+                                    'notifyCustomer' => ['type' => 'boolean', 'default' => false],
+                                    'visibleOnFront' => ['type' => 'boolean', 'default' => false],
+                                ],
+                                'required' => ['comment'],
+                            ],
+                        ],
+                    ]),
+                ),
+            ),
         ),
     ],
     graphQlOperations: [

--- a/app/code/core/Mage/Sales/Api/ShipmentProcessor.php
+++ b/app/code/core/Mage/Sales/Api/ShipmentProcessor.php
@@ -276,6 +276,10 @@ final class ShipmentProcessor extends \Maho\ApiPlatform\Processor
         // Register and save
         $shipment->register();
 
+        // Without a change on the order itself its save() short-circuits, so the
+        // qty_shipped that register() put on the items never persists.
+        $shipment->getOrder()->setIsInProcess(true);
+
         \Mage::getModel('core/resource_transaction')
             ->addObject($shipment)
             ->addObject($shipment->getOrder())

--- a/tests/Api/V2/Write/ShipmentTest.php
+++ b/tests/Api/V2/Write/ShipmentTest.php
@@ -89,6 +89,52 @@ describe('POST /api/rest/v2/orders/{orderId}/shipments', function (): void {
         expect($second['status'])->toBe(400);
     });
 
+    it('ships only the requested qty for a partial shipment', function (): void {
+        $orderId = seedShippableOrder(2);
+
+        if (!$orderId) {
+            $this->markTestSkipped('Could not seed a shippable order in this store');
+        }
+
+        $itemId = null;
+        foreach (Mage::getModel('sales/order')->load($orderId)->getAllVisibleItems() as $item) {
+            $itemId = (int) $item->getId();
+            break;
+        }
+        expect($itemId)->not->toBeNull();
+
+        $partial = apiPost("/api/rest/v2/orders/{$orderId}/shipments", [
+            'items' => [['orderItemId' => $itemId, 'qty' => 1]],
+        ], adminToken());
+
+        expect($partial['status'])->toBeSuccessful();
+        expect((float) $partial['json']['totalQty'])->toBe(1.0);
+
+        $order = Mage::getModel('sales/order')->load($orderId);
+        expect((float) $order->getItemById($itemId)->getQtyShipped())->toBe(1.0);
+        expect($order->canShip())->toBeTrue();
+
+        $rest = apiPost("/api/rest/v2/orders/{$orderId}/shipments", [], adminToken());
+
+        expect($rest['status'])->toBeSuccessful();
+
+        $order = Mage::getModel('sales/order')->load($orderId);
+        expect((float) $order->getItemById($itemId)->getQtyShipped())->toBe(2.0);
+        expect($order->canShip())->toBeFalse();
+    });
+
+    it('documents the request body in the OpenAPI spec', function (): void {
+        $spec = apiGet('/api/docs.json');
+
+        expect($spec['status'])->toBe(200);
+
+        $schema = $spec['json']['paths']['/api/rest/v2/orders/{orderId}/shipments']['post']
+            ['requestBody']['content']['application/json']['schema']['properties'] ?? null;
+
+        expect($schema)->toBeArray();
+        expect(array_keys($schema))->toContain('items', 'tracks', 'comment', 'notifyCustomer');
+    });
+
     it('creates a shipment with tracking info', function (): void {
         $orderId = findShippableOrderId();
 

--- a/tests/Api/V2/Write/ShipmentTest.php
+++ b/tests/Api/V2/Write/ShipmentTest.php
@@ -16,6 +16,10 @@ declare(strict_types=1);
  * @group write
  */
 
+afterAll(function (): void {
+    cleanupTestData();
+});
+
 describe('POST /api/rest/v2/orders/{orderId}/shipments', function (): void {
 
     it('requires authentication', function (): void {
@@ -52,6 +56,37 @@ describe('POST /api/rest/v2/orders/{orderId}/shipments', function (): void {
         expect($response['json']['totalQty'])->toBeGreaterThan(0);
         expect($response['json'])->toHaveKey('items');
         expect($response['json']['items'])->toBeArray();
+    });
+
+    it('persists qty_shipped so the order cannot be shipped twice', function (): void {
+        $orderId = findShippableOrderId();
+
+        if (!$orderId) {
+            $this->markTestSkipped('No shippable order found in database');
+        }
+
+        $first = apiPost("/api/rest/v2/orders/{$orderId}/shipments", [
+            'notifyCustomer' => false,
+        ], adminToken());
+
+        expect($first['status'])->toBeSuccessful();
+        expect($first['json']['totalQty'])->toBeGreaterThan(0);
+
+        $order = Mage::getModel('sales/order')->load($orderId);
+
+        $shippedQty = 0.0;
+        foreach ($order->getAllItems() as $item) {
+            $shippedQty += (float) $item->getQtyShipped();
+        }
+
+        expect($shippedQty)->toBeGreaterThan(0.0);
+        expect($order->canShip())->toBeFalse();
+
+        $second = apiPost("/api/rest/v2/orders/{$orderId}/shipments", [
+            'notifyCustomer' => false,
+        ], adminToken());
+
+        expect($second['status'])->toBe(400);
     });
 
     it('creates a shipment with tracking info', function (): void {
@@ -235,7 +270,14 @@ describe('GraphQL Shipment queries', function (): void {
 
 // Helper functions
 
+// A seeded order per test: scanning the database instead hands the same order to
+// consecutive tests whenever a shipment fails to consume it.
 function findShippableOrderId(): ?int
+{
+    return seedShippableOrder() ?? scanShippableOrderId();
+}
+
+function scanShippableOrderId(): ?int
 {
     try {
         // Any open order that canShip() qualifies - offline-payment orders may
@@ -257,6 +299,94 @@ function findShippableOrderId(): ?int
     }
 
     return null;
+}
+
+// A configurable's variant would be promoted to its parent by the cart API, so
+// insist on a plain, individually visible simple product.
+function shippableSku(): ?string
+{
+    static $sku = false;
+
+    if ($sku !== false) {
+        return $sku;
+    }
+
+    $sku = null;
+    try {
+        Tests\Helpers\ApiV2Helper::ensureMahoBootstrapped();
+
+        $collection = Mage::getModel('catalog/product')->getCollection()
+            ->addAttributeToSelect('sku')
+            ->addAttributeToFilter('type_id', Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)
+            ->addAttributeToFilter('status', Mage_Catalog_Model_Product_Status::STATUS_ENABLED)
+            ->addAttributeToFilter('visibility', ['neq' => Mage_Catalog_Model_Product_Visibility::VISIBILITY_NOT_VISIBLE])
+            ->addAttributeToFilter('required_options', 0)
+            ->setPageSize(20);
+
+        foreach ($collection as $product) {
+            if ($product->isSalable()) {
+                $sku = (string) $product->getSku();
+                break;
+            }
+        }
+    } catch (\Throwable $e) {
+        $sku = null;
+    }
+
+    $sku ??= fixtures('write_test_sku');
+
+    return $sku;
+}
+
+function seedShippableOrder(int $qty = 1): ?int
+{
+    try {
+        $sku = shippableSku();
+        if (!$sku) {
+            return null;
+        }
+
+        $address = [
+            'firstName' => 'Shipment',
+            'lastName' => 'Tester',
+            'street' => ['1 Shipment Way'],
+            'city' => 'Los Angeles',
+            'region' => 'California',
+            'postcode' => '90210',
+            'countryId' => 'US',
+            'telephone' => '5550100',
+        ];
+
+        $create = apiPost('/api/rest/v2/carts', [], customerToken());
+        if (!in_array($create['status'], [200, 201], true) || empty($create['json']['id'])) {
+            return null;
+        }
+        $cartId = (int) $create['json']['id'];
+        trackCreated('quote', $cartId);
+
+        $add = apiPost("/api/rest/v2/carts/{$cartId}/items", ['sku' => $sku, 'qty' => $qty], customerToken());
+        if (!in_array($add['status'], [200, 201], true)) {
+            return null;
+        }
+
+        $place = apiPost('/api/rest/v2/orders', [
+            'cartId' => $cartId,
+            'shippingAddress' => $address,
+            'billingAddress' => $address,
+            'paymentMethod' => 'cashondelivery',
+            'shippingMethod' => 'freeshipping_freeshipping',
+        ], customerToken());
+        if (!in_array($place['status'], [200, 201], true) || empty($place['json']['id'])) {
+            return null;
+        }
+        $orderId = (int) $place['json']['id'];
+        trackCreated('order', $orderId);
+
+        $order = Mage::getModel('sales/order')->load($orderId);
+        return ($order->getId() && $order->canShip()) ? $orderId : null;
+    } catch (\Throwable $e) {
+        return null;
+    }
 }
 
 function findOrderWithShipments(): ?int


### PR DESCRIPTION
`ShipmentProcessor` registered the shipment but left the order with no changed data, so `Mage_Core_Model_Abstract::save()` short-circuited on `_hasModelChanged()` and never ran `_afterSave()`, where the order items `register()` had just updated get written. `qty_shipped` stayed 0, `canShip()` stayed true so an order could be shipped repeatedly, and `_checkState()` never ran so invoiced orders never reached `complete`.

Marking the order as in process before the transaction save fixes it, matching the adminhtml shipment controller and the SOAP API. Covers REST and GraphQL, both go through `doCreateShipment()`.

The shipment write tests also seeded nothing: `findShippableOrderId()` scanned the database and skipped when it found nothing, so the file was dead on a clean sample-data install. It now places a fresh cash-on-delivery order per test. That also removes the coupling that hid this bug, since the old scan kept returning the same order precisely because no shipment ever consumed it.

Fixes #1251

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->