### PR TITLE
Product prices in the admin now show up to 4 decimals instead of rounding to 2

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Option.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Option.php
@@ -315,11 +315,8 @@ class Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Options_Option extends Mage_
 
     public function getPriceValue($value, $type)
     {
-        if ($type == 'percent') {
-            return number_format($value, 2, null, '');
-        }
-        if ($type == 'fixed') {
-            return number_format($value, 2, null, '');
+        if ($type == 'percent' || $type == 'fixed') {
+            return Mage::helper('adminhtml')->formatPriceForInput($value);
         }
     }
 }

--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
@@ -75,6 +75,6 @@ class Mage_Adminhtml_Block_Catalog_Product_Helper_Form_Price extends \Maho\Data\
             return null;
         }
 
-        return number_format((float) $value, 2, null, '');
+        return Mage::helper('adminhtml')->formatPriceForInput($value);
     }
 }

--- a/app/code/core/Mage/Adminhtml/Helper/Data.php
+++ b/app/code/core/Mage/Adminhtml/Helper/Data.php
@@ -35,6 +35,16 @@ class Mage_Adminhtml_Helper_Data extends Mage_Adminhtml_Helper_Help_Mapping
     }
 
     /**
+     * Format a stored price for an admin form input: full 4-decimal storage
+     * precision, trailing zeros trimmed, never fewer than 2 decimals.
+     */
+    public function formatPriceForInput(float|string $value): string
+    {
+        $formatted = number_format((float) $value, 4, '.', '');
+        return str_pad(rtrim($formatted, '0'), strpos($formatted, '.') + 3, '0');
+    }
+
+    /**
      * @return false|int
      */
     public function getCurrentUserId()

--- a/tests/Backend/Unit/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/OptionTest.php
+++ b/tests/Backend/Unit/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/OptionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('Custom option price precision in the admin form', function () {
+    // Regression for #1262: getPriceValue() rounded to 2 decimals, so a stored
+    // 10.6557 displayed as 10.66 and the next save wrote 10.66 back.
+
+    it('renders fixed prices with the full stored 4-decimal precision', function () {
+        $block = new Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Options_Option();
+
+        expect($block->getPriceValue('10.6557', 'fixed'))->toBe('10.6557');
+        expect($block->getPriceValue('10.6600', 'fixed'))->toBe('10.66');
+        expect($block->getPriceValue('10.5', 'fixed'))->toBe('10.50');
+    });
+
+    it('renders percent prices with the full stored 4-decimal precision', function () {
+        $block = new Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Options_Option();
+
+        expect($block->getPriceValue('12.3456', 'percent'))->toBe('12.3456');
+        expect($block->getPriceValue('12.3400', 'percent'))->toBe('12.34');
+    });
+});

--- a/tests/Backend/Unit/Adminhtml/Block/Catalog/Product/Helper/Form/PriceTest.php
+++ b/tests/Backend/Unit/Adminhtml/Block/Catalog/Product/Helper/Form/PriceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('Admin product price field precision', function () {
+    // Regression for #1262: the field rendered number_format($value, 2), so a
+    // stored 10.6557 displayed as 10.66 and the next save wrote 10.66 back.
+
+    it('renders the full stored 4-decimal precision', function () {
+        $element = new Mage_Adminhtml_Block_Catalog_Product_Helper_Form_Price();
+        $element->setValue('10.6557');
+
+        expect($element->getEscapedValue())->toBe('10.6557');
+    });
+
+    it('trims trailing zeros down to two decimals', function () {
+        $element = new Mage_Adminhtml_Block_Catalog_Product_Helper_Form_Price();
+
+        $element->setValue('10.6600');
+        expect($element->getEscapedValue())->toBe('10.66');
+
+        $element->setValue('10.6550');
+        expect($element->getEscapedValue())->toBe('10.655');
+    });
+
+    it('keeps at least two decimals', function () {
+        $element = new Mage_Adminhtml_Block_Catalog_Product_Helper_Form_Price();
+
+        $element->setValue('10.5');
+        expect($element->getEscapedValue())->toBe('10.50');
+
+        $element->setValue('10');
+        expect($element->getEscapedValue())->toBe('10.00');
+    });
+
+    it('renders large values without a thousands separator', function () {
+        $element = new Mage_Adminhtml_Block_Catalog_Product_Helper_Form_Price();
+        $element->setValue('1234.5678');
+
+        expect($element->getEscapedValue())->toBe('1234.5678');
+    });
+
+    it('returns null for a non-numeric value', function () {
+        $element = new Mage_Adminhtml_Block_Catalog_Product_Helper_Form_Price();
+
+        $element->setValue('');
+        expect($element->getEscapedValue())->toBeNull();
+
+        $element->setValue('abc');
+        expect($element->getEscapedValue())->toBeNull();
+    });
+});


### PR DESCRIPTION
Fixes #1262.

The admin price form element (`Mage_Adminhtml_Block_Catalog_Product_Helper_Form_Price::getEscapedValue()`) and the custom option price renderer (`Option::getPriceValue()`) formatted stored values with `number_format($value, 2)`, while storage keeps 4 decimals (DECIMAL(12,4)). A stored `10.6557` displayed as `10.66`, and any save (even of an unrelated field) wrote the rounded value back.

Both now render through a shared `Mage_Adminhtml_Helper_Data::formatPriceForInput()`: full 4-decimal precision, trailing zeros trimmed, never fewer than 2 decimals. So `10.6557` renders as `10.6557` and `10.6600` still reads `10.66`.

Written test-first: the new Pest tests in `tests/Backend/Unit/Adminhtml/` fail against the unfixed code (verified: the element returned `10.66` for a stored `10.6557`).

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->