### PR TITLE
Ran the tests that call third-party services in one CI job only

### DIFF
--- a/.env.testing.dist
+++ b/.env.testing.dist
@@ -10,6 +10,3 @@ FEDEX_SANDBOX_ACCOUNT=
 # Leave empty for the standard Rate API; set to "comprehensive" only if your FedEx
 # project is registered as an Integrator Provider.
 FEDEX_SANDBOX_RATE_ENDPOINT=
-
-# Fixer API access key. Without it the live currency rate import tests skip.
-FIXERIO_API_KEY=

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -28,9 +28,11 @@ jobs:
       matrix:
         include:
           # The tests that call third-party services (currency-live, sandbox) run here only.
-          # They assert on what the service returns and store none of it, so repeating them
-          # per DB backend buys no coverage, and it multiplies both the rate-limit pressure
-          # and the odds that a vendor's bad day fails the run.
+          # Repeating a live call per DB backend buys little coverage, and it multiplies both
+          # the rate-limit pressure and the odds that a vendor's bad day fails the run. The
+          # rate and FedEx tests only assert on what the service returns; the PayPal browser
+          # test also stores an order, so the other backends do lose its order-total coverage.
+          # That is an accepted trade for a test that shares one sandbox account.
           - name: mysql-8.4
             live: true
             db_engine: mysql
@@ -210,7 +212,9 @@ jobs:
           FEDEX_SANDBOX_ACCOUNT: ${{ secrets.FEDEX_SANDBOX_ACCOUNT }}
           FEDEX_SANDBOX_RATE_ENDPOINT: ${{ secrets.FEDEX_SANDBOX_RATE_ENDPOINT }}
         run: |
-          EXCLUDE="--exclude-group currency-live,sandbox"
+          # One group per flag, and the "=" form: PHPUnit does not split the value on commas,
+          # and Pest collapses a repeated bare "--exclude-group" token into one.
+          EXCLUDE="--exclude-group=currency-live --exclude-group=sandbox"
           if [ "${{ matrix.live }}" = "true" ]; then EXCLUDE=""; fi
           ./vendor/bin/pest --display-errors --display-warnings $EXCLUDE
 
@@ -340,7 +344,7 @@ jobs:
           FEDEX_SANDBOX_ACCOUNT: ${{ secrets.FEDEX_SANDBOX_ACCOUNT }}
           FEDEX_SANDBOX_RATE_ENDPOINT: ${{ secrets.FEDEX_SANDBOX_RATE_ENDPOINT }}
         # See the matrix comment above: the live-service groups run in one job only.
-        run: ./vendor/bin/pest --display-errors --display-warnings --exclude-group currency-live,sandbox
+        run: ./vendor/bin/pest --display-errors --display-warnings --exclude-group=currency-live --exclude-group=sandbox
 
       - name: Upload browser test failure diagnostics
         if: failure()

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -27,7 +27,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # The tests that call third-party services (currency-live, sandbox) run here only.
+          # They assert on what the service returns and store none of it, so repeating them
+          # per DB backend buys no coverage, and it multiplies both the rate-limit pressure
+          # and the odds that a vendor's bad day fails the run.
           - name: mysql-8.4
+            live: true
             db_engine: mysql
             db_image: mysql:8.4
             db_user: root
@@ -204,8 +209,10 @@ jobs:
           FEDEX_SANDBOX_CLIENT_SECRET: ${{ secrets.FEDEX_SANDBOX_CLIENT_SECRET }}
           FEDEX_SANDBOX_ACCOUNT: ${{ secrets.FEDEX_SANDBOX_ACCOUNT }}
           FEDEX_SANDBOX_RATE_ENDPOINT: ${{ secrets.FEDEX_SANDBOX_RATE_ENDPOINT }}
