### PR TITLE
Derived the Rector PHP sets from composer.json instead of pinning them to php70

### DIFF
--- a/.phpstan.dist.baseline.neon
+++ b/.phpstan.dist.baseline.neon
@@ -8520,7 +8520,7 @@ parameters:
 				since 26.7 Use Maho_ApiPlatform instead.
 			'''
 			identifier: method.deprecatedClass
-			count: 18
+			count: 16
 			path: app/code/core/Mage/Catalog/Model/Category/Api.php
 
 		-
@@ -8535,7 +8535,7 @@ parameters:
 				since 26.7 Use Maho_ApiPlatform instead.
 			'''
 			identifier: method.deprecatedClass
-			count: 3
+			count: 2
 			path: app/code/core/Mage/Catalog/Model/Category/Api/V2.php
 
 		-
@@ -12476,12 +12476,6 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: app/code/core/Mage/Core/Helper/Data.php
-
-		-
-			rawMessage: 'Parameter #2 $callback of function array_filter expects (callable(string): bool)|null, ''trim'' given.'
-			identifier: argument.type
-			count: 1
-			path: app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
 
 		-
 			rawMessage: 'Method Mage_Core_Model_Abstract::_init() has no return type specified.'
@@ -22137,7 +22131,7 @@ parameters:
 				since 26.7 Use Maho_ApiPlatform instead.
 			'''
 			identifier: method.deprecatedClass
-			count: 12
+			count: 10
 			path: app/code/core/Maho/Blog/Model/Post/Api.php
 
 		-

--- a/.rector.php
+++ b/.rector.php
@@ -19,9 +19,20 @@ return RectorConfig::configure()
         __DIR__ . '/lib',
         __DIR__ . '/public',
     ])
-    ->withPhpSets(
-        php70: true,
-    )
+    ->withPhpSets()
+    ->withSkip([
+        // ReadOnlyClass / ReadOnlyProperty change the contract, not the code:
+        // a readonly class cannot be extended by a normal child, and a readonly
+        // property cannot be written from one. Maho classes exist to be extended.
+        Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class,
+        Rector\Php82\Rector\Class_\ReadOnlyClassRector::class,
+        // `const string FOO` is new syntax, and a child class cannot redeclare
+        // the constant with another type.
+        Rector\Php83\Rector\ClassConst\AddTypeToConstRector::class,
+        // Judges "extra" from the core signature alone, but a third-party
+        // subclass may well declare the parameter the caller is passing.
+        Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector::class,
+    ])
     ->withRules([
         SecureGetImageSizeRector::class,
         SecureUnserializeRector::class,
@@ -42,20 +53,18 @@ return RectorConfig::configure()
         DeadCode\Property\RemoveUselessVarTagRector::class,
         EarlyReturn\If_\ChangeNestedIfsToEarlyReturnRector::class,
         EarlyReturn\If_\RemoveAlwaysElseRector::class,
-        Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector::class,
-        Rector\Php71\Rector\List_\ListToArrayDestructRector::class,
-        Rector\Php74\Rector\Assign\NullCoalescingOperatorRector::class,
-        Rector\Php80\Rector\Class_\StringableForToStringRector::class,
-        Rector\Php80\Rector\ClassConstFetch\ClassOnThisVariableObjectRector::class,
-        Rector\Php80\Rector\FuncCall\ClassOnObjectRector::class,
-        Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector::class,
         Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector::class,
-        TypeDeclaration\ClassMethod\ReturnNeverTypeRector::class,
         TypeDeclaration\StmtsAwareInterface\SafeDeclareStrictTypesRector::class,
+    ])
+    // Promoting a Magento-lineage property renames the constructor parameter to
+    // the underscore-prefixed property name, which breaks named arguments.
+    // rename_property: false keeps promotion to the cases where both already agree.
+    ->withConfiguredRule(Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class, [
+        Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => false,
     ])
     ->withConfiguredRule(Rector\Php82\Rector\Param\AddSensitiveParameterAttributeRector::class, [
         'sensitive_parameters' => [
-            'apiKey', 'email', 'useremail', 'username', 'password'
+            'token', 'apiKey', 'email', 'useremail', 'username', 'password',
         ],
     ])
     // Varien_* to Maho\* namespace migration

--- a/.rector.php
+++ b/.rector.php
@@ -53,7 +53,6 @@ return RectorConfig::configure()
         DeadCode\Property\RemoveUselessVarTagRector::class,
         EarlyReturn\If_\ChangeNestedIfsToEarlyReturnRector::class,
         EarlyReturn\If_\RemoveAlwaysElseRector::class,
-        Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector::class,
         TypeDeclaration\StmtsAwareInterface\SafeDeclareStrictTypesRector::class,
     ])
     // Promoting a Magento-lineage property renames the constructor parameter to
@@ -64,7 +63,7 @@ return RectorConfig::configure()
     ])
     ->withConfiguredRule(Rector\Php82\Rector\Param\AddSensitiveParameterAttributeRector::class, [
         'sensitive_parameters' => [
-            'token', 'apiKey', 'email', 'useremail', 'username', 'password',
+            'token', 'apiKey', 'email', 'useremail', 'username', 'password', 'newPassword',
         ],
     ])
     // Varien_* to Maho\* namespace migration

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -638,7 +638,7 @@ final class Mage
             } else {
                 self::$_app->init($code, $type, $options);
             }
-        } catch (Mage_Core_Model_Session_Exception $e) {
+        } catch (Mage_Core_Model_Session_Exception) {
             header('Location: ' . self::getBaseUrl());
             die;
         } catch (Mage_Core_Model_Store_Exception $e) {
@@ -676,7 +676,7 @@ final class Mage
                 'options'    => $options,
             ]);
             \Maho\Profiler::stop('mage');
-        } catch (Mage_Core_Model_Session_Exception $e) {
+        } catch (Mage_Core_Model_Session_Exception) {
             header('Location: ' . self::getBaseUrl());
             die();
         } catch (Mage_Core_Model_Store_Exception $e) {
@@ -795,7 +795,7 @@ final class Mage
             if ($logger !== false) {
                 $logger->log($message, $level, $file, $forceLog);
             }
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Silently fail to avoid logging loops
         }
     }

--- a/app/code/core/Mage/Admin/Model/Acl/Role/Registry.php
+++ b/app/code/core/Mage/Admin/Model/Acl/Role/Registry.php
@@ -26,7 +26,7 @@ class Mage_Admin_Model_Acl_Role_Registry extends \Laminas\Permissions\Acl\Role\R
                 $roleId = $role;
                 $role = $this->get($role);
             }
-        } catch (\Laminas\Permissions\Acl\Exception\InvalidArgumentException $e) {
+        } catch (\Laminas\Permissions\Acl\Exception\InvalidArgumentException) {
             throw new \Laminas\Permissions\Acl\Exception\InvalidArgumentException("Child Role id '$roleId' does not exist");
         }
 
@@ -41,7 +41,7 @@ class Mage_Admin_Model_Acl_Role_Registry extends \Laminas\Permissions\Acl\Role\R
                     $roleParentId = $parent;
                 }
                 $roleParent = $this->get($roleParentId);
-            } catch (\Laminas\Permissions\Acl\Exception\InvalidArgumentException $e) {
+            } catch (\Laminas\Permissions\Acl\Exception\InvalidArgumentException) {
                 throw new \Laminas\Permissions\Acl\Exception\InvalidArgumentException("Parent Role id '$roleParentId' does not exist");
             }
             $this->roles[$roleId]['parents'][$roleParentId] = $roleParent;

--- a/app/code/core/Mage/Admin/Model/Resource/User.php
+++ b/app/code/core/Mage/Admin/Model/Resource/User.php
@@ -226,10 +226,7 @@ class Mage_Admin_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstrac
                 $this->saveReloadAclFlag($user, 1);
             }
             $adapter->commit();
-        } catch (Mage_Core_Exception $e) {
-            $adapter->rollBack();
-            throw $e;
-        } catch (Exception $e) {
+        } catch (Mage_Core_Exception|Exception $e) {
             $adapter->rollBack();
             throw $e;
         }
@@ -444,7 +441,7 @@ class Mage_Admin_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstrac
         try {
             $unsterilizedData = Mage::helper('core/unserializeArray')->unserialize($user->getExtra());
             $user->setExtra($unsterilizedData);
-        } catch (\Throwable $e) {
+        } catch (\Throwable) {
             // Catch Throwable, not Exception — PHP 8's TypeError extends
             // Error (not Exception), and the helper called above can throw
             // TypeError (json_validate requires string) on a re-load where

--- a/app/code/core/Mage/Admin/Model/Session.php
+++ b/app/code/core/Mage/Admin/Model/Session.php
@@ -245,12 +245,12 @@ class Mage_Admin_Model_Session extends Mage_Core_Model_Session_Abstract
 
             try {
                 return $acl->isAllowed($user->getAclRole(), $resource, $privilege);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 try {
                     if (!$acl->hasResource($resource)) {
                         return $acl->isAllowed($user->getAclRole(), null, $privilege);
                     }
-                } catch (Exception $e) {
+                } catch (Exception) {
                 }
             }
         }
@@ -315,7 +315,7 @@ class Mage_Admin_Model_Session extends Mage_Core_Model_Session_Abstract
                 'user_name' => $username,
                 'exception' => $e,
             ]);
-        } catch (Exception $e) {
+        } catch (Exception) {
         }
 
         if ($request && !$request->getParam('messageSent')) {

--- a/app/code/core/Mage/AdminNotification/Model/Feed.php
+++ b/app/code/core/Mage/AdminNotification/Model/Feed.php
@@ -126,13 +126,13 @@ class Mage_AdminNotification_Model_Feed extends Mage_Core_Model_Abstract
         try {
             $response = $client->request('GET', $this->getFeedUrl());
             $data = trim($response->getContent());
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
 
         try {
             $xml  = new SimpleXMLElement($data);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
 
@@ -147,7 +147,7 @@ class Mage_AdminNotification_Model_Feed extends Mage_Core_Model_Abstract
         try {
             $data = $this->getFeedData();
             $xml  = new SimpleXMLElement($data);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $xml  = new SimpleXMLElement('<?xml version="1.0" encoding="utf-8" ?><feed />');
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesedit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Api/Tab/Rolesedit.php
@@ -94,7 +94,7 @@ class Mage_Adminhtml_Block_Api_Tab_Rolesedit extends Mage_Adminhtml_Block_Widget
         if (empty($item['children'])) {
             unset($item['children']);
         } else {
-            usort($item['children'], [$this, '_sortTree']);
+            usort($item['children'], $this->_sortTree(...));
         }
         return $item;
     }

--- a/app/code/core/Mage/Adminhtml/Block/Cache/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cache/Grid.php
@@ -81,7 +81,7 @@ class Mage_Adminhtml_Block_Cache_Grid extends Mage_Adminhtml_Block_Widget_Grid
             'index'     => 'status',
             'type'      => 'options',
             'options'   => [0 => $this->__('Disabled'), 1 => $this->__('Enabled')],
-            'frame_callback' => [$this, 'decorateStatus'],
+            'frame_callback' => $this->decorateStatus(...),
         ]);
 
         return parent::_prepareColumns();

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
@@ -182,7 +182,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Crosssell extends Mage_Admin
             'validate_class'            => 'validate-number',
             'index'                     => 'position',
             'editable'                  => !$this->isReadonly(),
-            'filter_condition_callback' => [$this, '_addLinkModelFilterCallback'],
+            'filter_condition_callback' => $this->_addLinkModelFilterCallback(...),
         ]);
 
         return parent::_prepareColumns();

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group.php
@@ -27,7 +27,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Price_Group extends Mage_Adm
     #[\Override]
     protected function _sortValues($data)
     {
-        usort($data, [$this, '_sortGroupPrices']);
+        usort($data, $this->_sortGroupPrices(...));
         return $data;
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Tier.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Tier.php
@@ -35,7 +35,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Price_Tier extends Mage_Admi
     #[\Override]
     protected function _sortValues($data)
     {
-        usort($data, [$this, '_sortTierPrices']);
+        usort($data, $this->_sortTierPrices(...));
         return $data;
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
@@ -190,7 +190,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Related extends Mage_Adminht
             'index'                     => 'position',
             'width'                     => 60,
             'editable'                  => !$this->_getProduct()->getRelatedReadonly(),
-            'filter_condition_callback' => [$this, '_addLinkModelFilterCallback'],
+            'filter_condition_callback' => $this->_addLinkModelFilterCallback(...),
         ]);
 
         return parent::_prepareColumns();

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Group.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Group.php
@@ -144,7 +144,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Super_Group extends Mage_Adm
             'validate_class' => 'validate-number',
             'index'     => 'qty',
             'editable'  => true,
-            'filter_condition_callback' => [$this, '_addLinkModelFilterCallback'],
+            'filter_condition_callback' => $this->_addLinkModelFilterCallback(...),
         ]);
 
         $this->addColumn('position', [
@@ -155,7 +155,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Super_Group extends Mage_Adm
             'index'     => 'position',
             'width'     => '1',
             'editable'  => true,
-            'filter_condition_callback' => [$this, '_addLinkModelFilterCallback'],
+            'filter_condition_callback' => $this->_addLinkModelFilterCallback(...),
         ]);
 
         $this->addColumn('action', [

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
@@ -189,7 +189,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Upsell extends Mage_Adminhtm
             'validate_class'            => 'validate-number',
             'index'                     => 'position',
             'editable'                  => !$this->_getProduct()->getUpsellReadonly(),
-            'filter_condition_callback' => [$this, '_addLinkModelFilterCallback'],
+            'filter_condition_callback' => $this->_addLinkModelFilterCallback(...),
         ]);
 
         return parent::_prepareColumns();

--- a/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Checkout/Agreement/Grid.php
@@ -83,7 +83,7 @@ class Mage_Adminhtml_Block_Checkout_Agreement_Grid extends Mage_Adminhtml_Block_
                 'store_view'    => true,
                 'sortable'      => false,
                 'filter_condition_callback'
-                                => [$this, '_filterStoreCondition'],
+                                => $this->_filterStoreCondition(...),
             ]);
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Block/Grid.php
@@ -58,7 +58,7 @@ class Mage_Adminhtml_Block_Cms_Block_Grid extends Mage_Adminhtml_Block_Widget_Gr
                 'store_view'    => true,
                 'sortable'      => false,
                 'filter_condition_callback'
-                                => [$this, '_filterStoreCondition'],
+                                => $this->_filterStoreCondition(...),
             ]);
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Grid.php
@@ -70,7 +70,7 @@ class Mage_Adminhtml_Block_Cms_Page_Grid extends Mage_Adminhtml_Block_Widget_Gri
                 'store_view'    => true,
                 'sortable'      => false,
                 'filter_condition_callback'
-                                => [$this, '_filterStoreCondition'],
+                                => $this->_filterStoreCondition(...),
             ]);
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
+++ b/app/code/core/Mage/Adminhtml/Block/Page/Menu.php
@@ -158,7 +158,7 @@ class Mage_Adminhtml_Block_Page_Menu extends Mage_Adminhtml_Block_Template
             $sortOrder++;
         }
 
-        uasort($parentArr, [$this, '_sortMenu']);
+        uasort($parentArr, $this->_sortMenu(...));
 
         $last = array_key_last($parentArr);
         if (!is_null($last)) {
@@ -217,7 +217,7 @@ class Mage_Adminhtml_Block_Page_Menu extends Mage_Adminhtml_Block_Template
     {
         try {
             $res =  Mage::getSingleton('admin/session')->isAllowed($resource);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
         return $res;
@@ -232,7 +232,7 @@ class Mage_Adminhtml_Block_Page_Menu extends Mage_Adminhtml_Block_Template
     #[\Override]
     protected function _afterToHtml($html)
     {
-        $html = preg_replace_callback('#' . Mage_Adminhtml_Model_Url::SECRET_KEY_PARAM_NAME . '/\$([^\/].*)/([^\$].*)\$#', [$this, '_callbackSecretKey'], $html);
+        $html = preg_replace_callback('#' . Mage_Adminhtml_Model_Url::SECRET_KEY_PARAM_NAME . '/\$([^\/].*)/([^\$].*)\$#', $this->_callbackSecretKey(...), $html);
 
         return $html;
     }

--- a/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesedit.php
+++ b/app/code/core/Mage/Adminhtml/Block/Permissions/Tab/Rolesedit.php
@@ -168,7 +168,7 @@ class Mage_Adminhtml_Block_Permissions_Tab_Rolesedit extends Mage_Adminhtml_Bloc
         if (empty($item['children'])) {
             unset($item['children']);
         } else {
-            usort($item['children'], [$this, '_sortTree']);
+            usort($item['children'], $this->_sortTree(...));
         }
         return $item;
     }

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid.php
@@ -175,7 +175,7 @@ class Mage_Adminhtml_Block_Report_Grid extends Mage_Adminhtml_Block_Widget_Grid
                 $to = DateTime::createFromFormat($shortDateFormat, $toValue) ?: new DateTime($toValue);
 
                 $collection->setInterval($from, $to);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_errors[] = Mage::helper('reports')->__('Invalid date specified.');
             }
         }

--- a/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Refresh/Statistics/Grid.php
@@ -45,7 +45,7 @@ class Mage_Adminhtml_Block_Report_Refresh_Statistics_Grid extends Mage_Adminhtml
             }
 
             return Mage::app()->getLocale()->utcToStore(0, $dateObj)->format(Mage_Core_Model_Locale::DATETIME_FORMAT);
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Graceful degradation - return raw value
             return $lastUpdate;
         }

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Grid/Column/Renderer/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Grid/Column/Renderer/Date.php
@@ -60,14 +60,14 @@ class Mage_Adminhtml_Block_Report_Sales_Grid_Column_Renderer_Date extends Mage_A
                     : new DateTime($data);
 
                 return $this->_getFormatter()->format($dateObj);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 try {
                     $dateObj = ($column->getTimezone())
                         ? Mage::app()->getLocale()->utcToStore(null, $data)
                         : new DateTime($data);
 
                     return $this->_getFormatter()->format($dateObj);
-                } catch (Exception $e2) {
+                } catch (Exception) {
                     // Final fallback: return raw data
                     return (string) $data;
                 }

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Default.php
@@ -48,7 +48,7 @@ class Mage_Adminhtml_Block_Sales_Items_Column_Default extends Mage_Adminhtml_Blo
             try {
                 $group = Mage::getModel('catalog/product_option')->groupFactory($optionInfo['option_type']);
                 return $group->getCustomizedView($optionInfo);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 return $default;
             }
         }

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Grid.php
@@ -108,7 +108,7 @@ class Mage_Adminhtml_Block_Sales_Order_Grid extends Mage_Adminhtml_Block_Widget_
             'type'  => 'options',
             'width' => '150px',
             'options' => Mage::getSingleton('sales/order_config')->getStatuses(),
-            'frame_callback' => [$this, 'decorateStatus'],
+            'frame_callback' => $this->decorateStatus(...),
         ]);
 
         if ($this->isAllowed('sales/order/actions/view')) {

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/Status/Grid.php
@@ -35,7 +35,7 @@ class Mage_Adminhtml_Block_Sales_Order_Status_Grid extends Mage_Adminhtml_Block_
         $this->addColumn('label', [
             'header' => Mage::helper('sales')->__('Status'),
             'index' => 'label',
-            'frame_callback' => [$this, 'decorateLabel'],
+            'frame_callback' => $this->decorateLabel(...),
         ]);
 
         $this->addColumn('status', [
@@ -60,7 +60,7 @@ class Mage_Adminhtml_Block_Sales_Order_Status_Grid extends Mage_Adminhtml_Block_
             'type'  => 'text',
             'index' => 'state',
             'width'     => '250px',
-            'frame_callback' => [$this, 'decorateState'],
+            'frame_callback' => $this->decorateState(...),
         ]);
 
         $this->addColumn('unassign', [
@@ -68,7 +68,7 @@ class Mage_Adminhtml_Block_Sales_Order_Status_Grid extends Mage_Adminhtml_Block_
             'index'     => 'unassign',
             'width'     => '100px',
             'type'      => 'text',
-            'frame_callback' => [$this, 'decorateAction'],
+            'frame_callback' => $this->decorateAction(...),
             'sortable'  => false,
             'filter'    => false,
         ]);

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Info.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Info.php
@@ -42,7 +42,7 @@ class Mage_Adminhtml_Block_Sales_Order_View_Info extends Mage_Adminhtml_Block_Sa
                 $store->getGroup()->getName(),
                 $store->getName(),
             ];
-            return implode('<br>', array_map([$this, 'escapeHtml'], $name));
+            return implode('<br>', array_map($this->escapeHtml(...), $name));
         }
         return null;
     }

--- a/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/History.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Order/View/Tab/History.php
@@ -106,7 +106,7 @@ class Mage_Adminhtml_Block_Sales_Order_View_Tab_History extends Mage_Adminhtml_B
             );
         }
 
-        usort($history, [self::class, '_sortHistoryByTimestamp']);
+        usort($history, self::_sortHistoryByTimestamp(...));
         return $history;
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Form.php
@@ -110,7 +110,7 @@ class Mage_Adminhtml_Block_System_Config_Form extends Mage_Adminhtml_Block_Widge
             }
             foreach ($section->groups as $groups) {
                 $groups = (array) $groups;
-                usort($groups, [$this, '_sortForm']);
+                usort($groups, $this->_sortForm(...));
 
                 foreach ($groups as $group) {
                     if (!$this->_canShowField($group)) {
@@ -294,7 +294,7 @@ class Mage_Adminhtml_Block_System_Config_Form extends Mage_Adminhtml_Block_Widge
                     $group->sort_fields->direction_desc ? SORT_DESC : SORT_ASC,
                 );
             } else {
-                usort($elements, [$this, '_sortForm']);
+                usort($elements, $this->_sortForm(...));
             }
 
             foreach ($elements as $element) {

--- a/app/code/core/Mage/Adminhtml/Block/System/Config/Tabs.php
+++ b/app/code/core/Mage/Adminhtml/Block/System/Config/Tabs.php
@@ -47,8 +47,8 @@ class Mage_Adminhtml_Block_System_Config_Tabs extends Mage_Adminhtml_Block_Widge
 
         $sections = (array) $sections;
 
-        usort($sections, [$this, '_sort']);
-        usort($tabs, [$this, '_sort']);
+        usort($sections, $this->_sort(...));
+        usort($tabs, $this->_sort(...));
 
         foreach ($tabs as $tab) {
             $helperName = $configFields->getAttributeModule($tab);

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid.php
@@ -580,14 +580,13 @@ class Mage_Adminhtml_Block_Widget_Grid extends Mage_Adminhtml_Block_Widget
     {
         if ($this->getCollection()) {
             $field = $column->getFilterIndex() ?: $column->getIndex();
-            if ($column->getFilterConditionCallback() && $column->getFilterConditionCallback()[0] instanceof self) {
-                call_user_func($column->getFilterConditionCallback(), $this->getCollection(), $column);
+            $conditionCallback = $column->getFilterConditionCallback();
+            if (is_callable($conditionCallback)) {
+                call_user_func($conditionCallback, $this->getCollection(), $column);
             } else {
                 $cond = $column->getFilter()->getCondition();
                 if ($field && $cond !== null) {
-                    $filtered = array_map(static function ($value) {
-                        return is_object($value) ? $value->__toString() : $value;
-                    }, is_array($cond) ? array_values($cond) : [$cond]);
+                    $filtered = array_map(static fn($value) => is_object($value) ? $value->__toString() : $value, is_array($cond) ? array_values($cond) : [$cond]);
                     if (in_array('\'%NULL%\'', $filtered, true) || in_array('NULL', $filtered, true)) {
                         $this->getCollection()->addFieldToFilter($field, ['null' => true]);
                     } else {

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php
@@ -14,7 +14,7 @@
  * @method bool getCopyable()
  * @method $this setCopyable(bool $value)
  * @method string getDir()
- * @method array getFilterConditionCallback()
+ * @method callable getFilterConditionCallback()
  * @method string getFilterIndex()
  * @method $this setFormat(string $value)
  * @method string getIndex()
@@ -157,7 +157,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
          * should return new version of rendered value
          */
         $frameCallback = $this->getFrameCallback();
-        if (is_array($frameCallback)) {
+        if (is_callable($frameCallback)) {
             $renderedValue = call_user_func($frameCallback, $renderedValue, $row, $this, false);
         }
 
@@ -185,7 +185,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column extends Mage_Adminhtml_Block_Widge
          * should return new version of rendered value
          */
         $frameCallback = $this->getFrameCallback();
-        if (is_array($frameCallback)) {
+        if (is_callable($frameCallback)) {
             $renderedValue = call_user_func($frameCallback, $renderedValue, $row, $this, true);
         }
 

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
@@ -39,7 +39,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Filter_Datetime extends Mage_Admin
 
                 // Update the value with the processed date string
                 $value['to'] = $dateTime->format(Mage_Core_Model_Locale::DATETIME_FORMAT);
-            } catch (Exception $e) {
+            } catch (Exception) {
             }
         }
         return $value;

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Date.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Date.php
@@ -44,7 +44,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Date extends Mage_Adminht
                 }
 
                 return $this->_getFormatter()->format($dateObj);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // Fallback to simple format
                 try {
                     if ($this->getColumn()->getTimezone()) {
@@ -53,7 +53,7 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Date extends Mage_Adminht
                         $dateObj = new DateTime($data);
                     }
                     return $dateObj->format('M j, Y');
-                } catch (Exception $e2) {
+                } catch (Exception) {
                     return $data;
                 }
             }

--- a/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
+++ b/app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
@@ -47,12 +47,12 @@ class Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Datetime extends Mage_Adm
                     : new DateTime($data);
 
                 return $this->_getFormatter($locale)->format($dateObj);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // Fallback to simple format
                 try {
                     $dateObj = Mage::app()->getLocale()->utcToStore(null, $data);
                     return $dateObj->format('M j, Y, g:i:s A');
-                } catch (Exception $e2) {
+                } catch (Exception) {
                     return $data;
                 }
             }

--- a/app/code/core/Mage/Adminhtml/Controller/Report/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Report/Abstract.php
@@ -100,7 +100,7 @@ abstract class Mage_Adminhtml_Controller_Report_Abstract extends Mage_Adminhtml_
                     }
 
                     $updatedAt = Mage::app()->getLocale()->utcToStore(0, $dateObj)->format(Mage_Core_Model_Locale::DATETIME_FORMAT);
-                } catch (Exception $e) {
+                } catch (Exception) {
                     // Graceful degradation - use raw value
                     $updatedAt = $lastUpdate;
                 }

--- a/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Composite.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Catalog/Product/Composite.php
@@ -85,7 +85,7 @@ class Mage_Adminhtml_Helper_Catalog_Product_Composite extends Mage_Core_Helper_A
 
         } catch (Mage_Core_Exception $e) {
             $controller->getResponse()->setBodyJson([ 'error' => true, 'message' => $e->getMessage() ]);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $controller->getResponse()->setBodyJson([ 'error' => true, 'message' => $this->__('Internal Error') ]);
         }
 

--- a/app/code/core/Mage/Adminhtml/Helper/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Data.php
@@ -56,7 +56,7 @@ class Mage_Adminhtml_Helper_Data extends Mage_Adminhtml_Helper_Help_Mapping
         $data = [];
         $filterString = base64_decode($filterString);
         parse_str($filterString, $data);
-        array_walk_recursive($data, [$this, 'decodeFilter']);
+        array_walk_recursive($data, $this->decodeFilter(...));
         return $data;
     }
 

--- a/app/code/core/Mage/Adminhtml/Model/Config/Data.php
+++ b/app/code/core/Mage/Adminhtml/Model/Config/Data.php
@@ -259,7 +259,7 @@ class Mage_Adminhtml_Model_Config_Data extends \Maho\DataObject
                 $resource = $acl->getResource($resourceLookup);
                 return $session->isAllowed($resource->getResourceId());
             }
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
         return false;

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
@@ -898,7 +898,7 @@ class Mage_Adminhtml_Model_Sales_Order_Create extends \Maho\DataObject implement
                         );
                     }
                     [$label, $value] = explode(':', $additionalOption, 2);
-                } catch (Exception $e) {
+                } catch (Exception) {
                     Mage::throwException(Mage::helper('adminhtml')->__('There is an error in one of the option rows.'));
                 }
                 $label = trim($label);

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Color.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Color.php
@@ -20,7 +20,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_Color extends Mage_Core_Model_C
 
         $validate = [];
         if (isset($config->validate)) {
-            $validate = array_map('trim', explode(' ', $config->validate));
+            $validate = array_map(trim(...), explode(' ', $config->validate));
         }
 
         if (!(string) $this->getValue() && !in_array('required-entry', $validate)) {

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Currency/Cron.php
@@ -37,7 +37,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_Currency_Cron extends Mage_Core
                 ->setValue($cronExprString)
                 ->setPath(self::CRON_STRING_PATH)
                 ->save();
-        } catch (Exception $e) {
+        } catch (Exception) {
             throw new Exception(Mage::helper('cron')->__('Unable to save the cron expression.'));
         }
         return $this;

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Log/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Log/Cron.php
@@ -49,7 +49,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_Log_Cron extends Mage_Core_Mode
                 ->setValue($cronExprString)
                 ->setPath(self::CRON_STRING_PATH)
                 ->save();
-        } catch (Exception $e) {
+        } catch (Exception) {
             Mage::throwException(Mage::helper('adminhtml')->__('Unable to save the cron expression.'));
         }
         return $this;

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Product/Alert/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Product/Alert/Cron.php
@@ -40,7 +40,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_Product_Alert_Cron extends Mage
                 ->setValue($cronExprString)
                 ->setPath(self::CRON_STRING_PATH)
                 ->save();
-        } catch (Exception $e) {
+        } catch (Exception) {
             throw new Exception(Mage::helper('cron')->__('Unable to save the cron expression.'));
         }
         return $this;

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized/Array.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Serialized/Array.php
@@ -19,7 +19,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_Serialized_Array extends Mage_A
     {
         try {
             Mage::helper('core')->jsonEncode($this->getValue());
-        } catch (Exception $e) {
+        } catch (Exception) {
             Mage::throwException(Mage::helper('adminhtml')->__('Serialized data is incorrect'));
         }
 

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap/Cron.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Backend/Sitemap/Cron.php
@@ -40,7 +40,7 @@ class Mage_Adminhtml_Model_System_Config_Backend_Sitemap_Cron extends Mage_Core_
                 ->setValue($cronExprString)
                 ->setPath(self::CRON_STRING_PATH)
                 ->save();
-        } catch (Exception $e) {
+        } catch (Exception) {
             throw new Exception(Mage::helper('cron')->__('Unable to save the cron expression.'));
         }
         return $this;

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Admin/Page.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Admin/Page.php
@@ -96,7 +96,7 @@ class Mage_Adminhtml_Model_System_Config_Source_Admin_Page
             $sortOrder++;
         }
 
-        uasort($parentArr, [$this, '_sortMenu']);
+        uasort($parentArr, $this->_sortMenu(...));
 
         $last = array_key_last($parentArr);
         if (!is_null($last)) {

--- a/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Allregion.php
+++ b/app/code/core/Mage/Adminhtml/Model/System/Config/Source/Allregion.php
@@ -27,7 +27,7 @@ class Mage_Adminhtml_Model_System_Config_Source_Allregion
             foreach ($regionsCollection as $region) {
                 $countryRegions[$region->getCountryId()][$region->getId()] = $region->getDefaultName();
             }
-            uksort($countryRegions, [$this, 'sortRegionCountries']);
+            uksort($countryRegions, $this->sortRegionCountries(...));
 
             $this->_options = [];
             foreach ($countryRegions as $countryId => $regions) {

--- a/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Api/RoleController.php
@@ -107,7 +107,7 @@ class Mage_Adminhtml_Api_RoleController extends Mage_Adminhtml_Controller_Action
         try {
             Mage::getModel('api/roles')->load($rid)->delete();
             Mage::getSingleton('adminhtml/session')->addSuccess($this->__('The role has been deleted.'));
-        } catch (Exception $e) {
+        } catch (Exception) {
             Mage::getSingleton('adminhtml/session')->addError($this->__('An error occurred while deleting this role.'));
         }
 
@@ -174,7 +174,7 @@ class Mage_Adminhtml_Api_RoleController extends Mage_Adminhtml_Controller_Action
 
             $rid = $role->getId();
             Mage::getSingleton('adminhtml/session')->addSuccess($this->__('The role has been saved.'));
-        } catch (Exception $e) {
+        } catch (Exception) {
             Mage::getSingleton('adminhtml/session')->addError($this->__('An error occurred while saving this role.'));
         }
 

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
@@ -89,7 +89,7 @@ class Mage_Adminhtml_Catalog_Product_Action_AttributeController extends Mage_Adm
                                 } else {
                                     throw new Exception('Invalid date format');
                                 }
-                            } catch (Exception $e) {
+                            } catch (Exception) {
                                 // Fallback: try to parse as standard format
                                 $date = DateTime::createFromFormat($dateFormat, $value);
                                 if ($date !== false) {

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/SetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/SetController.php
@@ -42,7 +42,7 @@ class Mage_Adminhtml_Catalog_Product_Action_SetController extends Mage_Adminhtml
             );
         } catch (Mage_Core_Exception $e) {
             $this->_getSession()->addError($e->getMessage());
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_getSession()->addError($this->__('Internal Error'));
         }
         $this->_redirect('*/catalog_product/', ['_current' => true]);

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/SetController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/SetController.php
@@ -184,7 +184,7 @@ class Mage_Adminhtml_Catalog_Product_SetController extends Mage_Adminhtml_Contro
 
             $this->_getSession()->addSuccess($this->__('The attribute set has been removed.'));
             $this->getResponse()->setRedirect($this->getUrl('*/*/'));
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_getSession()->addError($this->__('An error occurred while deleting this set.'));
             $this->_redirectReferer();
         }

--- a/app/code/core/Mage/Adminhtml/controllers/Checkout/AgreementController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Checkout/AgreementController.php
@@ -91,7 +91,7 @@ class Mage_Adminhtml_Checkout_AgreementController extends Mage_Adminhtml_Control
                 return;
             } catch (Mage_Core_Exception $e) {
                 Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
-            } catch (Exception $e) {
+            } catch (Exception) {
                 Mage::getSingleton('adminhtml/session')->addError(Mage::helper('checkout')->__('An error occurred while saving this condition.'));
             }
 
@@ -121,7 +121,7 @@ class Mage_Adminhtml_Checkout_AgreementController extends Mage_Adminhtml_Control
             return;
         } catch (Mage_Core_Exception $e) {
             Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
-        } catch (Exception $e) {
+        } catch (Exception) {
             Mage::getSingleton('adminhtml/session')->addError(Mage::helper('checkout')->__('An error occurred while deleting this condition.'));
         }
 

--- a/app/code/core/Mage/Adminhtml/controllers/IndexController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/IndexController.php
@@ -301,7 +301,7 @@ class Mage_Adminhtml_IndexController extends Mage_Adminhtml_Controller_Action
                 'minAdminPasswordLength' => Mage::getModel('admin/user')->getMinAdminPasswordLength(),
             ];
             $this->_outTemplate('resetforgottenpassword', $data);
-        } catch (Exception $exception) {
+        } catch (Exception) {
             $this->_getSession()->addError(Mage::helper('adminhtml')->__('Your password reset link has expired.'));
             $this->_redirect('*/*/forgotpassword', ['_nosecret' => true]);
         }

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreditmemoController.php
@@ -238,7 +238,7 @@ class Mage_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Con
                 'message'   => $e->getMessage(),
             ];
             $response = Mage::helper('core')->jsonEncode($response);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $response = [
                 'error'     => true,
                 'message'   => $this->__('Cannot update the item\'s quantity.'),
@@ -327,7 +327,7 @@ class Mage_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Con
                 $this->_getSession()->addSuccess($this->__('The credit memo has been canceled.'));
             } catch (Mage_Core_Exception $e) {
                 $this->_getSession()->addError($e->getMessage());
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_getSession()->addError($this->__('Unable to cancel the credit memo.'));
             }
             $this->_redirect('*/*/view', ['creditmemo_id' => $creditmemo->getId()]);
@@ -350,7 +350,7 @@ class Mage_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Con
                 $this->_getSession()->addSuccess($this->__('The credit memo has been voided.'));
             } catch (Mage_Core_Exception $e) {
                 $this->_getSession()->addError($e->getMessage());
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_getSession()->addError($this->__('Unable to void the credit memo.'));
             }
             $this->_redirect('*/*/view', ['creditmemo_id' => $creditmemo->getId()]);
@@ -391,7 +391,7 @@ class Mage_Adminhtml_Sales_Order_CreditmemoController extends Mage_Adminhtml_Con
                 'message'   => $e->getMessage(),
             ];
             $response = Mage::helper('core')->jsonEncode($response);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $response = [
                 'error'     => true,
                 'message'   => $this->__('Cannot add new comment.'),

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/InvoiceController.php
@@ -192,7 +192,7 @@ class Mage_Adminhtml_Sales_Order_InvoiceController extends Mage_Adminhtml_Contro
                 'message'   => $e->getMessage(),
             ];
             $response = Mage::helper('core')->jsonEncode($response);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $response = [
                 'error'     => true,
                 'message'   => $this->__('Cannot update item quantity.'),
@@ -309,7 +309,7 @@ class Mage_Adminhtml_Sales_Order_InvoiceController extends Mage_Adminhtml_Contro
                 $this->_getSession()->addSuccess($this->__('The invoice has been captured.'));
             } catch (Mage_Core_Exception $e) {
                 $this->_getSession()->addError($e->getMessage());
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_getSession()->addError($this->__('Invoice capturing error.'));
             }
             $this->_redirect('*/*/view', ['invoice_id' => $invoice->getId()]);
@@ -334,7 +334,7 @@ class Mage_Adminhtml_Sales_Order_InvoiceController extends Mage_Adminhtml_Contro
                 $this->_getSession()->addSuccess($this->__('The invoice has been canceled.'));
             } catch (Mage_Core_Exception $e) {
                 $this->_getSession()->addError($e->getMessage());
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_getSession()->addError($this->__('Invoice canceling error.'));
             }
             $this->_redirect('*/*/view', ['invoice_id' => $invoice->getId()]);
@@ -359,7 +359,7 @@ class Mage_Adminhtml_Sales_Order_InvoiceController extends Mage_Adminhtml_Contro
                 $this->_getSession()->addSuccess($this->__('The invoice has been voided.'));
             } catch (Mage_Core_Exception $e) {
                 $this->_getSession()->addError($e->getMessage());
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_getSession()->addError($this->__('Invoice voiding error.'));
             }
             $this->_redirect('*/*/view', ['invoice_id' => $invoice->getId()]);
@@ -394,7 +394,7 @@ class Mage_Adminhtml_Sales_Order_InvoiceController extends Mage_Adminhtml_Contro
                 'message'   => $e->getMessage(),
             ];
             $response = Mage::helper('core')->jsonEncode($response);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $response = [
                 'error'     => true,
                 'message'   => $this->__('Cannot add new comment.'),

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/ShipmentController.php
@@ -251,7 +251,7 @@ class Mage_Adminhtml_Sales_Order_ShipmentController extends Mage_Adminhtml_Contr
                 $this->_getSession()->addSuccess($this->__('The shipment has been canceled.'));
             } catch (Mage_Core_Exception $e) {
                 $this->_getSession()->addError($e->getMessage());
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_getSession()->addError($this->__('Cannot cancel the shipment.'));
             }
             $this->_redirect('*/*/view', ['shipment_id' => $shipment->getId()]);
@@ -282,7 +282,7 @@ class Mage_Adminhtml_Sales_Order_ShipmentController extends Mage_Adminhtml_Contr
             }
         } catch (Mage_Core_Exception $e) {
             $this->_getSession()->addError($e->getMessage());
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_getSession()->addError($this->__('Cannot send shipment information.'));
         }
         $this->_redirect('*/*/view', [
@@ -328,7 +328,7 @@ class Mage_Adminhtml_Sales_Order_ShipmentController extends Mage_Adminhtml_Contr
                 'error'     => true,
                 'message'   => $e->getMessage(),
             ];
-        } catch (Exception $e) {
+        } catch (Exception) {
             $response = [
                 'error'     => true,
                 'message'   => $this->__('Cannot add tracking number.'),
@@ -362,7 +362,7 @@ class Mage_Adminhtml_Sales_Order_ShipmentController extends Mage_Adminhtml_Contr
                         'message'   => $this->__('Cannot initialize shipment for delete tracking number.'),
                     ];
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $response = [
                     'error'     => true,
                     'message'   => $this->__('Cannot delete tracking number.'),
@@ -392,7 +392,7 @@ class Mage_Adminhtml_Sales_Order_ShipmentController extends Mage_Adminhtml_Contr
         if ($track->getId()) {
             try {
                 $response = $track->getNumberDetail();
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $response = [
                     'error'     => true,
                     'message'   => $this->__('Cannot retrieve tracking number detail.'),
@@ -456,7 +456,7 @@ class Mage_Adminhtml_Sales_Order_ShipmentController extends Mage_Adminhtml_Contr
                 'message'   => $e->getMessage(),
             ];
             $response = Mage::helper('core')->jsonEncode($response);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $response = [
                 'error'     => true,
                 'message'   => $this->__('Cannot add new comment.'),

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/View/GiftmessageController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/View/GiftmessageController.php
@@ -34,7 +34,7 @@ class Mage_Adminhtml_Sales_Order_View_GiftmessageController extends Mage_Adminht
                 ->saveAllInOrder();
         } catch (Mage_Core_Exception $e) {
             $this->_getSession()->addError($e->getMessage());
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_getSession()->addError(Mage::helper('giftmessage')->__('An error occurred while saving the gift message.'));
         }
 

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/OrderController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/OrderController.php
@@ -173,7 +173,7 @@ class Mage_Adminhtml_Sales_OrderController extends Mage_Adminhtml_Controller_Act
                 );
             } catch (Mage_Core_Exception $e) {
                 $this->_getSession()->addError($e->getMessage());
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_getSession()->addError($this->__('The order was not put on hold.'));
             }
             $this->_redirect('*/sales_order/view', ['order_id' => $order->getId()]);
@@ -195,7 +195,7 @@ class Mage_Adminhtml_Sales_OrderController extends Mage_Adminhtml_Controller_Act
                 );
             } catch (Mage_Core_Exception $e) {
                 $this->_getSession()->addError($e->getMessage());
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_getSession()->addError($this->__('The order was not unheld.'));
             }
             $this->_redirect('*/sales_order/view', ['order_id' => $order->getId()]);
@@ -272,7 +272,7 @@ class Mage_Adminhtml_Sales_OrderController extends Mage_Adminhtml_Controller_Act
                     'error'     => true,
                     'message'   => $e->getMessage(),
                 ];
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $response = [
                     'error'     => true,
                     'message'   => $this->__('Cannot add order history.'),

--- a/app/code/core/Mage/Adminhtml/controllers/System/AccountController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/AccountController.php
@@ -98,7 +98,7 @@ class Mage_Adminhtml_System_AccountController extends Mage_Adminhtml_Controller_
             Mage::getSingleton('adminhtml/session')->addSuccess(Mage::helper('adminhtml')->__('The account has been saved.'));
         } catch (Mage_Core_Exception $e) {
             Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
-        } catch (Exception $e) {
+        } catch (Exception) {
             Mage::getSingleton('adminhtml/session')->addError(Mage::helper('adminhtml')->__('An error occurred while saving account.'));
         }
         $this->getResponse()->setRedirect($this->getUrl('*/*/'));

--- a/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php
@@ -275,11 +275,11 @@ class Mage_Adminhtml_System_ConfigController extends Mage_Adminhtml_Controller_A
                 }
                 return true;
             }
-        } catch (\Laminas\Permissions\Acl\Exception\ExceptionInterface $e) {
+        } catch (\Laminas\Permissions\Acl\Exception\ExceptionInterface) {
             $this->norouteAction();
             $this->setFlag('', self::FLAG_NO_DISPATCH, true);
             return false;
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->deniedAction();
             $this->setFlag('', self::FLAG_NO_DISPATCH, true);
             return false;

--- a/app/code/core/Mage/Adminhtml/controllers/System/Convert/ProfileController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/System/Convert/ProfileController.php
@@ -286,7 +286,7 @@ class Mage_Adminhtml_System_Convert_ProfileController extends Mage_Adminhtml_Con
                     $batchModel->beforeFinish();
                 } catch (Mage_Core_Exception $e) {
                     $result['error'] = $e->getMessage();
-                } catch (Exception $e) {
+                } catch (Exception) {
                     $result['error'] = Mage::helper('adminhtml')->__('An error occurred while finishing process. Please refresh the cache');
                 }
                 $batchModel->delete();

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/ClassController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/ClassController.php
@@ -35,7 +35,7 @@ class Mage_Adminhtml_Tax_ClassController extends Mage_Adminhtml_Controller_Actio
                 Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
                 Mage::getSingleton('adminhtml/session')->setClassData($postData);
                 $this->_redirectReferer();
-            } catch (Exception $e) {
+            } catch (Exception) {
                 Mage::getSingleton('adminhtml/session')->addError(
                     Mage::helper('tax')->__('An error occurred while saving this tax class.'),
                 );

--- a/app/code/core/Mage/Adminhtml/controllers/Tax/RateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Tax/RateController.php
@@ -167,7 +167,7 @@ class Mage_Adminhtml_Tax_RateController extends Mage_Adminhtml_Controller_Action
                     return true;
                 } catch (Mage_Core_Exception $e) {
                     Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
-                } catch (Exception $e) {
+                } catch (Exception) {
                     Mage::getSingleton('adminhtml/session')->addError(Mage::helper('tax')->__('An error occurred while deleting this rate.'));
                 }
                 if ($referer = $this->getRequest()->getServer('HTTP_REFERER')) {
@@ -247,7 +247,7 @@ class Mage_Adminhtml_Tax_RateController extends Mage_Adminhtml_Controller_Action
                 Mage::getSingleton('adminhtml/session')->addSuccess(Mage::helper('tax')->__('The tax rate has been imported.'));
             } catch (Mage_Core_Exception $e) {
                 Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
-            } catch (Exception $e) {
+            } catch (Exception) {
                 Mage::getSingleton('adminhtml/session')->addError(Mage::helper('tax')->__('Invalid file upload attempt'));
             }
         } else {

--- a/app/code/core/Mage/Api/Api/AuthTokenProcessor.php
+++ b/app/code/core/Mage/Api/Api/AuthTokenProcessor.php
@@ -22,20 +22,13 @@ use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class AuthTokenProcessor extends \Maho\ApiPlatform\Processor
 {
-    private JwtService $jwtService;
-    private TokenBlacklist $tokenBlacklist;
-    private CartService $cartService;
-
     public function __construct(
         Security $security,
-        JwtService $jwtService,
-        TokenBlacklist $tokenBlacklist,
-        CartService $cartService,
+        private JwtService $jwtService,
+        private TokenBlacklist $tokenBlacklist,
+        private CartService $cartService,
     ) {
         parent::__construct($security);
-        $this->jwtService = $jwtService;
-        $this->tokenBlacklist = $tokenBlacklist;
-        $this->cartService = $cartService;
     }
 
     #[\Override]
@@ -364,7 +357,7 @@ class AuthTokenProcessor extends \Maho\ApiPlatform\Processor
             return $dto;
         } catch (UnauthorizedHttpException $e) {
             throw $e;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             throw new UnauthorizedHttpException('Bearer', 'Invalid or expired token');
         }
     }

--- a/app/code/core/Mage/Api/Model/Acl/Role/Registry.php
+++ b/app/code/core/Mage/Api/Model/Acl/Role/Registry.php
@@ -29,7 +29,7 @@ class Mage_Api_Model_Acl_Role_Registry extends \Laminas\Permissions\Acl\Role\Reg
                 $roleId = $role;
                 $role = $this->get($role);
             }
-        } catch (\Laminas\Permissions\Acl\Exception\InvalidArgumentException $e) {
+        } catch (\Laminas\Permissions\Acl\Exception\InvalidArgumentException) {
             throw new \Laminas\Permissions\Acl\Exception\InvalidArgumentException("Child Role id '$roleId' does not exist");
         }
 
@@ -44,7 +44,7 @@ class Mage_Api_Model_Acl_Role_Registry extends \Laminas\Permissions\Acl\Role\Reg
                     $roleParentId = $parent;
                 }
                 $roleParent = $this->get($roleParentId);
-            } catch (\Laminas\Permissions\Acl\Exception\InvalidArgumentException $e) {
+            } catch (\Laminas\Permissions\Acl\Exception\InvalidArgumentException) {
                 throw new \Laminas\Permissions\Acl\Exception\InvalidArgumentException("Parent Role id '$roleParentId' does not exist");
             }
             $this->roles[$roleId]['parents'][$roleParentId] = $roleParent;

--- a/app/code/core/Mage/Api/Model/Resource/Acl.php
+++ b/app/code/core/Mage/Api/Model/Resource/Acl.php
@@ -131,7 +131,7 @@ class Mage_Api_Model_Resource_Acl extends Mage_Core_Model_Resource_Db_Abstract
                         ),
                     );
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
             }
         }
 

--- a/app/code/core/Mage/Api/Model/Resource/Rules.php
+++ b/app/code/core/Mage/Api/Model/Resource/Rules.php
@@ -56,7 +56,7 @@ class Mage_Api_Model_Resource_Rules extends Mage_Core_Model_Resource_Db_Abstract
         } catch (Mage_Core_Exception $e) {
             $adapter->rollBack();
             throw $e;
-        } catch (Exception $e) {
+        } catch (Exception) {
             $adapter->rollBack();
         }
     }

--- a/app/code/core/Mage/Api/Model/Resource/User.php
+++ b/app/code/core/Mage/Api/Model/Resource/User.php
@@ -280,7 +280,7 @@ class Mage_Api_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstract
         } catch (Mage_Core_Exception $e) {
             $adapter->rollBack();
             throw $e;
-        } catch (Exception $e) {
+        } catch (Exception) {
             $adapter->rollBack();
         }
         return $this;

--- a/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Adapter/Soap.php
@@ -160,9 +160,7 @@ class Mage_Api_Model_Server_Adapter_Soap extends \Maho\DataObject implements Mag
                             $this->_soap->handle(),
                         ),
                     );
-            } catch (LaminasSoapException $e) {
-                $this->fault($e->getCode(), $e->getMessage());
-            } catch (Exception $e) {
+            } catch (LaminasSoapException|Exception $e) {
                 $this->fault($e->getCode(), $e->getMessage());
             }
         }

--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -17,7 +17,7 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
 
     public function __construct()
     {
-        set_error_handler([$this, 'handlePhpError'], E_ALL);
+        set_error_handler($this->handlePhpError(...), E_ALL);
         Mage::app()->loadAreaPart(Mage_Core_Model_App_Area::AREA_ADMINHTML, Mage_Core_Model_App_Area::PART_EVENTS);
     }
 
@@ -208,7 +208,7 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
         try {
             $this->_startSession();
             $this->_getSession()->login($username, $apiKey);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_fault('access_denied');
             return;
         }
@@ -596,9 +596,7 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
     {
         $row = preg_replace_callback(
             '/[^\x{0009}\x{000a}\x{000d}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]/u',
-            function ($matches) {
-                return '&#' . Mage::helper('core/string')->uniOrd($matches[0]) . ';';
-            },
+            fn($matches) => '&#' . Mage::helper('core/string')->uniOrd($matches[0]) . ';',
             $row,
         );
         return $row;

--- a/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/V2/Adapter/Soap.php
@@ -69,9 +69,7 @@ class Mage_Api_Model_Server_V2_Adapter_Soap extends Mage_Api_Model_Server_Adapte
                     ->setHeader('Content-Type', 'text/xml; charset=' . $apiConfigCharset)
                     ->setHeader('Content-Length', strlen($content), true)
                     ->setBody($content);
-            } catch (LaminasSoapException $e) {
-                $this->fault($e->getCode(), $e->getMessage());
-            } catch (Exception $e) {
+            } catch (LaminasSoapException|Exception $e) {
                 $this->fault($e->getCode(), $e->getMessage());
             }
         }

--- a/app/code/core/Mage/Api/Model/Server/Wsi/Adapter/Soap.php
+++ b/app/code/core/Mage/Api/Model/Server/Wsi/Adapter/Soap.php
@@ -90,9 +90,7 @@ class Mage_Api_Model_Server_Wsi_Adapter_Soap extends Mage_Api_Model_Server_Adapt
                     ->setHeader('Content-Type', 'text/xml; charset=' . $apiConfigCharset)
                     ->setHeader('Content-Length', strlen($content), true)
                     ->setBody($content);
-            } catch (LaminasSoapException $e) {
-                $this->fault($e->getCode(), $e->getMessage());
-            } catch (Exception $e) {
+            } catch (LaminasSoapException|Exception $e) {
                 $this->fault($e->getCode(), $e->getMessage());
             }
         }

--- a/app/code/core/Mage/Api/Model/Session.php
+++ b/app/code/core/Mage/Api/Model/Session.php
@@ -166,7 +166,7 @@ class Mage_Api_Model_Session extends Mage_Core_Model_Session_Abstract
 
             try {
                 return $acl->isAllowed($user->getAclRole(), $resource, $privilege);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 return false;
             }
         }

--- a/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Grid.php
+++ b/app/code/core/Mage/Api2/Block/Adminhtml/Roles/Grid.php
@@ -60,7 +60,7 @@ class Mage_Api2_Block_Adminhtml_Roles_Grid extends Mage_Adminhtml_Block_Widget_G
         $this->addColumn('tole_user_type', [
             'header'         => Mage::helper('oauth')->__('User Type'),
             'sortable'       => false,
-            'frame_callback' => [$this, 'decorateUserType'],
+            'frame_callback' => $this->decorateUserType(...),
         ]);
 
         $this->addColumn('created_at', [

--- a/app/code/core/Mage/Api2/Exception.php
+++ b/app/code/core/Mage/Api2/Exception.php
@@ -14,24 +14,16 @@
 class Mage_Api2_Exception extends Exception
 {
     /**
-     * Log the exception in the log file?
-     */
-    protected bool $shouldLog = true;
-
-    /**
      * Exception constructor
      *
      * @param string $message
      * @param int $code
-     * @param bool $shouldLog
      */
-    public function __construct($message, $code, $shouldLog = true)
+    public function __construct($message, $code, protected bool $shouldLog = true)
     {
         if ($code <= 100 || $code >= 599) {
             throw new Exception(sprintf('Invalid Exception code "%d"', $code));
         }
-
-        $this->shouldLog = $shouldLog;
         parent::__construct($message, $code);
     }
 

--- a/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Tree.php
+++ b/app/code/core/Mage/Api2/Model/Acl/Global/Rule/Tree.php
@@ -325,7 +325,7 @@ class Mage_Api2_Model_Acl_Global_Rule_Tree extends Mage_Core_Helper_Abstract
             }
         }
         if (!empty($item[self::NAME_CHILDREN])) {
-            usort($item[self::NAME_CHILDREN], [$this, '_sortTree']);
+            usort($item[self::NAME_CHILDREN], $this->_sortTree(...));
         } elseif ($isGroup) {
             //skip empty group
             return null;

--- a/app/code/core/Mage/Api2/Model/Config.php
+++ b/app/code/core/Mage/Api2/Model/Config.php
@@ -333,7 +333,7 @@ class Mage_Api2_Model_Config extends \Maho\Simplexml\Config
         }
 
         $versions = explode(',', (string) $element);
-        if (count(array_filter($versions, 'is_numeric')) != count($versions)) {
+        if (count(array_filter($versions, is_numeric(...))) != count($versions)) {
             throw new Exception(sprintf('Invalid resource "%s" versions in config.', htmlspecialchars($node)));
         }
 

--- a/app/code/core/Mage/Api2/Model/Dispatcher.php
+++ b/app/code/core/Mage/Api2/Model/Dispatcher.php
@@ -74,7 +74,7 @@ class Mage_Api2_Model_Dispatcher
 
         try {
             $modelObj = Mage::getModel($class);
-        } catch (Exception $e) {
+        } catch (Exception) {
             // getModel() throws exception when in application is in development mode - skip it to next check
         }
         if (empty($modelObj) || !$modelObj instanceof Mage_Api2_Model_Resource) {

--- a/app/code/core/Mage/Api2/Model/Request.php
+++ b/app/code/core/Mage/Api2/Model/Request.php
@@ -254,7 +254,7 @@ class Mage_Api2_Model_Request extends Mage_Core_Controller_Request_Http
         if (!is_array($include)) {
             $include = explode(',', $include);
         }
-        return array_map('trim', $include);
+        return array_map(trim(...), $include);
     }
 
     /**

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Json.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Json.php
@@ -29,7 +29,7 @@ class Mage_Api2_Model_Request_Interpreter_Json implements Mage_Api2_Model_Reques
 
         try {
             $decoded = Mage::helper('core')->jsonDecode($body);
-        } catch (JsonException $e) {
+        } catch (JsonException) {
             throw new Mage_Api2_Exception('Decoding error.', Mage_Api2_Model_Server::HTTP_BAD_REQUEST);
         }
 

--- a/app/code/core/Mage/Api2/Model/Request/Interpreter/Xml.php
+++ b/app/code/core/Mage/Api2/Model/Request/Interpreter/Xml.php
@@ -42,7 +42,7 @@ class Mage_Api2_Model_Request_Interpreter_Xml implements Mage_Api2_Model_Request
         }
         $body = str_contains($body, '<?xml') ? $body : '<?xml version="1.0"?>' . PHP_EOL . $body;
 
-        set_error_handler([$this, '_loadErrorHandler']); // Warnings and errors are suppressed
+        set_error_handler($this->_loadErrorHandler(...)); // Warnings and errors are suppressed
         $config = simplexml_load_string($body, 'SimpleXMLElement', LIBXML_NONET);
         restore_error_handler();
 

--- a/app/code/core/Mage/Api2/Model/Resource.php
+++ b/app/code/core/Mage/Api2/Model/Resource.php
@@ -765,7 +765,7 @@ abstract class Mage_Api2_Model_Resource
                 } else {
                     $collection->addFieldToFilter($attributeCode, $filterEntry);
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_critical(self::RESOURCE_COLLECTION_FILTERING_ERROR);
             }
         }
@@ -833,7 +833,7 @@ abstract class Mage_Api2_Model_Resource
 
         try {
             return $globalAcl->isAllowed($this->getApiUser(), $resourceId, $this->getOperation());
-        } catch (Mage_Api2_Exception $e) {
+        } catch (Mage_Api2_Exception) {
             throw new Exception('Invalid arguments for isAllowed() call');
         }
     }
@@ -1049,7 +1049,7 @@ abstract class Mage_Api2_Model_Resource
                 }
                 $store = Mage::app()->getStore($store);
             }
-        } catch (Mage_Core_Model_Store_Exception $e) {
+        } catch (Mage_Core_Model_Store_Exception) {
             // store does not exist
             $this->_critical('Requested store is invalid', Mage_Api2_Model_Server::HTTP_BAD_REQUEST);
         }

--- a/app/code/core/Mage/Bundle/Model/Product/Type.php
+++ b/app/code/core/Mage/Bundle/Model/Product/Type.php
@@ -622,7 +622,7 @@ class Mage_Bundle_Model_Product_Type extends Mage_Catalog_Model_Product_Type_Abs
             $selectionIds = [];
 
             // Shuffle selection array by option position
-            usort($selections, [$this, 'shakeSelections']);
+            usort($selections, $this->shakeSelections(...));
 
             foreach ($selections as $selection) {
                 if ($selection->getSelectionCanChangeQty() && isset($qtys[$selection->getOptionId()])) {
@@ -658,7 +658,7 @@ class Mage_Bundle_Model_Product_Type extends Mage_Catalog_Model_Product_Type_Abs
                 }
 
                 $result[] = $_result[0]->setParentProductId($product->getId())
-                    ->addCustomOption('bundle_option_ids', Mage::helper('core')->jsonEncode(array_map('\intval', $optionIds)))
+                    ->addCustomOption('bundle_option_ids', Mage::helper('core')->jsonEncode(array_map(\intval(...), $optionIds)))
                     ->addCustomOption('bundle_selection_attributes', Mage::helper('core')->jsonEncode($attributes));
 
                 if ($isStrictProcessMode) {
@@ -675,7 +675,7 @@ class Mage_Bundle_Model_Product_Type extends Mage_Catalog_Model_Product_Type_Abs
             foreach ($result as $item) {
                 $item->addCustomOption('bundle_identity', $uniqueKey);
             }
-            $product->addCustomOption('bundle_option_ids', Mage::helper('core')->jsonEncode(array_map('\intval', $optionIds)));
+            $product->addCustomOption('bundle_option_ids', Mage::helper('core')->jsonEncode(array_map(\intval(...), $optionIds)));
             $product->addCustomOption('bundle_selection_ids', Mage::helper('core')->jsonEncode($selectionIds));
 
             return $result;

--- a/app/code/core/Mage/Catalog/Api/CategoryProcessor.php
+++ b/app/code/core/Mage/Catalog/Api/CategoryProcessor.php
@@ -302,7 +302,7 @@ final class CategoryProcessor extends \Maho\ApiPlatform\Processor
             return array_values($value);
         }
         if (is_string($value)) {
-            return array_values(array_filter(array_map('trim', explode(',', $value)), static fn(string $code): bool => $code !== ''));
+            return array_values(array_filter(array_map(trim(...), explode(',', $value)), static fn(string $code): bool => $code !== ''));
         }
         throw new BadRequestHttpException('available_sort_by must be an array of sort-by codes');
     }
@@ -519,7 +519,7 @@ final class CategoryProcessor extends \Maho\ApiPlatform\Processor
         }
 
         // The store root and every descendant carry the root id in their path.
-        $pathIds = array_map('intval', explode('/', (string) $category->getPath()));
+        $pathIds = array_map(intval(...), explode('/', (string) $category->getPath()));
         if (array_intersect($pathIds, $allowedRootIds) === []) {
             throw new AccessDeniedHttpException("Access denied for this category's store");
         }

--- a/app/code/core/Mage/Catalog/Api/CategoryProvider.php
+++ b/app/code/core/Mage/Catalog/Api/CategoryProvider.php
@@ -127,7 +127,7 @@ final class CategoryProvider extends \Maho\ApiPlatform\Provider
 
         // The store root and every descendant carry the root id in their path
         // ("1/<root>/..."). Anchoring with slashes prevents substring matches.
-        $pathIds = array_map('intval', explode('/', (string) $category->getPath()));
+        $pathIds = array_map(intval(...), explode('/', (string) $category->getPath()));
         return in_array($rootCategoryId, $pathIds, true);
     }
 
@@ -267,7 +267,7 @@ final class CategoryProvider extends \Maho\ApiPlatform\Provider
         // Get children IDs
         $childrenIds = $category->getChildren();
         if ($childrenIds) {
-            $dto->childrenIds = array_map('intval', explode(',', $childrenIds));
+            $dto->childrenIds = array_map(intval(...), explode(',', $childrenIds));
         }
 
         // Include children categories if requested

--- a/app/code/core/Mage/Catalog/Api/ConfigurableSetupProcessor.php
+++ b/app/code/core/Mage/Catalog/Api/ConfigurableSetupProcessor.php
@@ -118,7 +118,7 @@ final class ConfigurableSetupProcessor extends \Maho\ApiPlatform\Processor
         $childProductIds = $body['childProductIds'] ?? $body['child_product_ids'] ?? [];
         if (!empty($childProductIds)) {
             $childData = [];
-            foreach (array_map('intval', $childProductIds) as $childId) {
+            foreach (array_map(intval(...), $childProductIds) as $childId) {
                 $this->authorizeAssociatedProductWebsites($childId);
                 $childData[$childId] = [];
             }

--- a/app/code/core/Mage/Catalog/Api/ConfigurableSetupProvider.php
+++ b/app/code/core/Mage/Catalog/Api/ConfigurableSetupProvider.php
@@ -44,7 +44,7 @@ final class ConfigurableSetupProvider extends \Maho\ApiPlatform\Provider
 
         // Get child IDs
         $dto->childProductIds = array_map(
-            'intval',
+            intval(...),
             $typeInstance->getUsedProductIds($product),
         );
 

--- a/app/code/core/Mage/Catalog/Api/GraphQL/ProductQueryHandler.php
+++ b/app/code/core/Mage/Catalog/Api/GraphQL/ProductQueryHandler.php
@@ -25,12 +25,7 @@ use Maho\ApiPlatform\Security\AdminAcl;
  */
 class ProductQueryHandler
 {
-    private ProductProvider $productProvider;
-
-    public function __construct(ProductProvider $productProvider)
-    {
-        $this->productProvider = $productProvider;
-    }
+    public function __construct(private ProductProvider $productProvider) {}
 
     /**
      * Handle getProduct query

--- a/app/code/core/Mage/Catalog/Api/LayeredFilterProvider.php
+++ b/app/code/core/Mage/Catalog/Api/LayeredFilterProvider.php
@@ -45,7 +45,7 @@ final class LayeredFilterProvider extends \Maho\ApiPlatform\Provider
         if ($cached !== false) {
             $data = \Mage::helper('core')->jsonDecode($cached, true);
             if (is_array($data)) {
-                $filters = array_map(fn(array $f) => $this->arrayToDto($f), $data);
+                $filters = array_map($this->arrayToDto(...), $data);
                 return new TraversablePaginator(new \ArrayIterator($filters), 1, 100, count($filters));
             }
         }
@@ -53,7 +53,7 @@ final class LayeredFilterProvider extends \Maho\ApiPlatform\Provider
         $filters = $this->buildFilters($categoryId);
 
         if (!empty($filters)) {
-            $cacheData = array_map(fn(LayeredFilter $f) => $this->dtoToArray($f), $filters);
+            $cacheData = array_map($this->dtoToArray(...), $filters);
             \Mage::app()->getCache()->save(
                 \Mage::helper('core')->jsonEncode($cacheData),
                 $cacheKey,

--- a/app/code/core/Mage/Catalog/Api/ProductProcessor.php
+++ b/app/code/core/Mage/Catalog/Api/ProductProcessor.php
@@ -614,7 +614,7 @@ final class ProductProcessor extends \Maho\ApiPlatform\Processor
 
     private function assignCategories(Mage_Catalog_Model_Product $product, array $categoryIds): void
     {
-        $categoryIds = array_map('intval', $categoryIds);
+        $categoryIds = array_map(intval(...), $categoryIds);
         $product->setCategoryIds($categoryIds);
         $this->safeSave($product, 'assign categories');
     }
@@ -730,7 +730,7 @@ final class ProductProcessor extends \Maho\ApiPlatform\Processor
      */
     private function updateCategoriesDirect(int $productId, array $categoryIds): void
     {
-        $categoryIds = array_map('intval', $categoryIds);
+        $categoryIds = array_map(intval(...), $categoryIds);
 
         $resource = Mage::getSingleton('core/resource');
         $write = $resource->getConnection('core_write');
@@ -740,7 +740,7 @@ final class ProductProcessor extends \Maho\ApiPlatform\Processor
             "SELECT category_id FROM {$table} WHERE product_id = ?",
             [$productId],
         );
-        $existing = array_map('intval', $existing);
+        $existing = array_map(intval(...), $existing);
 
         $toAdd = array_diff($categoryIds, $existing);
         $toRemove = array_diff($existing, $categoryIds);
@@ -915,7 +915,7 @@ final class ProductProcessor extends \Maho\ApiPlatform\Processor
         $data->linksPurchasedSeparately = $product->getData('links_purchased_separately') !== null
             ? (bool) $product->getData('links_purchased_separately') : null;
         $data->samplesTitle = self::stringOrNull($product->getData('samples_title'));
-        $data->websiteIds = array_map('intval', $product->getWebsiteIds());
+        $data->websiteIds = array_map(intval(...), $product->getWebsiteIds());
         return $data;
     }
 

--- a/app/code/core/Mage/Catalog/Api/ProductProvider.php
+++ b/app/code/core/Mage/Catalog/Api/ProductProvider.php
@@ -58,7 +58,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         }
         $allowedWebsiteIds = $this->allowedWebsiteIds($this->requireUser());
         if ($allowedWebsiteIds !== null
-            && array_intersect(array_map('intval', $dto->websiteIds ?? []), $allowedWebsiteIds) === []
+            && array_intersect(array_map(intval(...), $dto->websiteIds ?? []), $allowedWebsiteIds) === []
         ) {
             throw new AccessDeniedHttpException("Access denied for this product's websites");
         }
@@ -344,7 +344,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         // guessing its id/sku/barcode (the collection path already filters this).
         if ($visibleOnly) {
             $websiteId = (int) StoreContext::getStore()->getWebsiteId();
-            if (!in_array($websiteId, array_map('intval', $product->getWebsiteIds()), true)) {
+            if (!in_array($websiteId, array_map(intval(...), $product->getWebsiteIds()), true)) {
                 return null;
             }
         }
@@ -441,7 +441,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
                 $cachedData = \Mage::helper('core')->jsonDecode($cached, true);
                 if ($cachedData !== null) {
                     // Reconstruct Product DTOs from cached data
-                    $products = array_map(fn($data) => Product::fromArray($data), $cachedData['products']);
+                    $products = array_map(Product::fromArray(...), $cachedData['products']);
                     return new TraversablePaginator(new \ArrayIterator($products), $cachedData['page'], $cachedData['pageSize'], $cachedData['total']);
                 }
             }
@@ -729,7 +729,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
         }
 
         // Detail-only: an extra query per product, too costly for listings.
-        $dto->websiteIds = array_map('intval', $product->getWebsiteIds());
+        $dto->websiteIds = array_map(intval(...), $product->getWebsiteIds());
 
         if ($stockData) {
             // Full column set on purpose: this feeds the cache, and
@@ -950,7 +950,7 @@ final class ProductProvider extends \Maho\ApiPlatform\Provider
                 $decoded = @unserialize($rawAmounts, ['allowed_classes' => false]);
                 if ($decoded === false && !str_starts_with($rawAmounts, 'b:')) {
                     // CSV fallback
-                    foreach (array_map('trim', explode(',', $rawAmounts)) as $piece) {
+                    foreach (array_map(trim(...), explode(',', $rawAmounts)) as $piece) {
                         if (is_numeric($piece)) {
                             $amounts[] = (float) $piece;
                         }

--- a/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Date.php
+++ b/app/code/core/Mage/Catalog/Block/Product/View/Options/Type/Date.php
@@ -78,7 +78,7 @@ class Mage_Catalog_Block_Product_View_Options_Type_Date extends Mage_Catalog_Blo
             try {
                 $dateTime = new DateTime($dateValue);
                 $isoValue = $dateTime->format(Mage_Core_Model_Locale::DATE_FORMAT);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $isoValue = is_string($dateValue) ? $dateValue : '';
             }
         }
@@ -144,7 +144,7 @@ class Mage_Catalog_Block_Product_View_Options_Type_Date extends Mage_Catalog_Blo
                 } else {
                     $timeValue = $value;
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $timeValue = $value;
             }
         }
@@ -214,7 +214,7 @@ class Mage_Catalog_Block_Product_View_Options_Type_Date extends Mage_Catalog_Blo
             try {
                 $dateTime = new DateTime($datetimeValue);
                 $isoValue = $dateTime->format(Mage_Core_Model_Locale::HTML5_DATETIME_FORMAT);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $isoValue = '';
             }
         } elseif ($dateValue || $timeValue) {
@@ -245,7 +245,7 @@ class Mage_Catalog_Block_Product_View_Options_Type_Date extends Mage_Catalog_Blo
                 }
 
                 $isoValue = $dateTime->format(Mage_Core_Model_Locale::HTML5_DATETIME_FORMAT);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $isoValue = '';
             }
         }

--- a/app/code/core/Mage/Catalog/Helper/Data.php
+++ b/app/code/core/Mage/Catalog/Helper/Data.php
@@ -479,7 +479,7 @@ class Mage_Catalog_Helper_Data extends Mage_Core_Helper_Abstract
             return $result;
         }
 
-        $forbiddenExtensions = array_map('trim', array_map('strtolower', explode(',', $forbiddenExtensionsConfig)));
+        $forbiddenExtensions = array_map(trim(...), array_map(strtolower(...), explode(',', $forbiddenExtensionsConfig)));
 
         // Split extensions into allowed and forbidden
         foreach ($inputExtensions as $extension) {

--- a/app/code/core/Mage/Catalog/Helper/Product/Configuration.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Configuration.php
@@ -193,7 +193,7 @@ class Mage_Catalog_Helper_Product_Configuration extends Mage_Core_Helper_Abstrac
                 try {
                     $group = Mage::getModel('catalog/product_option')->groupFactory($optionInfo['option_type']);
                     return ['value' => $group->getCustomizedView($optionInfo)];
-                } catch (Exception $e) {
+                } catch (Exception) {
                     return $_default;
                 }
             }

--- a/app/code/core/Mage/Catalog/Helper/Product/Options.php
+++ b/app/code/core/Mage/Catalog/Helper/Product/Options.php
@@ -37,7 +37,7 @@ class Mage_Catalog_Helper_Product_Options extends Mage_Core_Helper_Abstract
             $response->sendHeaders();
 
             readfile($filePath);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
         return true;

--- a/app/code/core/Mage/Catalog/Model/Api/Resource.php
+++ b/app/code/core/Mage/Catalog/Model/Api/Resource.php
@@ -77,7 +77,7 @@ class Mage_Catalog_Model_Api_Resource extends Mage_Api_Model_Resource_Abstract
 
         try {
             $storeId = Mage::app()->getStore($store)->getId();
-        } catch (Mage_Core_Model_Store_Exception $e) {
+        } catch (Mage_Core_Model_Store_Exception) {
             $this->_fault('store_not_exists');
         }
 
@@ -112,7 +112,7 @@ class Mage_Catalog_Model_Api_Resource extends Mage_Api_Model_Resource_Abstract
         if (!is_null($store)) {
             try {
                 $storeId = Mage::app()->getStore($store)->getId();
-            } catch (Mage_Core_Model_Store_Exception $e) {
+            } catch (Mage_Core_Model_Store_Exception) {
                 $this->_fault('store_not_exists');
             }
 

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Validator/Product.php
@@ -183,7 +183,7 @@ class Mage_Catalog_Model_Api2_Product_Validator_Product extends Mage_Api2_Model_
                 if ($attribute->getBackendType() == 'datetime') {
                     try {
                         $attribute->getBackend()->formatDate($value);
-                    } catch (Exception $e) {
+                    } catch (Exception) {
                         $this->_addError(sprintf('Invalid date in the "%s" field.', $attributeCode));
                     }
                 }

--- a/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest.php
+++ b/app/code/core/Mage/Catalog/Model/Api2/Product/Website/Rest.php
@@ -146,7 +146,7 @@ abstract class Mage_Catalog_Model_Api2_Product_Website_Rest extends Mage_Catalog
                         ],
                     );
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_errorMessage(
                     Mage_Api2_Model_Resource::RESOURCE_INTERNAL_ERROR,
                     Mage_Api2_Model_Server::HTTP_INTERNAL_ERROR,

--- a/app/code/core/Mage/Catalog/Model/Category/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Api.php
@@ -56,7 +56,7 @@ class Mage_Catalog_Model_Category_Api extends Mage_Catalog_Model_Api_Resource
                     $store = Mage::app()->getStore($store);
                     $storeId = $store->getId();
                     $ids = $store->getRootCategoryId();
-                } catch (Mage_Core_Model_Store_Exception $e) {
+                } catch (Mage_Core_Model_Store_Exception) {
                     $this->_fault('store_not_exists');
                 }
             } else { // load children of specified category id
@@ -269,9 +269,7 @@ class Mage_Catalog_Model_Category_Api extends Mage_Catalog_Model_Api_Resource
             }
 
             $category->save();
-        } catch (Mage_Core_Exception $e) {
-            $this->_fault('data_invalid', $e->getMessage());
-        } catch (Exception $e) {
+        } catch (Mage_Core_Exception|Exception $e) {
             $this->_fault('data_invalid', $e->getMessage());
         }
 
@@ -314,9 +312,7 @@ class Mage_Catalog_Model_Category_Api extends Mage_Catalog_Model_Api_Resource
             }
 
             $category->save();
-        } catch (Mage_Core_Exception $e) {
-            $this->_fault('data_invalid', $e->getMessage());
-        } catch (Mage_Eav_Model_Entity_Attribute_Exception $e) {
+        } catch (Mage_Core_Exception|Mage_Eav_Model_Entity_Attribute_Exception $e) {
             $this->_fault('data_invalid', $e->getMessage());
         }
 

--- a/app/code/core/Mage/Catalog/Model/Category/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Api/V2.php
@@ -135,9 +135,7 @@ class Mage_Catalog_Model_Category_Api_V2 extends Mage_Catalog_Model_Category_Api
                 }
             }
             $category->save();
-        } catch (Mage_Core_Exception $e) {
-            $this->_fault('data_invalid', $e->getMessage());
-        } catch (Mage_Eav_Model_Entity_Attribute_Exception $e) {
+        } catch (Mage_Core_Exception|Mage_Eav_Model_Entity_Attribute_Exception $e) {
             $this->_fault('data_invalid', $e->getMessage());
         }
 

--- a/app/code/core/Mage/Catalog/Model/Category/Dynamic/Rule.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Dynamic/Rule.php
@@ -212,7 +212,7 @@ class Mage_Catalog_Model_Category_Dynamic_Rule extends Mage_Rule_Model_Abstract
 
             Mage::getSingleton('core/resource_iterator')->walk(
                 $productCollection->getSelect(),
-                [[$this, 'callbackValidateProduct']],
+                [$this->callbackValidateProduct(...)],
                 [
                     'attributes' => $this->getCollectedAttributes(),
                     'product'    => Mage::getModel('catalog/product'),

--- a/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Convert/Adapter/Product.php
@@ -711,7 +711,7 @@ class Mage_Catalog_Model_Convert_Adapter_Product extends Mage_Eav_Model_Convert_
                     if (!in_array($website->getId(), $websiteIds)) {
                         $websiteIds[] = $website->getId();
                     }
-                } catch (Exception $e) {
+                } catch (Exception) {
                 }
             }
             $product->setWebsiteIds($websiteIds);
@@ -851,7 +851,7 @@ class Mage_Catalog_Model_Convert_Adapter_Product extends Mage_Eav_Model_Convert_
     {
         try {
             return $this->saveRow($importData);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
     }

--- a/app/code/core/Mage/Catalog/Model/Design.php
+++ b/app/code/core/Mage/Catalog/Model/Design.php
@@ -93,7 +93,7 @@ class Mage_Catalog_Model_Design extends Mage_Core_Model_Abstract
                     if (!Mage::getModel('core/layout_validator')->isValid($customLayout)) {
                         $customLayout = '';
                     }
-                } catch (Exception $e) {
+                } catch (Exception) {
                     $customLayout = '';
                 }
             }

--- a/app/code/core/Mage/Catalog/Model/Layer.php
+++ b/app/code/core/Mage/Catalog/Model/Layer.php
@@ -210,9 +210,7 @@ class Mage_Catalog_Model_Layer extends \Maho\DataObject
                 }
             }
         }
-        uasort($attributes, function ($a, $b) {
-            return $a->getPosition() - $b->getPosition();
-        });
+        uasort($attributes, fn($a, $b) => $a->getPosition() - $b->getPosition());
 
         return $attributes;
     }

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Attribute.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Attribute.php
@@ -143,7 +143,7 @@ class Mage_Catalog_Model_Layer_Filter_Attribute extends Mage_Catalog_Model_Layer
         }
 
         // Request params can nest (?code[][]=1), so drop non-scalars before trimming.
-        $values = array_map('trim', array_map('strval', array_filter($values, 'is_scalar')));
+        $values = array_map(trim(...), array_map(strval(...), array_filter($values, is_scalar(...))));
 
         return array_values(array_unique(array_filter($values, fn(string $value): bool => $value !== '')));
     }
@@ -220,7 +220,7 @@ class Mage_Catalog_Model_Layer_Filter_Attribute extends Mage_Catalog_Model_Layer
             $optionsCount = $this->_getResource()->getCount($this);
             // Values already selected are shown as removable state chips, so drop
             // them from the option list; the rest stay available to be OR-ed in.
-            $appliedValues = array_map('strval', $this->getAppliedValues());
+            $appliedValues = array_map(strval(...), $this->getAppliedValues());
             $data = [];
             foreach ($options as $option) {
                 if (is_array($option['value'])) {

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Item.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Item.php
@@ -92,7 +92,7 @@ class Mage_Catalog_Model_Layer_Filter_Item extends \Maho\DataObject
         $values = $filter->getAppliedValues();
         $values[] = $this->getValue();
 
-        return implode(',', array_unique(array_map('strval', $values)));
+        return implode(',', array_unique(array_map(strval(...), $values)));
     }
 
     /**
@@ -109,7 +109,7 @@ class Mage_Catalog_Model_Layer_Filter_Item extends \Maho\DataObject
         }
 
         $remaining = array_diff(
-            array_map('strval', $filter->getAppliedValues()),
+            array_map(strval(...), $filter->getAppliedValues()),
             [(string) $this->getValue()],
         );
 

--- a/app/code/core/Mage/Catalog/Model/Layer/Filter/Price.php
+++ b/app/code/core/Mage/Catalog/Model/Layer/Filter/Price.php
@@ -487,7 +487,7 @@ class Mage_Catalog_Model_Layer_Filter_Price extends Mage_Catalog_Model_Layer_Fil
     {
         $prices = $this->_getResource()->loadPrices($this, $limit, $offset, $lowerPrice, $upperPrice);
         if ($prices) {
-            $prices = array_map('\floatval', $prices);
+            $prices = array_map(\floatval(...), $prices);
         }
 
         return $prices;
@@ -505,7 +505,7 @@ class Mage_Catalog_Model_Layer_Filter_Price extends Mage_Catalog_Model_Layer_Fil
     {
         $prices = $this->_getResource()->loadPreviousPrices($this, $price, $index, $lowerPrice);
         if ($prices) {
-            $prices = array_map('\floatval', $prices);
+            $prices = array_map(\floatval(...), $prices);
         }
 
         return $prices;
@@ -523,7 +523,7 @@ class Mage_Catalog_Model_Layer_Filter_Price extends Mage_Catalog_Model_Layer_Fil
     {
         $prices = $this->_getResource()->loadNextPrices($this, $price, $rightIndex, $upperPrice);
         if ($prices) {
-            $prices = array_map('\floatval', $prices);
+            $prices = array_map(\floatval(...), $prices);
         }
 
         return $prices;

--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -580,7 +580,7 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
         } elseif (!is_array($ids)) {
             Mage::throwException(Mage::helper('catalog')->__('Invalid category IDs.'));
         }
-        $ids = array_filter(array_map('\intval', $ids));
+        $ids = array_filter(array_map(\intval(...), $ids));
         $this->setData('category_ids', $ids);
         return $this;
     }

--- a/app/code/core/Mage/Catalog/Model/Product/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Api.php
@@ -288,7 +288,7 @@ class Mage_Catalog_Model_Product_Api extends Mage_Catalog_Model_Api_Resource
                 if (is_string($website)) {
                     try {
                         $website = Mage::app()->getWebsite($website)->getId();
-                    } catch (Exception $e) {
+                    } catch (Exception) {
                     }
                 }
             }

--- a/app/code/core/Mage/Catalog/Model/Product/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Api/V2.php
@@ -277,7 +277,7 @@ class Mage_Catalog_Model_Product_Api_V2 extends Mage_Catalog_Model_Product_Api
                 if (is_string($website)) {
                     try {
                         $website = Mage::app()->getWebsite($website)->getId();
-                    } catch (Exception $e) {
+                    } catch (Exception) {
                     }
                 }
             }

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/File.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/File.php
@@ -21,7 +21,7 @@ class Mage_Catalog_Model_Product_Attribute_Backend_File extends Mage_Eav_Model_E
         // Set attribute-specific allowed extensions if configured
         $attribute = $this->getAttribute();
         if ($attribute && $attribute->getData('file_extensions')) {
-            $extensions = array_filter(array_map('trim', explode(',', $attribute->getData('file_extensions'))));
+            $extensions = array_filter(array_map(trim(...), explode(',', $attribute->getData('file_extensions'))));
             if (!empty($extensions)) {
                 $validator->setAllowedExtensions($extensions);
             }

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Backend/Media.php
@@ -580,7 +580,7 @@ class Mage_Catalog_Model_Product_Attribute_Backend_Media extends Mage_Eav_Model_
         $destDirectory = dirname($this->_getConfig()->getMediaPath($file));
         try {
             $ioObject->open(['path' => $destDirectory]);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $ioObject->mkdir($destDirectory, 0777, true);
             $ioObject->open(['path' => $destDirectory]);
         }
@@ -637,7 +637,7 @@ class Mage_Catalog_Model_Product_Attribute_Backend_Media extends Mage_Eav_Model_
                 $this->_getConfig()->getMediaPath($file),
                 $this->_getConfig()->getMediaPath($destFile),
             );
-        } catch (Exception $e) {
+        } catch (Exception) {
             $file = $this->_getConfig()->getMediaPath($file);
             $io = new \Maho\Io\File();
             Mage::throwException(

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Media/Api.php
@@ -166,7 +166,7 @@ class Mage_Catalog_Model_Product_Attribute_Media_Api extends Mage_Catalog_Model_
             $product->save();
         } catch (Mage_Core_Exception $e) {
             $this->_fault('not_created', $e->getMessage());
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_fault('not_created', Mage::helper('catalog')->__('Cannot create image.'));
         }
 
@@ -213,7 +213,7 @@ class Mage_Catalog_Model_Product_Attribute_Media_Api extends Mage_Catalog_Model_
                 $fileName = Mage::getBaseDir('media') . DS . 'catalog' . DS . 'product' . $file;
                 $ioAdapter->open(['path' => dirname($fileName)]);
                 $ioAdapter->write(basename($fileName), $fileContent, 0666);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_fault('not_created', Mage::helper('catalog')->__('Can\'t create image.'));
             }
         }

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api.php
@@ -118,7 +118,7 @@ class Mage_Catalog_Model_Product_Attribute_Tierprice_Api extends Mage_Catalog_Mo
             } else {
                 try {
                     $tierPrice['website'] = Mage::app()->getWebsite($tierPrice['website'])->getId();
-                } catch (Mage_Core_Exception $e) {
+                } catch (Mage_Core_Exception) {
                     $tierPrice['website'] = 0;
                 }
             }

--- a/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Attribute/Tierprice/Api/V2.php
@@ -39,7 +39,7 @@ class Mage_Catalog_Model_Product_Attribute_Tierprice_Api_V2 extends Mage_Catalog
             } else {
                 try {
                     $tierPrice->website = Mage::app()->getWebsite($tierPrice->website)->getId();
-                } catch (Mage_Core_Exception $e) {
+                } catch (Mage_Core_Exception) {
                     $tierPrice->website = 0;
                 }
             }

--- a/app/code/core/Mage/Catalog/Model/Product/Link/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Link/Api.php
@@ -115,7 +115,7 @@ class Mage_Catalog_Model_Product_Link_Api extends Mage_Catalog_Model_Api_Resourc
 
             $indexerPrice = Mage::getResourceModel('catalog/product_indexer_price');
             $indexerPrice->reindexProductIds($productId);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_fault('data_invalid', Mage::helper('catalog')->__('Link product does not exist.'));
         }
 
@@ -171,7 +171,7 @@ class Mage_Catalog_Model_Product_Link_Api extends Mage_Catalog_Model_Api_Resourc
 
             $indexerPrice = Mage::getResourceModel('catalog/product_indexer_price');
             $indexerPrice->reindexProductIds($productId);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_fault('data_invalid', Mage::helper('catalog')->__('Link product does not exist.'));
         }
 
@@ -211,7 +211,7 @@ class Mage_Catalog_Model_Product_Link_Api extends Mage_Catalog_Model_Api_Resourc
 
         try {
             $link->getResource()->saveProductLinks($product, $links, $typeId);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_fault('not_removed');
         }
 

--- a/app/code/core/Mage/Catalog/Model/Product/Link/Api/V2.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Link/Api/V2.php
@@ -120,7 +120,7 @@ class Mage_Catalog_Model_Product_Link_Api_V2 extends Mage_Catalog_Model_Product_
 
             $indexerPrice = Mage::getResourceModel('catalog/product_indexer_price');
             $indexerPrice->reindexProductIds($productId);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_fault('data_invalid', Mage::helper('catalog')->__('Link product does not exist.'));
         }
 

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Api.php
@@ -276,7 +276,7 @@ class Mage_Catalog_Model_Product_Option_Api extends Mage_Catalog_Model_Api_Resou
             $option->deletePrices($optionId);
             $option->deleteTitles($optionId);
             $option->delete();
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_fault('delete_option_error');
         }
         return true;

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Observer.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Observer.php
@@ -31,7 +31,7 @@ class Mage_Catalog_Model_Product_Option_Observer
                             $group = $option->groupFactory($option->getType())
                                 ->setQuoteItemOption($itemOption)
                                 ->copyQuoteToOrder();
-                        } catch (Exception $e) {
+                        } catch (Exception) {
                             continue;
                         }
                     }

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/Date.php
@@ -153,7 +153,7 @@ class Mage_Catalog_Model_Product_Option_Type_Date extends Mage_Catalog_Model_Pro
                 $this->_setInternalInRequest($result);
 
                 return $result;
-            } catch (Exception $e) {
+            } catch (Exception) {
                 return null;
             }
         } else {
@@ -249,7 +249,7 @@ class Mage_Catalog_Model_Product_Option_Type_Date extends Mage_Catalog_Model_Pro
                 return $value['options'][$this->getOption()->getId()];
             }
             return ['date_internal' => $optionValue];
-        } catch (Exception $e) {
+        } catch (Exception) {
             return ['date_internal' => $optionValue];
         }
     }

--- a/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Option/Type/File.php
@@ -55,7 +55,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
             if (isset($optionInfo['value'])) {
                 return $optionInfo['value'];
             }
-        } catch (Exception $e) {
+        } catch (Exception) {
             return $optionInfo['value'];
         }
         return '';
@@ -235,7 +235,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
             $_forbidden = $this->_parseExtensionsString(Mage::getStoreConfig('catalog/custom_options/forbidden_extensions'));
 
             // ALWAYS check forbidden list first (security)
-            if ($_forbidden !== null && in_array($fileExtension, array_map('strtolower', $_forbidden))) {
+            if ($_forbidden !== null && in_array($fileExtension, array_map(strtolower(...), $_forbidden))) {
                 Mage::throwException(
                     Mage::helper('catalog')->__('The following file extensions are not allowed for security reasons: %s', $fileExtension),
                 );
@@ -244,7 +244,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
             if ($_allowed !== null) {
                 // Check if any allowed extension is in the forbidden list
                 if ($_forbidden !== null) {
-                    $forbiddenFound = array_intersect(array_map('strtolower', $_allowed), array_map('strtolower', $_forbidden));
+                    $forbiddenFound = array_intersect(array_map(strtolower(...), $_allowed), array_map(strtolower(...), $_forbidden));
                     if (!empty($forbiddenFound)) {
                         Mage::throwException(Mage::helper('catalog')->__(
                             'The following file extensions are not allowed for security reasons: %s',
@@ -254,7 +254,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
                 }
 
                 // Validate the uploaded file extension against allowed list
-                if (!in_array($fileExtension, array_map('strtolower', $_allowed))) {
+                if (!in_array($fileExtension, array_map(strtolower(...), $_allowed))) {
                     Mage::throwException(
                         Mage::helper('catalog')->__('The following file extensions are not allowed for security reasons: %s', $fileExtension),
                     );
@@ -366,14 +366,14 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
 
         if ($_allowed !== null) {
             // Check if allowed extension is in forbidden list first
-            if ($_forbidden !== null && in_array($extension, array_map('strtolower', $_forbidden))) {
+            if ($_forbidden !== null && in_array($extension, array_map(strtolower(...), $_forbidden))) {
                 $errors[] = sprintf('The file extension "%s" is not allowed for security reasons.', $extension);
-            } elseif (!in_array($extension, array_map('strtolower', $_allowed))) {
+            } elseif (!in_array($extension, array_map(strtolower(...), $_allowed))) {
                 $errors[] = sprintf('The file extension "%s" is not allowed.', $extension);
             }
         } else {
             // No specific allowed extensions - check forbidden list
-            if ($_forbidden !== null && in_array($extension, array_map('strtolower', $_forbidden))) {
+            if ($_forbidden !== null && in_array($extension, array_map(strtolower(...), $_forbidden))) {
                 $errors[] = sprintf('The file extension "%s" is not allowed for security reasons.', $extension);
             }
         }
@@ -450,7 +450,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
             $result = Mage::helper('core')->jsonEncode($value);
             try {
                 Mage::helper('core')->jsonDecode($result);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 Mage::throwException(Mage::helper('catalog')->__('File options format is not valid.'));
             }
         } else {
@@ -496,7 +496,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
                 $this->_formattedOptionValue = $this->_getOptionHtml($value);
                 $this->getConfigurationItemOption()->setValue(Mage::helper('core')->jsonEncode($value));
                 return $this->_formattedOptionValue;
-            } catch (Exception $e) {
+            } catch (Exception) {
                 return $optionValue;
             }
         }
@@ -532,7 +532,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
                 Mage::helper('core')->escapeHtml($title),
                 $sizes,
             );
-        } catch (Exception $e) {
+        } catch (Exception) {
             Mage::throwException(Mage::helper('catalog')->__('File options format is not valid.'));
         }
     }
@@ -583,7 +583,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
                 Mage::helper('core')->escapeHtml($value['title']),
                 $this->getConfigurationItemOption()->getId(),
             );
-        } catch (Exception $e) {
+        } catch (Exception) {
             return $optionValue;
         }
     }
@@ -604,7 +604,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
             $option = Mage::getModel('sales/quote_item_option')->load($confItemOptionId);
             try {
                 return $option->getValue();
-            } catch (Exception $e) {
+            } catch (Exception) {
                 return null;
             }
         } else {
@@ -623,7 +623,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
     {
         try {
             return Mage::helper('core/unserializeArray')->unserialize($optionValue);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -649,7 +649,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
             $dir = pathinfo($orderFileFullPath, PATHINFO_DIRNAME);
             $this->_createWriteableDir($dir);
             @copy($quoteFileFullPath, $orderFileFullPath);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return $this;
         }
         return $this;
@@ -876,7 +876,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
         $_forbidden = $this->_parseExtensionsString(
             Mage::getStoreConfig('catalog/custom_options/forbidden_extensions'),
         );
-        if ($_forbidden !== null && in_array($fileExtension, array_map('strtolower', $_forbidden))) {
+        if ($_forbidden !== null && in_array($fileExtension, array_map(strtolower(...), $_forbidden))) {
             Mage::throwException(
                 Mage::helper('catalog')->__('The following file extensions are not allowed for security reasons: %s', $fileExtension),
             );
@@ -886,7 +886,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
         $_allowed = $this->_parseExtensionsString($option->getFileExtension());
         if ($_allowed !== null) {
             if ($_forbidden !== null) {
-                $forbiddenFound = array_intersect(array_map('strtolower', $_allowed), array_map('strtolower', $_forbidden));
+                $forbiddenFound = array_intersect(array_map(strtolower(...), $_allowed), array_map(strtolower(...), $_forbidden));
                 if (!empty($forbiddenFound)) {
                     Mage::throwException(Mage::helper('catalog')->__(
                         'The following file extensions are not allowed for security reasons: %s',
@@ -894,7 +894,7 @@ class Mage_Catalog_Model_Product_Option_Type_File extends Mage_Catalog_Model_Pro
                     ));
                 }
             }
-            if (!in_array($fileExtension, array_map('strtolower', $_allowed))) {
+            if (!in_array($fileExtension, array_map(strtolower(...), $_allowed))) {
                 Mage::throwException(
                     Mage::helper('catalog')->__('The following file extensions are not allowed for security reasons: %s', $fileExtension),
                 );

--- a/app/code/core/Mage/Catalog/Model/Product/Website.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Website.php
@@ -36,7 +36,7 @@ class Mage_Catalog_Model_Product_Website extends Mage_Core_Model_Abstract
     {
         try {
             $this->_getResource()->removeProducts($websiteIds, $productIds);
-        } catch (Exception $e) {
+        } catch (Exception) {
             Mage::throwException(
                 Mage::helper('catalog')->__('An error occurred while removing products from websites.'),
             );
@@ -55,7 +55,7 @@ class Mage_Catalog_Model_Product_Website extends Mage_Core_Model_Abstract
     {
         try {
             $this->_getResource()->addProducts($websiteIds, $productIds);
-        } catch (Exception $e) {
+        } catch (Exception) {
             Mage::throwException(
                 Mage::helper('catalog')->__('An error occurred while adding products to websites.'),
             );

--- a/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Category/Flat.php
@@ -445,7 +445,7 @@ class Mage_Catalog_Model_Resource_Category_Flat extends Mage_Index_Model_Resourc
                 ->limit(1);
             try {
                 $this->_isBuilt[$storeId] = (bool) $this->_getReadAdapter()->fetchOne($select);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_isBuilt[$storeId] = false;
             }
         }

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -1630,7 +1630,7 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
             }
             // Set additional field filters
             foreach ($this->_priceDataFieldFilters as $filterData) {
-                $select->where(call_user_func_array('sprintf', $filterData));
+                $select->where(call_user_func_array(sprintf(...), $filterData));
             }
         } else {
             $fromPart['price_index']['joinCondition'] = $joinCond;

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Flat.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Flat.php
@@ -227,7 +227,7 @@ class Mage_Catalog_Model_Resource_Product_Flat extends Mage_Core_Model_Resource_
                 ->limit(1);
             try {
                 $this->_isBuilt[$storeId] = (bool) $this->_getReadAdapter()->fetchOne($select);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_isBuilt[$storeId] = false;
             }
         }

--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
@@ -260,9 +260,7 @@ class Mage_Catalog_Model_Resource_Product_Type_Configurable_Attribute_Collection
                 }
             }
 
-            uasort($values, function ($a, $b) {
-                return $a['order'] - $b['order'];
-            });
+            uasort($values, fn($a, $b) => $a['order'] - $b['order']);
 
             foreach ($pricings[0] as $pricing) {
                 // Adding pricing to options

--- a/app/code/core/Mage/CatalogInventory/Api/StockUpdateProcessor.php
+++ b/app/code/core/Mage/CatalogInventory/Api/StockUpdateProcessor.php
@@ -201,7 +201,7 @@ final class StockUpdateProcessor extends \Maho\ApiPlatform\Processor
             $skuToProductId[$sku] = $productId;
         }
 
-        $this->authorizeStockWebsites(array_map('intval', array_values($skuToProductId)));
+        $this->authorizeStockWebsites(array_map(intval(...), array_values($skuToProductId)));
 
         $write = \Mage::getSingleton('core/resource')->getConnection('core_write');
 
@@ -276,7 +276,7 @@ final class StockUpdateProcessor extends \Maho\ApiPlatform\Processor
         $productResource = \Mage::getResourceSingleton('catalog/product');
         $websiteIdsByProduct = $productResource->getWebsiteIdsByProductIds($productIds);
         foreach ($productIds as $productId) {
-            $websiteIds = array_map('intval', $websiteIdsByProduct[$productId] ?? []);
+            $websiteIds = array_map(intval(...), $websiteIdsByProduct[$productId] ?? []);
             if (array_intersect($websiteIds, $allowedWebsiteIds) === []) {
                 throw new AccessDeniedHttpException("Access denied for this product's websites");
             }

--- a/app/code/core/Mage/CatalogInventory/Helper/Minsaleqty.php
+++ b/app/code/core/Mage/CatalogInventory/Helper/Minsaleqty.php
@@ -66,7 +66,7 @@ class Mage_CatalogInventory_Helper_Minsaleqty extends Mage_Core_Helper_Abstract
         if (is_string($value) && !empty($value)) {
             try {
                 return Mage::helper('core/unserializeArray')->unserialize($value);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 return [];
             }
         } else {

--- a/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Api2/Stock/Item/Rest.php
@@ -120,7 +120,7 @@ abstract class Mage_CatalogInventory_Model_Api2_Stock_Item_Rest extends Mage_Cat
                         'item_id' => $itemData['item_id'] ?? null,
                     ]);
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_errorMessage(
                     Mage_Api2_Model_Resource::RESOURCE_INTERNAL_ERROR,
                     Mage_Api2_Model_Server::HTTP_INTERNAL_ERROR,

--- a/app/code/core/Mage/CatalogInventory/Model/Observer.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Observer.php
@@ -729,7 +729,7 @@ class Mage_CatalogInventory_Model_Observer
          * This limits the number of stock re-indexing that takes place,
          * especially in stores where stock is not managed
          **/
-        $productIds = array_map('\intval', $productIds);
+        $productIds = array_map(\intval(...), $productIds);
         $stockCollection = Mage::getModel('cataloginventory/stock_item')->getCollection()
             ->addFieldToFilter('product_id', ['in' => $productIds])
             ->addFieldToFilter('manage_stock', ['eq' => 1]);

--- a/app/code/core/Mage/CatalogRule/Block/Product/Widget/OnSale.php
+++ b/app/code/core/Mage/CatalogRule/Block/Product/Widget/OnSale.php
@@ -66,7 +66,7 @@ class Mage_CatalogRule_Block_Product_Widget_OnSale extends Mage_Catalog_Block_Pr
             $rulePrices = array_intersect_key($rulePrices, $ruleProductIds);
         }
 
-        $productIds = array_map('intval', array_keys($rulePrices));
+        $productIds = array_map(intval(...), array_keys($rulePrices));
 
         $collection = $this->_prepareStorefrontCollection($productIds);
         if (!empty($productIds)) {
@@ -116,7 +116,7 @@ class Mage_CatalogRule_Block_Product_Widget_OnSale extends Mage_Catalog_Block_Pr
             ->where('oi.store_id = ?', (int) Mage::app()->getStore()->getId())
             ->group('oi.product_id')
             ->order(new Maho\Db\Expr('SUM(oi.qty_ordered) DESC'));
-        $sold = array_map('intval', $adapter->fetchCol($select));
+        $sold = array_map(intval(...), $adapter->fetchCol($select));
 
         return array_merge($sold, array_values(array_diff($productIds, $sold)));
     }
@@ -146,6 +146,6 @@ class Mage_CatalogRule_Block_Product_Widget_OnSale extends Mage_Catalog_Block_Pr
         }
         arsort($discounts);
 
-        return array_map('intval', array_keys($discounts));
+        return array_map(intval(...), array_keys($discounts));
     }
 }

--- a/app/code/core/Mage/CatalogRule/Model/Rule.php
+++ b/app/code/core/Mage/CatalogRule/Model/Rule.php
@@ -218,7 +218,7 @@ class Mage_CatalogRule_Model_Rule extends Mage_Rule_Model_Abstract
 
                 Mage::getSingleton('core/resource_iterator')->walk(
                     $productCollection->getSelect(),
-                    [[$this, 'callbackValidateProduct']],
+                    [$this->callbackValidateProduct(...)],
                     [
                         'attributes' => $this->getCollectedAttributes(),
                         'product'    => Mage::getModel('catalog/product'),

--- a/app/code/core/Mage/CatalogSearch/Block/Autocomplete/Category/List.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Autocomplete/Category/List.php
@@ -38,9 +38,7 @@ class Mage_CatalogSearch_Block_Autocomplete_Category_List extends Mage_Core_Bloc
             // Split query into words and filter by minimum length
             $words = Mage::helper('core/string')->splitWords($query, true, $maxQueryWords);
             if ($words) {
-                $words = array_filter($words, function ($word) use ($minQueryLength) {
-                    return strlen($word) >= $minQueryLength;
-                });
+                $words = array_filter($words, fn($word) => strlen($word) >= $minQueryLength);
             }
 
             // If no valid words remain, fall back to full phrase search

--- a/app/code/core/Mage/CatalogSearch/Helper/Data.php
+++ b/app/code/core/Mage/CatalogSearch/Helper/Data.php
@@ -277,7 +277,7 @@ class Mage_CatalogSearch_Helper_Data extends Mage_Core_Helper_Abstract
             $wordsFull = $stringHelper->splitWords($this->getQueryText(), true);
             $wordsLike = $stringHelper->splitWords($this->getQueryText(), true, $this->getMaxQueryWords());
             if (count($wordsFull) > count($wordsLike)) {
-                $wordsCut = array_map([$this, 'escapeHtml'], array_diff($wordsFull, $wordsLike));
+                $wordsCut = array_map($this->escapeHtml(...), array_diff($wordsFull, $wordsLike));
                 $this->addNoteMessage(
                     $this->__('Maximum words count is %1$s. In your search query was cut next part: %2$s.', $this->getMaxQueryWords(), implode(' ', $wordsCut)),
                 );

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -91,7 +91,7 @@ class CartMapper
                     'code' => $payment->getMethod(),
                     'title' => $payment->getMethodInstance()->getTitle(),
                 ];
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 $cart->selectedPaymentMethod = [
                     'code' => $payment->getMethod(),
                     'title' => $payment->getMethod(),

--- a/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
+++ b/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
@@ -30,14 +30,7 @@ class CartMutationHandler
 {
     use AdminQuoteTrait;
 
-    private CartService $cartService;
-    private CartMapper $cartMapper;
-
-    public function __construct(CartService $cartService, CartMapper $cartMapper)
-    {
-        $this->cartService = $cartService;
-        $this->cartMapper = $cartMapper;
-    }
+    public function __construct(private CartService $cartService, private CartMapper $cartMapper) {}
 
     /**
      * Handle getCart query

--- a/app/code/core/Mage/Checkout/Model/Api/Resource.php
+++ b/app/code/core/Mage/Checkout/Model/Api/Resource.php
@@ -48,7 +48,7 @@ class Mage_Checkout_Model_Api_Resource extends Mage_Api_Model_Resource_Abstract
 
         try {
             $quote = $this->_getQuote($quoteId);
-        } catch (Mage_Api_Exception $e) {
+        } catch (Mage_Api_Exception) {
             return false;
         }
 
@@ -75,7 +75,7 @@ class Mage_Checkout_Model_Api_Resource extends Mage_Api_Model_Resource_Abstract
 
         try {
             $storeId = Mage::app()->getStore($store)->getId();
-        } catch (Mage_Core_Model_Store_Exception $e) {
+        } catch (Mage_Core_Model_Store_Exception) {
             $this->_fault('store_not_exists');
         }
 

--- a/app/code/core/Mage/Checkout/Model/Cart.php
+++ b/app/code/core/Mage/Checkout/Model/Cart.php
@@ -297,7 +297,7 @@ class Mage_Checkout_Model_Cart extends \Maho\DataObject implements Mage_Checkout
                 if ($product->getId() && $product->isVisibleInCatalog()) {
                     try {
                         $this->getQuote()->addProduct($product);
-                    } catch (Exception $e) {
+                    } catch (Exception) {
                         $allAdded = false;
                     }
                 } else {

--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -812,7 +812,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
                 $quote->setCouponCode($oldCouponCode)->collectTotals()->save();
             }
             return false;
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Restore old coupon if any
             if ($oldCouponCode) {
                 $quote->setCouponCode($oldCouponCode)->collectTotals()->save();
@@ -939,7 +939,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
                 return;
             }
             $this->_getSession()->addSuccess($message);
-        } catch (Exception $e) {
+        } catch (Exception) {
             if ($isAjax) {
                 $this->getResponse()->setBodyJson([
                     'success' => false,
@@ -993,7 +993,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
                 $result['success'] = 1;
                 $result['message'] = $this->__('Item was removed successfully.');
                 Mage::dispatchEvent('ajax_cart_remove_item_success', ['id' => $id]);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $result['success'] = 0;
                 $result['error'] = $this->__('Can not remove the item.');
             }
@@ -1047,7 +1047,7 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
                     $result['notice'] = $quoteItem->getMessage();
                 }
                 $result['success'] = 1;
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $result['success'] = 0;
                 $result['error'] = $this->__('Can not save item.');
             }

--- a/app/code/core/Mage/Cms/Api/CmsBlock.php
+++ b/app/code/core/Mage/Cms/Api/CmsBlock.php
@@ -104,7 +104,7 @@ class CmsBlock extends CrudResource
         $dto->status = ($dto->isActive ?? false) ? 'enabled' : 'disabled';
 
         if (method_exists($model->getResource(), 'lookupStoreIds')) {
-            $dto->stores = array_map('intval', $model->getResource()->lookupStoreIds($model->getId()));
+            $dto->stores = array_map(intval(...), $model->getResource()->lookupStoreIds($model->getId()));
         }
     }
 }

--- a/app/code/core/Mage/Cms/Api/CmsPage.php
+++ b/app/code/core/Mage/Cms/Api/CmsPage.php
@@ -150,7 +150,7 @@ class CmsPage extends CrudResource
         $dto->customThemeTo = $dto->customThemeTo ? substr($dto->customThemeTo, 0, 10) : null;
 
         if (method_exists($model->getResource(), 'lookupStoreIds')) {
-            $dto->stores = array_map('intval', $model->getResource()->lookupStoreIds($model->getId()));
+            $dto->stores = array_map(intval(...), $model->getResource()->lookupStoreIds($model->getId()));
         }
     }
 }

--- a/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
+++ b/app/code/core/Mage/Cms/Helper/Wysiwyg/Images.php
@@ -111,7 +111,7 @@ class Mage_Cms_Helper_Wysiwyg_Images extends Mage_Core_Helper_Abstract
     {
         $path = $this->idDecode($id);
         $storageRoot = realpath($this->getStorageRoot());
-        if (!strstr($path, $storageRoot)) {
+        if (!strstr($path, (string) $storageRoot)) {
             $path = $storageRoot . DS . $path;
         }
         return $path;

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Mediafallback.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Mediafallback.php
@@ -56,9 +56,7 @@ class Mage_ConfigurableSwatches_Helper_Mediafallback extends Mage_Core_Helper_Ab
         }
 
         // normalize to all lower case before we start using them
-        $optionLabels = array_map(function ($value) {
-            return array_map('Mage_ConfigurableSwatches_Helper_Data::normalizeKey', $value);
-        }, $optionLabels);
+        $optionLabels = array_map(fn($value) => array_map(Mage_ConfigurableSwatches_Helper_Data::normalizeKey(...), $value), $optionLabels);
 
         foreach ($parentProducts as $parentProduct) {
             $mapping = [];
@@ -153,9 +151,7 @@ class Mage_ConfigurableSwatches_Helper_Mediafallback extends Mage_Core_Helper_Ab
             $imageTypes = array_intersect(['image', 'small_image'], $imageTypes);
 
             $imagesByLabel = [];
-            $imageHaystack = array_map(function ($value) {
-                return Mage_ConfigurableSwatches_Helper_Data::normalizeKey($value['label']);
-            }, $mediaGallery['images']);
+            $imageHaystack = array_map(fn($value) => Mage_ConfigurableSwatches_Helper_Data::normalizeKey($value['label']), $mediaGallery['images']);
 
             // load images from the configurable product for swapping
             if (is_array($mapping)) {

--- a/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
+++ b/app/code/core/Mage/ConfigurableSwatches/Helper/Productimg.php
@@ -96,7 +96,7 @@ class Mage_ConfigurableSwatches_Helper_Productimg extends Mage_Core_Helper_Abstr
             $searchValues = [];
 
             if (!is_null($preValues) && is_array($preValues)) { // If a pre-defined list of valid values was passed
-                $preValues = array_map('Mage_ConfigurableSwatches_Helper_Data::normalizeKey', $preValues);
+                $preValues = array_map(Mage_ConfigurableSwatches_Helper_Data::normalizeKey(...), $preValues);
                 foreach ($preValues as $value) {
                     $searchValues[] = $value;
                 }
@@ -124,9 +124,7 @@ class Mage_ConfigurableSwatches_Helper_Productimg extends Mage_Core_Helper_Abstr
                 return; //nothing to do here
             }
 
-            $imageHaystack = array_map(function ($value) {
-                return Mage_ConfigurableSwatches_Helper_Data::normalizeKey($value['label']);
-            }, $mediaGallery['images']);
+            $imageHaystack = array_map(fn($value) => Mage_ConfigurableSwatches_Helper_Data::normalizeKey($value['label']), $mediaGallery['images']);
 
             foreach ($searchValues as $label) {
                 $imageKeys = [];

--- a/app/code/core/Mage/Core/Api/StoreConfigProvider.php
+++ b/app/code/core/Mage/Core/Api/StoreConfigProvider.php
@@ -33,7 +33,7 @@ final class StoreConfigProvider extends \Maho\ApiPlatform\Provider
                 } else {
                     throw new \Symfony\Component\HttpKernel\Exception\NotFoundHttpException("Store with code '$storeCode' not found");
                 }
-            } catch (\Mage_Core_Model_Store_Exception $e) {
+            } catch (\Mage_Core_Model_Store_Exception) {
                 throw new \Symfony\Component\HttpKernel\Exception\NotFoundHttpException("Store with code '$storeCode' not found");
             }
         } else {

--- a/app/code/core/Mage/Core/Api/StoreProcessor.php
+++ b/app/code/core/Mage/Core/Api/StoreProcessor.php
@@ -50,7 +50,7 @@ class StoreProcessor extends \Maho\ApiPlatform\Processor
             if ($store && $store->getId() && $store->getIsActive()) {
                 return $store;
             }
-        } catch (\Mage_Core_Model_Store_Exception $e) {
+        } catch (\Mage_Core_Model_Store_Exception) {
             // Store not found
         }
 

--- a/app/code/core/Mage/Core/Api/UrlResolverProvider.php
+++ b/app/code/core/Mage/Core/Api/UrlResolverProvider.php
@@ -328,7 +328,7 @@ final class UrlResolverProvider extends \Maho\ApiPlatform\Provider
             $post = $collection->getFirstItem();
 
             return $post->getId() ? $post : null;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return null;
         }
     }

--- a/app/code/core/Mage/Core/Block/Html/Date.php
+++ b/app/code/core/Mage/Core/Block/Html/Date.php
@@ -44,7 +44,7 @@ class Mage_Core_Block_Html_Date extends Mage_Core_Block_Template
                 } else {
                     $isoValue = $dateTime->format(Mage_Core_Model_Locale::DATE_FORMAT);
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // If parsing fails, use the original value
                 $isoValue = $this->getValue();
             }

--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -211,9 +211,7 @@ abstract class Mage_Core_Helper_Abstract
     {
         $html = preg_replace_callback(
             "# <(?![/a-z]) | (?<=\s)>(?![a-z]) #xi",
-            function ($matches) {
-                return htmlentities($matches[0]);
-            },
+            fn($matches) => htmlentities($matches[0]),
             $html,
         );
         $html =  strip_tags($html);

--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -1276,7 +1276,7 @@ XML;
     public function packageInstallWarning(string $package, string $separator = ' '): string
     {
         $missing = array_filter(
-            array_map('trim', explode(',', $package)),
+            array_map(trim(...), explode(',', $package)),
             static fn(string $name): bool => $name !== '' && !\Composer\InstalledVersions::isInstalled($name),
         );
         if ($missing === []) {
@@ -1314,7 +1314,7 @@ XML;
         $packageName = 'mahocommerce/icons';
         try {
             $installPath = \Composer\InstalledVersions::getInstallPath($packageName);
-        } catch (OutOfBoundsException $e) {
+        } catch (OutOfBoundsException) {
             return '';
         }
         if ($installPath === null) {

--- a/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
+++ b/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
@@ -89,13 +89,7 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
 
     protected function getConfigKey(string $configKey): array
     {
-        $configKeyParts = array_filter(
-            explode(
-                static::ENV_KEY_SEPARATOR,
-                $configKey,
-            ),
-            static fn(string $part): bool => (bool) trim($part),
-        );
+        $configKeyParts = array_filter(explode(static::ENV_KEY_SEPARATOR, $configKey));
         [$unused, $scope] = $configKeyParts;
         return [$configKeyParts, $scope];
     }

--- a/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
+++ b/app/code/core/Mage/Core/Helper/EnvironmentConfigLoader.php
@@ -94,7 +94,7 @@ class Mage_Core_Helper_EnvironmentConfigLoader extends Mage_Core_Helper_Abstract
                 static::ENV_KEY_SEPARATOR,
                 $configKey,
             ),
-            'trim',
+            static fn(string $part): bool => (bool) trim($part),
         );
         [$unused, $scope] = $configKeyParts;
         return [$configKeyParts, $scope];

--- a/app/code/core/Mage/Core/Helper/Purifier.php
+++ b/app/code/core/Mage/Core/Helper/Purifier.php
@@ -50,8 +50,6 @@ class Mage_Core_Helper_Purifier extends Mage_Core_Helper_Abstract
      */
     public const DATA_ATTRIBUTE_PATTERN = '/\bdata-[a-z][a-z0-9_-]*/i';
 
-    protected ?HtmlSanitizerInterface $sanitizer;
-
     /**
      * How many per-data-attribute-set sanitizers to keep.
      *
@@ -65,10 +63,7 @@ class Mage_Core_Helper_Purifier extends Mage_Core_Helper_Abstract
     /** @var array<string, HtmlSanitizerInterface> */
     protected array $sanitizerCache = [];
 
-    public function __construct(?HtmlSanitizerInterface $sanitizer = null)
-    {
-        $this->sanitizer = $sanitizer;
-    }
+    public function __construct(protected ?HtmlSanitizerInterface $sanitizer = null) {}
 
     /**
      * The sanitization policy.
@@ -108,7 +103,7 @@ class Mage_Core_Helper_Purifier extends Mage_Core_Helper_Abstract
     public function purify($content)
     {
         if (is_array($content)) {
-            return array_map(fn($item) => $this->purify($item), $content);
+            return array_map($this->purify(...), $content);
         }
 
         $content = (string) $content;
@@ -128,7 +123,7 @@ class Mage_Core_Helper_Purifier extends Mage_Core_Helper_Abstract
         }
 
         preg_match_all(self::DATA_ATTRIBUTE_PATTERN, $content, $matches);
-        $dataAttributes = array_unique(array_map('strtolower', $matches[0]));
+        $dataAttributes = array_unique(array_map(strtolower(...), $matches[0]));
         sort($dataAttributes);
 
         $key = implode(',', $dataAttributes);

--- a/app/code/core/Mage/Core/Model/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Abstract.php
@@ -371,7 +371,7 @@ abstract class Mage_Core_Model_Abstract extends \Maho\DataObject
                 $this->_getResource()->save($this);
                 $this->_afterSave();
             }
-            $this->_getResource()->addCommitCallback([$this, 'afterCommitCallback'])
+            $this->_getResource()->addCommitCallback($this->afterCommitCallback(...))
                 ->commit();
             $this->_hasDataChanges = false;
         } catch (Throwable $e) {

--- a/app/code/core/Mage/Core/Model/Cache/Marshaller.php
+++ b/app/code/core/Mage/Core/Model/Cache/Marshaller.php
@@ -22,7 +22,7 @@ class Mage_Core_Model_Cache_Marshaller implements MarshallerInterface
         foreach ($values as $id => $value) {
             try {
                 $serialized[$id] = serialize($value);
-            } catch (\Throwable $e) {
+            } catch (\Throwable) {
                 $failed[] = $id;
             }
         }

--- a/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
+++ b/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
@@ -279,9 +279,7 @@ class Mage_Core_Model_Controller_Front_Observer
 
     private function processRewriteUrl(string $url): string
     {
-        return preg_replace_callback('/\{(\w+)\}/', function (array $matches): string {
-            return \Maho\Routing\RouteCollectionBuilder::getFrontNameByRoute($matches[1]) ?? $matches[1];
-        }, $url) ?? $url;
+        return preg_replace_callback('/\{(\w+)\}/', fn(array $matches): string => \Maho\Routing\RouteCollectionBuilder::getFrontNameByRoute($matches[1]) ?? $matches[1], $url) ?? $url;
     }
 
     private function enforceHttps(Mage_Core_Controller_Request_Http $request, Mage_Core_Controller_Response_Http $response): void

--- a/app/code/core/Mage/Core/Model/Email/Template.php
+++ b/app/code/core/Mage/Core/Model/Email/Template.php
@@ -290,8 +290,8 @@ class Mage_Core_Model_Email_Template extends Mage_Core_Model_Email_Template_Abst
         $variables = $this->_addEmailVariables($variables, $processor->getStoreId());
 
         $processor
-            ->setTemplateProcessor([$this, 'getTemplateByConfigPath'])
-            ->setIncludeProcessor([$this, 'getInclude'])
+            ->setTemplateProcessor($this->getTemplateByConfigPath(...))
+            ->setIncludeProcessor($this->getInclude(...))
             ->setVariables($variables);
 
         try {

--- a/app/code/core/Mage/Core/Model/Email/Template/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Abstract.php
@@ -241,7 +241,7 @@ abstract class Mage_Core_Model_Email_Template_Abstract extends Mage_Core_Model_T
             if (!$filesToLoad) {
                 return '';
             }
-            $files = array_map('trim', explode(',', $filesToLoad));
+            $files = array_map(trim(...), explode(',', $filesToLoad));
 
             $css = '';
             foreach ($files as $fileName) {

--- a/app/code/core/Mage/Core/Model/Email/Template/Filter.php
+++ b/app/code/core/Mage/Core/Model/Email/Template/Filter.php
@@ -44,7 +44,7 @@ class Mage_Core_Model_Email_Template_Filter extends \Maho\Filter\Template
      */
     public function __construct()
     {
-        $this->_modifiers['escape'] = [$this, 'modifierEscape'];
+        $this->_modifiers['escape'] = $this->modifierEscape(...);
         $this->_permissionVariable = Mage::getModel('admin/variable');
         $this->_permissionBlock = Mage::getModel('admin/block');
     }

--- a/app/code/core/Mage/Core/Model/File/Validator/Extension.php
+++ b/app/code/core/Mage/Core/Model/File/Validator/Extension.php
@@ -80,8 +80,8 @@ class Mage_Core_Model_File_Validator_Extension
     {
         $forbiddenConfig = Mage::getStoreConfig($this->forbiddenConfigPath);
         if ($forbiddenConfig) {
-            $extensions = array_map('trim', explode(',', $forbiddenConfig));
-            $this->forbiddenExtensions = array_map('strtolower', $extensions);
+            $extensions = array_map(trim(...), explode(',', $forbiddenConfig));
+            $this->forbiddenExtensions = array_map(strtolower(...), $extensions);
         }
         return $this;
     }
@@ -94,7 +94,7 @@ class Mage_Core_Model_File_Validator_Extension
     public function setAllowedExtensions(?array $extensions): self
     {
         if ($extensions !== null) {
-            $this->allowedExtensions = array_map('strtolower', array_map('trim', $extensions));
+            $this->allowedExtensions = array_map(strtolower(...), array_map(trim(...), $extensions));
         } else {
             $this->allowedExtensions = null;
         }

--- a/app/code/core/Mage/Core/Model/Layout/Validator.php
+++ b/app/code/core/Mage/Core/Model/Layout/Validator.php
@@ -109,7 +109,7 @@ class Mage_Core_Model_Layout_Validator
             $value = trim($value);
             try {
                 $value = simplexml_load_string('<config>' . $value . '</config>', \Maho\Simplexml\Element::class);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_error(self::XML_INVALID);
                 return false;
             }
@@ -121,7 +121,7 @@ class Mage_Core_Model_Layout_Validator
         if ($templatePaths = $value->xpath('//*[@template]')) {
             try {
                 $this->_validateTemplatePath($templatePaths);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_error(self::INVALID_TEMPLATE_PATH);
                 return false;
             }

--- a/app/code/core/Mage/Core/Model/Locale.php
+++ b/app/code/core/Mage/Core/Model/Locale.php
@@ -633,7 +633,7 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
                     return $dateObj->format(self::HTML5_DATETIME_FORMAT);
                 }
                 return $dateObj->format(self::DATE_FORMAT);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 return null;
             }
         }
@@ -887,7 +887,7 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
             try {
                 $currencySymbolModel = Mage::getSingleton('currencysymbol/system_currencysymbol');
                 $customSymbol = $currencySymbolModel->getCurrencySymbol($currency, $this->getLocaleCode());
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // CurrencySymbol module may not be available, continue with default behavior
             }
 
@@ -1452,7 +1452,7 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
                     // Use country code itself as fallback when translation fails
                     $countries[$code] = $code;
                 }
-            } catch (IntlException $e) {
+            } catch (IntlException) {
                 // Use country code itself as fallback for exceptions
                 $countries[$code] = $code;
             }
@@ -1476,7 +1476,7 @@ class Mage_Core_Model_Locale extends \Maho\DataObject
             }
             // Use country code itself as fallback when translation fails
             return $countryId;
-        } catch (IntlException $e) {
+        } catch (IntlException) {
             // Use country code itself as fallback for exceptions
             return $countryId;
         }

--- a/app/code/core/Mage/Core/Model/Logger.php
+++ b/app/code/core/Mage/Core/Model/Logger.php
@@ -42,7 +42,7 @@ class Mage_Core_Model_Logger
             // Use backend configuration when no XML config present
             try {
                 $logActive = Mage::getStoreConfig('dev/log/active');
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $logActive = true;
             }
 
@@ -52,7 +52,7 @@ class Mage_Core_Model_Logger
 
             try {
                 $minLogLevel = (int) Mage::getStoreConfig('dev/log/min_level');
-            } catch (Throwable $e) {
+            } catch (Throwable) {
                 $minLogLevel = Mage::LOG_DEBUG;
             }
         }

--- a/app/code/core/Mage/Core/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Core/Model/Resource/Setup.php
@@ -754,7 +754,7 @@ class Mage_Core_Model_Resource_Setup
         switch ($actionType) {
             case self::TYPE_DB_INSTALL:
             case self::TYPE_DATA_INSTALL:
-                uksort($arrFiles, 'version_compare');
+                uksort($arrFiles, version_compare(...));
                 foreach ($arrFiles as $version => $file) {
                     if (version_compare($version, $toVersion) !== self::VERSION_COMPARE_GREATER) {
                         $arrRes[0] = [
@@ -767,7 +767,7 @@ class Mage_Core_Model_Resource_Setup
 
             case self::TYPE_DB_UPGRADE:
             case self::TYPE_DATA_UPGRADE:
-                uksort($arrFiles, 'version_compare');
+                uksort($arrFiles, version_compare(...));
                 foreach ($arrFiles as $version => $file) {
                     $versionInfo = explode('-', $version);
 

--- a/app/code/core/Mage/Core/Model/Security/HtmlEscapedString.php
+++ b/app/code/core/Mage/Core/Model/Security/HtmlEscapedString.php
@@ -10,21 +10,10 @@ declare(strict_types=1);
 
 class Mage_Core_Model_Security_HtmlEscapedString implements Stringable
 {
-    protected string $originalValue;
-
-    /**
-     * @var string[]|null
-     */
-    protected ?array $allowedTags;
-
     /**
      * @param string[]|null $allowedTags
      */
-    public function __construct(string $originalValue, ?array $allowedTags = null)
-    {
-        $this->originalValue = $originalValue;
-        $this->allowedTags = $allowedTags;
-    }
+    public function __construct(protected string $originalValue, protected ?array $allowedTags = null) {}
 
     /**
      * Get escaped html entities

--- a/app/code/core/Mage/Core/Model/Session.php
+++ b/app/code/core/Mage/Core/Model/Session.php
@@ -158,7 +158,7 @@ class Mage_Core_Model_Session extends Mage_Core_Model_Session_Abstract
             // PHP updates the file mtime every time the session is accessed/written
             return $file->getMTime() < $expireTime;
 
-        } catch (Exception $e) {
+        } catch (Exception) {
             // If we can't get file modification time, consider it expired
             return true;
         }

--- a/app/code/core/Mage/Core/Model/Session/Abstract.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract.php
@@ -369,7 +369,7 @@ class Mage_Core_Model_Session_Abstract extends \Maho\DataObject
                 $currentCookieDomain = $cookie->getDomain();
                 foreach (array_keys($sessionHosts) as $host) {
                     // Delete cookies with the same name for parent domains
-                    if (strpos($currentCookieDomain, $host) > 0) {
+                    if (strpos($currentCookieDomain, (string) $host) > 0) {
                         $cookie->delete($this->getSessionName(), null, $host);
                     }
                 }

--- a/app/code/core/Mage/Core/Model/Store/Api.php
+++ b/app/code/core/Mage/Core/Model/Store/Api.php
@@ -47,7 +47,7 @@ class Mage_Core_Model_Store_Api extends Mage_Api_Model_Resource_Abstract
         // Retrieve store info
         try {
             $store = Mage::app()->getStore($storeId);
-        } catch (Mage_Core_Model_Store_Exception $e) {
+        } catch (Mage_Core_Model_Store_Exception) {
             $this->_fault('store_not_exists');
         }
 

--- a/app/code/core/Mage/Core/Model/Translate.php
+++ b/app/code/core/Mage/Core/Model/Translate.php
@@ -367,7 +367,7 @@ class Mage_Core_Model_Translate
             } else {
                 $result = false;
             }
-        } catch (ValueError $e) {
+        } catch (ValueError) {
             $result = false;
         }
 

--- a/app/code/core/Mage/Core/data/core_setup/data-upgrade-1.6.0.10-2.0.0.php
+++ b/app/code/core/Mage/Core/data/core_setup/data-upgrade-1.6.0.10-2.0.0.php
@@ -70,7 +70,7 @@ try {
     foreach ($ruleTables as $tableConfig) {
         try {
             $tableName = $installer->getTable($tableConfig['table']);
-        } catch (Exception $e) {
+        } catch (Exception) {
             continue;
         }
 

--- a/app/code/core/Mage/Cron/Block/Adminhtml/System/Tools/Cronjobs/Grid.php
+++ b/app/code/core/Mage/Cron/Block/Adminhtml/System/Tools/Cronjobs/Grid.php
@@ -71,7 +71,7 @@ class Mage_Cron_Block_Adminhtml_System_Tools_Cronjobs_Grid extends Mage_Adminhtm
             'index' => 'cron_expr',
             'align' => 'center',
             'sortable' => false,
-            'frame_callback' => [$this, 'decorateSchedule'],
+            'frame_callback' => $this->decorateSchedule(...),
         ]);
 
         $this->addColumn('last_executed_at', [
@@ -86,7 +86,7 @@ class Mage_Cron_Block_Adminhtml_System_Tools_Cronjobs_Grid extends Mage_Adminhtm
             'index' => 'last_status',
             'align' => 'center',
             'sortable' => false,
-            'frame_callback' => [$this, 'decorateLastStatus'],
+            'frame_callback' => $this->decorateLastStatus(...),
         ]);
 
         $this->addColumn('next_run_at', [
@@ -101,14 +101,14 @@ class Mage_Cron_Block_Adminhtml_System_Tools_Cronjobs_Grid extends Mage_Adminhtm
             'index' => 'is_enabled',
             'align' => 'center',
             'sortable' => false,
-            'frame_callback' => [$this, 'decorateJobStatus'],
+            'frame_callback' => $this->decorateJobStatus(...),
         ]);
 
         $this->addColumn('action', [
             'header' => Mage::helper('cron')->__('Actions'),
             'sortable' => false,
             'filter' => false,
-            'frame_callback' => [$this, 'decorateActions'],
+            'frame_callback' => $this->decorateActions(...),
         ]);
 
         return parent::_prepareColumns();

--- a/app/code/core/Mage/Customer/Api/CustomerProcessor.php
+++ b/app/code/core/Mage/Customer/Api/CustomerProcessor.php
@@ -576,7 +576,7 @@ final class CustomerProcessor extends \Maho\ApiPlatform\Processor
 
         // The source prepends an empty option; only positive ids are real values.
         $optionIds = array_values(array_filter(
-            array_map('intval', array_column($options, 'value')),
+            array_map(intval(...), array_column($options, 'value')),
             fn(int $id): bool => $id > 0,
         ));
 

--- a/app/code/core/Mage/Customer/Api/CustomerProcessor.php
+++ b/app/code/core/Mage/Customer/Api/CustomerProcessor.php
@@ -617,7 +617,8 @@ final class CustomerProcessor extends \Maho\ApiPlatform\Processor
     /**
      * Shared logic for changing customer password (used by both REST and GraphQL)
      */
-    private function doChangePassword(string $currentPassword, string $newPassword): Customer
+    private function doChangePassword(string $currentPassword, #[\SensitiveParameter]
+        string $newPassword): Customer
     {
         $customerId = $this->getAuthenticatedCustomerId();
         if (!$customerId) {

--- a/app/code/core/Mage/Customer/Api/CustomerService.php
+++ b/app/code/core/Mage/Customer/Api/CustomerService.php
@@ -192,7 +192,7 @@ class CustomerService
         // allowlist matches nothing (IN (-1)).
         $websiteCond = '';
         if ($websiteIds !== null) {
-            $websiteList = implode(',', array_map('intval', $websiteIds === [] ? [-1] : $websiteIds));
+            $websiteList = implode(',', array_map(intval(...), $websiteIds === [] ? [-1] : $websiteIds));
             $websiteCond = " AND c.website_id IN ({$websiteList})";
         }
 
@@ -514,7 +514,8 @@ class CustomerService
      * Reset password using token
      */
     public function resetPassword(#[\SensitiveParameter]
-        string $email, string $token, string $newPassword): bool
+        string $email, #[\SensitiveParameter]
+        string $token, string $newPassword): bool
     {
         $customer = $this->getCustomerByEmail($email);
 

--- a/app/code/core/Mage/Customer/Api/CustomerService.php
+++ b/app/code/core/Mage/Customer/Api/CustomerService.php
@@ -475,6 +475,7 @@ class CustomerService
     public function changePassword(
         \Mage_Customer_Model_Customer $customer,
         string $currentPassword,
+        #[\SensitiveParameter]
         string $newPassword,
     ): bool {
         // Validate current password
@@ -515,7 +516,8 @@ class CustomerService
      */
     public function resetPassword(#[\SensitiveParameter]
         string $email, #[\SensitiveParameter]
-        string $token, string $newPassword): bool
+        string $token, #[\SensitiveParameter]
+        string $newPassword): bool
     {
         $customer = $this->getCustomerByEmail($email);
 

--- a/app/code/core/Mage/Customer/Api/GraphQL/CustomerQueryHandler.php
+++ b/app/code/core/Mage/Customer/Api/GraphQL/CustomerQueryHandler.php
@@ -27,14 +27,7 @@ use Maho\ApiPlatform\Security\AdminAcl;
  */
 class CustomerQueryHandler
 {
-    private CustomerService $customerService;
-    private CustomerProvider $customerProvider;
-
-    public function __construct(CustomerService $customerService, CustomerProvider $customerProvider)
-    {
-        $this->customerService = $customerService;
-        $this->customerProvider = $customerProvider;
-    }
+    public function __construct(private CustomerService $customerService, private CustomerProvider $customerProvider) {}
 
     /**
      * Handle searchCustomers query
@@ -61,7 +54,7 @@ class CustomerQueryHandler
         $edges = array_map(fn($c) => ['node' => $this->mapCustomer($c)], $customers);
         return ['customers' => [
             'edges' => $edges,
-            'items' => array_map([$this, 'mapCustomer'], $customers),
+            'items' => array_map($this->mapCustomer(...), $customers),
             'total' => $result['total'] ?? 0,
         ]];
     }

--- a/app/code/core/Mage/Customer/Helper/Data.php
+++ b/app/code/core/Mage/Customer/Helper/Data.php
@@ -429,7 +429,8 @@ class Mage_Customer_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Retrieve magic link login URL with token
      */
-    public function getMagicLinkUrl(string $token): string
+    public function getMagicLinkUrl(#[\SensitiveParameter]
+        string $token): string
     {
         return $this->_getUrl('customer/account/magiclinklogin', ['token' => $token]);
     }

--- a/app/code/core/Mage/Customer/Model/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Customer.php
@@ -970,7 +970,8 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
     /**
      * Validate magic link token
      */
-    public function validateMagicLinkToken(string $token): bool
+    public function validateMagicLinkToken(#[\SensitiveParameter]
+        string $token): bool
     {
         if (empty($token) || empty($this->getRpToken())) {
             return false;

--- a/app/code/core/Mage/Customer/Model/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Customer.php
@@ -355,7 +355,8 @@ class Mage_Customer_Model_Customer extends Mage_Core_Model_Abstract
      * @param   string $newPassword
      * @return  $this
      */
-    public function changePassword($newPassword)
+    public function changePassword(#[\SensitiveParameter]
+        $newPassword)
     {
         $this->_getResource()->changePassword($this, $newPassword);
         return $this;

--- a/app/code/core/Mage/Customer/Model/Observer.php
+++ b/app/code/core/Mage/Customer/Model/Observer.php
@@ -223,7 +223,7 @@ class Mage_Customer_Model_Observer
                     }
                 }
             }
-        } catch (Exception $e) {
+        } catch (Exception) {
             Mage::register(self::VIV_PROCESSED_FLAG, false, true);
         }
     }

--- a/app/code/core/Mage/Customer/Model/Resource/Customer.php
+++ b/app/code/core/Mage/Customer/Model/Resource/Customer.php
@@ -216,7 +216,8 @@ class Mage_Customer_Model_Resource_Customer extends Mage_Eav_Model_Entity_Abstra
      * @param string $newPassword
      * @return $this
      */
-    public function changePassword(Mage_Customer_Model_Customer $customer, $newPassword)
+    public function changePassword(Mage_Customer_Model_Customer $customer, #[\SensitiveParameter]
+        $newPassword)
     {
         $customer->setPassword($newPassword)->setPasswordCreatedAt(time());
         $this->saveAttribute($customer, 'password_hash');

--- a/app/code/core/Mage/Customer/Model/Session.php
+++ b/app/code/core/Mage/Customer/Model/Session.php
@@ -226,7 +226,7 @@ class Mage_Customer_Model_Session extends Mage_Core_Model_Session_Abstract
             if ($e->getCode() === Mage_Customer_Model_Customer::EXCEPTION_2FA_INVALID) {
                 $this->setRequireTwofa(true);
             }
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Mage::logException($e); // PA DSS violation: this exception log can disclose customer password
         }
     }

--- a/app/code/core/Mage/Customer/controllers/AccountController.php
+++ b/app/code/core/Mage/Customer/controllers/AccountController.php
@@ -169,7 +169,7 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
                     }
                     $session->addError($message);
                     $session->setUsername($login['username']);
-                } catch (Exception $e) {
+                } catch (Exception) {
                     // Mage::logException($e); // PA DSS violation: this exception log can disclose customer password
                 }
 
@@ -401,7 +401,7 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
                     'Thank you for registering! We have sent you an email with a login link to %s.',
                     Mage::helper('customer')->escapeHtml($customer->getEmail()),
                 ));
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $session->addError($this->__('Registration successful, but we could not send the login link. Please use the login page.'));
             }
             $url = $this->_getUrl('*/*/index', ['_secure' => true]);
@@ -661,7 +661,7 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
                 try {
                     $customer->setConfirmation(null);
                     $customer->save();
-                } catch (Exception $e) {
+                } catch (Exception) {
                     throw new Exception($this->__('Failed to confirm customer account.'));
                 }
 
@@ -838,7 +838,7 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
             $this->_validateResetPasswordLinkToken($customerId, $resetPasswordLinkToken);
             $this->loadLayout();
             $this->renderLayout();
-        } catch (Exception $exception) {
+        } catch (Exception) {
             $this->_getSession()->addError(Mage::helper('customer')->__('Your password reset link has expired.'));
             $this->_redirect('*/*/forgotpassword');
         }
@@ -859,7 +859,7 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
             $this->_validateResetPasswordLinkToken($customerId, $resetPasswordLinkToken);
             $this->_saveRestorePasswordParameters($customerId, $resetPasswordLinkToken)
                 ->_redirect('*/*/changeforgotten');
-        } catch (Exception $exception) {
+        } catch (Exception) {
             $this->_getSession()->addError(Mage::helper('customer')->__('Your password reset link has expired.'));
             $this->_redirect('*/*/forgotpassword');
         }

--- a/app/code/core/Mage/Dataflow/Model/Convert/Container/Abstract.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Container/Abstract.php
@@ -114,7 +114,7 @@ abstract class Mage_Dataflow_Model_Convert_Container_Abstract implements Mage_Da
         if ($this->isSerialized($data)) {
             try {
                 Mage::helper('core/unserializeArray')->unserialize($data);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $result = false;
                 $this->addException(
                     'Invalid data, expecting serialized array.',

--- a/app/code/core/Mage/Dataflow/Model/Convert/Iterator.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Iterator.php
@@ -35,7 +35,7 @@ class Mage_Dataflow_Model_Session_Adapter_Iterator extends Mage_Dataflow_Model_C
         if ($adapterCb = $this->_parseCallback($this->getVar('adapter'), 'saveRow')) {
             $callbacks[] = $adapterCb;
         }
-        $callbacks[] = [$this, 'updateProgress'];
+        $callbacks[] = $this->updateProgress(...);
 
         echo $this->_getProgressBarHtml($sessionId, $total['cnt']);
 

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Csv.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Csv.php
@@ -41,7 +41,7 @@ class Mage_Dataflow_Model_Convert_Parser_Csv extends Mage_Dataflow_Model_Convert
 
         try {
             $adapter = Mage::getModel($adapterName);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $message = Mage::helper('dataflow')
                 ->__('Declared adapter %s was not found.', $adapterName);
             $this->addException($message, Mage_Dataflow_Model_Convert_Exception::FATAL);

--- a/app/code/core/Mage/Dataflow/Model/Convert/Parser/Xml/Excel.php
+++ b/app/code/core/Mage/Dataflow/Model/Convert/Parser/Xml/Excel.php
@@ -38,7 +38,7 @@ class Mage_Dataflow_Model_Convert_Parser_Xml_Excel extends Mage_Dataflow_Model_C
 
         try {
             $adapter = Mage::getModel($adapterName);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $message = Mage::helper('dataflow')->__('Declared adapter %s was not found.', $adapterName);
             $this->addException($message, Mage_Dataflow_Model_Convert_Exception::FATAL);
             return $this;
@@ -193,7 +193,7 @@ class Mage_Dataflow_Model_Convert_Parser_Xml_Excel extends Mage_Dataflow_Model_C
 
         try {
             $xmlElement = new SimpleXMLElement($xml);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $message = 'Invalid XML row';
             $this->addException($message, Mage_Dataflow_Model_Convert_Exception::ERROR);
             return $this;

--- a/app/code/core/Mage/Dataflow/Model/Profile.php
+++ b/app/code/core/Mage/Dataflow/Model/Profile.php
@@ -191,7 +191,7 @@ class Mage_Dataflow_Model_Profile extends Mage_Core_Model_Abstract
                             foreach ($cells as $cell) {
                                 $fileData[] = $this->getNode($cell, 'Data')->item(0)->nodeValue;
                             }
-                        } catch (Exception $e) {
+                        } catch (Exception) {
                             foreach ($newUploadedFilenames as $k => $v) {
                                 unlink($path . $v);
                             }

--- a/app/code/core/Mage/Directory/Api/CountryProvider.php
+++ b/app/code/core/Mage/Directory/Api/CountryProvider.php
@@ -73,7 +73,7 @@ final class CountryProvider extends \Maho\ApiPlatform\Provider
                 $data = null;
             }
             if (is_array($data)) {
-                $countries = array_map(fn(array $c) => $this->arrayToDto($c), $data);
+                $countries = array_map($this->arrayToDto(...), $data);
                 $total = count($countries);
                 return new TraversablePaginator(new \ArrayIterator($countries), 1, max($total, 300), $total);
             }
@@ -98,7 +98,7 @@ final class CountryProvider extends \Maho\ApiPlatform\Provider
         usort($countries, fn($a, $b) => strcmp($a->name, $b->name));
 
         // Cache for 1 hour
-        $cacheData = array_map(fn(Country $c) => $this->dtoToArray($c), $countries);
+        $cacheData = array_map($this->dtoToArray(...), $countries);
         \Mage::app()->getCache()->save(
             (string) \Mage::helper('core')->jsonEncode($cacheData),
             $cacheKey,

--- a/app/code/core/Mage/Downloadable/Helper/File.php
+++ b/app/code/core/Mage/Downloadable/Helper/File.php
@@ -62,7 +62,7 @@ class Mage_Downloadable_Helper_File extends Mage_Core_Helper_Abstract
                         $basePath,
                         $file[0]['file'],
                     );
-                } catch (Exception $e) {
+                } catch (Exception) {
                     Mage::throwException(Mage::helper('downloadable')->__('An error occurred while saving the file(s).'));
                 }
             }
@@ -85,7 +85,7 @@ class Mage_Downloadable_Helper_File extends Mage_Core_Helper_Abstract
         $destDirectory = dirname($this->getFilePath($basePath, $file));
         try {
             $ioObject->open(['path' => $destDirectory]);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $ioObject->mkdir($destDirectory, 0777, true);
             $ioObject->open(['path' => $destDirectory]);
         }

--- a/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/Product/EditController.php
+++ b/app/code/core/Mage/Downloadable/controllers/Adminhtml/Downloadable/Product/EditController.php
@@ -114,7 +114,7 @@ class Mage_Downloadable_Adminhtml_Downloadable_Product_EditController extends Ma
             }
             try {
                 $this->_processDownload($resource, $resourceType);
-            } catch (Mage_Core_Exception $e) {
+            } catch (Mage_Core_Exception) {
                 $this->_getSession()->addError(
                     Mage::helper('downloadable')->__('An error occurred while getting the requested content.'),
                 );

--- a/app/code/core/Mage/Downloadable/controllers/DownloadController.php
+++ b/app/code/core/Mage/Downloadable/controllers/DownloadController.php
@@ -96,7 +96,7 @@ class Mage_Downloadable_DownloadController extends Mage_Core_Controller_Front_Ac
             try {
                 $this->_processDownload($resource, $resourceType);
                 exit(0);
-            } catch (Mage_Core_Exception $e) {
+            } catch (Mage_Core_Exception) {
                 $this->_getSession()->addError(Mage::helper('downloadable')->__('Sorry, there was an error getting requested content. Please contact the store owner.'));
             }
         }
@@ -131,7 +131,7 @@ class Mage_Downloadable_DownloadController extends Mage_Core_Controller_Front_Ac
             try {
                 $this->_processDownload($resource, $resourceType);
                 exit(0);
-            } catch (Mage_Core_Exception $e) {
+            } catch (Mage_Core_Exception) {
                 $this->_getCustomerSession()->addError(Mage::helper('downloadable')->__('Sorry, there was an error getting requested content. Please contact the store owner.'));
             }
         }
@@ -203,7 +203,7 @@ class Mage_Downloadable_DownloadController extends Mage_Core_Controller_Front_Ac
                 }
                 $linkPurchasedItem->save();
                 exit(0);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->_getCustomerSession()->addError(
                     Mage::helper('downloadable')->__('An error occurred while getting the requested content. Please contact the store owner.'),
                 );

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/File.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/File.php
@@ -89,7 +89,7 @@ class Mage_Eav_Model_Attribute_Data_File extends Mage_Eav_Model_Attribute_Data_A
 
         if (!empty($rules['file_extensions'])) {
             $extensions = explode(',', $rules['file_extensions']);
-            $extensions = array_map('trim', $extensions);
+            $extensions = array_map(trim(...), $extensions);
             if (!in_array($extension, $extensions)) {
                 return [
                     Mage::helper('eav')->__('"%s" is not a valid file extension.', $label),

--- a/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
+++ b/app/code/core/Mage/Eav/Model/Attribute/Data/Multiline.php
@@ -22,7 +22,7 @@ class Mage_Eav_Model_Attribute_Data_Multiline extends Mage_Eav_Model_Attribute_D
         if (!is_array($value)) {
             $value = false;
         } else {
-            $value = array_map([$this, '_applyInputFilter'], $value);
+            $value = array_map($this->_applyInputFilter(...), $value);
         }
         return $value;
     }
@@ -115,7 +115,7 @@ class Mage_Eav_Model_Attribute_Data_Multiline extends Mage_Eav_Model_Attribute_D
         if (!is_array($values)) {
             $values = explode("\n", (string) $values);
         }
-        $values = array_map([$this, '_applyOutputFilter'], $values);
+        $values = array_map($this->_applyOutputFilter(...), $values);
         $output = match ($format) {
             Mage_Eav_Model_Attribute_Data::OUTPUT_FORMAT_ARRAY => $values,
             Mage_Eav_Model_Attribute_Data::OUTPUT_FORMAT_HTML => implode('<br>', $values),

--- a/app/code/core/Mage/Eav/Model/Entity/Abstract.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Abstract.php
@@ -529,7 +529,7 @@ abstract class Mage_Eav_Model_Entity_Abstract extends Mage_Core_Model_Resource_A
         }
 
         $this->_sortingSetId = $setId;
-        uasort($attributes, [$this, 'attributesCompare']);
+        uasort($attributes, $this->attributesCompare(...));
         return $attributes;
     }
 

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute.php
@@ -158,7 +158,7 @@ class Mage_Eav_Model_Entity_Attribute extends Mage_Eav_Model_Entity_Attribute_Ab
             try {
                 // Set the normalized value (NumberFormatter::parse returns a float)
                 $this->setDefaultValue((int) $parsedValue);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 throw Mage::exception('Mage_Eav', Mage::helper('eav')->__('Invalid default decimal value'));
             }
         }
@@ -179,7 +179,7 @@ class Mage_Eav_Model_Entity_Attribute extends Mage_Eav_Model_Entity_Attribute_Ab
                     $parsed = DateTime::createFromFormat($format, $defaultValue);
                     $defaultValue = ($parsed !== false ? $parsed : new DateTime($defaultValue))->getTimestamp();
                     $this->setDefaultValue($defaultValue);
-                } catch (Exception $e) {
+                } catch (Exception) {
                     throw Mage::exception('Mage_Eav', Mage::helper('eav')->__('Invalid default date'));
                 }
             }

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Datetime.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Datetime.php
@@ -28,7 +28,7 @@ class Mage_Eav_Model_Entity_Attribute_Backend_Datetime extends Mage_Eav_Model_En
         if (!$_formated && $object->hasData($attributeName)) {
             try {
                 $value = $this->formatDate($object->getData($attributeName));
-            } catch (Exception $e) {
+            } catch (Exception) {
                 throw Mage::exception('Mage_Eav', Mage::helper('eav')->__('Invalid date'));
             }
 
@@ -114,7 +114,7 @@ class Mage_Eav_Model_Entity_Attribute_Backend_Datetime extends Mage_Eav_Model_En
 
             $dateTime = DateTime::createFromFormat($phpFormat, $date);
             return $dateTime ? $dateTime->format(Mage_Core_Model_Locale::DATETIME_FORMAT) : null;
-        } catch (Exception $e) {
+        } catch (Exception) {
             return null;
         }
     }

--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Serialized.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Backend/Serialized.php
@@ -69,7 +69,7 @@ class Mage_Eav_Model_Entity_Attribute_Backend_Serialized extends Mage_Eav_Model_
                 $unserialized = Mage::helper('core/string')
                     ->unserialize($object->getData($attrCode));
                 $object->setData($attrCode, $unserialized);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $object->unsetData($attrCode);
             }
         }

--- a/app/code/core/Mage/GiftMessage/Model/Observer.php
+++ b/app/code/core/Mage/GiftMessage/Model/Observer.php
@@ -105,7 +105,7 @@ class Mage_GiftMessage_Model_Observer extends \Maho\DataObject
                             $giftMessage->delete();
                             $entity->setGiftMessageId(0)
                                 ->save();
-                        } catch (Exception $e) {
+                        } catch (Exception) {
                         }
                     }
                     continue;
@@ -119,7 +119,7 @@ class Mage_GiftMessage_Model_Observer extends \Maho\DataObject
 
                     $entity->setGiftMessageId($giftMessage->getId())
                         ->save();
-                } catch (Exception $e) {
+                } catch (Exception) {
                 }
             }
         }

--- a/app/code/core/Mage/GoogleAnalytics/Block/Metapixel.php
+++ b/app/code/core/Mage/GoogleAnalytics/Block/Metapixel.php
@@ -344,7 +344,7 @@ class Mage_GoogleAnalytics_Block_Metapixel extends Mage_Core_Block_Template
             $options = $source instanceof Mage_Eav_Model_Entity_Attribute_Source_Table
                 ? $source->getAllOptions(false, true)
                 : $source->getAllOptions();
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             return '';
         }
         foreach ($options as $option) {

--- a/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Filter.php
+++ b/app/code/core/Mage/ImportExport/Block/Adminhtml/Export/Filter.php
@@ -214,7 +214,7 @@ class Mage_ImportExport_Block_Adminhtml_Export_Filter extends Mage_Adminhtml_Blo
             'header'         => Mage::helper('importexport')->__('Filter'),
             'sortable'       => false,
             'filter'         => false,
-            'frame_callback' => [$this, 'decorateFilter'],
+            'frame_callback' => $this->decorateFilter(...),
         ]);
 
         if ($this->hasOperation()) {

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Abstract.php
@@ -398,7 +398,7 @@ abstract class Mage_ImportExport_Model_Export_Entity_Abstract
                         }
                     }
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // ignore exceptions connected with source models
             }
         }

--- a/app/code/core/Mage/ImportExport/Model/Export/Entity/Category.php
+++ b/app/code/core/Mage/ImportExport/Model/Export/Entity/Category.php
@@ -154,7 +154,7 @@ class Mage_ImportExport_Model_Export_Entity_Category extends Mage_ImportExport_M
                            ($options[0] === 'Yes' && $options[1] === 'No'))))) {
                         $this->_indexValueAttributes[] = $attribute->getAttributeCode();
                     }
-                } catch (Exception $e) {
+                } catch (Exception) {
                     // Skip attributes that can't provide options
                     continue;
                 }

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Abstract.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Abstract.php
@@ -350,7 +350,7 @@ abstract class Mage_ImportExport_Model_Import_Entity_Abstract
                         }
                     }
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // ignore exceptions connected with source models
             }
         }

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Category.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Category.php
@@ -614,7 +614,7 @@ class Mage_ImportExport_Model_Import_Entity_Category extends Mage_ImportExport_M
                 if (isset($options[$value])) {
                     return $options[$value];
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // If we can't get options, return the original value
             }
         }

--- a/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
+++ b/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php
@@ -1688,7 +1688,7 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
         try {
             $res = $this->_getUploader()->move($fileName);
             return $res['file'];
-        } catch (Exception $e) {
+        } catch (Exception) {
             return '';
         }
     }
@@ -1762,7 +1762,7 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
                 try {
                     $this->_connection
                             ->insertOnDuplicate($mediaValueTableName, $valueArr, ['value_id']);
-                } catch (Exception $e) {
+                } catch (Exception) {
                     $this->_connection->delete(
                         $mediaGalleryTableName,
                         $this->_connection->quoteInto('value_id IN (?)', $newMediaValues),

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Mysql.php
@@ -85,7 +85,7 @@ class Mage_ImportExport_Model_Resource_Helper_Mysql extends Mage_Core_Model_Reso
         if (!self::$instantInformationSchemaStatsExpiry) {
             try {
                 $this->_getReadAdapter()->query('SET information_schema_stats_expiry = 0;');
-            } catch (Exception $e) {
+            } catch (Exception) {
             }
             self::$instantInformationSchemaStatsExpiry = true;
         }

--- a/app/code/core/Mage/ImportExport/Model/Resource/Helper/Sqlite.php
+++ b/app/code/core/Mage/ImportExport/Model/Resource/Helper/Sqlite.php
@@ -48,7 +48,7 @@ class Mage_ImportExport_Model_Resource_Helper_Sqlite extends Mage_Core_Model_Res
             if ($result !== false) {
                 return (int) $result + 1;
             }
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // sqlite_sequence might not exist if AUTOINCREMENT hasn't been used
         }
 

--- a/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
+++ b/app/code/core/Mage/Index/Block/Adminhtml/Process/Grid.php
@@ -117,7 +117,7 @@ class Mage_Index_Block_Adminhtml_Process_Grid extends Mage_Adminhtml_Block_Widge
             'index'     => 'status',
             'type'      => 'options',
             'options'   => $this->_processModel->getStatusesOptions(),
-            'frame_callback' => [$this, 'decorateStatus'],
+            'frame_callback' => $this->decorateStatus(...),
         ]);
 
         $this->addColumn('update_required', [
@@ -128,7 +128,7 @@ class Mage_Index_Block_Adminhtml_Process_Grid extends Mage_Adminhtml_Block_Widge
             'index'     => 'update_required',
             'type'      => 'options',
             'options'   => $this->_processModel->getUpdateRequiredOptions(),
-            'frame_callback' => [$this, 'decorateUpdateRequired'],
+            'frame_callback' => $this->decorateUpdateRequired(...),
         ]);
 
         $this->addColumn('ended_at', [
@@ -136,7 +136,7 @@ class Mage_Index_Block_Adminhtml_Process_Grid extends Mage_Adminhtml_Block_Widge
             'type'      => 'datetime',
             'align'     => 'left',
             'index'     => 'ended_at',
-            'frame_callback' => [$this, 'decorateDate'],
+            'frame_callback' => $this->decorateDate(...),
         ]);
 
         $this->addColumn(

--- a/app/code/core/Mage/Index/Model/Indexer/Abstract.php
+++ b/app/code/core/Mage/Index/Model/Indexer/Abstract.php
@@ -215,12 +215,9 @@ abstract class Mage_Index_Model_Indexer_Abstract extends Mage_Core_Model_Abstrac
         } elseif ($this->matchEntityAndType(Mage_Catalog_Model_Product::ENTITY, Mage_Index_Model_Event::TYPE_MASS_ACTION)) {
             // Create comprehensive mass action data object that all indexers expect
             $actionObject = new class ($entityIds) extends \Maho\DataObject {
-                private array $productIds;
-
-                public function __construct(array $productIds)
+                public function __construct(private array $productIds)
                 {
                     parent::__construct();
-                    $this->productIds = $productIds;
                 }
 
                 public function getProductIds(): array

--- a/app/code/core/Mage/Index/Model/Process.php
+++ b/app/code/core/Mage/Index/Model/Process.php
@@ -244,7 +244,7 @@ class Mage_Index_Model_Process extends Mage_Core_Model_Abstract
 
         try {
             $this->getIndexer()->processEvent($event);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $isError = true;
         }
         $event->resetData();
@@ -352,7 +352,7 @@ class Mage_Index_Model_Process extends Mage_Core_Model_Abstract
                         $event->addProcessId($this->getId());
                     }
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $event->addProcessId($this->getId(), self::EVENT_STATUS_ERROR);
             }
             $event->save();

--- a/app/code/core/Mage/Index/Model/Progress.php
+++ b/app/code/core/Mage/Index/Model/Progress.php
@@ -42,7 +42,8 @@ class Mage_Index_Model_Progress
     /**
      * @throws Mage_Core_Exception when the token is not one we generated
      */
-    public function setToken(string $token): self
+    public function setToken(#[\SensitiveParameter]
+        string $token): self
     {
         // Reaches us straight from the request and ends up in a file path
         if (!preg_match(self::TOKEN_PATTERN, $token)) {

--- a/app/code/core/Mage/Index/Model/Runner.php
+++ b/app/code/core/Mage/Index/Model/Runner.php
@@ -18,7 +18,8 @@ class Mage_Index_Model_Runner
      * still alive", which is what the poller needs. Scoped to the run, otherwise a later run
      * rebuilding the same index would keep a dead run's dialog spinning.
      */
-    public static function lockName(string $token, string $code): string
+    public static function lockName(#[\SensitiveParameter]
+        string $token, string $code): string
     {
         return 'index_run_' . $token . '_' . $code;
     }

--- a/app/code/core/Mage/Install/Helper/Data.php
+++ b/app/code/core/Mage/Install/Helper/Data.php
@@ -77,7 +77,7 @@ class Mage_Install_Helper_Data extends Mage_Core_Helper_Abstract
             $process->setTimeout(10);
             $process->run();
             return $process->isSuccessful();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
     }

--- a/app/code/core/Mage/Install/Model/Installer.php
+++ b/app/code/core/Mage/Install/Model/Installer.php
@@ -67,7 +67,7 @@ class Mage_Install_Model_Installer extends Maho\DataObject
 
             Mage::getModel('install/installer_env')->install();
             $result = true;
-        } catch (Exception $e) {
+        } catch (Exception) {
             $result = false;
         }
         $this->setData('server_check_status', $result);

--- a/app/code/core/Mage/Install/Model/Installer/SampleData.php
+++ b/app/code/core/Mage/Install/Model/Installer/SampleData.php
@@ -335,7 +335,7 @@ class Mage_Install_Model_Installer_SampleData
             }
 
             fclose($handle);
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Non-critical, continue installation
         }
     }
@@ -446,7 +446,7 @@ class Mage_Install_Model_Installer_SampleData
     {
         // Split SQL into individual statements
         $statements = preg_split('/;\s*$/m', $sql);
-        $statements = array_filter(array_map('trim', $statements));
+        $statements = array_filter(array_map(trim(...), $statements));
         $total = count($statements);
         $current = 0;
 

--- a/app/code/core/Mage/Log/Model/Visitor.php
+++ b/app/code/core/Mage/Log/Model/Visitor.php
@@ -103,7 +103,7 @@ class Mage_Log_Model_Visitor extends Mage_Core_Model_Abstract
             $ignoreAgents = $ignoreAgents->asArray();
             $userAgent = $this->_httpHelper->getHttpUserAgent();
             foreach ($ignoreAgents as $ignoreAgent) {
-                if (stripos($userAgent, $ignoreAgent) !== false) {
+                if (stripos($userAgent, (string) $ignoreAgent) !== false) {
                     $this->_skipRequestLogging = true;
                     break;
                 }

--- a/app/code/core/Mage/Newsletter/Model/Resource/Subscriber.php
+++ b/app/code/core/Mage/Newsletter/Model/Resource/Subscriber.php
@@ -172,7 +172,7 @@ class Mage_Newsletter_Model_Resource_Subscriber extends Mage_Core_Model_Resource
                 'queue_id = ?' => $queue->getId(),
             ]);
             $this->_write->commit();
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_write->rollBack();
             Mage::throwException(Mage::helper('newsletter')->__('Cannot mark as received subscriber.'));
         }

--- a/app/code/core/Mage/Newsletter/Model/Template.php
+++ b/app/code/core/Mage/Newsletter/Model/Template.php
@@ -190,8 +190,8 @@ class Mage_Newsletter_Model_Template extends Mage_Core_Model_Email_Template_Abst
         $variables = $this->_addEmailVariables($variables, $processor->getStoreId());
 
         $processor
-            ->setTemplateProcessor([$this, 'getTemplateByConfigPath'])
-            ->setIncludeProcessor([$this, 'getInclude'])
+            ->setTemplateProcessor($this->getTemplateByConfigPath(...))
+            ->setIncludeProcessor($this->getInclude(...))
             ->setVariables($variables);
 
         // Filter the template text so that all HTML content will be present

--- a/app/code/core/Mage/Newsletter/controllers/ManageController.php
+++ b/app/code/core/Mage/Newsletter/controllers/ManageController.php
@@ -60,7 +60,7 @@ class Mage_Newsletter_ManageController extends Mage_Core_Controller_Front_Action
             } else {
                 Mage::getSingleton('customer/session')->addSuccess($this->__('The subscription has been removed.'));
             }
-        } catch (Exception $e) {
+        } catch (Exception) {
             Mage::getSingleton('customer/session')->addError($this->__('An error occurred while saving your subscription.'));
         }
         $this->_redirect('customer/account/');

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens/Grid.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/AuthorizedTokens/Grid.php
@@ -64,13 +64,13 @@ class Mage_Oauth_Block_Adminhtml_Oauth_AuthorizedTokens_Grid extends Mage_Adminh
             'header'    => $this->__('User Type'),
             //'index'     => array('customer_id', 'admin_id'),
             'options'   => [0 => $this->__('Admin'), 1 => $this->__('Customer')],
-            'frame_callback' => [$this, 'decorateUserType'],
+            'frame_callback' => $this->decorateUserType(...),
         ]);
 
         $this->addColumn('user_id', [
             'header'    => $this->__('User ID'),
             //'index'     => array('customer_id', 'admin_id'),
-            'frame_callback' => [$this, 'decorateUserId'],
+            'frame_callback' => $this->decorateUserId(...),
         ]);
 
         /** @var Mage_Adminhtml_Model_System_Config_Source_Yesno $sourceYesNo */

--- a/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Grid.php
+++ b/app/code/core/Mage/Oauth/Block/Adminhtml/Oauth/Consumer/Grid.php
@@ -57,7 +57,7 @@ class Mage_Oauth_Block_Adminhtml_Oauth_Consumer_Grid extends Mage_Adminhtml_Bloc
             'width' => '100px',
             'sortable' => false,
             'filter' => false,
-            'frame_callback' => [$this, 'decorateProtocol'],
+            'frame_callback' => $this->decorateProtocol(...),
         ]);
 
         $this->addColumn('admin_api', [
@@ -66,7 +66,7 @@ class Mage_Oauth_Block_Adminhtml_Oauth_Consumer_Grid extends Mage_Adminhtml_Bloc
             'width' => '150px',
             'sortable' => false,
             'filter' => false,
-            'frame_callback' => [$this, 'decorateApiRole'],
+            'frame_callback' => $this->decorateApiRole(...),
         ]);
 
         $this->addColumn('last_used_at', [

--- a/app/code/core/Mage/Oauth/Helper/Data.php
+++ b/app/code/core/Mage/Oauth/Helper/Data.php
@@ -121,7 +121,8 @@ class Mage_Oauth_Helper_Data extends Mage_Core_Helper_Abstract
      * @param bool $rejected OPTIONAL Add user reject sign
      * @return bool|string
      */
-    public function getFullCallbackUrl(Mage_Oauth_Model_Token $token, $rejected = false)
+    public function getFullCallbackUrl(#[\SensitiveParameter]
+        Mage_Oauth_Model_Token $token, $rejected = false)
     {
         $callbackUrl = $token->getCallbackUrl();
 

--- a/app/code/core/Mage/Oauth/Model/Server.php
+++ b/app/code/core/Mage/Oauth/Model/Server.php
@@ -716,7 +716,7 @@ class Mage_Oauth_Model_Server
         $pairs = [];
 
         // Sort by key using natural comparison
-        uksort($params, 'strnatcmp');
+        uksort($params, strnatcmp(...));
 
         foreach ($params as $key => $value) {
             if (is_array($value)) {

--- a/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
+++ b/app/code/core/Mage/Oauth/controllers/Adminhtml/Oauth/AuthorizedTokensController.php
@@ -152,7 +152,8 @@ class Mage_Oauth_Adminhtml_Oauth_AuthorizedTokensController extends Mage_Adminht
      * @param Mage_Oauth_Model_Token $token Token object
      * @param string $newStatus Name of new token status
      */
-    protected function _sendTokenStatusChangeNotification($token, $newStatus)
+    protected function _sendTokenStatusChangeNotification(#[\SensitiveParameter]
+        $token, $newStatus)
     {
         if (($adminId = $token->getAdminId())) {
             /** @var Mage_Admin_Model_Session $session */

--- a/app/code/core/Mage/Paygate/Helper/Data.php
+++ b/app/code/core/Mage/Paygate/Helper/Data.php
@@ -105,7 +105,7 @@ class Mage_Paygate_Helper_Data extends Mage_Core_Helper_Abstract
         $pattern .= ' %s';
         $texts[] = $exception;
 
-        return call_user_func_array([$this, '__'], array_merge([$pattern], $texts));
+        return call_user_func_array($this->__(...), array_merge([$pattern], $texts));
     }
 
     /**

--- a/app/code/core/Mage/Payment/Helper/Data.php
+++ b/app/code/core/Mage/Payment/Helper/Data.php
@@ -75,7 +75,7 @@ class Mage_Payment_Helper_Data extends Mage_Core_Helper_Abstract
             $res[] = $methodInstance;
         }
 
-        usort($res, [$this, '_sortMethods']);
+        usort($res, $this->_sortMethods(...));
         return $res;
     }
 

--- a/app/code/core/Mage/Payment/Model/Restriction.php
+++ b/app/code/core/Mage/Payment/Model/Restriction.php
@@ -46,7 +46,7 @@ class Mage_Payment_Model_Restriction extends Mage_Core_Model_Abstract
             // Check if this restriction applies to the payment method
             $paymentMethods = $restriction->getPaymentMethods();
             if ($paymentMethods && !empty(trim($paymentMethods))) {
-                $methodCodes = array_map('trim', explode(',', $paymentMethods));
+                $methodCodes = array_map(trim(...), explode(',', $paymentMethods));
                 if (!in_array($paymentMethodCode, $methodCodes)) {
                     continue; // This restriction doesn't apply to this payment method
                 }
@@ -100,7 +100,7 @@ class Mage_Payment_Model_Restriction extends Mage_Core_Model_Abstract
 
         // Website restriction
         if ($restriction->getWebsites() && $quote) {
-            $websiteIds = array_map('trim', explode(',', $restriction->getWebsites()));
+            $websiteIds = array_map(trim(...), explode(',', $restriction->getWebsites()));
             $storeWebsiteId = Mage::app()->getStore($quote->getStoreId())->getWebsiteId();
             if (!in_array($storeWebsiteId, $websiteIds)) {
                 return false;
@@ -109,12 +109,12 @@ class Mage_Payment_Model_Restriction extends Mage_Core_Model_Abstract
 
         // Customer group restriction
         if ($restriction->getCustomerGroups() && $customer) {
-            $customerGroupIds = array_map('trim', explode(',', $restriction->getCustomerGroups()));
+            $customerGroupIds = array_map(trim(...), explode(',', $restriction->getCustomerGroups()));
             if (!in_array($customer->getGroupId(), $customerGroupIds)) {
                 return false;
             }
         } elseif ($restriction->getCustomerGroups() && $quote) {
-            $customerGroupIds = array_map('trim', explode(',', $restriction->getCustomerGroups()));
+            $customerGroupIds = array_map(trim(...), explode(',', $restriction->getCustomerGroups()));
             if (!in_array($quote->getCustomerGroupId(), $customerGroupIds)) {
                 return false;
             }

--- a/app/code/core/Mage/Payment/Model/Restriction/Rule.php
+++ b/app/code/core/Mage/Payment/Model/Restriction/Rule.php
@@ -88,7 +88,7 @@ class Mage_Payment_Model_Restriction_Rule extends Mage_Rule_Model_Abstract
             // Check if this restriction applies to the payment method
             $paymentMethods = $restriction->getPaymentMethods();
             if ($paymentMethods && !empty(trim($paymentMethods))) {
-                $methodCodes = array_map('trim', explode(',', $paymentMethods));
+                $methodCodes = array_map(trim(...), explode(',', $paymentMethods));
                 if (!in_array($paymentMethodCode, $methodCodes)) {
                     continue; // This restriction doesn't apply to this payment method
                 }

--- a/app/code/core/Mage/Rating/Model/Resource/Rating.php
+++ b/app/code/core/Mage/Rating/Model/Resource/Rating.php
@@ -127,7 +127,7 @@ class Mage_Rating_Model_Resource_Rating extends Mage_Core_Model_Resource_Db_Abst
                     ->from($ratingTitleTable, ['store_id', 'value'])
                     ->where('rating_id = :rating_id');
                 $old    = $adapter->fetchPairs($select, [':rating_id' => $ratingId]);
-                $new    = array_filter(array_map('trim', $object->getRatingCodes()));
+                $new    = array_filter(array_map(trim(...), $object->getRatingCodes()));
 
                 $insert = array_diff_assoc($new, $old);
                 $delete = array_diff_assoc($old, $new);

--- a/app/code/core/Mage/Reports/Block/Product/Widget/Bestsellers.php
+++ b/app/code/core/Mage/Reports/Block/Product/Widget/Bestsellers.php
@@ -84,7 +84,7 @@ class Mage_Reports_Block_Product_Widget_Bestsellers extends Mage_Catalog_Block_P
                 ->where('o.created_at <= ?', $to);
         }
 
-        return array_map('intval', $adapter->fetchCol($select));
+        return array_map(intval(...), $adapter->fetchCol($select));
     }
 
     /**

--- a/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Report/Abstract.php
@@ -204,7 +204,7 @@ abstract class Mage_Reports_Model_Resource_Report_Abstract extends Mage_Core_Mod
                 while ($date = $query->fetchColumn()) {
                     $selectResult[] = $date;
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $selectResult = false;
             }
             $selectResultCache[$cacheKey] = $selectResult;

--- a/app/code/core/Mage/Review/Api/Review.php
+++ b/app/code/core/Mage/Review/Api/Review.php
@@ -221,6 +221,6 @@ class Review extends CrudResource
                 ->where('review_id = ?', (int) $model->getId());
             $stores = $read->fetchCol($select);
         }
-        $dto->stores = array_map('intval', $stores);
+        $dto->stores = array_map(intval(...), $stores);
     }
 }

--- a/app/code/core/Mage/Review/Api/ReviewProcessor.php
+++ b/app/code/core/Mage/Review/Api/ReviewProcessor.php
@@ -96,7 +96,7 @@ final class ReviewProcessor extends \Maho\ApiPlatform\Processor
         // only a review with no real store assignment counts as all-stores.
         $user = $this->requireUser();
         $reviewStoreIds = array_values(array_filter(
-            array_map('intval', (array) $review->getStores()),
+            array_map(intval(...), (array) $review->getStores()),
             static fn(int $id): bool => $id !== 0,
         ));
         $this->validateEntityStoreAccess($reviewStoreIds === [] ? [0] : $reviewStoreIds, $user, 'review');
@@ -134,7 +134,7 @@ final class ReviewProcessor extends \Maho\ApiPlatform\Processor
     private function resolveModerationStores(array $stores, ApiUser $user): array
     {
         try {
-            return $this->resolveStoreIds(array_map('strval', $stores), $user);
+            return $this->resolveStoreIds(array_map(strval(...), $stores), $user);
         } catch (\Mage_Core_Model_Store_Exception) {
             throw new BadRequestHttpException('stores contains an unknown store');
         }

--- a/app/code/core/Mage/Review/Api/ReviewProvider.php
+++ b/app/code/core/Mage/Review/Api/ReviewProvider.php
@@ -132,13 +132,13 @@ final class ReviewProvider extends CrudProvider
                 return new TraversablePaginator(new \ArrayIterator($reviews), $page, $pageSize, $total);
             },
             serialize: fn(TraversablePaginator $result): array => [
-                'reviews' => array_map(fn(Review $r) => $this->reviewDtoToArray($r), iterator_to_array($result)),
+                'reviews' => array_map($this->reviewDtoToArray(...), iterator_to_array($result)),
                 'page' => (int) $result->getCurrentPage(),
                 'pageSize' => (int) $result->getItemsPerPage(),
                 'total' => (int) $result->getTotalItems(),
             ],
             deserialize: fn(array $data): TraversablePaginator => new TraversablePaginator(
-                new \ArrayIterator(array_map(fn(array $r) => $this->arrayToReviewDto($r), $data['reviews'])),
+                new \ArrayIterator(array_map($this->arrayToReviewDto(...), $data['reviews'])),
                 $data['page'],
                 $data['pageSize'],
                 $data['total'],
@@ -262,7 +262,7 @@ final class ReviewProvider extends CrudProvider
         // tokens bypass the current-store check but a store-restricted one
         // still only sees reviews assigned to at least one allowed store.
         $storeIds = array_values(array_filter(
-            array_map('intval', (array) $review->getStores()),
+            array_map(intval(...), (array) $review->getStores()),
             static fn(int $id): bool => $id !== 0,
         ));
         if ($checkVisibility && !$this->isAdmin() && $storeIds !== []) {

--- a/app/code/core/Mage/Review/Model/Resource/Review.php
+++ b/app/code/core/Mage/Review/Model/Resource/Review.php
@@ -348,7 +348,7 @@ class Mage_Review_Model_Resource_Review extends Mage_Core_Model_Resource_Db_Abst
                     $writeAdapter->insert($this->_aggregateTable, $data->getData());
                 }
                 $writeAdapter->commit();
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $writeAdapter->rollBack();
             }
         }

--- a/app/code/core/Mage/Review/controllers/ProductController.php
+++ b/app/code/core/Mage/Review/controllers/ProductController.php
@@ -148,7 +148,7 @@ class Mage_Review_ProductController extends Mage_Core_Controller_Front_Action
 
                     $review->aggregate();
                     $session->addSuccess($this->__('Your review has been accepted for moderation.'));
-                } catch (Exception $e) {
+                } catch (Exception) {
                     $session->setFormData($data);
                     $session->addError($this->__('Unable to post the review.'));
                 }

--- a/app/code/core/Mage/Rss/Block/Catalog/New.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/New.php
@@ -84,7 +84,7 @@ class Mage_Rss_Block_Catalog_New extends Mage_Rss_Block_Catalog_Abstract
         */
         Mage::getSingleton('core/resource_iterator')->walk(
             $products->getSelect(),
-            [[$this, 'addNewItemXmlCallback']],
+            [$this->addNewItemXmlCallback(...)],
             ['rssObj' => $rssObj, 'product' => $product],
         );
 

--- a/app/code/core/Mage/Rss/Block/Catalog/NotifyStock.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/NotifyStock.php
@@ -76,7 +76,7 @@ class Mage_Rss_Block_Catalog_NotifyStock extends Mage_Rss_Block_Abstract
         */
         Mage::getSingleton('core/resource_iterator')->walk(
             $collection->getSelect(),
-            [[$this, 'addNotifyItemXmlCallback']],
+            [$this->addNotifyItemXmlCallback(...)],
             ['rssObj' => $rssObj, 'product' => $product, 'globalQty' => $globalNotifyStockQty],
         );
 

--- a/app/code/core/Mage/Rss/Block/Catalog/Review.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Review.php
@@ -63,7 +63,7 @@ class Mage_Rss_Block_Catalog_Review extends Mage_Rss_Block_Abstract
 
         Mage::getSingleton('core/resource_iterator')->walk(
             $collection->getSelect(),
-            [[$this, 'addReviewItemXmlCallback']],
+            [$this->addReviewItemXmlCallback(...)],
             ['rssObj' => $rssObj, 'reviewModel' => $reviewModel],
         );
         return $rssObj->createRssXml();

--- a/app/code/core/Mage/Rss/Block/Catalog/Special.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Special.php
@@ -88,7 +88,7 @@ class Mage_Rss_Block_Catalog_Special extends Mage_Rss_Block_Catalog_Abstract
         */
         Mage::getSingleton('core/resource_iterator')->walk(
             $specials->getSelect(),
-            [[$this, 'addSpecialXmlCallback']],
+            [$this->addSpecialXmlCallback(...)],
             ['rssObj' => $rssObj, 'results' => &$results],
         );
 

--- a/app/code/core/Mage/Rss/Block/Catalog/Tag.php
+++ b/app/code/core/Mage/Rss/Block/Catalog/Tag.php
@@ -57,7 +57,7 @@ class Mage_Rss_Block_Catalog_Tag extends Mage_Rss_Block_Catalog_Abstract
         $resourceHelper = Mage::getResourceHelper('core');
         Mage::getSingleton('core/resource_iterator')->walk(
             $resourceHelper->getQueryUsingAnalyticFunction($collection->getSelect()),
-            [[$this, 'addTaggedItemXml']],
+            [$this->addTaggedItemXml(...)],
             ['rssObj' => $rssObj, 'product' => $product],
             $collection->getSelect()->getAdapter(),
         );

--- a/app/code/core/Mage/Rss/Block/Order/New.php
+++ b/app/code/core/Mage/Rss/Block/Order/New.php
@@ -67,7 +67,7 @@ class Mage_Rss_Block_Order_New extends Mage_Core_Block_Template
         Mage::dispatchEvent('rss_order_new_collection_select', ['collection' => $collection]);
 
         Mage::getSingleton('core/resource_iterator')
-            ->walk($collection->getSelect(), [[$this, 'addNewOrderXmlCallback']], ['rssObj' => $rssObj, 'order' => $order , 'detailBlock' => $detailBlock]);
+            ->walk($collection->getSelect(), [$this->addNewOrderXmlCallback(...)], ['rssObj' => $rssObj, 'order' => $order , 'detailBlock' => $detailBlock]);
 
         return $rssObj->createRssXml();
     }

--- a/app/code/core/Mage/Rule/Model/Condition/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Abstract.php
@@ -738,7 +738,7 @@ abstract class Mage_Rule_Model_Condition_Abstract extends \Maho\DataObject imple
             case '!{}':
                 if (is_scalar($validatedValue) && is_array($value)) {
                     foreach ($value as $item) {
-                        if (stripos($validatedValue, $item) !== false) {
+                        if (stripos($validatedValue, (string) $item) !== false) {
                             $result = true;
                             break;
                         }

--- a/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
+++ b/app/code/core/Mage/Rule/Model/Condition/Product/Abstract.php
@@ -79,8 +79,8 @@ abstract class Mage_Rule_Model_Condition_Product_Abstract extends Mage_Rule_Mode
             $value = explode(',', $value);
         }
 
-        $value = array_map('trim', $value);
-        $value = array_filter($value, 'is_numeric');
+        $value = array_map(trim(...), $value);
+        $value = array_filter($value, is_numeric(...));
 
         return $value;
     }
@@ -139,7 +139,7 @@ abstract class Mage_Rule_Model_Condition_Product_Abstract extends Mage_Rule_Mode
         try {
             $obj = Mage::getSingleton('eav/config')
                 ->getAttribute(Mage_Catalog_Model_Product::ENTITY, $this->getAttribute());
-        } catch (Exception $e) {
+        } catch (Exception) {
             $obj = new \Maho\DataObject();
             $obj->setEntity(Mage::getResourceSingleton('catalog/product'))
                 ->setFrontendInput('text');

--- a/app/code/core/Mage/Sales/Api/AccountTokenService.php
+++ b/app/code/core/Mage/Sales/Api/AccountTokenService.php
@@ -44,7 +44,8 @@ final class AccountTokenService
      *
      * @throws \Mage_Core_Exception on invalid or expired tokens
      */
-    public static function verify(string $token, int $maxAgeSeconds = 86400): array
+    public static function verify(#[\SensitiveParameter]
+        string $token, int $maxAgeSeconds = 86400): array
     {
         $parts = explode('.', $token, 2);
         if (count($parts) !== 2) {

--- a/app/code/core/Mage/Sales/Api/GraphQL/OrderMutationHandler.php
+++ b/app/code/core/Mage/Sales/Api/GraphQL/OrderMutationHandler.php
@@ -29,14 +29,7 @@ class OrderMutationHandler
 {
     use AdminQuoteTrait;
 
-    private OrderService $orderService;
-    private OrderProvider $orderProvider;
-
-    public function __construct(OrderService $orderService, OrderProvider $orderProvider)
-    {
-        $this->orderService = $orderService;
-        $this->orderProvider = $orderProvider;
-    }
+    public function __construct(private OrderService $orderService, private OrderProvider $orderProvider) {}
 
     /**
      * Handle placeOrder mutation

--- a/app/code/core/Mage/Sales/Api/OrderProvider.php
+++ b/app/code/core/Mage/Sales/Api/OrderProvider.php
@@ -366,7 +366,7 @@ final class OrderProvider extends \Maho\ApiPlatform\Provider
             if (!$isCollectionOrder) {
                 try {
                     $dto->paymentMethodTitle = $payment->getMethodInstance()->getTitle();
-                } catch (\Exception $e) {
+                } catch (\Exception) {
                     $dto->paymentMethodTitle = $payment->getMethod();
                 }
             } else {
@@ -523,8 +523,8 @@ final class OrderProvider extends \Maho\ApiPlatform\Provider
         }
 
         return array_values(array_map(
-            'intval',
-            array_filter(array_map('trim', explode(',', $ruleIds)), fn(string $id): bool => $id !== ''),
+            intval(...),
+            array_filter(array_map(trim(...), explode(',', $ruleIds)), fn(string $id): bool => $id !== ''),
         ));
     }
 

--- a/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Default.php
+++ b/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Default.php
@@ -111,7 +111,7 @@ class Mage_Sales_Block_Order_Item_Renderer_Default extends Mage_Core_Block_Templ
                 try {
                     $group = Mage::getModel('catalog/product_option')->groupFactory($optionInfo['option_type']);
                     return ['value' => $group->getCustomizedView($optionInfo)];
-                } catch (Exception $e) {
+                } catch (Exception) {
                     return $_default;
                 }
             }

--- a/app/code/core/Mage/Sales/Model/Config/Ordered.php
+++ b/app/code/core/Mage/Sales/Model/Config/Ordered.php
@@ -116,7 +116,7 @@ abstract class Mage_Sales_Model_Config_Ordered extends Mage_Core_Model_Config_Ba
         reset($configArray);
         $element = current($configArray);
         if (isset($element['sort_order'])) {
-            uasort($configArray, [$this, '_compareSortOrder']);
+            uasort($configArray, $this->_compareSortOrder(...));
         } else {
             foreach ($configArray as $code => $data) {
                 foreach ($data['before'] as $beforeCode) {
@@ -150,7 +150,7 @@ abstract class Mage_Sales_Model_Config_Ordered extends Mage_Core_Model_Config_Ba
                     $configArray[$afterCode]['before'] = array_unique($configArray[$afterCode]['before']);
                 }
             }
-            uasort($configArray, [$this, '_compareTotals']);
+            uasort($configArray, $this->_compareTotals(...));
         }
         $sortedCollectors = array_keys($configArray);
         if (Mage::app()->useCache('config')) {

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Api.php
@@ -161,7 +161,7 @@ class Mage_Sales_Model_Order_Creditmemo_Api extends Mage_Sales_Model_Api_Resourc
         }
         try {
             $creditmemo->cancel()->save();
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_fault('status_not_changed', Mage::helper('sales')->__('Credit memo canceling problem.'));
         }
 

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Api.php
@@ -209,7 +209,7 @@ class Mage_Sales_Model_Order_Invoice_Api extends Mage_Sales_Model_Api_Resource
                 ->save();
         } catch (Mage_Core_Exception $e) {
             $this->_fault('status_not_changed', $e->getMessage());
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_fault('status_not_changed', Mage::helper('sales')->__('Invoice capturing problem.'));
         }
 
@@ -246,7 +246,7 @@ class Mage_Sales_Model_Order_Invoice_Api extends Mage_Sales_Model_Api_Resource
                 ->save();
         } catch (Mage_Core_Exception $e) {
             $this->_fault('status_not_changed', $e->getMessage());
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_fault('status_not_changed', Mage::helper('sales')->__('Invoice void problem'));
         }
 
@@ -282,7 +282,7 @@ class Mage_Sales_Model_Order_Invoice_Api extends Mage_Sales_Model_Api_Resource
                 ->save();
         } catch (Mage_Core_Exception $e) {
             $this->_fault('status_not_changed', $e->getMessage());
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_fault('status_not_changed', Mage::helper('sales')->__('Invoice canceling problem.'));
         }
 

--- a/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment/Transaction.php
@@ -352,7 +352,7 @@ class Mage_Sales_Model_Order_Payment_Transaction extends Mage_Core_Model_Abstrac
                 return false;
             }
             return true;
-        } catch (Mage_Core_Exception $e) {
+        } catch (Mage_Core_Exception) {
             // jam all logical exceptions, fallback to false
         }
         return false;

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Abstract.php
@@ -197,7 +197,7 @@ abstract class Mage_Sales_Model_Order_Pdf_Abstract extends \Maho\DataObject
     protected function _getTotalsList(Mage_Sales_Model_Abstract $source): array
     {
         $totals = Mage::getConfig()->getNode('global/pdf/totals')->asArray();
-        usort($totals, [$this, '_sortTotalsList']);
+        usort($totals, $this->_sortTotalsList(...));
         $totalModels = [];
         foreach ($totals as $index => $totalInfo) {
             if (!empty($totalInfo['model'])) {

--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -821,7 +821,7 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
                 $rates[$rate->getCarrier()][0]->carrier_sort_order = $rate->getCarrierInstance()->getSortOrder();
             }
         }
-        uasort($rates, [$this, '_sortRates']);
+        uasort($rates, $this->_sortRates(...));
         return $rates;
     }
 
@@ -1148,7 +1148,7 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
         }
         try {
             $return = Mage::helper('core/unserializeArray')->unserialize($tax);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $return = [];
         }
         return $return;

--- a/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php
@@ -407,7 +407,7 @@ abstract class Mage_Sales_Model_Quote_Item_Abstract extends Mage_Core_Model_Abst
                 ->setMessage($e->getMessage());
             $this->getQuote()->setHasError(true)
                 ->addMessage(Mage::helper('sales')->__('Some of the products below do not have all the required options.'));
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->setHasError(true)
                 ->setMessage(Mage::helper('sales')->__('Item options declaration error.'));
             $this->getQuote()->setHasError(true)

--- a/app/code/core/Mage/Sales/Model/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Payment.php
@@ -162,7 +162,7 @@ class Mage_Sales_Model_Quote_Payment extends Mage_Payment_Model_Info
         }
         try {
             $method = $this->getMethodInstance();
-        } catch (Mage_Core_Exception $e) {
+        } catch (Mage_Core_Exception) {
             return parent::_beforeSave();
         }
         $method->prepareSave();

--- a/app/code/core/Mage/Sales/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Setup.php
@@ -60,7 +60,7 @@ class Mage_Sales_Model_Resource_Setup extends Mage_Eav_Model_Entity_Setup
     protected function _flatTableExist($table)
     {
         $tablesList = $this->getConnection()->listTables();
-        return in_array(strtoupper($this->getTable($table)), array_map('strtoupper', $tablesList));
+        return in_array(strtoupper($this->getTable($table)), array_map(strtoupper(...), $tablesList));
     }
 
     /**

--- a/app/code/core/Mage/Sales/Model/Service/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Service/Quote.php
@@ -144,8 +144,8 @@ class Mage_Sales_Model_Service_Quote
         $order->setQuote($quote);
 
         $transaction->addObject($order);
-        $transaction->addCommitCallback([$order, 'place']);
-        $transaction->addCommitCallback([$order, 'save']);
+        $transaction->addCommitCallback($order->place(...));
+        $transaction->addCommitCallback($order->save(...));
 
         Mage::unregister('current_order');
         Mage::register('current_order', $order);

--- a/app/code/core/Mage/Sales/controllers/DownloadController.php
+++ b/app/code/core/Mage/Sales/controllers/DownloadController.php
@@ -37,7 +37,7 @@ class Mage_Sales_DownloadController extends Mage_Core_Controller_Front_Action
                 'value' => $filePath,
                 'type'  => 'filename',
             ]);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_forward('noRoute');
         }
     }
@@ -94,7 +94,7 @@ class Mage_Sales_DownloadController extends Mage_Core_Controller_Front_Action
                 return;
             }
             $this->_downloadFileAction($request['options'][$this->getRequest()->getParam('option_id')]);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_forward('noRoute');
         }
     }
@@ -139,7 +139,7 @@ class Mage_Sales_DownloadController extends Mage_Core_Controller_Front_Action
                 try {
                     $info = Mage::helper('core/unserializeArray')->unserialize($option->getValue());
                     $hasKeyAccess = isset($info['secret_key']) && hash_equals($info['secret_key'], $requestKey);
-                } catch (Exception $e) {
+                } catch (Exception) {
                     // Invalid data — deny access
                 }
             }
@@ -172,7 +172,7 @@ class Mage_Sales_DownloadController extends Mage_Core_Controller_Front_Action
         try {
             $info = Mage::helper('core/unserializeArray')->unserialize($option->getValue());
             $this->_downloadFileAction($info);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_forward('noRoute');
         }
         exit(0);

--- a/app/code/core/Mage/SalesRule/Api/Coupon.php
+++ b/app/code/core/Mage/SalesRule/Api/Coupon.php
@@ -269,8 +269,8 @@ class Coupon extends CrudResource
         $dto->usagePerCustomer = $rule->getUsesPerCustomer() ? (int) $rule->getUsesPerCustomer() : null;
         $dto->fromDate = $rule->getFromDate();
         $dto->toDate = $rule->getToDate();
-        $dto->websiteIds = array_map('intval', (array) $rule->getWebsiteIds());
-        $dto->customerGroupIds = array_map('intval', (array) $rule->getCustomerGroupIds());
+        $dto->websiteIds = array_map(intval(...), (array) $rule->getWebsiteIds());
+        $dto->customerGroupIds = array_map(intval(...), (array) $rule->getCustomerGroupIds());
         $dto->sortOrder = (int) $rule->getSortOrder();
         $dto->stopRulesProcessing = (bool) $rule->getStopRulesProcessing();
         $dto->discountQty = $rule->getDiscountQty() !== null ? (float) $rule->getDiscountQty() : null;

--- a/app/code/core/Mage/SalesRule/Api/CouponProcessor.php
+++ b/app/code/core/Mage/SalesRule/Api/CouponProcessor.php
@@ -345,7 +345,7 @@ final class CouponProcessor extends \Maho\ApiPlatform\Processor
             return;
         }
 
-        $ruleWebsiteIds = array_map('intval', (array) $rule->getWebsiteIds());
+        $ruleWebsiteIds = array_map(intval(...), (array) $rule->getWebsiteIds());
         if (array_intersect($ruleWebsiteIds, $allowedWebsiteIds) === []) {
             throw new NotFoundHttpException('Coupon not found');
         }
@@ -519,7 +519,7 @@ final class CouponProcessor extends \Maho\ApiPlatform\Processor
     /** @return int[] */
     private function normalizeWebsiteIds(mixed $value): array
     {
-        $known = array_map('intval', array_keys(\Mage::app()->getWebsites()));
+        $known = array_map(intval(...), array_keys(\Mage::app()->getWebsites()));
         $ids = $this->normalizeIdList($value, $known, 'websiteIds', 'website');
 
         // A restricted token may only target websites its store allowlist maps to.
@@ -538,7 +538,7 @@ final class CouponProcessor extends \Maho\ApiPlatform\Processor
     /** @return int[] */
     private function normalizeCustomerGroupIds(mixed $value): array
     {
-        $known = array_map('intval', array_keys(\Mage::getModel('customer/group')->getCollection()->toOptionHash()));
+        $known = array_map(intval(...), array_keys(\Mage::getModel('customer/group')->getCollection()->toOptionHash()));
         return $this->normalizeIdList($value, $known, 'customerGroupIds', 'customer group');
     }
 

--- a/app/code/core/Mage/SalesRule/Api/CouponProvider.php
+++ b/app/code/core/Mage/SalesRule/Api/CouponProvider.php
@@ -40,7 +40,7 @@ final class CouponProvider extends \Maho\ApiPlatform\Provider
             /** @var \Mage_SalesRule_Model_Rule $rule */
             $rule = \Mage::getModel('salesrule/rule');
             $rule->load($coupon->getRuleId());
-            $ruleWebsiteIds = array_map('intval', (array) $rule->getWebsiteIds());
+            $ruleWebsiteIds = array_map(intval(...), (array) $rule->getWebsiteIds());
             if (array_intersect($ruleWebsiteIds, $allowedWebsiteIds) === []) {
                 throw new NotFoundHttpException('Coupon not found');
             }

--- a/app/code/core/Mage/Tag/Model/Resource/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Tag/Relation.php
@@ -145,7 +145,7 @@ class Mage_Tag_Model_Resource_Tag_Relation extends Mage_Core_Model_Resource_Db_A
         if (!is_array($addedIds)) {
             $addedIds = [];
         } else {
-            $addedIds = array_filter(array_map('intval', $addedIds));
+            $addedIds = array_filter(array_map(intval(...), $addedIds));
         }
 
         $bind = [

--- a/app/code/core/Mage/Tag/controllers/CustomerController.php
+++ b/app/code/core/Mage/Tag/controllers/CustomerController.php
@@ -111,7 +111,7 @@ class Mage_Tag_CustomerController extends Mage_Core_Controller_Front_Action
                     self::PARAM_NAME_URL_ENCODED => Mage::helper('core')->urlEncode(Mage::getUrl('customer/account/')),
                 ]));
                 return;
-            } catch (Exception $e) {
+            } catch (Exception) {
                 Mage::getSingleton('tag/session')->addError(Mage::helper('tag')->__('Unable to remove tag. Please, try again later.'));
             }
         } else {

--- a/app/code/core/Mage/Tax/Api/TaxRule.php
+++ b/app/code/core/Mage/Tax/Api/TaxRule.php
@@ -135,8 +135,8 @@ class TaxRule extends CrudResource
         // the shared CrudProvider iteration, out of scope here. Left as-is for now.
 
         /** @var \Mage_Tax_Model_Calculation_Rule $model */
-        $dto->customerTaxClassIds = array_map('intval', $model->getCustomerTaxClasses());
-        $dto->productTaxClassIds = array_map('intval', $model->getProductTaxClasses());
-        $dto->taxRateIds = array_map('intval', $model->getRates());
+        $dto->customerTaxClassIds = array_map(intval(...), $model->getCustomerTaxClasses());
+        $dto->productTaxClassIds = array_map(intval(...), $model->getProductTaxClasses());
+        $dto->taxRateIds = array_map(intval(...), $model->getRates());
     }
 }

--- a/app/code/core/Mage/Tax/Api/TaxRuleProcessor.php
+++ b/app/code/core/Mage/Tax/Api/TaxRuleProcessor.php
@@ -70,8 +70,8 @@ final class TaxRuleProcessor extends CrudProcessor
             $rates    = $rates !== [] ? $rates : $model->getRates();
         }
 
-        $model->setData('tax_customer_class', array_values(array_map('intval', $customer)));
-        $model->setData('tax_product_class', array_values(array_map('intval', $product)));
-        $model->setData('tax_rate', array_values(array_map('intval', $rates)));
+        $model->setData('tax_customer_class', array_values(array_map(intval(...), $customer)));
+        $model->setData('tax_product_class', array_values(array_map(intval(...), $product)));
+        $model->setData('tax_rate', array_values(array_map(intval(...), $rates)));
     }
 }

--- a/app/code/core/Mage/Uploader/Block/Abstract.php
+++ b/app/code/core/Mage/Uploader/Block/Abstract.php
@@ -218,6 +218,6 @@ abstract class Mage_Uploader_Block_Abstract extends Mage_Adminhtml_Block_Widget
      */
     protected function _prepareElementsIds($targets)
     {
-        return array_map([$this, 'getElementId'], array_unique(array_values($targets)));
+        return array_map($this->getElementId(...), array_unique(array_values($targets)));
     }
 }

--- a/app/code/core/Mage/Uploader/Helper/File.php
+++ b/app/code/core/Mage/Uploader/Helper/File.php
@@ -666,10 +666,10 @@ class Mage_Uploader_Helper_File extends Mage_Core_Helper_Abstract
     public function getMimeTypeFromExtensionList($extensionsList)
     {
         if (is_string($extensionsList)) {
-            $extensionsList = array_map('trim', explode(',', $extensionsList));
+            $extensionsList = array_map(trim(...), explode(',', $extensionsList));
         }
 
-        return array_map([$this, 'getMimeTypeByExtension'], $extensionsList);
+        return array_map($this->getMimeTypeByExtension(...), $extensionsList);
     }
 
     /**

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/OAuthClient.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/OAuthClient.php
@@ -13,16 +13,11 @@ class Mage_Usa_Model_Shipping_Carrier_Fedex_OAuthClient
     private const TOKEN_CACHE_KEY_PREFIX = 'fedex_oauth_token_';
 
     public const CACHE_TAG = 'fedex_oauth';
-
-    private string $clientId;
-    private string $clientSecret;
     private string $tokenEndpoint;
     private Mage_Core_Model_Cache $cache;
 
-    public function __construct(string $clientId, string $clientSecret, string $baseUrl)
+    public function __construct(private string $clientId, private string $clientSecret, string $baseUrl)
     {
-        $this->clientId = $clientId;
-        $this->clientSecret = $clientSecret;
         $this->tokenEndpoint = $baseUrl . '/oauth/token';
         $this->cache = Mage::app()->getCache();
     }

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/RestClient.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Fedex/RestClient.php
@@ -19,10 +19,7 @@ class Mage_Usa_Model_Shipping_Carrier_Fedex_RestClient
     private const ENDPOINT_TRACK = '/track/v1/trackingnumbers';
     private const ENDPOINT_SHIP = '/ship/v1/shipments';
     private const ENDPOINT_SHIP_CANCEL = '/ship/v1/shipments/cancel';
-
-    private Mage_Usa_Model_Shipping_Carrier_Fedex_OAuthClient $oauthClient;
     private string $baseUrl;
-    private bool $debugMode;
     private string $rateEndpoint;
     private \Symfony\Contracts\HttpClient\HttpClientInterface $client;
 
@@ -32,14 +29,12 @@ class Mage_Usa_Model_Shipping_Carrier_Fedex_RestClient
     }
 
     public function __construct(
-        Mage_Usa_Model_Shipping_Carrier_Fedex_OAuthClient $oauthClient,
+        private Mage_Usa_Model_Shipping_Carrier_Fedex_OAuthClient $oauthClient,
         bool $sandbox = false,
-        bool $debugMode = false,
+        private bool $debugMode = false,
         string $rateEndpoint = Mage_Usa_Model_Shipping_Carrier_Fedex::RATE_ENDPOINT_STANDARD,
     ) {
-        $this->oauthClient = $oauthClient;
         $this->baseUrl = self::getBaseUrl($sandbox);
-        $this->debugMode = $debugMode;
         $this->rateEndpoint = $rateEndpoint === Mage_Usa_Model_Shipping_Carrier_Fedex::RATE_ENDPOINT_COMPREHENSIVE
             ? self::ENDPOINT_RATES_COMPREHENSIVE
             : self::ENDPOINT_RATES;

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Ups.php
@@ -901,7 +901,7 @@ class Mage_Usa_Model_Shipping_Carrier_Ups extends Mage_Usa_Model_Shipping_Carrie
         $rawJsonRequest = $this->_formShipmentRestRequest($request);
         try {
             $accessToken = $this->setAPIAccessRequest();
-        } catch (Exception $e) {
+        } catch (Exception) {
             $result->setErrors(Mage::helper('usa')->__('Authentication error'));
             return $result;
         }

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps.php
@@ -1143,7 +1143,7 @@ class Mage_Usa_Model_Shipping_Carrier_Usps extends Mage_Usa_Model_Shipping_Carri
                         $dt = new DateTime($event['eventTimestamp']);
                         $deliveryDate = $dt->format('Y-m-d');
                         $deliveryTime = $dt->format('H:i:s');
-                    } catch (Exception $e) {
+                    } catch (Exception) {
                         // Invalid timestamp, leave empty
                     }
                 }

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/OAuthClient.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/OAuthClient.php
@@ -11,16 +11,11 @@ declare(strict_types=1);
 class Mage_Usa_Model_Shipping_Carrier_Usps_OAuthClient
 {
     private const TOKEN_CACHE_KEY_PREFIX = 'usps_oauth_token_';
-
-    private string $clientId;
-    private string $clientSecret;
     private string $tokenEndpoint;
     private Mage_Core_Model_Cache $cache;
 
-    public function __construct(string $clientId, string $clientSecret, string $baseUrl)
+    public function __construct(private string $clientId, private string $clientSecret, string $baseUrl)
     {
-        $this->clientId = $clientId;
-        $this->clientSecret = $clientSecret;
         $this->tokenEndpoint = $baseUrl . '/oauth2/v3/token';
         $this->cache = Mage::app()->getCache();
     }

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/RestClient.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/RestClient.php
@@ -18,20 +18,15 @@ class Mage_Usa_Model_Shipping_Carrier_Usps_RestClient
     private const ENDPOINT_DOMESTIC_LABEL = '/labels/v3/label';
     private const ENDPOINT_INTERNATIONAL_LABEL = '/international-labels/v3/label';
     private const ENDPOINT_PAYMENT_AUTH = '/payments/v3/payment-authorization';
-
-    private Mage_Usa_Model_Shipping_Carrier_Usps_OAuthClient $oauthClient;
     private string $baseUrl;
-    private bool $debugMode;
     private ?string $paymentAuthToken = null;
 
     public function __construct(
-        Mage_Usa_Model_Shipping_Carrier_Usps_OAuthClient $oauthClient,
+        private Mage_Usa_Model_Shipping_Carrier_Usps_OAuthClient $oauthClient,
         string $environment = 'production',
-        bool $debugMode = false,
+        private bool $debugMode = false,
     ) {
-        $this->oauthClient = $oauthClient;
         $this->baseUrl = ($environment === 'test') ? self::BASE_URL_TEST : self::BASE_URL_PRODUCTION;
-        $this->debugMode = $debugMode;
     }
 
     /**
@@ -80,7 +75,8 @@ class Mage_Usa_Model_Shipping_Carrier_Usps_RestClient
     /**
      * Set payment authorization token
      */
-    public function setPaymentAuthToken(string $token): void
+    public function setPaymentAuthToken(#[\SensitiveParameter]
+        string $token): void
     {
         $this->paymentAuthToken = $token;
     }
@@ -242,10 +238,10 @@ class Mage_Usa_Model_Shipping_Carrier_Usps_RestClient
                             $errorMessage = $this->extractErrorMessage($errorData);
                             throw new Exception($errorMessage, $e->getCode(), $e);
                         }
-                    } catch (Exception $jsonEx) {
+                    } catch (Exception) {
                         // Not JSON, use original exception
                     }
-                } catch (Exception $ex) {
+                } catch (Exception) {
                     // Ignore if we can't get the response body
                 }
             }

--- a/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Method.php
+++ b/app/code/core/Mage/Usa/Model/Shipping/Carrier/Usps/Source/Method.php
@@ -20,9 +20,7 @@ class Mage_Usa_Model_Shipping_Carrier_Usps_Source_Method
         }
 
         // Sort alphabetically by label
-        usort($arr, function ($a, $b) {
-            return strcmp($a['label'], $b['label']);
-        });
+        usort($arr, fn($a, $b) => strcmp($a['label'], $b['label']));
 
         return $arr;
     }

--- a/app/code/core/Mage/Weee/Block/Renderer/Weee/Tax.php
+++ b/app/code/core/Mage/Weee/Block/Renderer/Weee/Tax.php
@@ -94,7 +94,7 @@ class Mage_Weee_Block_Renderer_Weee_Tax extends Mage_Adminhtml_Block_Widget impl
         $data = $this->getElement()->getValue();
 
         if (is_array($data) && count($data)) {
-            usort($data, [$this, '_sortWeeeTaxes']);
+            usort($data, $this->_sortWeeeTaxes(...));
             $values = $data;
         }
         return $values;

--- a/app/code/core/Mage/Widget/Model/Widget.php
+++ b/app/code/core/Mage/Widget/Model/Widget.php
@@ -125,7 +125,7 @@ class Mage_Widget_Model_Widget extends \Maho\DataObject
                 }
             }
         }
-        uasort($newParams, [$this, '_sortParameters']);
+        uasort($newParams, $this->_sortParameters(...));
         $object->setData('parameters', $newParams);
 
         return $object;
@@ -152,7 +152,7 @@ class Mage_Widget_Model_Widget extends \Maho\DataObject
                             throw new Exception();
                         }
                     }
-                } catch (Exception $e) {
+                } catch (Exception) {
                     unset($result->{$code});
                     continue;
                 }
@@ -184,7 +184,7 @@ class Mage_Widget_Model_Widget extends \Maho\DataObject
                     'description'   => $helper->__((string) $widget->description),
                 ];
             }
-            usort($result, [$this, '_sortWidgets']);
+            usort($result, $this->_sortWidgets(...));
             $this->setData('widgets_array', $result);
         }
         return $this->_getData('widgets_array');

--- a/app/code/core/Mage/Wishlist/Api/WishlistItem.php
+++ b/app/code/core/Mage/Wishlist/Api/WishlistItem.php
@@ -182,7 +182,7 @@ class WishlistItem extends CrudResource
             return (string) \Mage::helper('catalog/image')
                 ->init($product, 'small_image')
                 ->resize(300);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return '';
         }
     }

--- a/app/code/core/Mage/Wishlist/Api/WishlistProcessor.php
+++ b/app/code/core/Mage/Wishlist/Api/WishlistProcessor.php
@@ -23,12 +23,9 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 final class WishlistProcessor extends \Maho\ApiPlatform\Processor
 {
-    private CartService $cartService;
-
-    public function __construct(Security $security, CartService $cartService)
+    public function __construct(Security $security, private CartService $cartService)
     {
         parent::__construct($security);
-        $this->cartService = $cartService;
     }
 
     /**

--- a/app/code/core/Mage/Wishlist/Api/WishlistProvider.php
+++ b/app/code/core/Mage/Wishlist/Api/WishlistProvider.php
@@ -78,7 +78,7 @@ final class WishlistProvider extends \Maho\ApiPlatform\Provider
                 $data = null;
             }
             if (is_array($data)) {
-                return array_map(fn(array $d) => $this->arrayToWishlistDto($d), $data);
+                return array_map($this->arrayToWishlistDto(...), $data);
             }
         }
 
@@ -106,7 +106,7 @@ final class WishlistProvider extends \Maho\ApiPlatform\Provider
         }
 
         \Mage::app()->getCache()->save(
-            (string) \Mage::helper('core')->jsonEncode(array_map(fn(WishlistItem $i) => $this->wishlistDtoToArray($i), $items)),
+            (string) \Mage::helper('core')->jsonEncode(array_map($this->wishlistDtoToArray(...), $items)),
             $cacheKey,
             ['API_WISHLIST', "API_WISHLIST_{$customerId}"],
             $this->getCacheTtl(),

--- a/app/code/core/Mage/Wishlist/Controller/Abstract.php
+++ b/app/code/core/Mage/Wishlist/Controller/Abstract.php
@@ -156,7 +156,7 @@ abstract class Mage_Wishlist_Controller_Abstract extends Mage_Core_Controller_Fr
             // save wishlist model for setting date of last update
             try {
                 $wishlist->save();
-            } catch (Exception $e) {
+            } catch (Exception) {
                 Mage::getSingleton('wishlist/session')->addError($this->__('Cannot update wishlist'));
                 $redirectUrl = $indexUrl;
             }

--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -240,7 +240,7 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
             $session->addSuccess($message);
         } catch (Mage_Core_Exception $e) {
             $session->addError($this->__('An error occurred while adding item to wishlist: %s', $e->getMessage()));
-        } catch (Exception $e) {
+        } catch (Exception) {
             $session->addError($this->__('An error occurred while adding item to wishlist.'));
         }
 
@@ -414,7 +414,7 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
                         ->setQty($qty)
                         ->save();
                     $updatedItems++;
-                } catch (Exception $e) {
+                } catch (Exception) {
                     Mage::getSingleton('customer/session')->addError(
                         $this->__('Can\'t save description %s', Mage::helper('core')->escapeHtml($description)),
                     );
@@ -426,7 +426,7 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
                 try {
                     $wishlist->save();
                     Mage::helper('wishlist')->calculate();
-                } catch (Exception $e) {
+                } catch (Exception) {
                     Mage::getSingleton('customer/session')->addError($this->__('Can\'t update wishlist'));
                 }
             }
@@ -468,7 +468,7 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
             Mage::getSingleton('customer/session')->addError(
                 $this->__('An error occurred while deleting the item from wishlist: %s', $e->getMessage()),
             );
-        } catch (Exception $e) {
+        } catch (Exception) {
             Mage::getSingleton('customer/session')->addError(
                 $this->__('An error occurred while deleting the item from wishlist.'),
             );
@@ -803,7 +803,7 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
                     'type'  => 'filename',
                 ]);
             }
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_forward('noRoute');
         }
         exit(0);

--- a/app/code/core/Maho/AccessibilityScan/Model/Runner.php
+++ b/app/code/core/Maho/AccessibilityScan/Model/Runner.php
@@ -355,7 +355,7 @@ class Maho_AccessibilityScan_Model_Runner
      */
     protected function wcagLevelFromTags(array $tags): ?string
     {
-        $tags = array_map('strval', $tags);
+        $tags = array_map(strval(...), $tags);
         foreach (['aaa' => 'AAA', 'aa' => 'AA', 'a' => 'A'] as $suffix => $level) {
             foreach ($tags as $tag) {
                 if (preg_match('/^wcag2\d?' . $suffix . '$/', $tag)) {

--- a/app/code/core/Maho/AccessibilityScan/Model/TemplateMapper.php
+++ b/app/code/core/Maho/AccessibilityScan/Model/TemplateMapper.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 class Maho_AccessibilityScan_Model_TemplateMapper
 {
-    protected string $rawHtml;
-
     /**
      * Hint wrapper intervals as [start offset, end offset, nesting depth, template path]
      *
@@ -22,9 +20,8 @@ class Maho_AccessibilityScan_Model_TemplateMapper
      */
     protected array $intervals = [];
 
-    public function __construct(string $rawHtml)
+    public function __construct(protected string $rawHtml)
     {
-        $this->rawHtml = $rawHtml;
         $this->parseHints();
     }
 

--- a/app/code/core/Maho/AdminActivityLog/Block/Adminhtml/Login/Grid.php
+++ b/app/code/core/Maho/AdminActivityLog/Block/Adminhtml/Login/Grid.php
@@ -74,7 +74,7 @@ class Maho_AdminActivityLog_Block_Adminhtml_Login_Grid extends Mage_Adminhtml_Bl
                 'logout' => $this->__('Logout'),
                 'failed' => $this->__('Failed'),
             ],
-            'frame_callback' => [$this, 'decorateType'],
+            'frame_callback' => $this->decorateType(...),
         ]);
 
         $this->addExportType('*/*/exportCsv', Mage::helper('adminactivitylog')->__('CSV'));

--- a/app/code/core/Maho/AdminActivityLog/Helper/Data.php
+++ b/app/code/core/Maho/AdminActivityLog/Helper/Data.php
@@ -63,7 +63,7 @@ class Maho_AdminActivityLog_Helper_Data extends Mage_Core_Helper_Abstract
             if ($resource instanceof Mage_Core_Model_Resource_Db_Abstract) {
                 return array_keys($resource->getReadConnection()->describeTable($resource->getMainTable()));
             }
-        } catch (Throwable $e) {
+        } catch (Throwable) {
         }
         return null;
     }

--- a/app/code/core/Maho/Ai/Model/Platform.php
+++ b/app/code/core/Maho/Ai/Model/Platform.php
@@ -82,7 +82,7 @@ class Maho_Ai_Model_Platform
 
         $result = [];
         foreach ($providers->children() as $code => $node) {
-            $capabilities = array_map('trim', explode(',', (string) ($node->capabilities ?? '')));
+            $capabilities = array_map(trim(...), explode(',', (string) ($node->capabilities ?? '')));
             if (in_array($capability, $capabilities, true)) {
                 $result[(string) $code] = [
                     'label'      => (string) $node->label,

--- a/app/code/core/Maho/Ai/Model/Platform/Factory.php
+++ b/app/code/core/Maho/Ai/Model/Platform/Factory.php
@@ -181,7 +181,7 @@ class Maho_Ai_Model_Platform_Factory
             throw new Mage_Core_Exception("Unknown AI platform: {$platformCode}");
         }
 
-        $capabilities = array_map('trim', explode(',', (string) ($config->capabilities ?? '')));
+        $capabilities = array_map(trim(...), explode(',', (string) ($config->capabilities ?? '')));
         if (!in_array($capability, $capabilities, true)) {
             throw new Mage_Core_Exception("Platform '{$platformCode}' does not support {$capability}.");
         }

--- a/app/code/core/Maho/Ai/Model/Resource/Vector.php
+++ b/app/code/core/Maho/Ai/Model/Resource/Vector.php
@@ -73,7 +73,7 @@ class Maho_Ai_Model_Resource_Vector extends Mage_Core_Model_Resource_Db_Abstract
         }
 
         $decoded = Mage::helper('core')->jsonDecode((string) $row['vector']);
-        $vector = is_array($decoded) ? array_map('floatval', array_values($decoded)) : [];
+        $vector = is_array($decoded) ? array_map(floatval(...), array_values($decoded)) : [];
 
         return [
             'vector'     => $vector,

--- a/app/code/core/Maho/Ai/Model/Safety/InputValidator.php
+++ b/app/code/core/Maho/Ai/Model/Safety/InputValidator.php
@@ -76,7 +76,7 @@ class Maho_Ai_Model_Safety_InputValidator
         // Check custom blocked patterns from config
         $customPatterns = (string) Mage::getStoreConfig('maho_ai/safety/blocked_patterns');
         if ($customPatterns) {
-            foreach (array_filter(array_map('trim', explode("\n", $customPatterns))) as $pattern) {
+            foreach (array_filter(array_map(trim(...), explode("\n", $customPatterns))) as $pattern) {
                 if (@preg_match($pattern, $input)) {
                     return [
                         'safe'   => false,

--- a/app/code/core/Maho/ApiPlatform/Block/Adminhtml/Apiplatform/User/Edit/Tab/Main.php
+++ b/app/code/core/Maho/ApiPlatform/Block/Adminhtml/Apiplatform/User/Edit/Tab/Main.php
@@ -113,9 +113,9 @@ class Maho_ApiPlatform_Block_Adminhtml_Apiplatform_User_Edit_Tab_Main extends Ma
             try {
                 $decoded = Mage::helper('core')->jsonDecode($rawAllowedStoreIds);
                 if (is_array($decoded)) {
-                    $allowedStoreIds = array_map('intval', $decoded);
+                    $allowedStoreIds = array_map(intval(...), $decoded);
                 }
-            } catch (JsonException $e) {
+            } catch (JsonException) {
                 $allowedStoreIds = [];
             }
         }

--- a/app/code/core/Maho/ApiPlatform/controllers/Adminhtml/Apiplatform/UserController.php
+++ b/app/code/core/Maho/ApiPlatform/controllers/Adminhtml/Apiplatform/UserController.php
@@ -75,7 +75,7 @@ class Maho_ApiPlatform_Adminhtml_Apiplatform_UserController extends Mage_Adminht
             $model->setEmail($data['email'] ?? $model->getEmail());
             $model->setIsActive($data['is_active'] ?? $model->getIsActive());
             if (array_key_exists('allowed_store_ids', $data)) {
-                $storeIds = array_values(array_filter(array_map('intval', (array) $data['allowed_store_ids'])));
+                $storeIds = array_values(array_filter(array_map(intval(...), (array) $data['allowed_store_ids'])));
                 $model->setAllowedStoreIds($storeIds === [] ? null : Mage::helper('core')->jsonEncode($storeIds));
             }
         }
@@ -120,7 +120,7 @@ class Maho_ApiPlatform_Adminhtml_Apiplatform_UserController extends Mage_Adminht
             // Normalize the store-restriction multiselect into a JSON array of
             // ints (empty selection => null => all stores). The JWT issuer reads
             // this column to scope tokens.
-            $storeIds = array_values(array_filter(array_map('intval', (array) ($data['allowed_store_ids'] ?? []))));
+            $storeIds = array_values(array_filter(array_map(intval(...), (array) ($data['allowed_store_ids'] ?? []))));
             $model->setAllowedStoreIds($storeIds === [] ? null : Mage::helper('core')->jsonEncode($storeIds));
 
             // Set API key if provided

--- a/app/code/core/Maho/ApiPlatform/symfony/EventListener/ApiExceptionListener.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/EventListener/ApiExceptionListener.php
@@ -30,12 +30,7 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException as Serialize
  */
 class ApiExceptionListener implements EventSubscriberInterface
 {
-    private bool $debug;
-
-    public function __construct(bool $debug = false)
-    {
-        $this->debug = $debug;
-    }
+    public function __construct(private bool $debug = false) {}
 
     #[\Override]
     public static function getSubscribedEvents(): array

--- a/app/code/core/Maho/ApiPlatform/symfony/Exception/ApiException.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Exception/ApiException.php
@@ -18,19 +18,14 @@ namespace Maho\ApiPlatform\Exception;
  */
 class ApiException extends \RuntimeException
 {
-    protected string $errorCode;
-    protected array $details = [];
-
     public function __construct(
         string $message,
-        string $errorCode = 'api_error',
+        protected string $errorCode = 'api_error',
         int $httpStatusCode = 500,
-        array $details = [],
+        protected array $details = [],
         ?\Throwable $previous = null,
     ) {
         parent::__construct($message, $httpStatusCode, $previous);
-        $this->errorCode = $errorCode;
-        $this->details = $details;
     }
 
     public function getErrorCode(): string

--- a/app/code/core/Maho/ApiPlatform/symfony/Kernel.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Kernel.php
@@ -66,7 +66,7 @@ class Kernel extends BaseKernel
             // multiple entries instead of treating the whole string as one
             // (broken) origin literal.
             $origins = array_values(array_filter(
-                array_map('trim', explode(',', $corsOrigins)),
+                array_map(trim(...), explode(',', $corsOrigins)),
                 static fn(string $o): bool => $o !== '',
             ));
             // Reject `*` in the allowlist. NelmioCors echoes a wildcard origin

--- a/app/code/core/Maho/ApiPlatform/symfony/Security/AdminSessionAuthenticator.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Security/AdminSessionAuthenticator.php
@@ -74,7 +74,8 @@ class AdminSessionAuthenticator extends AbstractAuthenticator
      * Handle successful authentication
      */
     #[\Override]
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    public function onAuthenticationSuccess(Request $request, #[\SensitiveParameter]
+        TokenInterface $token, string $firewallName): ?Response
     {
         // Continue to the controller
         return null;
@@ -139,7 +140,8 @@ class AdminSessionAuthenticator extends AbstractAuthenticator
     /**
      * Verify HMAC bridge token
      */
-    public static function verifyBridgeToken(string $adminId, string $token): bool
+    public static function verifyBridgeToken(string $adminId, #[\SensitiveParameter]
+        string $token): bool
     {
         if ($token === '') {
             return false;

--- a/app/code/core/Maho/ApiPlatform/symfony/Security/ApiUserVoter.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Security/ApiUserVoter.php
@@ -43,7 +43,8 @@ class ApiUserVoter extends Voter
     }
 
     #[\Override]
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, #[\SensitiveParameter]
+        TokenInterface $token, ?Vote $vote = null): bool
     {
         $user = $token->getUser();
 

--- a/app/code/core/Maho/ApiPlatform/symfony/Security/OAuth2Authenticator.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Security/OAuth2Authenticator.php
@@ -73,9 +73,9 @@ class OAuth2Authenticator extends AbstractAuthenticator
                 throw new CustomUserMessageAuthenticationException('Token has expired');
             }
             throw new CustomUserMessageAuthenticationException('Invalid or expired token');
-        } catch (\Lcobucci\JWT\Token\InvalidTokenStructure|\Lcobucci\JWT\Encoding\CannotDecodeContent $e) {
+        } catch (\Lcobucci\JWT\Token\InvalidTokenStructure|\Lcobucci\JWT\Encoding\CannotDecodeContent) {
             throw new CustomUserMessageAuthenticationException('Malformed token');
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             throw new CustomUserMessageAuthenticationException('Invalid or expired token');
         }
 
@@ -109,7 +109,8 @@ class OAuth2Authenticator extends AbstractAuthenticator
      * Handle successful authentication
      */
     #[\Override]
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    public function onAuthenticationSuccess(Request $request, #[\SensitiveParameter]
+        TokenInterface $token, string $firewallName): ?Response
     {
         // Return null to allow the request to continue
         return null;
@@ -142,7 +143,7 @@ class OAuth2Authenticator extends AbstractAuthenticator
         $type = $payload->type ?? 'customer';
         $allowedStoreIds = null;
         if (isset($payload->allowed_store_ids) && is_array($payload->allowed_store_ids)) {
-            $allowedStoreIds = array_map('intval', $payload->allowed_store_ids);
+            $allowedStoreIds = array_map(intval(...), $payload->allowed_store_ids);
         }
 
         if ($type === 'admin' && isset($payload->admin_id)) {
@@ -184,7 +185,7 @@ class OAuth2Authenticator extends AbstractAuthenticator
             // allowed_store_ids claim, so changes to the user's store restriction
             // take effect immediately instead of waiting for the JWT to expire
             // (mirrors the live permission re-read above). [] means unrestricted.
-            $apiUserStoreIds = array_map('intval', $this->jwtService->getApiUserAllowedStoreIds($apiUser));
+            $apiUserStoreIds = array_map(intval(...), $this->jwtService->getApiUserAllowedStoreIds($apiUser));
             return new ApiUser(
                 identifier: (string) $payload->sub,
                 // No role: service accounts are authorized by their granular

--- a/app/code/core/Maho/ApiPlatform/symfony/Service/JwtService.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Service/JwtService.php
@@ -138,7 +138,7 @@ class JwtService
         // consumer side (OAuth2Authenticator) leaves allowedStoreIds null.
         $allowedStoreIds = $this->getApiUserAllowedStoreIds($apiUser);
         if ($allowedStoreIds !== []) {
-            $builder = $builder->withClaim('allowed_store_ids', array_map('intval', $allowedStoreIds));
+            $builder = $builder->withClaim('allowed_store_ids', array_map(intval(...), $allowedStoreIds));
         }
 
         $token = $builder->getToken($config->signer(), $config->signingKey());
@@ -228,7 +228,8 @@ class JwtService
      * @throws \Lcobucci\JWT\Token\InvalidTokenStructure If token format is invalid
      * @throws \RuntimeException If JWT secret is not configured
      */
-    public function decodeToken(string $token): object
+    public function decodeToken(#[\SensitiveParameter]
+        string $token): object
     {
         $config = $this->getConfig();
         $parsed = $config->parser()->parse($token);
@@ -286,7 +287,8 @@ class JwtService
      * @param string $token The JWT token to validate
      * @return bool True if valid, false otherwise
      */
-    public function isValidToken(string $token): bool
+    public function isValidToken(#[\SensitiveParameter]
+        string $token): bool
     {
         try {
             $this->decodeToken($token);
@@ -303,7 +305,8 @@ class JwtService
      * @param string $token The JWT token
      * @return int|null Customer ID or null if not a customer token
      */
-    public function getCustomerIdFromToken(string $token): ?int
+    public function getCustomerIdFromToken(#[\SensitiveParameter]
+        string $token): ?int
     {
         try {
             $payload = $this->decodeToken($token);
@@ -319,7 +322,8 @@ class JwtService
      * @param string $token The JWT token
      * @return int|null Admin ID or null if not an admin token
      */
-    public function getAdminIdFromToken(string $token): ?int
+    public function getAdminIdFromToken(#[\SensitiveParameter]
+        string $token): ?int
     {
         try {
             $payload = $this->decodeToken($token);

--- a/app/code/core/Maho/ApiPlatform/symfony/Trait/ProductLoaderTrait.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Trait/ProductLoaderTrait.php
@@ -72,7 +72,7 @@ trait ProductLoaderTrait
             }
         } else {
             $websiteId = (int) StoreContext::getStore()->getWebsiteId();
-            if (!in_array($websiteId, array_map('intval', $product->getWebsiteIds()), true)
+            if (!in_array($websiteId, array_map(intval(...), $product->getWebsiteIds()), true)
                 || (int) $product->getStatus() !== Mage_Catalog_Model_Product_Status::STATUS_ENABLED
             ) {
                 throw new NotFoundHttpException('Product not found');
@@ -167,7 +167,7 @@ trait ProductLoaderTrait
             return;
         }
 
-        $productWebsiteIds = array_map('intval', $product->getWebsiteIds());
+        $productWebsiteIds = array_map(intval(...), $product->getWebsiteIds());
 
         if (array_intersect($productWebsiteIds, $allowedWebsiteIds) === []) {
             throw new AccessDeniedHttpException("Access denied for this product's websites");

--- a/app/code/core/Maho/Blog/Api/BlogCategory.php
+++ b/app/code/core/Maho/Blog/Api/BlogCategory.php
@@ -127,6 +127,6 @@ class BlogCategory extends CrudResource
 
     public static function afterLoad(self $dto, object $model): void
     {
-        $dto->stores = array_map('intval', $model->getStores());
+        $dto->stores = array_map(intval(...), $model->getStores());
     }
 }

--- a/app/code/core/Maho/Blog/Api/BlogPost.php
+++ b/app/code/core/Maho/Blog/Api/BlogPost.php
@@ -200,7 +200,7 @@ class BlogPost extends CrudResource
         if ($ids === []) {
             return;
         }
-        $existing = array_map('intval', \Mage::getResourceModel('blog/category_collection')
+        $existing = array_map(intval(...), \Mage::getResourceModel('blog/category_collection')
             ->addFieldToFilter('entity_id', ['in' => $ids])
             ->getAllIds());
         $missing = array_diff($ids, $existing);
@@ -218,8 +218,8 @@ class BlogPost extends CrudResource
         $dto->status = $dto->isActive ? 'enabled' : 'disabled';
         $dto->imageUrl = $model->getImageUrl();
 
-        $dto->stores = array_map('intval', $model->getStores());
-        $dto->categoryIds = array_map('intval', $model->getCategories());
+        $dto->stores = array_map(intval(...), $model->getStores());
+        $dto->categoryIds = array_map(intval(...), $model->getCategories());
 
         if ($model->getContent()) {
             $text = strip_tags($model->getContent());

--- a/app/code/core/Maho/Blog/Block/Adminhtml/Category/Grid.php
+++ b/app/code/core/Maho/Blog/Block/Adminhtml/Category/Grid.php
@@ -66,7 +66,7 @@ class Maho_Blog_Block_Adminhtml_Category_Grid extends Mage_Adminhtml_Block_Widge
                 'store_view'    => true,
                 'sortable'      => false,
                 'filter_condition_callback'
-                => [$this, '_filterStoreCondition'],
+                => $this->_filterStoreCondition(...),
             ]);
         }
 

--- a/app/code/core/Maho/Blog/Block/Adminhtml/Post/Grid.php
+++ b/app/code/core/Maho/Blog/Block/Adminhtml/Post/Grid.php
@@ -75,7 +75,7 @@ class Maho_Blog_Block_Adminhtml_Post_Grid extends Mage_Adminhtml_Block_Widget_Gr
                 'store_view'    => true,
                 'sortable'      => false,
                 'filter_condition_callback'
-                => [$this, '_filterStoreCondition'],
+                => $this->_filterStoreCondition(...),
             ]);
         }
 

--- a/app/code/core/Maho/Blog/Block/Autocomplete.php
+++ b/app/code/core/Maho/Blog/Block/Autocomplete.php
@@ -35,9 +35,7 @@ class Maho_Blog_Block_Autocomplete extends Mage_Core_Block_Template
             // Split query into words and filter by minimum length
             $words = Mage::helper('core/string')->splitWords($query, true, $maxQueryWords);
             if ($words) {
-                $words = array_filter($words, function ($word) use ($minQueryLength) {
-                    return strlen($word) >= $minQueryLength;
-                });
+                $words = array_filter($words, fn($word) => strlen($word) >= $minQueryLength);
             }
 
             // Build search conditions for title and content

--- a/app/code/core/Maho/Blog/Model/Api2/Post.php
+++ b/app/code/core/Maho/Blog/Model/Api2/Post.php
@@ -37,7 +37,7 @@ class Maho_Blog_Model_Api2_Post extends Mage_Api2_Model_Resource
 
         try {
             $post->save();
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_critical(self::RESOURCE_INTERNAL_ERROR);
         }
 
@@ -51,7 +51,7 @@ class Maho_Blog_Model_Api2_Post extends Mage_Api2_Model_Resource
         try {
             $post->addData($data);
             $post->save();
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_critical(self::RESOURCE_INTERNAL_ERROR);
         }
     }
@@ -62,7 +62,7 @@ class Maho_Blog_Model_Api2_Post extends Mage_Api2_Model_Resource
 
         try {
             $post->delete();
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->_critical(self::RESOURCE_INTERNAL_ERROR);
         }
     }

--- a/app/code/core/Maho/Blog/Model/Category.php
+++ b/app/code/core/Maho/Blog/Model/Category.php
@@ -84,7 +84,7 @@ class Maho_Blog_Model_Category extends Mage_Core_Model_Abstract
         if (!$path) {
             return [];
         }
-        return array_map('intval', explode('/', $path));
+        return array_map(intval(...), explode('/', $path));
     }
 
     /**

--- a/app/code/core/Maho/Blog/Model/Post/Api.php
+++ b/app/code/core/Maho/Blog/Model/Post/Api.php
@@ -67,9 +67,7 @@ class Maho_Blog_Model_Post_Api extends Mage_Api_Model_Resource_Abstract
                 ->save();
 
             return $post->getId();
-        } catch (Mage_Core_Exception $e) {
-            $this->_fault('data_invalid', $e->getMessage());
-        } catch (Exception $e) {
+        } catch (Mage_Core_Exception|Exception $e) {
             $this->_fault('data_invalid', $e->getMessage());
         }
     }
@@ -86,9 +84,7 @@ class Maho_Blog_Model_Post_Api extends Mage_Api_Model_Resource_Abstract
             $post->addData($postData)->save();
 
             return true;
-        } catch (Mage_Core_Exception $e) {
-            $this->_fault('data_invalid', $e->getMessage());
-        } catch (Exception $e) {
+        } catch (Mage_Core_Exception|Exception $e) {
             $this->_fault('data_invalid', $e->getMessage());
         }
     }

--- a/app/code/core/Maho/Blog/Model/Resource/Category.php
+++ b/app/code/core/Maho/Blog/Model/Resource/Category.php
@@ -339,7 +339,7 @@ class Maho_Blog_Model_Resource_Category extends Mage_Eav_Model_Entity_Abstract
             ->from($this->getEntityTable(), ['entity_id'])
             ->where('path LIKE ?', $path . '/%');
 
-        return array_map('intval', $adapter->fetchCol($select));
+        return array_map(intval(...), $adapter->fetchCol($select));
     }
 
     /**

--- a/app/code/core/Maho/Blog/Model/Resource/Post.php
+++ b/app/code/core/Maho/Blog/Model/Resource/Post.php
@@ -282,9 +282,9 @@ class Maho_Blog_Model_Resource_Post extends Mage_Eav_Model_Entity_Abstract
 
     protected function _saveCategoryRelations(\Maho\DataObject $post): void
     {
-        $oldCategoryIds = array_map('intval', $this->lookupCategoryIds((int) $post->getId()));
-        $newCategoryIds = array_map('intval', (array) $post->getData('categories'));
-        $positions = array_map('intval', (array) $post->getData('category_positions'));
+        $oldCategoryIds = array_map(intval(...), $this->lookupCategoryIds((int) $post->getId()));
+        $newCategoryIds = array_map(intval(...), (array) $post->getData('categories'));
+        $positions = array_map(intval(...), (array) $post->getData('category_positions'));
 
         $table = $this->getTable('blog/post_category');
         $adapter = $this->_getWriteAdapter();

--- a/app/code/core/Maho/Captcha/controllers/IndexController.php
+++ b/app/code/core/Maho/Captcha/controllers/IndexController.php
@@ -19,7 +19,7 @@ class Maho_Captcha_IndexController extends Mage_Core_Controller_Front_Action
             $this->getResponse()->setBodyJson($helper->createChallenge()->toArray());
         } catch (Mage_Core_Exception $e) {
             $error = $e->getMessage();
-        } catch (Exception $e) {
+        } catch (Exception) {
             $error = $helper->__('Internal Error');
         }
         if (isset($error)) {

--- a/app/code/core/Maho/CatalogLinkRule/Model/Processor.php
+++ b/app/code/core/Maho/CatalogLinkRule/Model/Processor.php
@@ -175,8 +175,8 @@ class Maho_CatalogLinkRule_Model_Processor
                 ->where('rule_id IS NOT NULL'),
         );
 
-        $covered = array_map('intval', $coveredProductIds);
-        $orphans = array_diff(array_map('intval', $withRuleLinks), $covered);
+        $covered = array_map(intval(...), $coveredProductIds);
+        $orphans = array_diff(array_map(intval(...), $withRuleLinks), $covered);
 
         foreach (array_chunk($orphans, self::BATCH_SIZE) as $orphanBatch) {
             $adapter->delete($linkTable, [

--- a/app/code/core/Maho/CustomerSegmentation/Helper/Data.php
+++ b/app/code/core/Maho/CustomerSegmentation/Helper/Data.php
@@ -22,7 +22,7 @@ class Maho_CustomerSegmentation_Helper_Data extends Mage_Core_Helper_Abstract
             $segmentIds = explode(',', (string) $segmentIds);
         }
 
-        return array_values(array_unique(array_filter(array_map('intval', $segmentIds))));
+        return array_values(array_unique(array_filter(array_map(intval(...), $segmentIds))));
     }
 
     /**
@@ -51,7 +51,7 @@ class Maho_CustomerSegmentation_Helper_Data extends Mage_Core_Helper_Abstract
         foreach ($collection as $segment) {
             $known[] = (int) $segment->getId();
 
-            $segmentWebsiteIds = array_map('intval', $segment->getWebsiteIdsArray());
+            $segmentWebsiteIds = array_map(intval(...), $segment->getWebsiteIdsArray());
             if ($websiteIds !== [] && array_intersect($segmentWebsiteIds, $websiteIds) === []) {
                 $outside[] = $segment->getName();
             }

--- a/app/code/core/Maho/CustomerSegmentation/Model/Segment.php
+++ b/app/code/core/Maho/CustomerSegmentation/Model/Segment.php
@@ -378,7 +378,7 @@ class Maho_CustomerSegmentation_Model_Segment extends Mage_Rule_Model_Abstract
 
         try {
             return $this->getEmailSequences()->getSize() > 0;
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Return false if there are database connection issues
             return false;
         }

--- a/app/code/core/Maho/CustomerSegmentation/Model/Segment/Condition/Abstract.php
+++ b/app/code/core/Maho/CustomerSegmentation/Model/Segment/Condition/Abstract.php
@@ -57,7 +57,7 @@ abstract class Maho_CustomerSegmentation_Model_Segment_Condition_Abstract extend
     {
         return match ($operator) {
             'LIKE', 'NOT LIKE' => '%' . $value . '%',
-            'IN', 'NOT IN' => is_array($value) ? array_map('trim', $value) : array_map('trim', explode(',', $value)),
+            'IN', 'NOT IN' => is_array($value) ? array_map(trim(...), $value) : array_map(trim(...), explode(',', $value)),
             default => $value,
         };
     }

--- a/app/code/core/Maho/CustomerSegmentation/Model/Segment/Condition/Combine.php
+++ b/app/code/core/Maho/CustomerSegmentation/Model/Segment/Condition/Combine.php
@@ -45,9 +45,7 @@ class Maho_CustomerSegmentation_Model_Segment_Condition_Combine extends Mage_Rul
                 'value' => 'customersegmentation/segment_condition_customer_clv|' . $code,
             ];
         }
-        usort($orderConditions, function ($a, $b) {
-            return strcasecmp($a['label'], $b['label']);
-        });
+        usort($orderConditions, fn($a, $b) => strcasecmp($a['label'], $b['label']));
 
         // Generate order items conditions from condition class
         $orderItemsConditions = [];

--- a/app/code/core/Maho/CustomerSegmentation/Model/Segment/Condition/Order/Attributes.php
+++ b/app/code/core/Maho/CustomerSegmentation/Model/Segment/Condition/Order/Attributes.php
@@ -106,9 +106,7 @@ class Maho_CustomerSegmentation_Model_Segment_Condition_Order_Attributes extends
 
             case 'currency_code':
                 $options = Mage::getSingleton('directory/currency')->getConfigAllowCurrencies();
-                $options = array_map(function ($code) {
-                    return ['value' => $code, 'label' => $code];
-                }, $options);
+                $options = array_map(fn($code) => ['value' => $code, 'label' => $code], $options);
                 break;
 
             case 'payment_method':

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Category/Grid.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Category/Grid.php
@@ -102,7 +102,7 @@ class Maho_FeedManager_Block_Adminhtml_Category_Grid extends Mage_Adminhtml_Bloc
             'index' => 'coverage',
             'filter' => false,
             'sortable' => false,
-            'frame_callback' => [$this, 'decorateCoverage'],
+            'frame_callback' => $this->decorateCoverage(...),
         ]);
 
         $this->addColumn('action', [
@@ -111,7 +111,7 @@ class Maho_FeedManager_Block_Adminhtml_Category_Grid extends Mage_Adminhtml_Bloc
             'width' => '120px',
             'filter' => false,
             'sortable' => false,
-            'frame_callback' => [$this, 'decorateAction'],
+            'frame_callback' => $this->decorateAction(...),
         ]);
 
         return parent::_prepareColumns();

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Dynamicrule/Grid.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Dynamicrule/Grid.php
@@ -64,7 +64,7 @@ class Maho_FeedManager_Block_Adminhtml_Dynamicrule_Grid extends Mage_Adminhtml_B
                 1 => $this->__('System'),
                 0 => $this->__('Custom'),
             ],
-            'frame_callback' => [$this, 'decorateType'],
+            'frame_callback' => $this->decorateType(...),
         ]);
 
         $this->addColumn('is_enabled', [
@@ -76,7 +76,7 @@ class Maho_FeedManager_Block_Adminhtml_Dynamicrule_Grid extends Mage_Adminhtml_B
                 1 => $this->__('Enabled'),
                 0 => $this->__('Disabled'),
             ],
-            'frame_callback' => [$this, 'decorateStatus'],
+            'frame_callback' => $this->decorateStatus(...),
         ]);
 
         $this->addColumn('updated_at', [

--- a/app/code/core/Maho/FeedManager/Model/Cron.php
+++ b/app/code/core/Maho/FeedManager/Model/Cron.php
@@ -157,7 +157,7 @@ class Maho_FeedManager_Model_Cron
             'hourly' => true,
             'daily' => $currentHour === 0,
             'twice_daily' => $currentHour === 0 || $currentHour === 12,
-            default => in_array($currentHour, array_map('intval', explode(',', $schedule))),
+            default => in_array($currentHour, array_map(intval(...), explode(',', $schedule))),
         };
     }
 

--- a/app/code/core/Maho/FeedManager/Model/Generator.php
+++ b/app/code/core/Maho/FeedManager/Model/Generator.php
@@ -391,7 +391,7 @@ class Maho_FeedManager_Model_Generator
         // Apply product type filter if set
         $includeTypes = $this->_feed->getData('include_product_types');
         if (!empty($includeTypes)) {
-            $types = array_map('trim', explode(',', $includeTypes));
+            $types = array_map(trim(...), explode(',', $includeTypes));
             $collection->addAttributeToFilter('type_id', ['in' => $types]);
         }
 

--- a/app/code/core/Maho/FeedManager/Model/Generator/Batch.php
+++ b/app/code/core/Maho/FeedManager/Model/Generator/Batch.php
@@ -320,7 +320,7 @@ class Maho_FeedManager_Model_Generator_Batch
                 'file_size' => (int) $fileSize,
                 'file_size_formatted' => (string) Mage::helper('feedmanager')->formatFileSize($fileSize),
                 'message' => "Feed generated successfully with {$this->_state['product_count']} products",
-                'errors' => array_values(array_map('strval', $this->_errors)),
+                'errors' => array_values(array_map(strval(...), $this->_errors)),
                 'has_destination' => (bool) $this->_feed->getDestinationId(),
                 'upload_status' => $uploadResult['status'],
                 'upload_message' => $uploadResult['message'],
@@ -563,7 +563,7 @@ class Maho_FeedManager_Model_Generator_Batch
             'batches_processed' => (int) ($this->_state['batches_processed'] ?? 0),
             'batches_total' => (int) ($this->_state['batches_total'] ?? 0),
             'message' => $message,
-            'errors' => array_values(array_map('strval', $this->_state['errors'])),
+            'errors' => array_values(array_map(strval(...), $this->_state['errors'])),
         ];
     }
 

--- a/app/code/core/Maho/FeedManager/Model/Generator/ProductWriterTrait.php
+++ b/app/code/core/Maho/FeedManager/Model/Generator/ProductWriterTrait.php
@@ -376,7 +376,7 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
         $includeTypes = $this->_feed->getData('include_product_types');
 
         if (!empty($includeTypes)) {
-            $types = array_map('trim', explode(',', $includeTypes));
+            $types = array_map(trim(...), explode(',', $includeTypes));
             $collection->addAttributeToFilter('type_id', ['in' => $types]);
         }
     }
@@ -820,7 +820,7 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
         try {
             $date = new DateTime($value);
             return $date->format('Y-m-d');
-        } catch (Exception $e) {
+        } catch (Exception) {
             return $value;
         }
     }

--- a/app/code/core/Maho/FeedManager/Model/Mapper.php
+++ b/app/code/core/Maho/FeedManager/Model/Mapper.php
@@ -616,7 +616,7 @@ class Maho_FeedManager_Model_Mapper
             if ($image && $image !== 'no_selection') {
                 return Mage::getBaseUrl('media') . 'catalog/product' . $image;
             }
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Silent fail
         }
 
@@ -648,7 +648,7 @@ class Maho_FeedManager_Model_Mapper
                     }
                 }
             }
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Silent fail - gallery may not be loaded
         }
 
@@ -1030,7 +1030,7 @@ class Maho_FeedManager_Model_Mapper
             foreach ($customPlatforms as $platform) {
                 $options[$platform] = ucfirst($platform);
             }
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Silently fail if table doesn't exist yet
         }
 
@@ -1264,7 +1264,7 @@ class Maho_FeedManager_Model_Mapper
                 if (is_array($value)) {
                     $result[$key] = $value;
                 } elseif (is_string($value) && str_contains($value, ',')) {
-                    $result[$key] = array_map('trim', explode(',', $value));
+                    $result[$key] = array_map(trim(...), explode(',', $value));
                 } else {
                     $result[$key] = $value ? [$value] : [];
                 }

--- a/app/code/core/Maho/FeedManager/Model/Transformer/Conditional.php
+++ b/app/code/core/Maho/FeedManager/Model/Transformer/Conditional.php
@@ -98,8 +98,8 @@ class Maho_FeedManager_Model_Transformer_Conditional extends Maho_FeedManager_Mo
             'not_empty' => $value !== null && $value !== '' && !(is_array($value) && empty($value)),
             'contains' => is_string($value) && str_contains($value, $compareValue),
             'not_contains' => !is_string($value) || !str_contains($value, $compareValue),
-            'in' => in_array((string) $value, array_map('trim', explode(',', $compareValue))),
-            'not_in' => !in_array((string) $value, array_map('trim', explode(',', $compareValue))),
+            'in' => in_array((string) $value, array_map(trim(...), explode(',', $compareValue))),
+            'not_in' => !in_array((string) $value, array_map(trim(...), explode(',', $compareValue))),
             default => false,
         };
     }

--- a/app/code/core/Maho/FeedManager/Model/Transformer/FormatDate.php
+++ b/app/code/core/Maho/FeedManager/Model/Transformer/FormatDate.php
@@ -61,7 +61,7 @@ class Maho_FeedManager_Model_Transformer_FormatDate extends Maho_FeedManager_Mod
             }
 
             return $date->format($outputFormat);
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Return original value if parsing fails
             return $value;
         }

--- a/app/code/core/Maho/FeedManager/Model/Transformer/RelativeDateRange.php
+++ b/app/code/core/Maho/FeedManager/Model/Transformer/RelativeDateRange.php
@@ -115,7 +115,7 @@ class Maho_FeedManager_Model_Transformer_RelativeDateRange extends Maho_FeedMana
             $tz = $timezone !== '' ? new DateTimeZone($timezone) : null;
             $start = new DateTime($startExpr, $tz);
             $end = new DateTime($endExpr, $tz);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return $value;
         }
 

--- a/app/code/core/Maho/FeedManager/Model/Transformer/UrlEncode.php
+++ b/app/code/core/Maho/FeedManager/Model/Transformer/UrlEncode.php
@@ -69,7 +69,7 @@ class Maho_FeedManager_Model_Transformer_UrlEncode extends Maho_FeedManager_Mode
         }
 
         if (isset($parts['path'])) {
-            $result .= implode('/', array_map('rawurlencode', explode('/', $parts['path'])));
+            $result .= implode('/', array_map(rawurlencode(...), explode('/', $parts['path'])));
         }
 
         if (isset($parts['query'])) {

--- a/app/code/core/Maho/FeedManager/controllers/Adminhtml/Feedmanager/FeedController.php
+++ b/app/code/core/Maho/FeedManager/controllers/Adminhtml/Feedmanager/FeedController.php
@@ -590,9 +590,7 @@ class Maho_FeedManager_Adminhtml_Feedmanager_FeedController extends Mage_Adminht
         $csv = '';
         foreach ($rows as $row) {
             if ($enclosure) {
-                $csv .= $enclosure . implode($enclosure . $delimiter . $enclosure, array_map(function ($v) use ($enclosure) {
-                    return str_replace($enclosure, $enclosure . $enclosure, (string) $v);
-                }, $row)) . $enclosure . "\n";
+                $csv .= $enclosure . implode($enclosure . $delimiter . $enclosure, array_map(fn($v) => str_replace($enclosure, $enclosure . $enclosure, (string) $v), $row)) . $enclosure . "\n";
             } else {
                 $csv .= implode($delimiter, $row) . "\n";
             }

--- a/app/code/core/Maho/Giftcard/Block/Adminhtml/Giftcard/Renderer/Currency.php
+++ b/app/code/core/Maho/Giftcard/Block/Adminhtml/Giftcard/Renderer/Currency.php
@@ -41,7 +41,7 @@ class Maho_Giftcard_Block_Adminhtml_Giftcard_Renderer_Currency extends Mage_Admi
         if ($websiteId) {
             try {
                 return Mage::app()->getWebsite($websiteId)->getBaseCurrencyCode();
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // Fall through to default
             }
         }

--- a/app/code/core/Maho/Giftcard/Block/Catalog/Product/Price.php
+++ b/app/code/core/Maho/Giftcard/Block/Catalog/Product/Price.php
@@ -53,7 +53,7 @@ class Maho_Giftcard_Block_Catalog_Product_Price extends Mage_Catalog_Block_Produ
         // Check fixed amounts
         $amounts = $product->getData('giftcard_amounts');
         if ($amounts) {
-            $amountsArray = array_map('trim', explode(',', $amounts));
+            $amountsArray = array_map(trim(...), explode(',', $amounts));
             $amountsArray = array_filter($amountsArray, fn($a) => is_numeric($a) && $a > 0);
             if ($amountsArray !== []) {
                 $maxPrice = (float) max($amountsArray);

--- a/app/code/core/Maho/Giftcard/Block/Catalog/Product/View/Type/Giftcard.php
+++ b/app/code/core/Maho/Giftcard/Block/Catalog/Product/View/Type/Giftcard.php
@@ -64,10 +64,8 @@ class Maho_Giftcard_Block_Catalog_Product_View_Type_Giftcard extends Mage_Catalo
             return [];
         }
 
-        $amountsArray = array_map('trim', explode(',', $amounts));
-        $amountsArray = array_filter($amountsArray, function ($amount) {
-            return is_numeric($amount) && $amount > 0;
-        });
+        $amountsArray = array_map(trim(...), explode(',', $amounts));
+        $amountsArray = array_filter($amountsArray, fn($amount) => is_numeric($amount) && $amount > 0);
 
         sort($amountsArray, SORT_NUMERIC);
         return $amountsArray;

--- a/app/code/core/Maho/Giftcard/Block/Checkout/Cart/Item/Renderer.php
+++ b/app/code/core/Maho/Giftcard/Block/Checkout/Cart/Item/Renderer.php
@@ -35,7 +35,7 @@ class Maho_Giftcard_Block_Checkout_Cart_Item_Renderer extends Mage_Checkout_Bloc
                 } else {
                     $optionValue = $formattedDate;
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // Fall through to default handling
             }
         }

--- a/app/code/core/Maho/Giftcard/Block/Sales/Order/Item/Renderer.php
+++ b/app/code/core/Maho/Giftcard/Block/Sales/Order/Item/Renderer.php
@@ -31,7 +31,7 @@ class Maho_Giftcard_Block_Sales_Order_Item_Renderer extends Mage_Sales_Block_Ord
                 } else {
                     $optionValue = $formattedDate;
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // Fall through to default handling
             }
         }

--- a/app/code/core/Maho/Giftcard/Model/Product/Price.php
+++ b/app/code/core/Maho/Giftcard/Model/Product/Price.php
@@ -58,7 +58,7 @@ class Maho_Giftcard_Model_Product_Price extends Mage_Catalog_Model_Product_Type_
         // Check fixed amounts
         $amounts = $product->getData('giftcard_amounts');
         if ($amounts) {
-            $amountsArray = array_map('trim', explode(',', $amounts));
+            $amountsArray = array_map(trim(...), explode(',', $amounts));
             $amountsArray = array_filter($amountsArray, fn($a) => is_numeric($a) && $a > 0);
             if ($amountsArray !== []) {
                 $minPrice = (float) min($amountsArray);

--- a/app/code/core/Maho/Giftcard/Model/Product/Type/Giftcard.php
+++ b/app/code/core/Maho/Giftcard/Model/Product/Type/Giftcard.php
@@ -132,8 +132,8 @@ class Maho_Giftcard_Model_Product_Type_Giftcard extends Mage_Catalog_Model_Produ
                 if ($giftcardType === 'combined') {
                     $allowedAmounts = $productInstance->getData('giftcard_amounts');
                     if ($allowedAmounts) {
-                        $amounts = array_map('trim', explode(',', $allowedAmounts));
-                        $amounts = array_map('floatval', $amounts);
+                        $amounts = array_map(trim(...), explode(',', $allowedAmounts));
+                        $amounts = array_map(floatval(...), $amounts);
                         foreach ($amounts as $allowedAmount) {
                             if (abs($amount - $allowedAmount) < 0.01) {
                                 $isFixedAmount = true;
@@ -159,8 +159,8 @@ class Maho_Giftcard_Model_Product_Type_Giftcard extends Mage_Catalog_Model_Produ
             if ($giftcardType === 'fixed') {
                 $allowedAmounts = $productInstance->getData('giftcard_amounts');
                 if ($allowedAmounts) {
-                    $amounts = array_map('trim', explode(',', $allowedAmounts));
-                    $amounts = array_map('floatval', $amounts);
+                    $amounts = array_map(trim(...), explode(',', $allowedAmounts));
+                    $amounts = array_map(floatval(...), $amounts);
                     $isValid = array_any($amounts, fn($allowedAmount) => abs($amount - $allowedAmount) < 0.01);
 
                     if (!$isValid) {
@@ -234,7 +234,7 @@ class Maho_Giftcard_Model_Product_Type_Giftcard extends Mage_Catalog_Model_Produ
         // For fixed amounts, return the lowest amount
         $amounts = $product->getData('giftcard_amounts');
         if ($amounts) {
-            $amountsArray = array_map('trim', explode(',', $amounts));
+            $amountsArray = array_map(trim(...), explode(',', $amounts));
             $amountsArray = array_filter($amountsArray, fn($a) => is_numeric($a) && $a > 0);
             if ($amountsArray !== []) {
                 return (float) min($amountsArray);

--- a/app/code/core/Maho/Giftcard/Model/Resource/Indexer/Price.php
+++ b/app/code/core/Maho/Giftcard/Model/Resource/Indexer/Price.php
@@ -227,10 +227,10 @@ class Maho_Giftcard_Model_Resource_Indexer_Price extends Mage_Catalog_Model_Reso
             // Check fixed amounts
             $amounts = $product->getData('giftcard_amounts');
             if ($amounts) {
-                $amountsArray = array_map('trim', explode(',', $amounts));
+                $amountsArray = array_map(trim(...), explode(',', $amounts));
                 $amountsArray = array_filter($amountsArray, fn($a) => is_numeric($a) && $a > 0);
                 if ($amountsArray !== []) {
-                    $amountsArray = array_map('floatval', $amountsArray);
+                    $amountsArray = array_map(floatval(...), $amountsArray);
                     $minPrice = min($amountsArray);
                     $maxPrice = max($amountsArray);
                 }

--- a/app/code/core/Maho/Giftcard/controllers/Adminhtml/Giftcard/ProductController.php
+++ b/app/code/core/Maho/Giftcard/controllers/Adminhtml/Giftcard/ProductController.php
@@ -46,7 +46,7 @@ class Maho_Giftcard_Adminhtml_Giftcard_ProductController extends Mage_Adminhtml_
 
             if ($amountType === 'fixed') {
                 // Create multiple products for fixed amounts
-                $amountsArray = array_map('trim', explode(',', $amounts));
+                $amountsArray = array_map(trim(...), explode(',', $amounts));
 
                 foreach ($amountsArray as $amount) {
                     if ($amount === '' || !is_numeric($amount)) {

--- a/app/code/core/Maho/Giftcard/controllers/CartController.php
+++ b/app/code/core/Maho/Giftcard/controllers/CartController.php
@@ -263,7 +263,7 @@ class Maho_Giftcard_CartController extends Mage_Core_Controller_Front_Action
                 );
             }
 
-        } catch (Exception $e) {
+        } catch (Exception) {
             Mage::getSingleton('checkout/session')->addError(
                 $this->__('Cannot remove gift card.'),
             );
@@ -435,7 +435,7 @@ class Maho_Giftcard_CartController extends Mage_Core_Controller_Front_Action
                 $result['message'] = $this->__('Gift card not found.');
             }
 
-        } catch (Exception $e) {
+        } catch (Exception) {
             $result['message'] = $this->__('Cannot remove gift card.');
         }
 

--- a/app/code/core/Maho/Intelligence/Model/Lsp/Handler/Completion.php
+++ b/app/code/core/Maho/Intelligence/Model/Lsp/Handler/Completion.php
@@ -10,19 +10,7 @@ declare(strict_types=1);
 
 class Maho_Intelligence_Model_Lsp_Handler_Completion
 {
-    private Maho_Intelligence_Model_Registry $registry;
-    private Maho_Intelligence_Model_Lsp_ContextDetector $detector;
-    private Maho_Intelligence_Model_Lsp_DocumentStore $documents;
-
-    public function __construct(
-        Maho_Intelligence_Model_Registry $registry,
-        Maho_Intelligence_Model_Lsp_ContextDetector $detector,
-        Maho_Intelligence_Model_Lsp_DocumentStore $documents,
-    ) {
-        $this->registry = $registry;
-        $this->detector = $detector;
-        $this->documents = $documents;
-    }
+    public function __construct(private Maho_Intelligence_Model_Registry $registry, private Maho_Intelligence_Model_Lsp_ContextDetector $detector, private Maho_Intelligence_Model_Lsp_DocumentStore $documents) {}
 
     public function handle(array $params): ?array
     {

--- a/app/code/core/Maho/Intelligence/Model/Lsp/Handler/Definition.php
+++ b/app/code/core/Maho/Intelligence/Model/Lsp/Handler/Definition.php
@@ -10,19 +10,7 @@ declare(strict_types=1);
 
 class Maho_Intelligence_Model_Lsp_Handler_Definition
 {
-    private Maho_Intelligence_Model_Registry $registry;
-    private Maho_Intelligence_Model_Lsp_ContextDetector $detector;
-    private Maho_Intelligence_Model_Lsp_DocumentStore $documents;
-
-    public function __construct(
-        Maho_Intelligence_Model_Registry $registry,
-        Maho_Intelligence_Model_Lsp_ContextDetector $detector,
-        Maho_Intelligence_Model_Lsp_DocumentStore $documents,
-    ) {
-        $this->registry = $registry;
-        $this->detector = $detector;
-        $this->documents = $documents;
-    }
+    public function __construct(private Maho_Intelligence_Model_Registry $registry, private Maho_Intelligence_Model_Lsp_ContextDetector $detector, private Maho_Intelligence_Model_Lsp_DocumentStore $documents) {}
 
     public function handle(array $params): array|null
     {

--- a/app/code/core/Maho/Intelligence/Model/Lsp/Handler/Diagnostic.php
+++ b/app/code/core/Maho/Intelligence/Model/Lsp/Handler/Diagnostic.php
@@ -50,12 +50,7 @@ class Maho_Intelligence_Model_Lsp_Handler_Diagnostic
         ],
     ];
 
-    private Maho_Intelligence_Model_Registry $registry;
-
-    public function __construct(Maho_Intelligence_Model_Registry $registry)
-    {
-        $this->registry = $registry;
-    }
+    public function __construct(private Maho_Intelligence_Model_Registry $registry) {}
 
     /**
      * @return array LSP diagnostic items

--- a/app/code/core/Maho/Intelligence/Model/Lsp/Handler/Hover.php
+++ b/app/code/core/Maho/Intelligence/Model/Lsp/Handler/Hover.php
@@ -10,19 +10,7 @@ declare(strict_types=1);
 
 class Maho_Intelligence_Model_Lsp_Handler_Hover
 {
-    private Maho_Intelligence_Model_Registry $registry;
-    private Maho_Intelligence_Model_Lsp_ContextDetector $detector;
-    private Maho_Intelligence_Model_Lsp_DocumentStore $documents;
-
-    public function __construct(
-        Maho_Intelligence_Model_Registry $registry,
-        Maho_Intelligence_Model_Lsp_ContextDetector $detector,
-        Maho_Intelligence_Model_Lsp_DocumentStore $documents,
-    ) {
-        $this->registry = $registry;
-        $this->detector = $detector;
-        $this->documents = $documents;
-    }
+    public function __construct(private Maho_Intelligence_Model_Registry $registry, private Maho_Intelligence_Model_Lsp_ContextDetector $detector, private Maho_Intelligence_Model_Lsp_DocumentStore $documents) {}
 
     public function handle(array $params): ?array
     {

--- a/app/code/core/Maho/MediaCleaner/controllers/Adminhtml/MediacleanerController.php
+++ b/app/code/core/Maho/MediaCleaner/controllers/Adminhtml/MediacleanerController.php
@@ -101,7 +101,7 @@ class Maho_MediaCleaner_Adminhtml_MediacleanerController extends Mage_Adminhtml_
                     ->where('attribute_id IN (?)', $attributeIds)
                     ->where('value <> ?', 'no_selection'),
             );
-            $dbImages = array_map([$this, 'removeLeadingSlash'], $dbImages);
+            $dbImages = array_map($this->removeLeadingSlash(...), $dbImages);
         }
 
         $placeholders = $db->fetchCol(
@@ -120,7 +120,7 @@ class Maho_MediaCleaner_Adminhtml_MediacleanerController extends Mage_Adminhtml_
                 ->where('value IS NOT NULL')
                 ->where('LENGTH(value) > 0'),
         );
-        $mediaGallery = array_map([$this, 'removeLeadingSlash'], $mediaGallery);
+        $mediaGallery = array_map($this->removeLeadingSlash(...), $mediaGallery);
 
         $fsImages = Mage::helper('mediacleaner')->scandirRecursive($mediaDir);
         $fsImages = str_replace("{$mediaDir}/", '', $fsImages);

--- a/app/code/core/Maho/Queue/Block/Adminhtml/Message/Grid.php
+++ b/app/code/core/Maho/Queue/Block/Adminhtml/Message/Grid.php
@@ -68,7 +68,7 @@ class Maho_Queue_Block_Adminhtml_Message_Grid extends Mage_Adminhtml_Block_Widge
         $this->addColumn('error_message', [
             'header'         => $helper->__('Error'),
             'index'          => 'error_message',
-            'frame_callback' => [$this, 'decorateError'],
+            'frame_callback' => $this->decorateError(...),
         ]);
 
         $this->addColumn('available_at', [

--- a/app/code/core/Maho/Revocation/Block/Adminhtml/Request/Grid.php
+++ b/app/code/core/Maho/Revocation/Block/Adminhtml/Request/Grid.php
@@ -88,7 +88,7 @@ class Maho_Revocation_Block_Adminhtml_Request_Grid extends Mage_Adminhtml_Block_
             'header' => $helper->__('Matched Order'),
             'index' => 'order_id',
             'width' => '100px',
-            'frame_callback' => [$this, 'decorateOrder'],
+            'frame_callback' => $this->decorateOrder(...),
         ]);
 
         $this->addColumn('suppressed_at', [

--- a/app/code/core/Maho/ShippingBridge/Model/Carrier.php
+++ b/app/code/core/Maho/ShippingBridge/Model/Carrier.php
@@ -312,7 +312,7 @@ class Maho_ShippingBridge_Model_Carrier extends Mage_Shipping_Model_Carrier_Abst
         if ($value === '') {
             return [];
         }
-        return array_filter(array_map('trim', explode(',', $value)));
+        return array_filter(array_map(trim(...), explode(',', $value)));
     }
 
     /**

--- a/app/code/core/Maho/SpeculationRules/Helper/Data.php
+++ b/app/code/core/Maho/SpeculationRules/Helper/Data.php
@@ -64,7 +64,7 @@ class Maho_SpeculationRules_Helper_Data extends Mage_Core_Helper_Abstract
             }
 
             // Parse selectors (one per line)
-            $selectors = array_filter(array_map('trim', explode("\n", $selectorsConfig)));
+            $selectors = array_filter(array_map(trim(...), explode("\n", $selectorsConfig)));
 
             if (empty($selectors)) {
                 continue;

--- a/lib/Maho.php
+++ b/lib/Maho.php
@@ -291,7 +291,7 @@ final class Maho
             }
 
             $reportFile = "{$reportDir}/$reportId";
-            $reportData = array_map('strip_tags', $reportData);
+            $reportData = array_map(strip_tags(...), $reportData);
             @file_put_contents($reportFile, serialize($reportData));
             @chmod($reportFile, 0640);
         }

--- a/lib/Maho/Data/Collection/Db.php
+++ b/lib/Maho/Data/Collection/Db.php
@@ -230,9 +230,7 @@ class Db extends Collection
             $countSelect->reset(Select::GROUP);
             $countSelect->distinct(true);
             $group = $this->getSelect()->getPart(Select::GROUP);
-            $group = array_map(function ($token) {
-                return $this->getSelect()->getAdapter()->quoteIdentifier($token, true);
-            }, $group);
+            $group = array_map(fn($identifier) => $this->getSelect()->getAdapter()->quoteIdentifier($identifier, true), $group);
             $countSelect->columns('COUNT(DISTINCT ' . implode(', ', $group) . ')');
         } else {
             $countSelect->columns('COUNT(*)');
@@ -241,13 +239,9 @@ class Db extends Collection
             // - there are no where clauses using joined tables
             // - all joins are left joins
             // - there are no join conditions using bind params (for simplicity)
-            $leftJoins = array_filter($countSelect->getPart(Select::FROM), function ($table) {
-                return ($table['joinType'] == Select::LEFT_JOIN || $table['joinType'] == Select::FROM);
-            });
+            $leftJoins = array_filter($countSelect->getPart(Select::FROM), fn($table) => $table['joinType'] == Select::LEFT_JOIN || $table['joinType'] == Select::FROM);
             if (count($leftJoins) == count($countSelect->getPart(Select::FROM))) {
-                $mainTable = array_filter($leftJoins, function ($table) {
-                    return $table['joinType'] == Select::FROM;
-                });
+                $mainTable = array_filter($leftJoins, fn($table) => $table['joinType'] == Select::FROM);
                 $mainTable = key($mainTable);
                 $mainTable = preg_quote($mainTable, '/');
                 $pattern = "/^$mainTable\\.\\w+/";
@@ -259,13 +253,9 @@ class Db extends Collection
                     });
                 });
                 if ($this->_bindParams) {
-                    $bindParams = array_map(function ($token) {
-                        return ltrim($token, ':');
-                    }, array_keys($this->_bindParams));
+                    $bindParams = array_map(fn($placeholder) => ltrim($placeholder, ':'), array_keys($this->_bindParams));
                     $bindPattern = '/:(' . implode('|', $bindParams) . ')/';
-                    $joinUsingBind = array_filter($leftJoins, function ($table) use ($bindPattern) {
-                        return !empty($table['joinCondition']) && preg_match($bindPattern, $table['joinCondition']);
-                    });
+                    $joinUsingBind = array_filter($leftJoins, fn($table) => !empty($table['joinCondition']) && preg_match($bindPattern, $table['joinCondition']));
                 }
                 if (empty($whereUsingJoin) && empty($joinUsingBind)) {
                     $from = array_slice($leftJoins, 0, 1);

--- a/lib/Maho/Data/Collection/Filesystem.php
+++ b/lib/Maho/Data/Collection/Filesystem.php
@@ -343,7 +343,7 @@ class Filesystem extends Collection
 
         // sort (keys are lost!)
         if (!empty($this->_orders)) {
-            usort($this->$attributeName, [$this, '_usort']);
+            usort($this->$attributeName, $this->_usort(...));
         }
     }
 
@@ -494,62 +494,62 @@ class Filesystem extends Collection
 
         // simply check whether equals
         if (!is_array($cond)) {
-            return $this->addCallbackFilter($field, $cond, $type, [$this, 'filterCallbackEq']);
+            return $this->addCallbackFilter($field, $cond, $type, $this->filterCallbackEq(...));
         }
 
         // versatile filters
         if (isset($cond['from']) || isset($cond['to'])) {
             $this->_addFilterBracket('(', 'and' === $type);
             if (isset($cond['from'])) {
-                $this->addCallbackFilter($field, $cond['from'], 'and', [$this, 'filterCallbackIsLessThan'], $inverted);
+                $this->addCallbackFilter($field, $cond['from'], 'and', $this->filterCallbackIsLessThan(...), $inverted);
             }
             if (isset($cond['to'])) {
-                $this->addCallbackFilter($field, $cond['to'], 'and', [$this, 'filterCallbackIsMoreThan'], $inverted);
+                $this->addCallbackFilter($field, $cond['to'], 'and', $this->filterCallbackIsMoreThan(...), $inverted);
             }
             return $this->_addFilterBracket(')');
         }
         if (isset($cond['eq'])) {
-            return $this->addCallbackFilter($field, $cond['eq'], $type, [$this, 'filterCallbackEq']);
+            return $this->addCallbackFilter($field, $cond['eq'], $type, $this->filterCallbackEq(...));
         }
         if (isset($cond['neq'])) {
-            return $this->addCallbackFilter($field, $cond['neq'], $type, [$this, 'filterCallbackEq'], $inverted);
+            return $this->addCallbackFilter($field, $cond['neq'], $type, $this->filterCallbackEq(...), $inverted);
         }
         if (isset($cond['like'])) {
-            return $this->addCallbackFilter($field, $cond['like'], $type, [$this, 'filterCallbackLike']);
+            return $this->addCallbackFilter($field, $cond['like'], $type, $this->filterCallbackLike(...));
         }
         if (isset($cond['nlike'])) {
-            return $this->addCallbackFilter($field, $cond['nlike'], $type, [$this, 'filterCallbackLike'], $inverted);
+            return $this->addCallbackFilter($field, $cond['nlike'], $type, $this->filterCallbackLike(...), $inverted);
         }
         if (isset($cond['in'])) {
-            return $this->addCallbackFilter($field, $cond['in'], $type, [$this, 'filterCallbackInArray']);
+            return $this->addCallbackFilter($field, $cond['in'], $type, $this->filterCallbackInArray(...));
         }
         if (isset($cond['nin'])) {
-            return $this->addCallbackFilter($field, $cond['nin'], $type, [$this, 'filterCallbackInArray'], $inverted);
+            return $this->addCallbackFilter($field, $cond['nin'], $type, $this->filterCallbackInArray(...), $inverted);
         }
         if (isset($cond['notnull'])) {
-            return $this->addCallbackFilter($field, $cond['notnull'], $type, [$this, 'filterCallbackIsNull'], $inverted);
+            return $this->addCallbackFilter($field, $cond['notnull'], $type, $this->filterCallbackIsNull(...), $inverted);
         }
         if (isset($cond['null'])) {
-            return $this->addCallbackFilter($field, $cond['null'], $type, [$this, 'filterCallbackIsNull']);
+            return $this->addCallbackFilter($field, $cond['null'], $type, $this->filterCallbackIsNull(...));
         }
         if (isset($cond['moreq'])) {
-            return $this->addCallbackFilter($field, $cond['moreq'], $type, [$this, 'filterCallbackIsLessThan'], $inverted);
+            return $this->addCallbackFilter($field, $cond['moreq'], $type, $this->filterCallbackIsLessThan(...), $inverted);
         }
         if (isset($cond['gt'])) {
-            return $this->addCallbackFilter($field, $cond['gt'], $type, [$this, 'filterCallbackIsMoreThan']);
+            return $this->addCallbackFilter($field, $cond['gt'], $type, $this->filterCallbackIsMoreThan(...));
         }
         if (isset($cond['lt'])) {
-            return $this->addCallbackFilter($field, $cond['lt'], $type, [$this, 'filterCallbackIsLessThan']);
+            return $this->addCallbackFilter($field, $cond['lt'], $type, $this->filterCallbackIsLessThan(...));
         }
         if (isset($cond['gteq'])) {
-            return $this->addCallbackFilter($field, $cond['gteq'], $type, [$this, 'filterCallbackIsLessThan'], $inverted);
+            return $this->addCallbackFilter($field, $cond['gteq'], $type, $this->filterCallbackIsLessThan(...), $inverted);
         }
         if (isset($cond['lteq'])) {
-            return $this->addCallbackFilter($field, $cond['lteq'], $type, [$this, 'filterCallbackIsMoreThan'], $inverted);
+            return $this->addCallbackFilter($field, $cond['lteq'], $type, $this->filterCallbackIsMoreThan(...), $inverted);
         }
         if (isset($cond['finset'])) {
             $filterValue = ($cond['finset'] ? explode(',', $cond['finset']) : []);
-            return $this->addCallbackFilter($field, $filterValue, $type, [$this, 'filterCallbackInArray']);
+            return $this->addCallbackFilter($field, $filterValue, $type, $this->filterCallbackInArray(...));
         }
 
         // add OR recursively

--- a/lib/Maho/Data/Form/Element/Date.php
+++ b/lib/Maho/Data/Form/Element/Date.php
@@ -128,7 +128,7 @@ class Date extends AbstractElement
                 }
                 $this->_value = $dateTime;
             }
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $this->_value = '';
         }
         return $this;

--- a/lib/Maho/Data/Form/Filter/Date.php
+++ b/lib/Maho/Data/Form/Filter/Date.php
@@ -65,7 +65,7 @@ class Date implements FilterInterface
         try {
             $date = new DateTime($value);
             return $date->format(\Mage_Core_Model_Locale::DATE_FORMAT);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Invalid date, return original value (will likely cause validation error downstream)
             return $value;
         }
@@ -88,7 +88,7 @@ class Date implements FilterInterface
         try {
             $date = new DateTime($value);
             return $date->format(\Mage_Core_Model_Locale::DATE_FORMAT);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Invalid date, return original value
             return $value;
         }

--- a/lib/Maho/Data/Form/Filter/Datetime.php
+++ b/lib/Maho/Data/Form/Filter/Datetime.php
@@ -51,7 +51,7 @@ class Datetime extends Date
         try {
             $date = new PhpDateTime($value);
             return $date->format(\Mage_Core_Model_Locale::DATETIME_FORMAT);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Invalid datetime, return original value (will likely cause validation error downstream)
             return $value;
         }
@@ -74,7 +74,7 @@ class Datetime extends Date
         try {
             $date = new PhpDateTime($value);
             return $date->format(\Mage_Core_Model_Locale::DATETIME_FORMAT);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Invalid datetime, return original value
             return $value;
         }

--- a/lib/Maho/Db/Adapter/AbstractPdoAdapter.php
+++ b/lib/Maho/Db/Adapter/AbstractPdoAdapter.php
@@ -1236,7 +1236,7 @@ abstract class AbstractPdoAdapter implements AdapterInterface
     protected function _getInsertSqlQuery(string $tableName, array $columns, array $values): string
     {
         $tableName = $this->quoteIdentifier($tableName, true);
-        $columns = array_map([$this, 'quoteIdentifier'], $columns);
+        $columns = array_map($this->quoteIdentifier(...), $columns);
         $columns = implode(',', $columns);
         $values = implode(', ', $values);
 
@@ -1284,7 +1284,7 @@ abstract class AbstractPdoAdapter implements AdapterInterface
                     $primaryKeyConstraint->getColumnNames(),
                 );
             }
-        } catch (\Doctrine\DBAL\Exception $e) {
+        } catch (\Doctrine\DBAL\Exception) {
             // Table might not have a primary key
         }
 

--- a/lib/Maho/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Mysql.php
@@ -1575,10 +1575,7 @@ class Mysql extends AbstractPdoAdapter
 
             // Decorate each column with additional info
             $ddl = array_map(
-                [
-                    $this,
-                    'decorateTableInfo',
-                ],
+                $this->decorateTableInfo(...),
                 $ddl,
             );
 
@@ -1633,7 +1630,7 @@ class Mysql extends AbstractPdoAdapter
             if ($params !== null) {
                 if (str_contains($params, ',')) {
                     // DECIMAL/NUMERIC type - has precision and scale
-                    $parts = array_map('trim', explode(',', $params));
+                    $parts = array_map(trim(...), explode(',', $params));
                     $result['precision'] = (int) $parts[0];
                     $result['scale'] = (int) $parts[1];
                 } else {
@@ -2284,7 +2281,7 @@ class Mysql extends AbstractPdoAdapter
         // PRIMARY KEY
         if (!empty($primary)) {
             asort($primary, SORT_NUMERIC);
-            $primary      = array_map([$this, 'quoteIdentifier'], array_keys($primary));
+            $primary      = array_map($this->quoteIdentifier(...), array_keys($primary));
             $definition[] = sprintf('  PRIMARY KEY (%s)', implode(', ', $primary));
         }
 
@@ -3518,7 +3515,7 @@ class Mysql extends AbstractPdoAdapter
         }
         $query = sprintf('%s INTO %s', $query, $this->quoteIdentifier($table));
         if ($fields) {
-            $columns = array_map([$this, 'quoteIdentifier'], $fields);
+            $columns = array_map($this->quoteIdentifier(...), $fields);
             $query = sprintf('%s (%s)', $query, implode(', ', $columns));
         }
 
@@ -4028,7 +4025,7 @@ class Mysql extends AbstractPdoAdapter
     protected function _getInsertSqlQuery(string $tableName, array $columns, array $values): string
     {
         $tableName = $this->quoteIdentifier($tableName, true);
-        $columns   = array_map([$this, 'quoteIdentifier'], $columns);
+        $columns   = array_map($this->quoteIdentifier(...), $columns);
         $columns   = implode(',', $columns);
         $values    = implode(', ', $values);
 

--- a/lib/Maho/Db/Adapter/Pdo/Pgsql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Pgsql.php
@@ -607,8 +607,7 @@ class Pgsql extends AbstractPdoAdapter
 
         // Helper expression to safely create a date, adjusting Feb 29 to Feb 28 in non-leap years
         // This prevents "date/time field value out of range" errors
-        $makeSafeDate = function (string $yearExpr) use ($dateField): string {
-            return "MAKE_DATE(
+        $makeSafeDate = (fn(string $yearExpr): string => "MAKE_DATE(
                 {$yearExpr}::int,
                 EXTRACT(MONTH FROM ({$dateField})::timestamp)::int,
                 CASE
@@ -618,8 +617,7 @@ class Pgsql extends AbstractPdoAdapter
                     THEN 28
                     ELSE EXTRACT(DAY FROM ({$dateField})::timestamp)::int
                 END
-            )";
-        };
+            )");
 
         $currentYear = "EXTRACT(YEAR FROM {$refDate}::timestamp)";
         $nextYear = "(EXTRACT(YEAR FROM {$refDate}::timestamp) + 1)";
@@ -1189,7 +1187,7 @@ class Pgsql extends AbstractPdoAdapter
         $insertSql = $this->_getInsertSqlQuery($table, $cols, $values);
 
         if ($updateFields) {
-            $conflictCols = array_map([$this, 'quoteIdentifier'], $conflictColumns);
+            $conflictCols = array_map($this->quoteIdentifier(...), $conflictColumns);
             $insertSql .= sprintf(
                 ' ON CONFLICT (%s) DO UPDATE SET %s',
                 implode(', ', $conflictCols),
@@ -1433,7 +1431,7 @@ class Pgsql extends AbstractPdoAdapter
 
         // $bind keys still align with their placeholders here (Expr entries were
         // unset above), so column names map positionally to array_values($bind).
-        $boundColumns = array_map('strval', array_keys($bind));
+        $boundColumns = array_map(strval(...), array_keys($bind));
         $params = $this->_encodeBinaryBindValues($tableName, $boundColumns, array_values($bind));
         $stmt = $this->query($sql, $params);
 
@@ -2055,7 +2053,7 @@ class Pgsql extends AbstractPdoAdapter
     {
         $query = sprintf('INSERT INTO %s', $this->quoteIdentifier($table));
         if ($fields) {
-            $columns = array_map([$this, 'quoteIdentifier'], $fields);
+            $columns = array_map($this->quoteIdentifier(...), $fields);
             $query = sprintf('%s (%s)', $query, implode(', ', $columns));
         }
 
@@ -2096,7 +2094,7 @@ class Pgsql extends AbstractPdoAdapter
                 }
 
                 if ($update) {
-                    $conflictCols = array_map([$this, 'quoteIdentifier'], $primaryKeys);
+                    $conflictCols = array_map($this->quoteIdentifier(...), $primaryKeys);
                     $query .= sprintf(
                         ' ON CONFLICT (%s) DO UPDATE SET %s',
                         implode(', ', $conflictCols),
@@ -2564,7 +2562,7 @@ class Pgsql extends AbstractPdoAdapter
         // PRIMARY KEY
         if (!empty($primary)) {
             asort($primary, SORT_NUMERIC);
-            $primary = array_map([$this, 'quoteIdentifier'], array_keys($primary));
+            $primary = array_map($this->quoteIdentifier(...), array_keys($primary));
             $definition[] = sprintf('  PRIMARY KEY (%s)', implode(', ', $primary));
         }
 

--- a/lib/Maho/Db/Adapter/Pdo/Pgsql.php
+++ b/lib/Maho/Db/Adapter/Pdo/Pgsql.php
@@ -607,7 +607,7 @@ class Pgsql extends AbstractPdoAdapter
 
         // Helper expression to safely create a date, adjusting Feb 29 to Feb 28 in non-leap years
         // This prevents "date/time field value out of range" errors
-        $makeSafeDate = (fn(string $yearExpr): string => "MAKE_DATE(
+        $makeSafeDate = fn(string $yearExpr): string => "MAKE_DATE(
                 {$yearExpr}::int,
                 EXTRACT(MONTH FROM ({$dateField})::timestamp)::int,
                 CASE
@@ -617,7 +617,7 @@ class Pgsql extends AbstractPdoAdapter
                     THEN 28
                     ELSE EXTRACT(DAY FROM ({$dateField})::timestamp)::int
                 END
-            )");
+            )";
 
         $currentYear = "EXTRACT(YEAR FROM {$refDate}::timestamp)";
         $nextYear = "(EXTRACT(YEAR FROM {$refDate}::timestamp) + 1)";

--- a/lib/Maho/Db/Adapter/Pdo/Sqlite.php
+++ b/lib/Maho/Db/Adapter/Pdo/Sqlite.php
@@ -961,7 +961,7 @@ class Sqlite extends AbstractPdoAdapter
         $insertSql = $this->_getInsertSqlQuery($table, $cols, $values);
 
         if ($updateFields) {
-            $conflictCols = array_map([$this, 'quoteIdentifier'], $conflictColumns);
+            $conflictCols = array_map($this->quoteIdentifier(...), $conflictColumns);
             $insertSql .= sprintf(
                 ' ON CONFLICT (%s) DO UPDATE SET %s',
                 implode(', ', $conflictCols),
@@ -1160,7 +1160,7 @@ class Sqlite extends AbstractPdoAdapter
                 );
                 $this->raw_query($sql);
                 return true;
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // Lock already exists
                 if ($timeout <= 0) {
                     return false;
@@ -1474,7 +1474,7 @@ class Sqlite extends AbstractPdoAdapter
                     $indexType,
                     $this->quoteIdentifier($indexData['KEY_NAME']),
                     $this->quoteIdentifier($actualTableName),
-                    implode(', ', array_map([$this, 'quoteIdentifier'], $indexData['COLUMNS_LIST'])),
+                    implode(', ', array_map($this->quoteIdentifier(...), $indexData['COLUMNS_LIST'])),
                 );
                 $conn->executeStatement($indexSql);
             }
@@ -1873,7 +1873,7 @@ class Sqlite extends AbstractPdoAdapter
 
         $query = sprintf('%s %s', $insertType, $this->quoteIdentifier($table));
         if ($fields) {
-            $columns = array_map([$this, 'quoteIdentifier'], $fields);
+            $columns = array_map($this->quoteIdentifier(...), $fields);
             $query = sprintf('%s (%s)', $query, implode(', ', $columns));
         }
 
@@ -2301,7 +2301,7 @@ class Sqlite extends AbstractPdoAdapter
             $hasInlinePrimary = array_any($definition, fn($def) => str_contains($def, 'PRIMARY KEY'));
             if (!$hasInlinePrimary) {
                 asort($primary, SORT_NUMERIC);
-                $primaryCols = array_map([$this, 'quoteIdentifier'], array_keys($primary));
+                $primaryCols = array_map($this->quoteIdentifier(...), array_keys($primary));
                 $definition[] = sprintf('  PRIMARY KEY (%s)', implode(', ', $primaryCols));
             }
         }
@@ -2764,7 +2764,7 @@ class Sqlite extends AbstractPdoAdapter
         foreach ($indexesBefore as $indexName => $indexInfo) {
             if (!isset($indexesAfter[$indexName])) {
                 $indexType = $indexInfo['type'] === \Doctrine\DBAL\Schema\Index\IndexType::UNIQUE ? 'UNIQUE INDEX' : 'INDEX';
-                $quotedColumns = array_map([$this, 'quoteIdentifier'], $indexInfo['columns']);
+                $quotedColumns = array_map($this->quoteIdentifier(...), $indexInfo['columns']);
                 $sql = sprintf(
                     'CREATE %s %s ON %s (%s)',
                     $indexType,

--- a/lib/Maho/Db/Ddl/Table.php
+++ b/lib/Maho/Db/Ddl/Table.php
@@ -591,7 +591,7 @@ class Table
      */
     protected function _normalizeIndexColumnPosition(array $columns): array
     {
-        uasort($columns, [$this, '_sortIndexColumnPosition']);
+        uasort($columns, $this->_sortIndexColumnPosition(...));
         $position = 0;
         foreach (array_keys($columns) as $columnId) {
             $columns[$columnId]['POSITION'] = $position;
@@ -605,7 +605,7 @@ class Table
      */
     protected function _normalizeColumnPosition(array $columns): array
     {
-        uasort($columns, [$this, '_sortColumnPosition']);
+        uasort($columns, $this->_sortColumnPosition(...));
         $position = 0;
         foreach (array_keys($columns) as $columnId) {
             $columns[$columnId]['COLUMN_POSITION'] = $position;

--- a/lib/Maho/Db/Schema/Canonicalizer.php
+++ b/lib/Maho/Db/Schema/Canonicalizer.php
@@ -95,7 +95,7 @@ final class Canonicalizer
      */
     private static function stripPhantomIndexes(Table $table, array $physicalIndexNames): void
     {
-        $physical = array_map('strtolower', $physicalIndexNames);
+        $physical = array_map(strtolower(...), $physicalIndexNames);
         foreach ($table->getIndexes() as $index) {
             if (self::isPrimaryIndex($table, $index)) {
                 continue;
@@ -203,7 +203,7 @@ final class Canonicalizer
             // If the live name is already a valid target name for this signature,
             // claim it and move on — never rename a correctly-named index.
             $candidates = $targetBySignature[$signature] ?? [];
-            $matchLower = array_map('strtolower', $candidates);
+            $matchLower = array_map(strtolower(...), $candidates);
             if (in_array(strtolower($liveName), $matchLower, true)) {
                 $usedTargetNames[strtolower($liveName)] = true;
                 continue;

--- a/lib/Maho/File/Uploader.php
+++ b/lib/Maho/File/Uploader.php
@@ -373,7 +373,7 @@ class Uploader
                 return count($violations) === 0;
             }
             return true;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
     }

--- a/lib/Maho/Filter/Template.php
+++ b/lib/Maho/Filter/Template.php
@@ -36,14 +36,14 @@ class Template
     /**
      * Template processor
      *
-     * @var array|string|null
+     * @var callable|null
      */
     protected $_templateProcessor = null;
 
     /**
      * Include processor
      *
-     * @var array|string|null
+     * @var callable|null
      */
     protected $_includeProcessor = null;
 
@@ -62,9 +62,9 @@ class Template
      * Sets the proccessor of templates. Templates are directives that include email templates based on system
      * configuration path.
      *
-     * @param array $callback it must return string
+     * @param callable $callback it must return string
      */
-    public function setTemplateProcessor(array $callback)
+    public function setTemplateProcessor(callable $callback)
     {
         $this->_templateProcessor = $callback;
         return $this;
@@ -73,7 +73,7 @@ class Template
     /**
      * Sets the proccessor of templates.
      *
-     * @return array|null
+     * @return callable|null
      */
     public function getTemplateProcessor()
     {
@@ -83,9 +83,9 @@ class Template
     /**
      * Sets the proccessor of includes.
      *
-     * @param array $callback it must return string
+     * @param callable $callback it must return string
      */
-    public function setIncludeProcessor(array $callback)
+    public function setIncludeProcessor(callable $callback)
     {
         $this->_includeProcessor = $callback;
         return $this;
@@ -94,7 +94,7 @@ class Template
     /**
      * Sets the proccessor of includes.
      *
-     * @return array|null
+     * @return callable|null
      */
     public function getIncludeProcessor()
     {

--- a/lib/Maho/Filter/Template/Simple.php
+++ b/lib/Maho/Filter/Template/Simple.php
@@ -65,7 +65,7 @@ class Simple extends DataObject
     {
         return preg_replace_callback(
             '#' . $this->_startTag . '(.*?)' . $this->_endTag . '#',
-            [$this, '_filterDataItem'],
+            $this->_filterDataItem(...),
             $value,
         );
     }

--- a/lib/Maho/Queue/Stamp/ClaimTokenStamp.php
+++ b/lib/Maho/Queue/Stamp/ClaimTokenStamp.php
@@ -19,6 +19,7 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
 final readonly class ClaimTokenStamp implements StampInterface
 {
     public function __construct(
+        #[\SensitiveParameter]
         public string $token,
     ) {}
 }

--- a/lib/MahoCLI/Commands/ConfigDelete.php
+++ b/lib/MahoCLI/Commands/ConfigDelete.php
@@ -143,7 +143,7 @@ class ConfigDelete extends BaseMahoCommand
                     }
                     break;
             }
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Ignore errors when getting names
         }
 

--- a/lib/MahoCLI/Commands/ConfigGet.php
+++ b/lib/MahoCLI/Commands/ConfigGet.php
@@ -114,7 +114,7 @@ class ConfigGet extends BaseMahoCommand
                 if ($decrypt && is_string($value) && $this->looksEncrypted($value)) {
                     try {
                         $value = Mage::helper('core')->decrypt($value);
-                    } catch (\Exception $e) {
+                    } catch (\Exception) {
                         $value = '<error>[Decryption failed]</error>';
                     }
                 }
@@ -198,7 +198,7 @@ class ConfigGet extends BaseMahoCommand
                     }
                     break;
             }
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Ignore errors when getting names
         }
 

--- a/lib/MahoCLI/Commands/ConfigSet.php
+++ b/lib/MahoCLI/Commands/ConfigSet.php
@@ -176,7 +176,7 @@ class ConfigSet extends BaseMahoCommand
                     }
                     break;
             }
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Ignore errors when getting names
         }
 

--- a/lib/MahoCLI/Commands/DatabaseCliTrait.php
+++ b/lib/MahoCLI/Commands/DatabaseCliTrait.php
@@ -163,7 +163,7 @@ trait DatabaseCliTrait
         $statements[] = $current;
 
         return array_values(array_filter(
-            array_map('trim', $statements),
+            array_map(trim(...), $statements),
             static fn(string $statement): bool => $statement !== '',
         ));
     }

--- a/lib/MahoCLI/Commands/FrontendLayoutDebug.php
+++ b/lib/MahoCLI/Commands/FrontendLayoutDebug.php
@@ -556,7 +556,7 @@ class FrontendLayoutDebug extends BaseMahoCommand
                 $templateFile = $block->getTemplateFile();
                 $templatePath = $templateFile ? $this->formatTemplatePath(\Maho::toRelativePath($templateFile)) : $block->getTemplate();
                 return "{$greenDot} {$name} {$orangeDot} {$type} {$redDot} {$templatePath}";
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 return "{$greenDot} {$name} {$orangeDot} {$type} {$redDot} {$block->getTemplate()} <fg=red>(not found)</>";
             }
         }

--- a/lib/MahoCLI/Commands/IndexReindexProduct.php
+++ b/lib/MahoCLI/Commands/IndexReindexProduct.php
@@ -38,7 +38,7 @@ class IndexReindexProduct extends BaseMahoCommand
     {
         $this->initMaho();
 
-        $productIds = array_map('intval', explode(',', $input->getArgument('product_ids')));
+        $productIds = array_map(intval(...), explode(',', $input->getArgument('product_ids')));
         $specificIndexers = $input->getOption('indexer');
         $includeChildren = $input->getOption('include-children');
 

--- a/lib/MahoCLI/Commands/Install.php
+++ b/lib/MahoCLI/Commands/Install.php
@@ -491,7 +491,7 @@ class Install extends BaseMahoCommand
             $storeId = $store->getId();
 
             // Read and parse CSV
-            $csvData = array_map('str_getcsv', file($csvPath));
+            $csvData = array_map(str_getcsv(...), file($csvPath));
             $headers = array_shift($csvData); // Remove header row
 
             $importedCount = 0;

--- a/lib/MahoCLI/Commands/MaintenanceEnable.php
+++ b/lib/MahoCLI/Commands/MaintenanceEnable.php
@@ -47,7 +47,7 @@ class MaintenanceEnable extends Command
 
         $ipOption = $input->getOption('ip');
         if ($ipOption !== null) {
-            $ips = array_filter(array_map('trim', explode(',', $ipOption)));
+            $ips = array_filter(array_map(trim(...), explode(',', $ipOption)));
             if ($ips) {
                 if (file_put_contents($maintenanceIpFile, implode("\n", $ips)) === false) {
                     $output->writeln('<error>Failed to create maintenance.ip file</error>');

--- a/lib/MahoCLI/Commands/Shell.php
+++ b/lib/MahoCLI/Commands/Shell.php
@@ -135,12 +135,8 @@ class Shell extends BaseMahoCommand
                 return $conn;
             },
             // Add some helpful shortcuts
-            'getModel' => function ($modelClass) {
-                return Mage::getModel($modelClass);
-            },
-            'getCollection' => function ($modelClass) {
-                return Mage::getModel($modelClass)->getCollection();
-            },
+            'getModel' => fn($modelClass) => Mage::getModel($modelClass),
+            'getCollection' => fn($modelClass) => Mage::getModel($modelClass)->getCollection(),
             'reconnect' => function () {
                 // Note: Connection management is handled automatically by Doctrine DBAL
                 echo "Note: Connection lifecycle is managed automatically by Doctrine DBAL.\n";

--- a/lib/MahoCLI/Commands/SysDirectoryRegionsImport.php
+++ b/lib/MahoCLI/Commands/SysDirectoryRegionsImport.php
@@ -81,7 +81,7 @@ class SysDirectoryRegionsImport extends BaseMahoCommand
         $this->initLogger(null, $logger);
 
         // Parse options with defaults
-        $locales = array_map('trim', explode(',', $options['locales'] ?? 'en_US'));
+        $locales = array_map(trim(...), explode(',', $options['locales'] ?? 'en_US'));
         $dryRun = $options['dryRun'] ?? false;
         $updateExisting = $options['updateExisting'] ?? false;
         $verbose = $options['verbose'] ?? false;
@@ -95,7 +95,7 @@ class SysDirectoryRegionsImport extends BaseMahoCommand
         $this->initLogger($output);
 
         $countryCode = strtoupper($input->getOption('country'));
-        $locales = array_map('trim', explode(',', $input->getOption('locales')));
+        $locales = array_map(trim(...), explode(',', $input->getOption('locales')));
         $dryRun = $input->getOption('dry-run');
         $updateExisting = $input->getOption('update-existing');
         $verbose = $output->isVerbose();

--- a/lib/MahoCLI/Commands/SysEncryptionKeyRegenerate.php
+++ b/lib/MahoCLI/Commands/SysEncryptionKeyRegenerate.php
@@ -122,8 +122,8 @@ class SysEncryptionKeyRegenerate extends BaseMahoCommand
 
                 Mage::dispatchEvent('encryption_key_regenerated', [
                     'output' => $output,
-                    'encrypt_callback' => [$this, 'encrypt'],
-                    'decrypt_callback' => [$this, 'decrypt'],
+                    'encrypt_callback' => $this->encrypt(...),
+                    'decrypt_callback' => $this->decrypt(...),
                 ]);
 
                 $writeConnection->commit();
@@ -218,7 +218,7 @@ class SysEncryptionKeyRegenerate extends BaseMahoCommand
                 $tableName,
                 $tableInfo['pk'],
                 $tableInfo['columns'],
-                [$this, 'decrypt'],
+                $this->decrypt(...),
             );
             $output->writeln(empty($failures) ? 'OK' : '<error>' . count($failures) . ' failure(s)</error>');
             $allFailures = array_merge($allFailures, $failures);
@@ -259,8 +259,8 @@ class SysEncryptionKeyRegenerate extends BaseMahoCommand
             Mage::getSingleton('core/resource')->getTableName('admin_user'),
             'user_id',
             ['twofa_secret'],
-            [$this, 'encrypt'],
-            [$this, 'decrypt'],
+            $this->encrypt(...),
+            $this->decrypt(...),
             output: $output,
         );
         $output->writeln($result ? 'OK' : '<comment>SKIPPED</comment>');

--- a/lib/MahoCLI/Commands/TranslationsMissing.php
+++ b/lib/MahoCLI/Commands/TranslationsMissing.php
@@ -81,7 +81,7 @@ class TranslationsMissing extends BaseMahoCommand
             );
         }
 
-        return array_filter(array_map('trim', $files));
+        return array_filter(array_map(trim(...), $files));
     }
 
     /**
@@ -155,7 +155,7 @@ class TranslationsMissing extends BaseMahoCommand
                     if (!$translateNode instanceof \SimpleXMLElement) {
                         continue;
                     }
-                    $translateChildren = array_map('trim', explode(' ', $translateNode->__toString()));
+                    $translateChildren = array_map(trim(...), explode(' ', $translateNode->__toString()));
                     foreach ($node->children() as $child) {
                         if (in_array($child->getName(), $translateChildren)) {
                             $matches[] = $child->__toString();

--- a/lib/MahoCLI/Commands/TranslationsUnused.php
+++ b/lib/MahoCLI/Commands/TranslationsUnused.php
@@ -79,7 +79,7 @@ class TranslationsUnused extends BaseMahoCommand
             // Grep for all XML files that might use the translate attribute
             explode("\n", (string) shell_exec("grep -Frl --exclude-dir='.git' --include=*.xml 'translate=' .")),
         );
-        return array_filter(array_map('trim', $files));
+        return array_filter(array_map(trim(...), $files));
     }
 
     /**
@@ -148,7 +148,7 @@ class TranslationsUnused extends BaseMahoCommand
                     if (!$translateNode instanceof \SimpleXMLElement) {
                         continue;
                     }
-                    $translateChildren = array_map('trim', explode(' ', $translateNode->__toString()));
+                    $translateChildren = array_map(trim(...), explode(' ', $translateNode->__toString()));
                     foreach ($node->children() as $child) {
                         if (in_array($child->getName(), $translateChildren)) {
                             $matches[] = $child->__toString();

--- a/lib/MahoCLI/Helper/SampleDataImporter.php
+++ b/lib/MahoCLI/Helper/SampleDataImporter.php
@@ -21,7 +21,6 @@ use PDO;
  */
 class SampleDataImporter
 {
-    private PDO $pdo;
     private mixed $logCallback;
 
     /**
@@ -165,9 +164,8 @@ class SampleDataImporter
      */
     private array $catalogEavAttributeColumns = [];
 
-    public function __construct(PDO $pdo, ?callable $logCallback = null)
+    public function __construct(private PDO $pdo, ?callable $logCallback = null)
     {
-        $this->pdo = $pdo;
         $this->logCallback = $logCallback;
         $this->loadTableSchemas();
         $this->loadEntityTypeIds();
@@ -928,7 +926,7 @@ class SampleDataImporter
         // Build dynamic INSERT for eav_attribute using schema columns (excluding auto-increment attribute_id)
         $columns = array_filter($this->eavAttributeColumns, fn($c) => $c !== 'attribute_id');
         $placeholders = implode(', ', array_fill(0, count($columns), '?'));
-        $columnList = implode(', ', array_map(fn($c) => $this->quoteIdentifier($c), $columns));
+        $columnList = implode(', ', array_map($this->quoteIdentifier(...), $columns));
 
         $stmt = $this->pdo->prepare("INSERT INTO eav_attribute ({$columnList}) VALUES ({$placeholders})");
 
@@ -985,7 +983,7 @@ class SampleDataImporter
         // Build dynamic INSERT using schema columns
         $columns = $this->catalogEavAttributeColumns;
         $placeholders = implode(', ', array_fill(0, count($columns), '?'));
-        $columnList = implode(', ', array_map(fn($c) => $this->quoteIdentifier($c), $columns));
+        $columnList = implode(', ', array_map($this->quoteIdentifier(...), $columns));
 
         $stmt = $this->pdo->prepare("INSERT INTO catalog_eav_attribute ({$columnList}) VALUES ({$placeholders})");
 
@@ -1141,7 +1139,7 @@ class SampleDataImporter
             $valuesBlock = $matches[2];
 
             // Find the position of attribute_id column
-            $columnList = array_map('trim', explode(',', str_replace('`', '', $columns)));
+            $columnList = array_map(trim(...), explode(',', str_replace('`', '', $columns)));
             $attrIdPos = array_search('attribute_id', $columnList);
 
             if ($attrIdPos === false) {
@@ -1170,7 +1168,7 @@ class SampleDataImporter
             $columns = $matches[1];
             $valuesBlock = $matches[2];
 
-            $columnList = array_map('trim', explode(',', str_replace('`', '', $columns)));
+            $columnList = array_map(trim(...), explode(',', str_replace('`', '', $columns)));
             $setIdPos = array_search('attribute_set_id', $columnList);
 
             if ($setIdPos === false) {
@@ -1194,7 +1192,7 @@ class SampleDataImporter
             $columns = $matches[1];
             $valuesBlock = $matches[2];
 
-            $columnList = array_map('trim', explode(',', str_replace('`', '', $columns)));
+            $columnList = array_map(trim(...), explode(',', str_replace('`', '', $columns)));
             $optionIdPos = array_search('option_id', $columnList);
 
             if ($optionIdPos === false) {
@@ -1219,7 +1217,7 @@ class SampleDataImporter
             $columns = $matches[1];
             $valuesBlock = $matches[2];
 
-            $columnList = array_map('trim', explode(',', str_replace('`', '', $columns)));
+            $columnList = array_map(trim(...), explode(',', str_replace('`', '', $columns)));
             $attrIdPos = array_search('attribute_id', $columnList);
             $valuePos = array_search('value', $columnList);
 
@@ -1249,7 +1247,7 @@ class SampleDataImporter
             $columns = $matches[1];
             $valuesBlock = $matches[2];
 
-            $columnList = array_map('trim', explode(',', str_replace('`', '', $columns)));
+            $columnList = array_map(trim(...), explode(',', str_replace('`', '', $columns)));
             $attrIdPos = array_search('attribute_id', $columnList);
             $valuePos = array_search('value', $columnList);
 
@@ -1412,7 +1410,7 @@ class SampleDataImporter
 
                     if (str_contains($value, ',')) {
                         // Comma-separated list of attribute IDs
-                        $ids = array_map('intval', explode(',', $value));
+                        $ids = array_map(intval(...), explode(',', $value));
                         $newIds = array_map(fn($id) => $this->attributeRemap[$id] ?? $id, $ids);
                         $value = implode(',', $newIds);
                     } else {
@@ -1489,7 +1487,7 @@ class SampleDataImporter
         $row = $result->fetch(\PDO::FETCH_ASSOC);
 
         if ($row && $row['value']) {
-            $ids = array_map('intval', explode(',', $row['value']));
+            $ids = array_map(intval(...), explode(',', $row['value']));
             $newIds = array_map(fn($id) => $this->attributeRemap[$id] ?? $id, $ids);
             $newValue = implode(',', $newIds);
 

--- a/lib/MahoCLI/Helper/SqlConverter.php
+++ b/lib/MahoCLI/Helper/SqlConverter.php
@@ -463,8 +463,8 @@ class SqlConverter
                 AND data_type = 'boolean'
             ");
             $stmt->execute(['table_name' => $tableName]);
-            return array_map('strtolower', $stmt->fetchAll(\PDO::FETCH_COLUMN));
-        } catch (\PDOException $e) {
+            return array_map(strtolower(...), $stmt->fetchAll(\PDO::FETCH_COLUMN));
+        } catch (\PDOException) {
             return [];
         }
     }


### PR DESCRIPTION
Brings `.rector.php` in line with the org baseline in [MahoCommerce/infrastructure](https://github.com/MahoCommerce/infrastructure/blob/main/.rector.php). `withPhpSets()` now reads the 8.3 target from `composer.json`, the eight hand-picked rules the sets already cover are gone, and `token` joins the sensitive parameter list.

Two skips are specific to Maho and not in the infra config:

- `RemoveExtraParametersRector` judges "extra" from the core signature alone, so it stripped arguments a third-party subclass may declare (`canUseAttribute($attribute, $product)` down to one argument).
- `ClassPropertyAssignToConstructorPromotionRector` runs with `rename_property: false`. Promotion collapses parameter and property into one declaration, so on Magento-lineage properties it renamed public constructor parameters to `$_expression`, `$_format` and the like, breaking named arguments on `Maho\Db\Expr`, `Maho\Db\Select` and 9 more. With the option off it only promotes where both names already agree.

Applying the sets rewrote 372 files, mostly unused catch variables, first-class callables, arrow functions and merged multi-catch blocks.

The first-class callable rules convert stored array and string callables into `Closure` objects, which broke three consumers that inspected callables by shape:

- `Grid_Column` tested `is_array()` on the frame callback, which would have silently skipped every grid cell decorator
- `Grid` read `[0]` of the filter condition callback, fatal on a `Closure`. It now runs whenever the callback is callable, where before it also required the callback to be bound to a grid instance.
- `Maho\Filter\Template` declared its processor setters as `array`

Two closure parameters in `Maho\Data\Collection\Db` named `$token` hold a SQL identifier and a bind placeholder, so they picked up `#[\SensitiveParameter]`; they are renamed to what they actually carry. `EnvironmentConfigLoader` passed `trim` as an `array_filter` predicate, which never matched the expected signature and was baselined, and now uses an explicit one.

`composer lint` is clean.