### PR TITLE
Added explicit width and height to product images in widgets and cart

### DIFF
--- a/app/design/frontend/base/default/template/catalog/product/list/upsell.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/list/upsell.phtml
@@ -19,7 +19,7 @@
     <?php foreach ($this->getItemCollection()->getItems() as $_link): ?>
         <li>
             <a href="<?= $_link->getProductUrl() ?>" title="<?= $this->escapeHtml($_link->getName()) ?>" class="product-image">
-                <img src="<?= $this->helper('catalog/image')->init($_link, 'small_image')->resize(280) ?>" srcset="<?= $this->helper('catalog/image')->init($_link, 'small_image')->resize(560) ?> 2x" alt="<?= $this->escapeHtml($_link->getName()) ?>">
+                <img src="<?= $this->helper('catalog/image')->init($_link, 'small_image')->resize(280) ?>" srcset="<?= $this->helper('catalog/image')->init($_link, 'small_image')->resize(560) ?> 2x" width="280" height="280" alt="<?= $this->escapeHtml($_link->getName()) ?>">
             </a>
             <h3 class="product-name"><a href="<?= $_link->getProductUrl() ?>" title="<?= $this->escapeHtml($_link->getName()) ?>"><?= $this->escapeHtml($_link->getName()) ?></a></h3>
             <?= $this->getPriceHtml($_link, true, '-upsell') ?>

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_images_list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/column/new_images_list.phtml
@@ -22,7 +22,7 @@
             <?php foreach ($_products->getItems() as $_product): ?>
                 <li class="item">
                     <?php $_imgSize = 310; // Images will be displayed at roughly this size when viewed at less than the medium breakpoint ?>
-                    <a class="product-image" href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>"><img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize*2) ?> 2x" alt="<?= $this->stripTags($_product->getName(), null, true) ?>"></a>
+                    <a class="product-image" href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>"><img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize*2) ?> 2x" width="<?= $_imgSize ?>" height="<?= $_imgSize ?>" alt="<?= $this->stripTags($_product->getName(), null, true) ?>"></a>
                 </li>
             <?php endforeach ?>
             </ol>

--- a/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_grid.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/widget/new/content/new_grid.phtml
@@ -25,7 +25,7 @@
                     <div>
                         <?php $_imgSize = 210; ?>
                         <a href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>" class="product-image">
-                            <img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x" alt="<?= $this->stripTags($_product->getName(), null, true) ?>">
+                            <img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x" width="<?= $_imgSize ?>" height="<?= $_imgSize ?>" alt="<?= $this->stripTags($_product->getName(), null, true) ?>">
                         </a>
                         <ul>
                             <?php if ($this->helper('wishlist')->isAllow()) : ?>

--- a/app/design/frontend/base/default/template/catalogrule/widget/onsale/column/onsale_images_list.phtml
+++ b/app/design/frontend/base/default/template/catalogrule/widget/onsale/column/onsale_images_list.phtml
@@ -20,7 +20,7 @@
             <?php foreach ($_products->getItems() as $_product): ?>
                 <li class="item">
                     <?php $_imgSize = 310; ?>
-                    <a class="product-image" href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>"><img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize*2) ?> 2x" alt="<?= $this->stripTags($_product->getName(), null, true) ?>"></a>
+                    <a class="product-image" href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>"><img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize*2) ?> 2x" width="<?= $_imgSize ?>" height="<?= $_imgSize ?>" alt="<?= $this->stripTags($_product->getName(), null, true) ?>"></a>
                 </li>
             <?php endforeach ?>
             </ol>

--- a/app/design/frontend/base/default/template/catalogrule/widget/onsale/content/onsale_grid.phtml
+++ b/app/design/frontend/base/default/template/catalogrule/widget/onsale/content/onsale_grid.phtml
@@ -23,7 +23,7 @@
                     <div>
                         <?php $_imgSize = 210; ?>
                         <a href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>" class="product-image">
-                            <img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x" alt="<?= $this->stripTags($_product->getName(), null, true) ?>">
+                            <img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x" width="<?= $_imgSize ?>" height="<?= $_imgSize ?>" alt="<?= $this->stripTags($_product->getName(), null, true) ?>">
                         </a>
                         <ul>
                             <?php if ($this->helper('wishlist')->isAllow()) : ?>

