### PR TITLE
Fixed admin order create: typed quantity ignored when adding products

### DIFF
--- a/public/js/mage/adminhtml/sales.js
+++ b/public/js/mage/adminhtml/sales.js
@@ -486,9 +486,21 @@ class AdminOrder
         }
 
         const product = this.gridProducts.get(checkboxEl.value);
+        if (!product) {
+            return;
+        }
+
+        // Only giftmessage is a checkbox here; qty and the custom-option inputs are
+        // text fields, whose .checked is undefined. Testing .checked for all of them
+        // meant a typed qty was never recorded, so the grid always submitted the
+        // qty captured when the row was first ticked.
         if (inputEl.name === 'giftmessage') {
-            delete product[inputEl.name];
-        } else if (inputEl.checked) {
+            if (inputEl.checked) {
+                product[inputEl.name] = inputEl.value;
+            } else {
+                delete product[inputEl.name];
+            }
+        } else {
             product[inputEl.name] = inputEl.value;
         }
     }
@@ -647,10 +659,8 @@ class AdminOrder
         const fieldsPrepare = {};
         const itemsFilter = [];
         for (const [productId, product] of this.gridProducts) {
-            let paramKey = `item[${productId}]`;
             for (const [key, value] of Object.entries(product)) {
-                paramKey += `[${key}]`;
-                fieldsPrepare[paramKey] = value;
+                fieldsPrepare[`item[${productId}][${key}]`] = value;
             }
             itemsFilter.push(productId);
         }

--- a/public/js/mage/adminhtml/sales.js
+++ b/public/js/mage/adminhtml/sales.js
@@ -490,10 +490,7 @@ class AdminOrder
             return;
         }
 
-        // Only giftmessage is a checkbox here; qty and the custom-option inputs are
-        // text fields, whose .checked is undefined. Testing .checked for all of them
-        // meant a typed qty was never recorded, so the grid always submitted the
-        // qty captured when the row was first ticked.
+        // giftmessage is the only checkbox here; qty and custom options are text inputs
         if (inputEl.name === 'giftmessage') {
             if (inputEl.checked) {
                 product[inputEl.name] = inputEl.value;
@@ -646,7 +643,7 @@ class AdminOrder
             }
             this.gridProducts.delete(element.value);
         }
-        grid.reloadParams = {'products[]': this.gridProducts.keys()};
+        grid.reloadParams = {'products[]': Array.from(this.gridProducts.keys())};
     }
 
     /**


### PR DESCRIPTION
## Problem

In **Sales → Orders → Create New Order → Add Products**, typing a quantity in the "Qty to Add" column has no effect. The order always receives **qty 1**, regardless of what was entered.

**To reproduce:** create an admin order, click *Add Products*, tick a row, type `3` in Qty to Add, click *Add Selected Product(s) to Order*. The item is added with qty 1. The submitted payload is `item[42][qty]: 1`.

## Cause

`productGridRowInputChange()` in `public/js/mage/adminhtml/sales.js` gated the assignment on `inputEl.checked`:

```js
const product = this.gridProducts.get(checkboxEl.value);
if (inputEl.name === 'giftmessage') {
    delete product[inputEl.name];
} else if (inputEl.checked) {
    product[inputEl.name] = inputEl.value;
}
```

Only `giftmessage` is a checkbox. `qty` and the custom-option fields are text inputs, whose `.checked` is `undefined` and therefore always falsy — so the branch never ran and the typed value was never recorded.

Nor could it be picked up earlier in the flow. `productGridRowInit()` disables those inputs until the row is ticked:

```js
input.disabled = !checkbox.checked || input.classList.contains('input-inactive');
```

so the user must tick first, and by then `productGridCheckboxCheck()` has already stored the default it just wrote:

```js
if (inputEl.name === 'qty' && !inputEl.value) {
    inputEl.value = 1;
}
```

The `giftmessage` branch was wrong in the other direction — an unconditional `delete`, so toggling it *on* removed the key instead of setting it.

## Second, latent issue

`productGridAddSelected()` mutated `paramKey` inside the field loop:

```js
let paramKey = `item[${productId}]`;
for (const [key, value] of Object.entries(product)) {
    paramKey += `[${key}]`;
    fieldsPrepare[paramKey] = value;
}
```

so the second and subsequent fields nested inside the first — `item[42][qty][giftmessage]` rather than `item[42][giftmessage]`. This was masked by the first bug, which guaranteed `qty` was the only field ever submitted. Fixing the first alone would have exposed it, so both are addressed here.

## Fix

- `giftmessage` is set when checked and deleted when unchecked; every other input stores its value unconditionally. Also guards against a missing `product` entry.
- The parameter key is built fresh per field.

## Verification

The two methods were extracted from the patched file and exercised standalone:

| Case | Result |
|---|---|
| tick row, type qty 3 | `{"qty":"3"}` |
| resulting payload | `item[42][qty]: "3"` |
| giftmessage on → off | key set → key deleted |
| qty + giftmessage together | `item[42][qty]`, `item[42][giftmessage]` |