### PR TITLE
Fixed admin form ajax validation errors redirecting to the dashboard

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/Action/AttributeController.php
@@ -269,6 +269,6 @@ class Mage_Adminhtml_Catalog_Product_Action_AttributeController extends Mage_Adm
             $response->setMessage($this->getLayout()->getMessagesBlock()->getGroupedHtml());
         }
 
-        $this->getResponse()->setBody($response->toJson());
+        $this->getResponse()->setBodyJson($response);
     }
 }

--- a/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Catalog/Product/AttributeController.php
@@ -146,7 +146,7 @@ class Mage_Adminhtml_Catalog_Product_AttributeController extends Mage_Adminhtml_
             $response->setMessage($this->getLayout()->getMessagesBlock()->getGroupedHtml());
         }
 
-        $this->getResponse()->setBody($response->toJson());
+        $this->getResponse()->setBodyJson($response);
     }
 
     /**

--- a/public/js/mage/adminhtml/form.js
+++ b/public/js/mage/adminhtml/form.js
@@ -56,7 +56,8 @@ class varienForm {
 
         mahoFetch(this.validationUrl, {
             method: 'POST',
-            body: formData
+            body: formData,
+            rejectOnError: false
         })
         .then(data => {
             this._processValidationResult(data);

--- a/public/js/varien/js.js
+++ b/public/js/varien/js.js
@@ -27,9 +27,11 @@ class MahoError extends Error {
  * @param {string} url - fetch url
  * @param {Object} [options] - fetch options
  * @param {Object} [options.loaderArea] - parameter to pass to showLoader(), false to disable
+ * @param {boolean} [options.rejectOnError] - false to return an { error: true } payload instead
+ *     of throwing, for endpoints that report domain errors as data
  */
 async function mahoFetch(url, options) {
-    const { loaderArea, ...fetchOptions } = options ?? {};
+    const { loaderArea, rejectOnError = true, ...fetchOptions } = options ?? {};
     try {
         if (loaderArea !== false && typeof showLoader === 'function') {
             showLoader(loaderArea)
@@ -65,7 +67,7 @@ async function mahoFetch(url, options) {
               : await response.text();
 
         if (typeof result === 'object' && result !== null) {
-            if (result.error) {
+            if (result.error && rejectOnError) {
                 const message = result.message ?? result.error;
                 throw new MahoError(typeof message === 'string' ? message : 'An error occurred.');
             } else if (result.ajaxExpired && result.ajaxRedirect) {

--- a/tests/Browser/AdminProductSkuValidationTest.php
+++ b/tests/Browser/AdminProductSkuValidationTest.php
@@ -41,7 +41,12 @@ function createSkuValidationProduct(string $sku, string $name): Mage_Catalog_Mod
     $product->setStoreId(Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID)
         ->setSku(SKU_VALIDATION_SKU_PREFIX . $sku)
         ->setName($name)
+        // Every required attribute, or client-side validation stops the save before the ajax call.
+        ->setDescription($name . ' description')
+        ->setShortDescription($name . ' short description')
         ->setPrice(24.99)
+        ->setWeight(1)
+        ->setTaxClassId(0)
         ->setStatus(Mage_Catalog_Model_Product_Status::STATUS_ENABLED)
         ->setVisibility(Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH)
         ->setTypeId(Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)
@@ -102,10 +107,9 @@ function createSkuValidationAdminUser(): void
         'is_active' => 1,
     ])->save();
 
-    Mage::getModel('admin/user')
-        ->setRoleId($role->getId())
-        ->setUserId($user->getId())
-        ->add();
+    Mage::getModel('admin/user')->load($user->getId())
+        ->setRoleIds([$role->getId()])
+        ->saveRelations();
 }
 
 it('reports a duplicate sku on the product form instead of leaving for the dashboard', function () {
@@ -128,6 +132,8 @@ it('reports a duplicate sku on the product form instead of leaving for the dashb
     // the browser navigated away instead.
     $page->text('#advice-validate-ajax-sku:visible');
 
-    $page->assertSee('must be unique')
-        ->assertDontSee('Dashboard');
+    $page->assertSee('must be unique');
+
+    // By url: the admin menu carries a visible "Dashboard" link on every page.
+    expect($page->url())->toContain('catalog_product/edit');
 });

--- a/tests/Browser/AdminProductSkuValidationTest.php
+++ b/tests/Browser/AdminProductSkuValidationTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Tests\MahoBrowserTestCase;
+
+uses(MahoBrowserTestCase::class)->group('browser');
+
+/**
+ * Regression for #1267: an ajax validation error must reach the form, not abort the request.
+ *
+ * catalog_product/validate reports a duplicate SKU as data, { error: true, attribute: 'sku' },
+ * with a 200. mahoFetch() turns an { error: true } payload into a thrown MahoError, so
+ * varienForm._validate() landed in its catch, called _processFailure() and sent the browser to
+ * BASE_URL. The admin lost the form and the message and arrived on the dashboard.
+ *
+ * Only a browser can catch that: the controller returns the right payload either way, and the
+ * repo has no js test harness.
+ */
+
+const SKU_VALIDATION_SKU_PREFIX = 'pest-sku-validation-';
+const SKU_VALIDATION_ADMIN_USERNAME = 'pest_sku_validation';
+const SKU_VALIDATION_ADMIN_PASSWORD = 'PestSkuValidation2026!';
+
+beforeEach(function () {
+    deleteSkuValidationFixtures();
+});
+
+afterEach(function () {
+    deleteSkuValidationFixtures();
+});
+
+function createSkuValidationProduct(string $sku, string $name): Mage_Catalog_Model_Product
+{
+    $product = Mage::getModel('catalog/product');
+    $product->setStoreId(Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID)
+        ->setSku(SKU_VALIDATION_SKU_PREFIX . $sku)
+        ->setName($name)
+        ->setPrice(24.99)
+        ->setStatus(Mage_Catalog_Model_Product_Status::STATUS_ENABLED)
+        ->setVisibility(Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH)
+        ->setTypeId(Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)
+        ->setAttributeSetId(4)
+        ->setWebsiteIds([1])
+        ->save();
+
+    return $product;
+}
+
+function deleteSkuValidationFixtures(): void
+{
+    /** @var Mage_Catalog_Model_Resource_Product_Collection $products */
+    $products = Mage::getResourceModel('catalog/product_collection');
+    $products->addAttributeToFilter('sku', ['like' => SKU_VALIDATION_SKU_PREFIX . '%']);
+
+    // Product deletion is admin-guarded, hence isSecureArea.
+    Mage::register('isSecureArea', true);
+    try {
+        foreach ($products as $product) {
+            $product->delete();
+        }
+    } finally {
+        Mage::unregister('isSecureArea');
+    }
+
+    $user = Mage::getModel('admin/user')->loadByUsername(SKU_VALIDATION_ADMIN_USERNAME);
+    if ($user->getId()) {
+        $roleId = (int) $user->getRole()->getRoleId();
+        $user->delete();
+        if ($roleId) {
+            Mage::getModel('admin/roles')->load($roleId)->delete();
+        }
+    }
+}
+
+/** A throwaway admin with full access, so the test doesn't depend on the install's password. */
+function createSkuValidationAdminUser(): void
+{
+    $role = Mage::getModel('admin/roles')
+        ->setName('Pest Sku Validation')
+        ->setRoleType('G')
+        ->setParentId(0)
+        ->save();
+
+    Mage::getModel('admin/rules')
+        ->setRoleId($role->getId())
+        ->setResources(['all'])
+        ->saveRel();
+
+    $user = Mage::getModel('admin/user');
+    $user->setData([
+        'username' => SKU_VALIDATION_ADMIN_USERNAME,
+        'firstname' => 'Pest',
+        'lastname' => 'Sku',
+        'email' => SKU_VALIDATION_ADMIN_USERNAME . '@example.test',
+        'password' => SKU_VALIDATION_ADMIN_PASSWORD,
+        'is_active' => 1,
+    ])->save();
+
+    Mage::getModel('admin/user')
+        ->setRoleId($role->getId())
+        ->setUserId($user->getId())
+        ->add();
+}
+
+it('reports a duplicate sku on the product form instead of leaving for the dashboard', function () {
+    $taken = createSkuValidationProduct('taken', 'Pest Sku Taken');
+    $edited = createSkuValidationProduct('edited', 'Pest Sku Edited');
+
+    createSkuValidationAdminUser();
+
+    $page = adminLoginAndVisit(
+        SKU_VALIDATION_ADMIN_USERNAME,
+        SKU_VALIDATION_ADMIN_PASSWORD,
+        '/admin/catalog_product/edit/id/' . $edited->getId(),
+        '#sku',
+    );
+
+    $page->fill('#sku', $taken->getSku())
+        ->click('button[title="Save"]');
+
+    // Reading the advice waits for the ajax round trip to paint it. Pre-fix it never appeared:
+    // the browser navigated away instead.
+    $page->text('#advice-validate-ajax-sku:visible');
+
+    $page->assertSee('must be unique')
+        ->assertDontSee('Dashboard');
+});


### PR DESCRIPTION
Fixes #1267.

`mahoFetch()` treats a JSON `{ error: true }` payload as a failure and throws, so `varienForm._validate()` always landed in its `.catch()` and called `_processFailure()`, which sets `location.href = BASE_URL`. `catalog_product/validate` reports a duplicate SKU exactly that way, so saving such a product dropped the form and the message and left the admin on the dashboard. The `if (response.error)` branches in `form.js` and in the product edit template were dead code.

Added a `rejectOnError` option to `mahoFetch()`, default `true` so no other caller changes, and opted `_validate()` out of it. This also covers customer edit, system variable, system design, the product mass-attribute update and widget instance.

The two product attribute validation endpoints needed a second fix to benefit: they wrote the encoded payload with `setBody()`, leaving the content type as text/html, so `mahoFetch()` returned a string and reading `.error` off it gave `undefined`. Both now use `setBodyJson()`.

Broken since #319 removed prototypejs, whose `Ajax.Request` passed the payload to `onComplete`.

New browser test saves a product with a taken SKU and asserts the inline advice shows and the browser stays on the form.