--- a/app/design/frontend/base/default/template/checkout/cart/crosssell.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/crosssell.phtml
@@ -20,6 +20,7 @@
                 <a class="product-image" href="<?= $_item->getProductUrl() ?>" title="<?= $this->escapeHtml($_item->getName()) ?>">
                     <img src="<?= $this->helper('catalog/image')->init($_item, 'thumbnail')->resize(210) ?>"
                          srcset="<?= $this->helper('catalog/image')->init($_item, 'thumbnail')->resize(420) ?> 2x"
+                         width="210" height="210"
                          alt="<?= $this->escapeHtml($_item->getName()) ?>">
                 </a>
                 <h3 class="product-name"><a href="<?= $_item->getProductUrl() ?>"><?= $this->escapeHtml($_item->getName()) ?></a></h3>

--- a/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
@@ -25,7 +25,7 @@ $_weeeAmount = $_item->getWeeeTaxAppliedAmount();
         <?php if ($this->hasProductUrl()):?>
             <a href="<?= $this->getProductUrl() ?>" title="<?= $this->escapeHtml($this->getProductName()) ?>" class="product-image">
         <?php endif ?>
-            <img src="<?= $this->getProductThumbnail()->resize(180) ?>" alt="<?= $this->escapeHtml($this->getProductName()) ?>">
+            <img src="<?= $this->getProductThumbnail()->resize(180) ?>" width="180" height="180" alt="<?= $this->escapeHtml($this->getProductName()) ?>">
         <?php if ($this->hasProductUrl()):?>
             </a>
         <?php endif ?>

--- a/app/design/frontend/base/default/template/email/catalog/product/list.phtml
+++ b/app/design/frontend/base/default/template/email/catalog/product/list.phtml
@@ -38,6 +38,7 @@ $_params = $this->escapeHtml(json_encode(['form_key' => $this->getFormKey()]));
                             <img id="product-collection-image-<?= $_product->getId() ?>"
                                  src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>"
                                  srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x"
+                                 width="<?= $_imgSize ?>" height="<?= $_imgSize ?>"
                                  alt="<?= $this->stripTags($this->getImageLabel($_product, 'small_image'), null, true) ?>">
                         </a>
                         <?php // Product description ?>
@@ -127,6 +128,7 @@ $_params = $this->escapeHtml(json_encode(['form_key' => $this->getFormKey()]));
                             <img id="product-collection-image-<?= $_product->getId() ?>"
                                  src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>"
                                  srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x"
+                                 width="<?= $_imgSize ?>" height="<?= $_imgSize ?>"
                                  alt="<?= $this->stripTags($this->getImageLabel($_product, 'small_image'), null, true) ?>">
                         </a>
                         <div class="product-info">

--- a/app/design/frontend/base/default/template/email/catalog/product/new.phtml
+++ b/app/design/frontend/base/default/template/email/catalog/product/new.phtml
@@ -24,6 +24,7 @@
                         <?php $_imgSize = 260; ?>
                         <img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>"
                              srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x"
+                             width="<?= $_imgSize ?>" height="<?= $_imgSize ?>"
                              alt="<?= $this->stripTags($this->getImageLabel($_product, 'small_image'), null, true) ?>">
                     </a>
                     <h3 class="product-name"><a href="<?= $_product->getProductUrl() ?>" title="<?= $this->escapeHtml($_product->getName()) ?>"><?= $this->escapeHtml($_product->getName()) ?></a></h3>

--- a/app/design/frontend/base/default/template/reports/widget/bestsellers/column/bestsellers_images_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/bestsellers/column/bestsellers_images_list.phtml
@@ -20,7 +20,7 @@
             <?php foreach ($_products->getItems() as $_product): ?>
                 <li class="item">
                     <?php $_imgSize = 310; ?>
-                    <a class="product-image" href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>"><img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize*2) ?> 2x" alt="<?= $this->stripTags($_product->getName(), null, true) ?>"></a>
+                    <a class="product-image" href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>"><img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize*2) ?> 2x" width="<?= $_imgSize ?>" height="<?= $_imgSize ?>" alt="<?= $this->stripTags($_product->getName(), null, true) ?>"></a>
                 </li>
             <?php endforeach ?>
             </ol>

