### PR TITLE
Fixed admin secret key validation when the dispatched controller name differs from the URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,10 @@ class My_Module_Checkout_CartController extends Mage_Checkout_CartController { /
   same base independently are a conflict: the compiler logs an error and falls back to module
   load order (local/community over core). Resolve it by having one override extend the other.
 - A subclass that adds **new** actions needs its own `#[Route]` for those actions (inheritance
-  only carries over the base's existing routes).
+  only carries over the base's existing routes). In the admin area, keep the path's controller
+  segment equal to the base's: it names the controller in the URL, and the admin secret key is
+  keyed on it, so `getUrl('*/*/myAction')` from a page the base renders must produce the same
+  pair the route dispatches with.
 - The legacy XML chain (`<{area}><routers><{routerCode}><args><modules><MyMod before|after="Mage_X"/>`)
   is still honored and wins over the compiled override. Migrate existing chains with
   `./maho legacy:migrate-routes`. Use the inheritance approach for new code.

--- a/app/code/core/Mage/Adminhtml/Controller/Action.php
+++ b/app/code/core/Mage/Adminhtml/Controller/Action.php
@@ -333,12 +333,12 @@ class Mage_Adminhtml_Controller_Action extends Mage_Core_Controller_Varien_Actio
             return true;
         }
 
-        if (!($secretKey = $this->getRequest()->getParam(Mage_Adminhtml_Model_Url::SECRET_KEY_PARAM_NAME))
-            || !hash_equals(Mage::getSingleton('adminhtml/url')->getSecretKey(), $secretKey)
-        ) {
+        $secretKey = $this->getRequest()->getParam(Mage_Adminhtml_Model_Url::SECRET_KEY_PARAM_NAME);
+        if (!is_string($secretKey) || $secretKey === '') {
             return false;
         }
-        return true;
+
+        return Mage::getSingleton('adminhtml/url')->validateSecretKey($secretKey);
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Model/Url.php
+++ b/app/code/core/Mage/Adminhtml/Model/Url.php
@@ -109,22 +109,10 @@ class Mage_Adminhtml_Model_Url extends Mage_Core_Model_Url
     {
         $salt = $formKey ?? Mage::getSingleton('core/session')->getFormKey();
 
-        // Validate against what the user actually requested: after _forward() the dispatched
-        // names change (e.g. catalog_category/index forwards to edit) but the URL's key was
-        // minted for the original action, so the before-forward snapshot takes precedence.
-        // Dispatched names come next; positional path parsing assumes the classic
-        // admin/<controller>/<action> shape and mis-slices legacy:migrate-routes routes that
-        // carry an extra frontName segment, so it stays only as a pre-dispatch fallback.
         if (!$controller || !$action) {
-            $p = explode('/', trim($this->getRequest()->getOriginalPathInfo(), '/'));
-            $controller = $controller
-                ?: $this->getRequest()->getBeforeForwardInfo('controller_name')
-                ?: $this->getRequest()->getControllerName()
-                ?: (empty($p[1]) ? null : $p[1]);
-            $action = $action
-                ?: $this->getRequest()->getBeforeForwardInfo('action_name')
-                ?: $this->getRequest()->getActionName()
-                ?: (empty($p[2]) ? null : $p[2]);
+            [$requestController, $requestAction] = $this->getSecretKeyPairs()[0] ?? [null, null];
+            $controller = $controller ?: $requestController;
+            $action = $action ?: $requestAction;
         }
 
         // Normalize case so the hash matches regardless of how the caller cased the
@@ -132,8 +120,55 @@ class Mage_Adminhtml_Model_Url extends Mage_Core_Model_Url
         // declared in #[Route], but the menu placeholder, getUrl(*/*/foo) shorthand,
         // and getOriginalPathInfo() can all surface different cases; lowercasing here
         // means generation and validation always agree.
-        $secret = strtolower($controller) . strtolower($action) . $salt;
+        $secret = strtolower((string) $controller) . strtolower((string) $action) . $salt;
         return Mage::helper('core')->getHash($secret);
+    }
+
+    /**
+     * Controller/action pairs the current request's secret key may have been minted for,
+     * most authoritative first: the before-forward snapshot (the names the user requested),
+     * then the dispatched names, then the positional path segments. Path slicing assumes the
+     * classic admin/<controller>/<action> shape and mis-slices legacy:migrate-routes routes
+     * that carry an extra frontName segment, so it stays last.
+     *
+     * @return list<array{string, string}>
+     */
+    public function getSecretKeyPairs(): array
+    {
+        $request = $this->getRequest();
+        $path = explode('/', trim((string) $request->getOriginalPathInfo(), '/'));
+
+        $candidates = [
+            [$request->getBeforeForwardInfo('controller_name'), $request->getBeforeForwardInfo('action_name')],
+            [$request->getControllerName(), $request->getActionName()],
+            [$path[1] ?? null, $path[2] ?? null],
+        ];
+
+        $pairs = [];
+        foreach ($candidates as [$controller, $action]) {
+            if (!$controller || !$action) {
+                continue;
+            }
+            $pairs[strtolower($controller) . '/' . strtolower($action)] = [$controller, $action];
+        }
+
+        return array_values($pairs);
+    }
+
+    /**
+     * Whether $secretKey is valid for the current request, i.e. minted for any pair
+     * getSecretKeyPairs() considers plausible. The salt is the session form key, so a key
+     * for any of those pairs is unforgeable without it.
+     */
+    public function validateSecretKey(string $secretKey): bool
+    {
+        foreach ($this->getSecretKeyPairs() as [$controller, $action]) {
+            if (hash_equals($this->getSecretKey($controller, $action), $secretKey)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/app/code/core/Mage/Adminhtml/Model/Url.php
+++ b/app/code/core/Mage/Adminhtml/Model/Url.php
@@ -127,9 +127,7 @@ class Mage_Adminhtml_Model_Url extends Mage_Core_Model_Url
     /**
      * Controller/action pairs the current request's secret key may have been minted for,
      * most authoritative first: the before-forward snapshot (the names the user requested),
-     * then the dispatched names, then the positional path segments. Path slicing assumes the
-     * classic admin/<controller>/<action> shape and mis-slices legacy:migrate-routes routes
-     * that carry an extra frontName segment, so it stays last.
+     * then the dispatched names, then the positional path segments.
      *
      * @return list<array{string, string}>
      */
@@ -137,12 +135,19 @@ class Mage_Adminhtml_Model_Url extends Mage_Core_Model_Url
     {
         $request = $this->getRequest();
         $path = explode('/', trim((string) $request->getOriginalPathInfo(), '/'));
+        $dispatchedAction = $request->getActionName();
 
         $candidates = [
             [$request->getBeforeForwardInfo('controller_name'), $request->getBeforeForwardInfo('action_name')],
-            [$request->getControllerName(), $request->getActionName()],
-            [$path[1] ?? null, $path[2] ?? null],
+            [$request->getControllerName(), $dispatchedAction],
         ];
+
+        // Same action only: path slicing assumes the classic admin/<controller>/<action> shape,
+        // and legacy:migrate-routes routes carry an extra frontName segment, so they slice to a
+        // pair every action on the controller would share.
+        if (!$dispatchedAction || strcasecmp($path[2] ?? '', $dispatchedAction) === 0) {
+            $candidates[] = [$path[1] ?? null, $path[2] ?? null];
+        }
 
         $pairs = [];
         foreach ($candidates as [$controller, $action]) {

--- a/composer.lock
+++ b/composer.lock
@@ -1816,16 +1816,16 @@
         },
         {
             "name": "mahocommerce/maho-composer-plugin",
-            "version": "v4.5.0",
+            "version": "v4.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MahoCommerce/maho-composer-plugin.git",
-                "reference": "ec46fff035b2063ab2d32ef661b88b347cc54f99"
+                "reference": "edb058a03ff7a57543e1b38fcfac8be4022ef88f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MahoCommerce/maho-composer-plugin/zipball/ec46fff035b2063ab2d32ef661b88b347cc54f99",
-                "reference": "ec46fff035b2063ab2d32ef661b88b347cc54f99",
+                "url": "https://api.github.com/repos/MahoCommerce/maho-composer-plugin/zipball/edb058a03ff7a57543e1b38fcfac8be4022ef88f",
+                "reference": "edb058a03ff7a57543e1b38fcfac8be4022ef88f",
                 "shasum": ""
             },
             "require": {
@@ -1863,7 +1863,7 @@
             "description": "Extension for Composer to copy assets and enable autoloading for Maho projects.",
             "support": {
                 "issues": "https://github.com/MahoCommerce/maho-composer-plugin/issues",
-                "source": "https://github.com/MahoCommerce/maho-composer-plugin/tree/v4.5.0"
+                "source": "https://github.com/MahoCommerce/maho-composer-plugin/tree/v4.5.1"
             },
             "funding": [
                 {
@@ -1879,7 +1879,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-11T20:49:47+00:00"
+            "time": "2026-08-12T10:56:20+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/tests/Backend/Unit/Adminhtml/Model/UrlTest.php
+++ b/tests/Backend/Unit/Adminhtml/Model/UrlTest.php
@@ -138,12 +138,24 @@ describe('Mage_Adminhtml_Model_Url::validateSecretKey()', function () {
     });
 
     it('accepts the key minted for the originally requested action after _forward', function () {
-        $key = $this->url->getSecretKey('catalog_product', 'createRestposten');
+        $key = $this->url->getSecretKey('adminhtml_catalog_product', 'createRestposten');
 
         $this->request->initForward();
         $this->request->setActionName('denied');
 
         expect($this->url->validateSecretKey($key))->toBeTrue();
+    });
+
+    it('ignores the path pair when the path slices to another action', function () {
+        // legacy:migrate-routes shape, whose extra frontName segment mis-slices
+        $this->request->setOriginalPathInfo('/admin/feedmanager/feed/index/key/abc123/');
+        $this->request
+            ->setControllerName('feedmanager_feed')
+            ->setActionName('delete');
+
+        $key = $this->url->getSecretKey('feedmanager', 'feed');
+
+        expect($this->url->validateSecretKey($key))->toBeFalse();
     });
 
     it('rejects a key minted for another action', function () {

--- a/tests/Backend/Unit/Adminhtml/Model/UrlTest.php
+++ b/tests/Backend/Unit/Adminhtml/Model/UrlTest.php
@@ -107,3 +107,60 @@ describe('Mage_Adminhtml_Model_Url::getSecretKey() path handling', function () {
             ->toBe($this->url->getSecretKey('cms_page', 'edit'));
     });
 });
+
+/**
+ * Regression coverage for #1260: the dispatched controller name comes from the route's
+ * compiled metadata (derived from the controller class), while a wildcard getUrl() mints
+ * the key from the controller rendering the current page. When an action lives on a class
+ * whose derived name differs, the two disagree and every admin GET fails.
+ */
+describe('Mage_Adminhtml_Model_Url::validateSecretKey()', function () {
+    beforeEach(function () {
+        $this->url = Mage::getModel('adminhtml/url');
+        $this->request = Mage::app()->getRequest();
+        $this->request->setBeforeForwardInfo([]);
+        $this->request->setOriginalPathInfo('/admin/catalog_product/createRestposten/key/abc123/');
+        $this->request
+            ->setControllerName('adminhtml_catalog_product')
+            ->setActionName('createRestposten');
+    });
+
+    it('accepts the key minted for the dispatched names', function () {
+        $key = $this->url->getSecretKey('adminhtml_catalog_product', 'createRestposten');
+
+        expect($this->url->validateSecretKey($key))->toBeTrue();
+    });
+
+    it('accepts the key minted for the requested path when the dispatched name differs (regression #1260)', function () {
+        $key = $this->url->getSecretKey('catalog_product', 'createRestposten');
+
+        expect($this->url->validateSecretKey($key))->toBeTrue();
+    });
+
+    it('accepts the key minted for the originally requested action after _forward', function () {
+        $key = $this->url->getSecretKey('catalog_product', 'createRestposten');
+
+        $this->request->initForward();
+        $this->request->setActionName('denied');
+
+        expect($this->url->validateSecretKey($key))->toBeTrue();
+    });
+
+    it('rejects a key minted for another action', function () {
+        $key = $this->url->getSecretKey('catalog_product', 'delete');
+
+        expect($this->url->validateSecretKey($key))->toBeFalse();
+    });
+
+    it('rejects a key minted for another controller', function () {
+        $key = $this->url->getSecretKey('cms_page', 'createRestposten');
+
+        expect($this->url->validateSecretKey($key))->toBeFalse();
+    });
+
+    it('rejects a key minted with a different form key', function () {
+        $key = $this->url->getSecretKey('catalog_product', 'createRestposten', 'some-other-form-key');
+
+        expect($this->url->validateSecretKey($key))->toBeFalse();
+    });
+});


### PR DESCRIPTION
Fixes #1260.

The admin secret key is keyed on a controller/action pair, but generation and validation read those names from different places. `getUrl('*/*/myAction')` expands the wildcards to the names of the controller rendering the current page; validation uses the dispatched names, which come from the matched route's compiled metadata (derived from the controller class). When an action lives on a class whose derived name differs from the page's, the two disagree and every admin GET on that action fails with a silent redirect to the dashboard. Magento 1 read both sides from the same URL segments, so they could not diverge.

`Mage_Adminhtml_Model_Url` gains `getSecretKeyPairs()` (before-forward snapshot, dispatched names, positional path segments, most authoritative first) and `validateSecretKey()`, which `hash_equals` against each pair. `getSecretKey()` with no arguments still returns the key for the first pair, so its behaviour and every caller are unchanged; the new pair builder just replaces its per-component fallback chain, so a pair can no longer mix sources.

Accepting several pairs widens nothing an attacker can reach: the salt is the session form key, so a key for any pair is unforgeable without it.

The companion fix, which removes the divergence at its source by deriving the compiled controller name from the declared route path, is MahoCommerce/maho-composer-plugin#61. That one needs a plugin release; this one stands alone and fixes the reported case on the current plugin.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->