-          FIXERIO_API_KEY: ${{ secrets.FIXERIO_API_KEY }}
-        run: ./vendor/bin/pest --display-errors --display-warnings
+        run: |
+          EXCLUDE="--exclude-group currency-live,sandbox"
+          if [ "${{ matrix.live }}" = "true" ]; then EXCLUDE=""; fi
+          ./vendor/bin/pest --display-errors --display-warnings $EXCLUDE
 
       - name: Upload browser test failure diagnostics
         if: failure()
@@ -332,8 +339,8 @@ jobs:
           FEDEX_SANDBOX_CLIENT_SECRET: ${{ secrets.FEDEX_SANDBOX_CLIENT_SECRET }}
           FEDEX_SANDBOX_ACCOUNT: ${{ secrets.FEDEX_SANDBOX_ACCOUNT }}
           FEDEX_SANDBOX_RATE_ENDPOINT: ${{ secrets.FEDEX_SANDBOX_RATE_ENDPOINT }}
-          FIXERIO_API_KEY: ${{ secrets.FIXERIO_API_KEY }}
-        run: ./vendor/bin/pest --display-errors --display-warnings
+        # See the matrix comment above: the live-service groups run in one job only.
+        run: ./vendor/bin/pest --display-errors --display-warnings --exclude-group currency-live,sandbox
 
       - name: Upload browser test failure diagnostics
         if: failure()

