### PR TITLE
Added ID column to the Manage Attribute Sets grid

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Attribute/Set/Grid.php
@@ -36,6 +36,14 @@ class Mage_Adminhtml_Block_Catalog_Product_Attribute_Set_Grid extends Mage_Admin
     #[\Override]
     protected function _prepareColumns()
     {
+        $this->addColumn('attribute_set_id', [
+            'header'    => Mage::helper('catalog')->__('ID'),
+            'align'     => 'right',
+            'width'     => '50px',
+            'type'      => 'number',
+            'index'     => 'attribute_set_id',
+        ]);
+
         $this->addColumn('set_name', [
             'header'    => Mage::helper('catalog')->__('Set Name'),
             'align'     => 'left',


### PR DESCRIPTION
The `Catalog > Attributes > Manage Attribute Sets` grid now shows the attribute set ID as the first column. The column is sortable and filterable as a number.

Closes #1253

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->