--- a/app/design/frontend/base/default/template/reports/widget/bestsellers/content/bestsellers_grid.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/bestsellers/content/bestsellers_grid.phtml
@@ -23,7 +23,7 @@
                     <div>
                         <?php $_imgSize = 210; ?>
                         <a href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>" class="product-image">
-                            <img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x" alt="<?= $this->stripTags($_product->getName(), null, true) ?>">
+                            <img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x" width="<?= $_imgSize ?>" height="<?= $_imgSize ?>" alt="<?= $this->stripTags($_product->getName(), null, true) ?>">
                         </a>
                         <ul>
                             <?php if ($this->helper('wishlist')->isAllow()) : ?>

--- a/app/design/frontend/base/default/template/reports/widget/compared/column/compared_images_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/column/compared_images_list.phtml
@@ -21,7 +21,7 @@
             <?php $i = 0; foreach ($_products as $_product): ?>
                 <li class="item">
                     <?php $_imgSize = 310; // Images will be displayed at roughly this size when viewed at less than the medium breakpoint ?>
-                    <a class="product-image" href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>"><img src="<?= $this->helper('catalog/image')->init($_product, 'thumbnail')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'thumbnail')->resize($_imgSize * 2) ?> 2x" alt="<?= $this->stripTags($_product->getName(), null, true) ?>"></a>
+                    <a class="product-image" href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>"><img src="<?= $this->helper('catalog/image')->init($_product, 'thumbnail')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'thumbnail')->resize($_imgSize * 2) ?> 2x" width="<?= $_imgSize ?>" height="<?= $_imgSize ?>" alt="<?= $this->stripTags($_product->getName(), null, true) ?>"></a>
                 </li>
             <?php endforeach ?>
             </ol>

--- a/app/design/frontend/base/default/template/reports/widget/compared/content/compared_grid.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/compared/content/compared_grid.phtml
@@ -25,6 +25,7 @@
                     <a href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>" class="product-image">
                         <img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>"
                              srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x"
+                             width="<?= $_imgSize ?>" height="<?= $_imgSize ?>"
                              alt="<?= $this->stripTags($_product->getName(), null, true) ?>">
                     </a>
                     <div class="product-info">

--- a/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_images_list.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/column/viewed_images_list.phtml
@@ -21,7 +21,7 @@
             <?php foreach ($_products as $_product): ?>
                 <li class="item">
                     <?php $_imgSize = 310; // Images will be displayed at roughly this size when viewed at less than the medium breakpoint ?>
-                    <a class="product-image" href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>"><img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x" alt="<?= $this->stripTags($_product->getName(), null, true) ?>"></a>
+                    <a class="product-image" href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>"><img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>" srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x" width="<?= $_imgSize ?>" height="<?= $_imgSize ?>" alt="<?= $this->stripTags($_product->getName(), null, true) ?>"></a>
                 </li>
             <?php endforeach ?>
             </ol>

--- a/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_grid.phtml
+++ b/app/design/frontend/base/default/template/reports/widget/viewed/content/viewed_grid.phtml
@@ -24,6 +24,7 @@
                 <a href="<?= $_product->getProductUrl() ?>" title="<?= $this->stripTags($_product->getName(), null, true) ?>" class="product-image">
                     <img src="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize) ?>"
                          srcset="<?= $this->helper('catalog/image')->init($_product, 'small_image')->resize($_imgSize * 2) ?> 2x"
+                         width="<?= $_imgSize ?>" height="<?= $_imgSize ?>"
                          alt="<?= $this->stripTags($_product->getName(), null, true) ?>">
                 </a>
                 <div class="product-info">


### PR DESCRIPTION
PageSpeed Insights reported "image elements do not have explicit width and height" for the new products widget on the home page.

The product image templates for the new products, on sale, viewed, compared and bestsellers widgets, plus upsell, cross-sell, the cart item row and the product email templates, rendered `<img>` without `width` and `height`. `catalog/product/list.phtml` already sets them; this applies the same convention everywhere.

Both attributes use the existing `$_imgSize` (or its literal). `resize($size)` with one argument keeps a square frame (`catalog/product_image/keep_frame` is on by default), so the ratio is right, and the CSS keeps `width: 100%; height: auto`, so the attributes only give the browser the aspect ratio to reserve space.

`blog/view.phtml` is still without dimensions: the post model exposes only the image URL, not its size.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->