--- a/app/code/core/Mage/Directory/Model/Resource/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Currency.php
@@ -130,7 +130,7 @@ class Mage_Directory_Model_Resource_Currency extends Mage_Core_Model_Resource_Db
             $data    = [];
             foreach ($rates as $currencyCode => $rate) {
                 foreach ($rate as $currencyTo => $value) {
-                    // An importer reports a missing currency as null; importRates() saves that unfiltered.
+                    // A custom importer can report a missing currency as null.
                     if ($value === null) {
                         continue;
                     }

--- a/app/code/core/Mage/Directory/Model/Resource/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Currency.php
@@ -130,6 +130,10 @@ class Mage_Directory_Model_Resource_Currency extends Mage_Core_Model_Resource_Db
             $data    = [];
             foreach ($rates as $currencyCode => $rate) {
                 foreach ($rate as $currencyTo => $value) {
+                    // An importer returns null for every currency the service left out.
+                    if ($value === null) {
+                        continue;
+                    }
                     $value = abs($value);
                     if ($value == 0) {
                         continue;

--- a/app/code/core/Mage/Directory/Model/Resource/Currency.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Currency.php
@@ -130,7 +130,7 @@ class Mage_Directory_Model_Resource_Currency extends Mage_Core_Model_Resource_Db
             $data    = [];
             foreach ($rates as $currencyCode => $rate) {
                 foreach ($rate as $currencyTo => $value) {
-                    // An importer returns null for every currency the service left out.
+                    // An importer reports a missing currency as null; importRates() saves that unfiltered.
                     if ($value === null) {
                         continue;
                     }

--- a/tests/Backend/Integration/Directory/Model/Currency/RateServicesLiveTest.php
+++ b/tests/Backend/Integration/Directory/Model/Currency/RateServicesLiveTest.php
@@ -7,11 +7,8 @@
 
 declare(strict_types=1);
 
-use Symfony\Component\HttpClient\HttpClient;
 use Tests\Helpers\ExchangerateapiHarness;
-use Tests\Helpers\FixerioHarness;
 use Tests\Helpers\FrankfurterHarness;
-use Tests\TestEnv;
 
 uses(Tests\MahoBackendTestCase::class)->group('currency-live');
 
@@ -19,6 +16,9 @@ uses(Tests\MahoBackendTestCase::class)->group('currency-live');
  * Talks to the real rate services, so it catches them changing under us (endpoint, auth,
  * response shape). The offline coverage lives in
  * tests/Backend/Unit/Directory/Model/Currency/Import/.
+ *
+ * Only the keyless services are covered here. Fixer's free tier allows far fewer calls per
+ * month than CI makes, so a live check of it cannot run often enough to be worth having.
  */
 function expectUsableRates(Mage_Directory_Model_Currency_Import_Eurbased $importer): void
 {
@@ -44,33 +44,4 @@ it('imports usable rates from Frankfurter', function () {
 
 it('imports usable rates from ExchangeRate-API', function () {
     expectUsableRates((new ExchangerateapiHarness())->setCurrencies(['EUR', 'GBP', 'USD'], ['EUR', 'USD']));
-});
-
-describe('Fixer', function () {
-    beforeEach(function () {
-        if (!TestEnv::has('FIXERIO_API_KEY')) {
-            test()->markTestSkipped('Fixer API key not set (FIXERIO_API_KEY)');
-        }
-        FixerioHarness::storeApiKey(TestEnv::get('FIXERIO_API_KEY'));
-    });
-
-    it('gets EUR-based rates from the live service', function () {
-        $url = str_replace(
-            ['{{ACCESS_KEY}}', '{{SYMBOLS}}'],
-            [TestEnv::get('FIXERIO_API_KEY'), 'EUR,GBP,USD'],
-            (new FixerioHarness())->getUrlTemplate(),
-        );
-
-        $response = HttpClient::create(['timeout' => 30])->request('GET', $url);
-        $body = json_decode($response->getContent(false), true);
-
-        expect($response->getStatusCode())->toBe(200);
-        expect($body['error']['type'] ?? null)->toBeNull();
-        expect($body['success'] ?? null)->toBeTrue();
-        expect($body['base'] ?? null)->toBe('EUR');
-    });
-
-    it('imports usable rates through the currency importer', function () {
-        expectUsableRates((new FixerioHarness())->setCurrencies(['EUR', 'GBP', 'USD'], ['EUR', 'USD']));
-    });
 });

--- a/tests/Backend/Integration/Directory/Model/Currency/SaveRatesTest.php
+++ b/tests/Backend/Integration/Directory/Model/Currency/SaveRatesTest.php
@@ -102,8 +102,8 @@ it('skips a zero rate', function () {
     expect(storedTestRates())->toBe(['XTA/XTC' => 1.25]);
 });
 
-// An importer returns null for every currency the service left out, and the cron hands that
-// array straight to saveRates(), so this is the ordinary path whenever a service is partial.
+// An importer reports a missing currency as null. The cron drops such a result, because the
+// importer records a message too, but importRates() and third-party callers save it unfiltered.
 it('skips a missing rate without tripping over the null', function () {
     $deprecations = [];
     set_error_handler(function (int $severity, string $message) use (&$deprecations): bool {

--- a/tests/Backend/Integration/Directory/Model/Currency/SaveRatesTest.php
+++ b/tests/Backend/Integration/Directory/Model/Currency/SaveRatesTest.php
@@ -19,7 +19,7 @@ uses(Tests\MahoBackendTestCase::class);
  */
 const SAVE_RATES_CODES = ['XTA', 'XTB', 'XTC'];
 
-function currencyRateTable(): string
+function saveRatesTable(): string
 {
     return Mage::getSingleton('core/resource')->getTableName('directory/currency_rate');
 }
@@ -27,11 +27,11 @@ function currencyRateTable(): string
 /**
  * @return array<string, float> keyed "FROM/TO"
  */
-function storedTestRates(): array
+function saveRatesStored(): array
 {
     $adapter = Mage::getSingleton('core/resource')->getConnection('core_read');
     $select = $adapter->select()
-        ->from(currencyRateTable(), ['currency_from', 'currency_to', 'rate'])
+        ->from(saveRatesTable(), ['currency_from', 'currency_to', 'rate'])
         ->where('currency_from IN (?)', SAVE_RATES_CODES)
         ->order('currency_from')
         ->order('currency_to');
@@ -44,33 +44,33 @@ function storedTestRates(): array
     return $rates;
 }
 
-function clearTestRates(): void
+function saveRatesClear(): void
 {
     $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
-    $adapter->delete(currencyRateTable(), ['currency_from IN (?)' => SAVE_RATES_CODES]);
-    $adapter->delete(currencyRateTable(), ['currency_to IN (?)' => SAVE_RATES_CODES]);
+    $adapter->delete(saveRatesTable(), ['currency_from IN (?)' => SAVE_RATES_CODES]);
+    $adapter->delete(saveRatesTable(), ['currency_to IN (?)' => SAVE_RATES_CODES]);
 }
 
-function saveTestRates(array $rates): void
+function saveRatesCall(array $rates): void
 {
     Mage::getModel('directory/currency')->saveRates($rates);
 }
 
 beforeEach(function () {
-    clearTestRates();
+    saveRatesClear();
 });
 
 afterEach(function () {
-    clearTestRates();
+    saveRatesClear();
 });
 
 it('writes one row per currency pair', function () {
-    saveTestRates([
+    saveRatesCall([
         'XTA' => ['XTB' => 1.25, 'XTC' => 0.8],
         'XTB' => ['XTA' => 0.8],
     ]);
 
-    expect(storedTestRates())->toBe([
+    expect(saveRatesStored())->toBe([
         'XTA/XTB' => 1.25,
         'XTA/XTC' => 0.8,
         'XTB/XTA' => 0.8,
@@ -78,32 +78,31 @@ it('writes one row per currency pair', function () {
 });
 
 it('updates an existing pair instead of adding a second row', function () {
-    saveTestRates(['XTA' => ['XTB' => 1.25]]);
-    saveTestRates(['XTA' => ['XTB' => 1.5]]);
+    saveRatesCall(['XTA' => ['XTB' => 1.25]]);
+    saveRatesCall(['XTA' => ['XTB' => 1.5]]);
 
-    expect(storedTestRates())->toBe(['XTA/XTB' => 1.5]);
+    expect(saveRatesStored())->toBe(['XTA/XTB' => 1.5]);
 });
 
 it('keeps the full scale of the rate column', function () {
-    saveTestRates(['XTA' => ['XTB' => 0.865725911176]]);
+    saveRatesCall(['XTA' => ['XTB' => 0.865725911176]]);
 
-    expect(storedTestRates()['XTA/XTB'])->toEqualWithDelta(0.865725911176, 0.0000000000005);
+    expect(saveRatesStored()['XTA/XTB'])->toEqualWithDelta(0.865725911176, 0.0000000000005);
 });
 
 it('stores the absolute value of a negative rate', function () {
-    saveTestRates(['XTA' => ['XTB' => -1.25]]);
+    saveRatesCall(['XTA' => ['XTB' => -1.25]]);
 
-    expect(storedTestRates())->toBe(['XTA/XTB' => 1.25]);
+    expect(saveRatesStored())->toBe(['XTA/XTB' => 1.25]);
 });
 
 it('skips a zero rate', function () {
-    saveTestRates(['XTA' => ['XTB' => 0, 'XTC' => 1.25]]);
+    saveRatesCall(['XTA' => ['XTB' => 0, 'XTC' => 1.25]]);
 
-    expect(storedTestRates())->toBe(['XTA/XTC' => 1.25]);
+    expect(saveRatesStored())->toBe(['XTA/XTC' => 1.25]);
 });
 
-// An importer reports a missing currency as null. The cron drops such a result, because the
-// importer records a message too, but importRates() and third-party callers save it unfiltered.
+// A custom importer can report a missing currency as null; core callers never do.
 it('skips a missing rate without tripping over the null', function () {
     $deprecations = [];
     set_error_handler(function (int $severity, string $message) use (&$deprecations): bool {
@@ -112,16 +111,16 @@ it('skips a missing rate without tripping over the null', function () {
     }, E_DEPRECATED);
 
     try {
-        saveTestRates(['XTA' => ['XTB' => 1.25, 'XTC' => null]]);
+        saveRatesCall(['XTA' => ['XTB' => 1.25, 'XTC' => null]]);
     } finally {
         restore_error_handler();
     }
 
     expect($deprecations)->toBe([]);
-    expect(storedTestRates())->toBe(['XTA/XTB' => 1.25]);
+    expect(saveRatesStored())->toBe(['XTA/XTB' => 1.25]);
 });
 
 it('rejects an empty rate set', function () {
-    expect(fn() => saveTestRates([]))
+    expect(fn() => saveRatesCall([]))
         ->toThrow(Mage_Core_Exception::class, 'Invalid rates received');
 });

--- a/tests/Backend/Integration/Directory/Model/Currency/SaveRatesTest.php
+++ b/tests/Backend/Integration/Directory/Model/Currency/SaveRatesTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * saveRates() upserts into directory_currency_rate on a two-column primary key, which every
+ * DB backend spells differently, and it stores decimal(24,12). Fixture rates keep the test
+ * offline, so it runs on every backend CI covers without calling a rate service.
+ *
+ * The codes are ISO 4217 "X" codes that no real currency uses, so a run never disturbs the
+ * store's own rates.
+ */
+const SAVE_RATES_CODES = ['XTA', 'XTB', 'XTC'];
+
+function currencyRateTable(): string
+{
+    return Mage::getSingleton('core/resource')->getTableName('directory/currency_rate');
+}
+
+/**
+ * @return array<string, float> keyed "FROM/TO"
+ */
+function storedTestRates(): array
+{
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_read');
+    $select = $adapter->select()
+        ->from(currencyRateTable(), ['currency_from', 'currency_to', 'rate'])
+        ->where('currency_from IN (?)', SAVE_RATES_CODES)
+        ->order('currency_from')
+        ->order('currency_to');
+
+    $rates = [];
+    foreach ($adapter->fetchAll($select) as $row) {
+        $rates[$row['currency_from'] . '/' . $row['currency_to']] = (float) $row['rate'];
+    }
+
+    return $rates;
+}
+
+function clearTestRates(): void
+{
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    $adapter->delete(currencyRateTable(), ['currency_from IN (?)' => SAVE_RATES_CODES]);
+    $adapter->delete(currencyRateTable(), ['currency_to IN (?)' => SAVE_RATES_CODES]);
+}
+
+function saveTestRates(array $rates): void
+{
+    Mage::getModel('directory/currency')->saveRates($rates);
+}
+
+beforeEach(function () {
+    clearTestRates();
+});
+
+afterEach(function () {
+    clearTestRates();
+});
+
+it('writes one row per currency pair', function () {
+    saveTestRates([
+        'XTA' => ['XTB' => 1.25, 'XTC' => 0.8],
+        'XTB' => ['XTA' => 0.8],
+    ]);
+
+    expect(storedTestRates())->toBe([
+        'XTA/XTB' => 1.25,
+        'XTA/XTC' => 0.8,
+        'XTB/XTA' => 0.8,
+    ]);
+});
+
+it('updates an existing pair instead of adding a second row', function () {
+    saveTestRates(['XTA' => ['XTB' => 1.25]]);
+    saveTestRates(['XTA' => ['XTB' => 1.5]]);
+
+    expect(storedTestRates())->toBe(['XTA/XTB' => 1.5]);
+});
+
+it('keeps the full scale of the rate column', function () {
+    saveTestRates(['XTA' => ['XTB' => 0.865725911176]]);
+
+    expect(storedTestRates()['XTA/XTB'])->toEqualWithDelta(0.865725911176, 0.0000000000005);
+});
+
+it('stores the absolute value of a negative rate', function () {
+    saveTestRates(['XTA' => ['XTB' => -1.25]]);
+
+    expect(storedTestRates())->toBe(['XTA/XTB' => 1.25]);
+});
+
+it('skips a zero rate', function () {
+    saveTestRates(['XTA' => ['XTB' => 0, 'XTC' => 1.25]]);
+
+    expect(storedTestRates())->toBe(['XTA/XTC' => 1.25]);
+});
+
+// An importer returns null for every currency the service left out, and the cron hands that
+// array straight to saveRates(), so this is the ordinary path whenever a service is partial.
+it('skips a missing rate without tripping over the null', function () {
+    $deprecations = [];
+    set_error_handler(function (int $severity, string $message) use (&$deprecations): bool {
+        $deprecations[] = $message;
+        return true;
+    }, E_DEPRECATED);
+
+    try {
+        saveTestRates(['XTA' => ['XTB' => 1.25, 'XTC' => null]]);
+    } finally {
+        restore_error_handler();
+    }
+
+    expect($deprecations)->toBe([]);
+    expect(storedTestRates())->toBe(['XTA/XTB' => 1.25]);
+});
+
+it('rejects an empty rate set', function () {
+    expect(fn() => saveTestRates([]))
+        ->toThrow(Mage_Core_Exception::class, 'Invalid rates received');
+});

--- a/tests/Browser/PaypalCheckoutTest.php
+++ b/tests/Browser/PaypalCheckoutTest.php
@@ -86,7 +86,7 @@ function bumpOrderIncrementId(): void
     $resource = Mage::getSingleton('core/resource');
     $write = $resource->getConnection('core_write');
     $orderType = Mage::getModel('eav/entity_type')->loadByCode('order');
-    // Millisecond base + random suffix: unique across concurrent CI jobs hitting the same
+    // Millisecond base + random suffix: unique across concurrent CI runs hitting the same
     // sandbox (which would otherwise collide and trip PayPal's duplicate-invoice block).
     $unique = (int) round(microtime(true) * 1000) * 100_000 + random_int(0, 99_999);
     $write->update(
@@ -250,7 +250,7 @@ it('renders inline PayPal card fields at checkout (Advanced Checkout, no popup)'
 it('completes a full card order through to the success page with reconciled totals', function (string $display, float $rate) {
     configureStoreCurrency($display, $rate);
 
-    // The 7 CI matrix jobs hit the one shared PayPal sandbox account concurrently, so a card
+    // Concurrent CI runs hit the one shared PayPal sandbox account, so a card
     // authorization is occasionally declined or slow-walked under that load. Retry the whole
     // card flow a few times, reserving a fresh invoice id each attempt (the sandbox blocks
     // duplicate invoice ids, so a retried order needs a new one). Most runs succeed first try.

--- a/tests/Browser/PaypalCheckoutTest.php
+++ b/tests/Browser/PaypalCheckoutTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 use Tests\Browser\MahoServer;
 use Tests\MahoBrowserTestCase;
 
-uses(MahoBrowserTestCase::class)->group('browser', 'paypal');
+uses(MahoBrowserTestCase::class)->group('browser', 'paypal', 'sandbox');
 
 beforeEach(function () {
     // Needs the store actually configured with PayPal credentials (the test harness or CI


### PR DESCRIPTION
The suite runs once per DB backend, so every live-service test was making its calls seven times per run. Those tests assert on what the service returns and store none of it, so the repetition bought no coverage while multiplying the rate-limit pressure and the odds that a vendor's bad day failed the run. That is what made the currency rate tests flaky.

- `currency-live` and `sandbox` now run in the `mysql-8.4` job only. Live calls per run drop from ~230 to ~33.
- The browser PayPal checkout joins the `sandbox` group; it drives a real sandbox checkout and was gated on credentials alone.
- Dropped the Fixer live tests and the `FIXERIO_API_KEY` secret. Fixer's free tier is [100 calls a month](https://fixer.io/pricing), which CI spends in a few runs, so a live check cannot run often enough to be worth keeping. Its offline coverage stays.
- Added `SaveRatesTest`, the missing coverage for `saveRates()`, which upserts into `directory_currency_rate` on a two-column primary key and stores `decimal(24,12)`. Fixture rates, no service call, so it runs on all seven backends.

That last test caught a bug: `abs()` was handed the `null`s an importer returns for the currencies a service left out, and `Mage_Directory_Model_Observer` passes the fetched array straight to `saveRates()`. So the scheduled update raised a deprecation on every partial import, which becomes a `TypeError` on PHP 9.