### PR TITLE
Fixed catalog price display: tax rounding, discount percent, and FPT amounts

### DIFF
--- a/app/code/core/Mage/Tax/Helper/Data.php
+++ b/app/code/core/Mage/Tax/Helper/Data.php
@@ -494,7 +494,7 @@ class Mage_Tax_Helper_Data extends Mage_Core_Helper_Abstract
 
         if ($percent === false || is_null($percent)) {
             if ($priceIncludesTax && !$includingPercent) {
-                return $price;
+                return $roundPrice ? $store->roundPrice($price) : $price;
             }
         }
 

--- a/app/code/core/Mage/Tax/Helper/Data.php
+++ b/app/code/core/Mage/Tax/Helper/Data.php
@@ -518,7 +518,8 @@ class Mage_Tax_Helper_Data extends Mage_Core_Helper_Abstract
                         $price = $this->_calculatePriceInclTax($price, $includingPercent, $percent, $store);
                     }
                 } else {
-                    $price = $this->_calculatePrice($price, $includingPercent, false);
+                    // round the tax first, like the display-driven branch below, so both agree to the cent
+                    $price = $this->_calculatePrice($price, $includingPercent, false, $roundPrice);
                 }
             } else {
                 if ($includingTax) {

--- a/app/code/core/Mage/Weee/Helper/Data.php
+++ b/app/code/core/Mage/Weee/Helper/Data.php
@@ -377,6 +377,38 @@ class Mage_Weee_Helper_Data extends Mage_Core_Helper_Abstract
     }
 
     /**
+     * Returns original amount to display excluding taxes, the counterpart of getAmountForDisplay()
+     */
+    public function getOriginalAmountForDisplay(Mage_Catalog_Model_Product $product): float
+    {
+        $amount = 0;
+        foreach ($this->_getOriginalProductWeeeAttributes($product) as $attribute) {
+            $amount += $attribute->getAmount();
+        }
+        return (float) $amount;
+    }
+
+    /**
+     * Returns original amount to display including taxes, the counterpart of getAmountForDisplayInclTaxes()
+     */
+    public function getOriginalAmountInclTaxes(Mage_Catalog_Model_Product $product): float
+    {
+        return $this->getAmountInclTaxes($this->_getOriginalProductWeeeAttributes($product));
+    }
+
+    /**
+     * @return \Maho\DataObject[]
+     */
+    protected function _getOriginalProductWeeeAttributes(Mage_Catalog_Model_Product $product): array
+    {
+        if (!$this->isEnabled()) {
+            return [];
+        }
+        return Mage::getSingleton('weee/tax')
+            ->getProductWeeeAttributes($product, null, null, null, true, true);
+    }
+
+    /**
      * Adds HTML containers and formats tier prices accordingly to the currency used
      *
      * @param Mage_Catalog_Model_Product $product

--- a/app/design/frontend/base/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price.phtml
@@ -34,6 +34,10 @@ $_minimalPriceValue = $_product->getMinimalPrice();
 $_minimalPriceValue = $_store->convertPrice($_minimalPriceValue);
 $_minimalPrice = $_taxHelper->getPrice($_product, $_minimalPriceValue, $_simplePricesTax);
 $_convertedFinalPrice = $_store->convertPrice($_product->getFinalPrice());
+// Visibility guards compare what the customer sees, so they use the rounded amounts; the tax
+// helper keeps the full-precision ones so it never adds tax to an already rounded base.
+$_minimalPriceRounded = $_store->roundPrice($_minimalPriceValue);
+$_convertedFinalPriceRounded = $_store->roundPrice($_convertedFinalPrice);
 $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStoreLabel();
 ?>
 
@@ -377,7 +381,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
 
     <?php endif /* if ($_finalPrice == $_price): */ ?>
 
-    <?php if ($this->getDisplayMinimalPrice() && $_minimalPriceValue && $_minimalPriceValue < $_convertedFinalPrice): ?>
+    <?php if ($this->getDisplayMinimalPrice() && $_minimalPriceRounded && $_minimalPriceRounded < $_convertedFinalPriceRounded): ?>
 
         <?php $_minimalPriceDisplayValue = $_minimalPrice; ?>
         <?php if ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, [0, 1, 4])): ?>
@@ -404,14 +408,14 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
 <?php else: /* if (!$_product->isGrouped()): */ ?>
     <?php
     $showMinPrice = $this->getDisplayMinimalPrice();
-    if ($showMinPrice && $_minimalPriceValue) {
+    if ($showMinPrice && $_minimalPriceRounded) {
         $_exclTax = $_taxHelper->getPrice($_product, $_minimalPriceValue);
         $_inclTax = $_taxHelper->getPrice($_product, $_minimalPriceValue, true);
-        $price = $_minimalPriceValue;
+        $price = $_minimalPriceRounded;
     } else {
-        $price = $_convertedFinalPrice;
-        $_exclTax = $_taxHelper->getPrice($_product, $price);
-        $_inclTax = $_taxHelper->getPrice($_product, $price, true);
+        $price = $_convertedFinalPriceRounded;
+        $_exclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice);
+        $_inclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, true);
     }
     ?>
     <?php if ($price): ?>

--- a/app/design/frontend/base/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price.phtml
@@ -54,14 +54,14 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
     <?php $_regularPrice = $_taxHelper->getPrice($_product, $_convertedPrice, $_simplePricesTax); ?>
     <?php $_finalPrice = $_taxHelper->getPrice($_product, $_convertedFinalPrice) ?>
     <?php $_finalPriceInclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, true) ?>
-    <?php $_finalPriceSimpleTax = $_simplePricesTax ? $_finalPriceInclTax : $_taxHelper->getPrice($_product, $_convertedFinalPrice, false) ?>
+    <?php $_finalPriceSimpleTax = $_simplePricesTax ? $_finalPriceInclTax : $_finalPrice ?>
     <?php $_weeeDisplayType = $_weeeHelper->getPriceDisplayType(); ?>
     <?php $_weeeInPrice = $_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, [0, 1, 4]); ?>
     <?php $_weeeTaxAmountSimpleTax = $_simplePricesTax ? $_weeeTaxAmountInclTaxes : $_weeeTaxAmount; ?>
     <?php
     // Both sides of the discount carry the tax and the FPT that the page prints, so the percent matches them.
     $_originalWeeeTaxAmountSimpleTax = 0;
-    if ($_weeeInPrice) {
+    if ($_weeeInPrice && $_finalPriceSimpleTax < $_regularPrice) {
         $_originalWeeeTaxAmountSimpleTax = $_simplePricesTax
             ? $_weeeHelper->getOriginalAmountInclTaxes($_product)
             : $_weeeHelper->getOriginalAmountForDisplay($_product);

--- a/app/design/frontend/base/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price.phtml
@@ -51,19 +51,33 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
 
     <div class="price-box">
     <?php $_convertedPrice = $_store->convertPrice($_product->getPrice()); ?>
-    <?php $_price = $_taxHelper->getPrice($_product, $_convertedPrice); ?>
     <?php $_regularPrice = $_taxHelper->getPrice($_product, $_convertedPrice, $_simplePricesTax); ?>
     <?php $_finalPrice = $_taxHelper->getPrice($_product, $_convertedFinalPrice) ?>
     <?php $_finalPriceInclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, true) ?>
-    <?php $_finalPriceSimpleTax = $_simplePricesTax ? $_finalPriceInclTax : $_finalPrice ?>
+    <?php $_finalPriceSimpleTax = $_simplePricesTax ? $_finalPriceInclTax : $_taxHelper->getPrice($_product, $_convertedFinalPrice, false) ?>
     <?php $_weeeDisplayType = $_weeeHelper->getPriceDisplayType(); ?>
-    <?php if ($_finalPrice >= $_price): ?>
+    <?php $_weeeInPrice = $_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, [0, 1, 4]); ?>
+    <?php $_weeeTaxAmountSimpleTax = $_simplePricesTax ? $_weeeTaxAmountInclTaxes : $_weeeTaxAmount; ?>
+    <?php
+    // Both sides of the discount carry the tax and the FPT that the page prints, so the percent matches them.
+    $_originalWeeeTaxAmountSimpleTax = 0;
+    if ($_weeeInPrice) {
+        $_originalWeeeTaxAmountSimpleTax = $_simplePricesTax
+            ? $_weeeHelper->getOriginalAmountInclTaxes($_product)
+            : $_weeeHelper->getOriginalAmountForDisplay($_product);
+        $_originalWeeeTaxAmountSimpleTax = $_store->roundPrice($_store->convertPrice($_originalWeeeTaxAmountSimpleTax));
+    }
+    $_oldPriceDisplay = $_regularPrice + $_originalWeeeTaxAmountSimpleTax;
+    $_newPriceDisplay = $_finalPriceSimpleTax + ($_weeeInPrice ? $_weeeTaxAmountSimpleTax : 0);
+    $_discountPercent = $_oldPriceDisplay > 0 ? round((($_oldPriceDisplay - $_newPriceDisplay) / $_oldPriceDisplay) * 100) : 0;
+    ?>
+    <?php if ($_discountPercent <= 0): ?>
         <?php if ($_taxHelper->displayBothPrices()): ?>
             <?php if ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, 0)): // including ?>
                 <span class="price-excluding-tax">
                     <span class="label"><?= $this->helper('tax')->__('Excl. Tax:') ?></span>
                     <span class="price" id="price-excluding-tax-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                        <?= $_coreHelper->formatPrice($_price + $_weeeTaxAmount, false) ?>
+                        <?= $_coreHelper->formatPrice($_finalPrice + $_weeeTaxAmount, false) ?>
                     </span>
                 </span>
                 <span class="price-including-tax">
@@ -76,7 +90,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <span class="price-excluding-tax">
                     <span class="label"><?= $this->helper('tax')->__('Excl. Tax:') ?></span>
                     <span class="price" id="price-excluding-tax-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                        <?= $_coreHelper->formatPrice($_price + $_weeeTaxAmount, false) ?>
+                        <?= $_coreHelper->formatPrice($_finalPrice + $_weeeTaxAmount, false) ?>
                     </span>
                 </span>
                 <span class="weee">(
@@ -96,7 +110,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <span class="price-excluding-tax">
                     <span class="label"><?= $this->helper('tax')->__('Excl. Tax:') ?></span>
                     <span class="price" id="price-excluding-tax-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                        <?= $_coreHelper->formatPrice($_price + $_weeeTaxAmount, false) ?>
+                        <?= $_coreHelper->formatPrice($_finalPrice + $_weeeTaxAmount, false) ?>
                     </span>
                 </span>
                 <span class="price-including-tax">
@@ -116,7 +130,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <span class="price-excluding-tax">
                     <span class="label"><?= $this->helper('tax')->__('Excl. Tax:') ?></span>
                     <span class="price" id="price-excluding-tax-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                        <?= $_coreHelper->formatPrice($_price, false) ?>
+                        <?= $_coreHelper->formatPrice($_finalPrice, false) ?>
                     </span>
                 </span>
                 <?php foreach ($_weeeTaxAttributes as $_weeeTaxAttribute): ?>
@@ -135,11 +149,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <span class="price-excluding-tax">
                     <span class="label"><?= $this->helper('tax')->__('Excl. Tax:') ?></span>
                     <span class="price" id="price-excluding-tax-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                        <?php if ($_finalPrice == $_price): ?>
-                            <?= $_coreHelper->formatPrice($_price, false) ?>
-                        <?php else: ?>
-                            <?= $_coreHelper->formatPrice($_finalPrice, false) ?>
-                        <?php endif ?>
+                        <?= $_coreHelper->formatPrice($_finalPrice, false) ?>
                     </span>
                 </span>
                 <span class="price-including-tax">
@@ -151,9 +161,8 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
             <?php endif ?>
         <?php else: ?>
             <?php if ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, [0, 1])): // including ?>
-                <?php $weeeAmountToDisplay = $_taxHelper->displayPriceIncludingTax() ? $_weeeTaxAmountInclTaxes : $_weeeTaxAmount ?>
                 <span class="regular-price" id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                     <?= $_coreHelper->currency($_price + $weeeAmountToDisplay, true, true) ?>
+                     <?= $_coreHelper->currency($_finalPrice + $_weeeTaxAmountSimpleTax, true, true) ?>
                 </span>
 
                 <?php if ($_weeeHelper->typeOfDisplay($_product, 1)): // show description ?>
@@ -161,7 +170,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <?php endif ?>
             <?php elseif ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, 4)): // incl. + weee ?>
                 <span class="regular-price" id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                    <?= $_coreHelper->formatPrice($_price + $_weeeTaxAmount, true) ?>
+                    <?= $_coreHelper->formatPrice($_finalPrice + $_weeeTaxAmountSimpleTax, true) ?>
                 </span>
                 <span class="weee">(
                     <?php foreach ($_weeeTaxAttributes as $_weeeTaxAttribute): ?>
@@ -171,37 +180,24 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                     <?php endforeach ?>
                     )</span>
             <?php elseif ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, 2)): // excl. + weee + final ?>
-                <?php $weeeAmountToDisplay = $_taxHelper->displayPriceIncludingTax() ? $_weeeTaxAmountInclTaxes : $_weeeTaxAmount ?>
                 <span class="regular-price" id="product-price-weee-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                    <?= $_coreHelper->currency($_price + $weeeAmountToDisplay, true, true) ?>
+                    <?= $_coreHelper->currency($_finalPrice + $_weeeTaxAmountSimpleTax, true, true) ?>
                 </span>
-                <span class="weee-info" data-tooltip="<?= strip_tags($_coreHelper->formatPrice($_price, false)) ?><?php foreach ($_weeeTaxAttributes as $_weeeTaxAttribute): ?> + <?= $this->escapeHtml($_weeeTaxAttribute->getName()) ?> <?= strip_tags($_coreHelper->currency($_weeeTaxAttribute->getAmount() + ($_taxHelper->displayPriceIncludingTax() ? $_weeeTaxAttribute->getTaxAmount() : 0), true, true)) ?><?php endforeach ?>"><?= $this->getIconSvg('info-circle') ?></span>
+                <span class="weee-info" data-tooltip="<?= strip_tags($_coreHelper->formatPrice($_finalPrice, false)) ?><?php foreach ($_weeeTaxAttributes as $_weeeTaxAttribute): ?> + <?= $this->escapeHtml($_weeeTaxAttribute->getName()) ?> <?= strip_tags($_coreHelper->currency($_weeeTaxAttribute->getAmount() + ($_taxHelper->displayPriceIncludingTax() ? $_weeeTaxAttribute->getTaxAmount() : 0), true, true)) ?><?php endforeach ?>"><?= $this->getIconSvg('info-circle') ?></span>
             <?php else: ?>
                 <span class="regular-price" id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                    <?php if ($_finalPrice == $_price): ?>
-                        <?= $_coreHelper->formatPrice($_price, true) ?>
-                    <?php else: ?>
-                        <?= $_coreHelper->formatPrice($_finalPrice, true) ?>
-                    <?php endif ?>
+                    <?= $_coreHelper->formatPrice($_finalPrice, true) ?>
                 </span>
             <?php endif ?>
         <?php endif ?>
-    <?php else: /* if ($_finalPrice == $_price): */ ?>
-        <?php $_originalWeeeTaxAmount = $_weeeHelper->getOriginalAmount($_product); ?>
-        <?php $_originalWeeeTaxAmount = $_store->roundPrice($_store->convertPrice($_originalWeeeTaxAmount)) ?>
-
+    <?php else: /* if ($_discountPercent <= 0): */ ?>
         <?php if ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, 0)): // including ?>
-            <?php $_oldPriceDisplay = $_regularPrice + $_originalWeeeTaxAmount; ?>
-            <?php $_newPriceDisplay = $_finalPrice + $_weeeTaxAmount; ?>
-            <?php $_discountPercent = round((($_oldPriceDisplay - $_newPriceDisplay) / $_oldPriceDisplay) * 100); ?>
             <p class="old-price">
                 <span class="price-label"><?= $this->__('Regular Price:') ?></span>
                 <span class="price" id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
                     <?= $_coreHelper->formatPrice($_oldPriceDisplay, false) ?>
                 </span>
-                <?php if ($_discountPercent > 0): ?>
-                    <span class="discount-percent">-<?= $_discountPercent ?>%</span>
-                <?php endif ?>
+                <span class="discount-percent">-<?= $_discountPercent ?>%</span>
             </p>
 
             <?php if ($_taxHelper->displayBothPrices()): ?>
@@ -224,23 +220,18 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <p class="special-price">
                     <span class="price-label"><?= $_specialPriceStoreLabel ?></span>
                 <span class="price" id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                    <?= $_coreHelper->formatPrice($_finalPrice + $_weeeTaxAmountInclTaxes, false) ?>
+                    <?= $_coreHelper->formatPrice($_newPriceDisplay, false) ?>
                 </span>
                 </p>
             <?php endif ?>
 
         <?php elseif ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, 1)): // incl. + weee ?>
-            <?php $_oldPriceDisplay = $_regularPrice + $_originalWeeeTaxAmount; ?>
-            <?php $_newPriceDisplay = $_finalPrice + $_weeeTaxAmount; ?>
-            <?php $_discountPercent = round((($_oldPriceDisplay - $_newPriceDisplay) / $_oldPriceDisplay) * 100); ?>
             <p class="old-price">
                 <span class="price-label"><?= $this->__('Regular Price:') ?></span>
                 <span class="price" id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
                     <?= $_coreHelper->formatPrice($_oldPriceDisplay, false) ?>
                 </span>
-                <?php if ($_discountPercent > 0): ?>
-                    <span class="discount-percent">-<?= $_discountPercent ?>%</span>
-                <?php endif ?>
+                <span class="discount-percent">-<?= $_discountPercent ?>%</span>
             </p>
 
             <p class="special-price">
@@ -269,7 +260,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
             <?php else: ?>
                 <span class="price-label"><?= $this->__('Special Price:') ?></span>
                 <span class="price" id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                    <?= $_coreHelper->formatPrice($_finalPrice + $_weeeTaxAmountInclTaxes, false) ?>
+                    <?= $_coreHelper->formatPrice($_newPriceDisplay, false) ?>
                 </span>
                 <span class="weee">(
                     <?php foreach ($_weeeTaxAttributes as $_weeeTaxAttribute): ?>
@@ -282,17 +273,12 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
             <?php endif ?>
             </p>
         <?php elseif ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, 4)): // incl. + weee ?>
-            <?php $_oldPriceDisplay = $_regularPrice + $_originalWeeeTaxAmount; ?>
-            <?php $_newPriceDisplay = $_finalPrice + $_weeeTaxAmount; ?>
-            <?php $_discountPercent = round((($_oldPriceDisplay - $_newPriceDisplay) / $_oldPriceDisplay) * 100); ?>
             <p class="old-price">
                 <span class="price-label"><?= $this->__('Regular Price:') ?></span>
                 <span class="price" id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
                     <?= $_coreHelper->formatPrice($_oldPriceDisplay, false) ?>
                 </span>
-                <?php if ($_discountPercent > 0): ?>
-                    <span class="discount-percent">-<?= $_discountPercent ?>%</span>
-                <?php endif ?>
+                <span class="discount-percent">-<?= $_discountPercent ?>%</span>
             </p>
 
             <p class="special-price">
@@ -300,7 +286,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <span class="price-excluding-tax">
                     <span class="label"><?= $this->helper('tax')->__('Excl. Tax:') ?></span>
                     <span class="price" id="price-excluding-tax-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                        <?= $_coreHelper->formatPrice($_newPriceDisplay, false) ?>
+                        <?= $_coreHelper->formatPrice($_finalPrice + $_weeeTaxAmount, false) ?>
                     </span>
                 </span>
             <span class="weee">(
@@ -318,15 +304,12 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
             </span>
             </p>
         <?php elseif ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, 2)): // excl. + weee + final ?>
-            <?php $_discountPercent = round((($_regularPrice - $_finalPrice) / $_regularPrice) * 100); ?>
             <p class="old-price">
                 <span class="price-label"><?= $this->__('Regular Price:') ?></span>
                 <span class="price" id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                    <?= $_coreHelper->formatPrice($_regularPrice, false) ?>
+                    <?= $_coreHelper->formatPrice($_oldPriceDisplay, false) ?>
                 </span>
-                <?php if ($_discountPercent > 0): ?>
-                    <span class="discount-percent">-<?= $_discountPercent ?>%</span>
-                <?php endif ?>
+                <span class="discount-percent">-<?= $_discountPercent ?>%</span>
             </p>
 
             <p class="special-price">
@@ -351,15 +334,12 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 </span>
             </p>
         <?php else: // excl. ?>
-            <?php $_discountPercent = round((($_regularPrice - $_finalPrice) / $_regularPrice) * 100); ?>
             <p class="old-price">
                 <span class="price-label"><?= $this->__('Regular Price:') ?></span>
                 <span class="price" id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                    <?= $_coreHelper->formatPrice($_regularPrice, false) ?>
+                    <?= $_coreHelper->formatPrice($_oldPriceDisplay, false) ?>
                 </span>
-                <?php if ($_discountPercent > 0): ?>
-                    <span class="discount-percent">-<?= $_discountPercent ?>%</span>
-                <?php endif ?>
+                <span class="discount-percent">-<?= $_discountPercent ?>%</span>
             </p>
 
             <?php if ($_taxHelper->displayBothPrices()): ?>
@@ -388,14 +368,11 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
             <?php endif ?>
         <?php endif ?>
 
-    <?php endif /* if ($_finalPrice == $_price): */ ?>
+    <?php endif /* if ($_discountPercent <= 0): */ ?>
 
     <?php if ($this->getDisplayMinimalPrice() && $_minimalPriceRounded && $_minimalPrice < $_finalPriceSimpleTax): ?>
 
-        <?php $_minimalPriceDisplayValue = $_minimalPrice; ?>
-        <?php if ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, [0, 1, 4])): ?>
-            <?php $_minimalPriceDisplayValue = $_minimalPrice + $_weeeTaxAmount; ?>
-        <?php endif ?>
+        <?php $_minimalPriceDisplayValue = $_minimalPrice + ($_weeeInPrice ? $_weeeTaxAmountSimpleTax : 0); ?>
 
         <?php if ($this->getUseLinkForAsLowAs()): ?>
             <a href="<?= $_product->getProductUrl() ?>" class="minimal-price-link">
@@ -411,7 +388,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
         <?php else: ?>
             </span>
         <?php endif ?>
-    <?php endif /* if ($this->getDisplayMinimalPrice() && $_minimalPrice && $_minimalPrice < $_finalPrice): */ ?>
+    <?php endif /* if ($this->getDisplayMinimalPrice() && $_minimalPrice && $_minimalPrice < $_finalPriceSimpleTax): */ ?>
     </div>
 
 <?php else: /* if (!$_product->isGrouped()): */ ?>

--- a/app/design/frontend/base/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price.phtml
@@ -55,7 +55,6 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
     <?php $_finalPrice = $_taxHelper->getPrice($_product, $_convertedFinalPrice) ?>
     <?php $_finalPriceInclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, true) ?>
     <?php $_finalPriceSimpleTax = $_simplePricesTax ? $_finalPriceInclTax : $_finalPrice ?>
-    <?php $_weeeDisplayType = $_weeeHelper->getPriceDisplayType(); ?>
     <?php $_weeeInPrice = $_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, [0, 1, 4]); ?>
     <?php $_weeeTaxAmountSimpleTax = $_simplePricesTax ? $_weeeTaxAmountInclTaxes : $_weeeTaxAmount; ?>
     <?php
@@ -162,7 +161,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
         <?php else: ?>
             <?php if ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, [0, 1])): // including ?>
                 <span class="regular-price" id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                     <?= $_coreHelper->currency($_finalPrice + $_weeeTaxAmountSimpleTax, true, true) ?>
+                     <?= $_coreHelper->formatPrice($_finalPrice + $_weeeTaxAmountSimpleTax, true) ?>
                 </span>
 
                 <?php if ($_weeeHelper->typeOfDisplay($_product, 1)): // show description ?>
@@ -181,7 +180,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                     )</span>
             <?php elseif ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, 2)): // excl. + weee + final ?>
                 <span class="regular-price" id="product-price-weee-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                    <?= $_coreHelper->currency($_finalPrice + $_weeeTaxAmountSimpleTax, true, true) ?>
+                    <?= $_coreHelper->formatPrice($_finalPrice + $_weeeTaxAmountSimpleTax, true) ?>
                 </span>
                 <span class="weee-info" data-tooltip="<?= strip_tags($_coreHelper->formatPrice($_finalPrice, false)) ?><?php foreach ($_weeeTaxAttributes as $_weeeTaxAttribute): ?> + <?= $this->escapeHtml($_weeeTaxAttribute->getName()) ?> <?= strip_tags($_coreHelper->currency($_weeeTaxAttribute->getAmount() + ($_taxHelper->displayPriceIncludingTax() ? $_weeeTaxAttribute->getTaxAmount() : 0), true, true)) ?><?php endforeach ?>"><?= $this->getIconSvg('info-circle') ?></span>
             <?php else: ?>
@@ -266,7 +265,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                     <?php foreach ($_weeeTaxAttributes as $_weeeTaxAttribute): ?>
                         <?= $_weeeSeparator ?>
                         <?= $_weeeTaxAttribute->getName() ?>
-                        : <?= $_coreHelper->currency($_weeeTaxAttribute->getAmount(), true, true) ?>
+                        : <?= $_coreHelper->currency($_weeeTaxAttribute->getAmount() + ($_taxHelper->displayPriceIncludingTax() ? $_weeeTaxAttribute->getTaxAmount() : 0), true, true) ?>
                         <?php $_weeeSeparator = ' + '; ?>
                     <?php endforeach ?>
                     )</span>

--- a/app/design/frontend/base/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price.phtml
@@ -199,7 +199,9 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <span class="price" id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
                     <?= $_coreHelper->formatPrice($_oldPriceDisplay, false) ?>
                 </span>
-                <span class="discount-percent">-<?= $_discountPercent ?>%</span>
+                <?php if ($_discountPercent > 0): ?>
+                    <span class="discount-percent">-<?= $_discountPercent ?>%</span>
+                <?php endif ?>
             </p>
 
             <?php if ($_taxHelper->displayBothPrices()): ?>
@@ -236,7 +238,9 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <span class="price" id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
                     <?= $_coreHelper->formatPrice($_oldPriceDisplay, false) ?>
                 </span>
-                <span class="discount-percent">-<?= $_discountPercent ?>%</span>
+                <?php if ($_discountPercent > 0): ?>
+                    <span class="discount-percent">-<?= $_discountPercent ?>%</span>
+                <?php endif ?>
             </p>
 
             <p class="special-price">
@@ -286,7 +290,9 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <span class="price" id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
                     <?= $_coreHelper->formatPrice($_oldPriceDisplay, false) ?>
                 </span>
-                <span class="discount-percent">-<?= $_discountPercent ?>%</span>
+                <?php if ($_discountPercent > 0): ?>
+                    <span class="discount-percent">-<?= $_discountPercent ?>%</span>
+                <?php endif ?>
             </p>
 
             <p class="special-price">
@@ -318,7 +324,9 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <span class="price" id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
                     <?= $_coreHelper->formatPrice($_regularPrice, false) ?>
                 </span>
-                <span class="discount-percent">-<?= $_discountPercent ?>%</span>
+                <?php if ($_discountPercent > 0): ?>
+                    <span class="discount-percent">-<?= $_discountPercent ?>%</span>
+                <?php endif ?>
             </p>
 
             <p class="special-price">
@@ -349,7 +357,9 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <span class="price" id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
                     <?= $_coreHelper->formatPrice($_regularPrice, false) ?>
                 </span>
-                <span class="discount-percent">-<?= $_discountPercent ?>%</span>
+                <?php if ($_discountPercent > 0): ?>
+                    <span class="discount-percent">-<?= $_discountPercent ?>%</span>
+                <?php endif ?>
             </p>
 
             <?php if ($_taxHelper->displayBothPrices()): ?>

--- a/app/design/frontend/base/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price.phtml
@@ -31,9 +31,9 @@ $_id = $_product->getId();
 $_weeeSeparator = '';
 $_simplePricesTax = ($_taxHelper->displayPriceIncludingTax() || $_taxHelper->displayBothPrices());
 $_minimalPriceValue = $_product->getMinimalPrice();
-$_minimalPriceValue = $_store->roundPrice($_store->convertPrice($_minimalPriceValue));
+$_minimalPriceValue = $_store->convertPrice($_minimalPriceValue);
 $_minimalPrice = $_taxHelper->getPrice($_product, $_minimalPriceValue, $_simplePricesTax);
-$_convertedFinalPrice = $_store->roundPrice($_store->convertPrice($_product->getFinalPrice()));
+$_convertedFinalPrice = $_store->convertPrice($_product->getFinalPrice());
 $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStoreLabel();
 ?>
 
@@ -48,7 +48,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
     <?php $_weeeTaxAmountInclTaxes = $_store->roundPrice($_store->convertPrice($_weeeTaxAmountInclTaxes)); ?>
 
     <div class="price-box">
-    <?php $_convertedPrice = $_store->roundPrice($_store->convertPrice($_product->getPrice())); ?>
+    <?php $_convertedPrice = $_store->convertPrice($_product->getPrice()); ?>
     <?php $_price = $_taxHelper->getPrice($_product, $_convertedPrice); ?>
     <?php $_regularPrice = $_taxHelper->getPrice($_product, $_convertedPrice, $_simplePricesTax); ?>
     <?php $_finalPrice = $_taxHelper->getPrice($_product, $_convertedFinalPrice) ?>

--- a/app/design/frontend/base/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price.phtml
@@ -34,8 +34,7 @@ $_minimalPriceValue = $_product->getMinimalPrice();
 $_minimalPriceValue = $_store->convertPrice($_minimalPriceValue);
 $_minimalPrice = $_taxHelper->getPrice($_product, $_minimalPriceValue, $_simplePricesTax);
 $_convertedFinalPrice = $_store->convertPrice($_product->getFinalPrice());
-// Visibility guards compare what the customer sees, so they use the rounded amounts; the tax
-// helper keeps the full-precision ones so it never adds tax to an already rounded base.
+// Rounded copies for the visibility checks; the tax helper needs the full-precision values.
 $_minimalPriceRounded = $_store->roundPrice($_minimalPriceValue);
 $_convertedFinalPriceRounded = $_store->roundPrice($_convertedFinalPrice);
 $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStoreLabel();
@@ -57,6 +56,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
     <?php $_regularPrice = $_taxHelper->getPrice($_product, $_convertedPrice, $_simplePricesTax); ?>
     <?php $_finalPrice = $_taxHelper->getPrice($_product, $_convertedFinalPrice) ?>
     <?php $_finalPriceInclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, true) ?>
+    <?php $_finalPriceSimpleTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, $_simplePricesTax) ?>
     <?php $_weeeDisplayType = $_weeeHelper->getPriceDisplayType(); ?>
     <?php if ($_finalPrice >= $_price): ?>
         <?php if ($_taxHelper->displayBothPrices()): ?>
@@ -381,7 +381,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
 
     <?php endif /* if ($_finalPrice == $_price): */ ?>
 
-    <?php if ($this->getDisplayMinimalPrice() && $_minimalPriceRounded && $_minimalPriceRounded < $_convertedFinalPriceRounded): ?>
+    <?php if ($this->getDisplayMinimalPrice() && $_minimalPriceRounded && $_minimalPrice < $_finalPriceSimpleTax): ?>
 
         <?php $_minimalPriceDisplayValue = $_minimalPrice; ?>
         <?php if ($_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, [0, 1, 4])): ?>

--- a/app/design/frontend/base/default/template/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/price.phtml
@@ -34,9 +34,8 @@ $_minimalPriceValue = $_product->getMinimalPrice();
 $_minimalPriceValue = $_store->convertPrice($_minimalPriceValue);
 $_minimalPrice = $_taxHelper->getPrice($_product, $_minimalPriceValue, $_simplePricesTax);
 $_convertedFinalPrice = $_store->convertPrice($_product->getFinalPrice());
-// Rounded copies for the visibility checks; the tax helper needs the full-precision values.
+// Rounded copy for the visibility checks; the tax helper needs the full-precision value.
 $_minimalPriceRounded = $_store->roundPrice($_minimalPriceValue);
-$_convertedFinalPriceRounded = $_store->roundPrice($_convertedFinalPrice);
 $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStoreLabel();
 ?>
 
@@ -56,7 +55,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
     <?php $_regularPrice = $_taxHelper->getPrice($_product, $_convertedPrice, $_simplePricesTax); ?>
     <?php $_finalPrice = $_taxHelper->getPrice($_product, $_convertedFinalPrice) ?>
     <?php $_finalPriceInclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, true) ?>
-    <?php $_finalPriceSimpleTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, $_simplePricesTax) ?>
+    <?php $_finalPriceSimpleTax = $_simplePricesTax ? $_finalPriceInclTax : $_finalPrice ?>
     <?php $_weeeDisplayType = $_weeeHelper->getPriceDisplayType(); ?>
     <?php if ($_finalPrice >= $_price): ?>
         <?php if ($_taxHelper->displayBothPrices()): ?>
@@ -413,7 +412,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
         $_inclTax = $_taxHelper->getPrice($_product, $_minimalPriceValue, true);
         $price = $_minimalPriceRounded;
     } else {
-        $price = $_convertedFinalPriceRounded;
+        $price = $_store->roundPrice($_convertedFinalPrice);
         $_exclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice);
         $_inclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, true);
     }

--- a/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
@@ -31,6 +31,9 @@ $_minimalPriceValue = $_product->getMinimalPrice();
 $_minimalPriceValue = $_store->convertPrice($_minimalPriceValue);
 $_minimalPrice = $_taxHelper->getPrice($_product, $_minimalPriceValue, $_simplePricesTax);
 $_convertedFinalPrice = $_store->convertPrice($_product->getFinalPrice());
+// Visibility guards compare what the customer sees, so they use the rounded amount; the tax
+// helper keeps the full-precision one so it never adds tax to an already rounded base.
+$_minimalPriceRounded = $_store->roundPrice($_minimalPriceValue);
 $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStoreLabel();
 ?>
 
@@ -367,7 +370,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
 
         <?php endif /* if ($_finalPrice == $_price): */ ?>
 
-        <?php if ($this->getDisplayMinimalPrice() && $_minimalPriceValue && $_minimalPriceValue < $_product->getFinalPrice()): ?>
+        <?php if ($this->getDisplayMinimalPrice() && $_minimalPriceRounded && $_minimalPriceRounded < $_product->getFinalPrice()): ?>
 
             <?php $_minimalPriceDisplayValue = $_minimalPrice; ?>
             <?php if ($_weeeTaxAmount && Mage::helper('weee')->typeOfDisplay($_product, [0, 1, 4])): ?>
@@ -395,7 +398,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
         $_exclTax = $this->helper('tax')->getPrice($_product, $_minimalPriceValue, $includingTax = null);
         $_inclTax = $this->helper('tax')->getPrice($_product, $_minimalPriceValue, $includingTax = true);
         ?>
-        <?php if ($this->getDisplayMinimalPrice() && $_minimalPriceValue): ?>
+        <?php if ($this->getDisplayMinimalPrice() && $_minimalPriceRounded): ?>
             <div class="price-box">
                 <p class="minimal-price">
                     <span class="price-label"><?= $this->__('From') ?></span>

--- a/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
@@ -58,7 +58,6 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
         <?php $_finalPrice = $_taxHelper->getPrice($_product, $_convertedFinalPrice) ?>
         <?php $_finalPriceInclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, true) ?>
         <?php $_finalPriceSimpleTax = $_simplePricesTax ? $_finalPriceInclTax : $_finalPrice ?>
-        <?php $_weeeDisplayType = $_weeeHelper->getPriceDisplayType(); ?>
         <?php $_weeeInPrice = $_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, [0, 1, 4]); ?>
         <?php $_weeeTaxAmountSimpleTax = $_simplePricesTax ? $_weeeTaxAmountInclTaxes : $_weeeTaxAmount; ?>
 
@@ -282,7 +281,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                         <?php foreach ($_weeeTaxAttributes as $_weeeTaxAttribute): ?>
                             <?= $_weeeSeparator ?>
                             <?= $_weeeTaxAttribute->getName() ?>
-                            : <?= $_coreHelper->currency($_weeeTaxAttribute->getAmount(), true, true) ?>
+                            : <?= $_coreHelper->currency($_weeeTaxAttribute->getAmount() + ($_taxHelper->displayPriceIncludingTax() ? $_weeeTaxAttribute->getTaxAmount() : 0), true, true) ?>
                             <?php $_weeeSeparator = ' + '; ?>
                         <?php endforeach ?>
                         )</span>

--- a/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
@@ -57,8 +57,10 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
         <?php $_regularPrice = $_taxHelper->getPrice($_product, $_convertedPrice, $_simplePricesTax); ?>
         <?php $_finalPrice = $_taxHelper->getPrice($_product, $_convertedFinalPrice) ?>
         <?php $_finalPriceInclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, true) ?>
-        <?php $_finalPriceSimpleTax = $_simplePricesTax ? $_finalPriceInclTax : $_finalPrice ?>
+        <?php $_finalPriceSimpleTax = $_simplePricesTax ? $_finalPriceInclTax : $_taxHelper->getPrice($_product, $_convertedFinalPrice, false) ?>
         <?php $_weeeDisplayType = $_weeeHelper->getPriceDisplayType(); ?>
+        <?php $_weeeInPrice = $_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, [0, 1, 4]); ?>
+        <?php $_weeeTaxAmountSimpleTax = $_simplePricesTax ? $_weeeTaxAmountInclTaxes : $_weeeTaxAmount; ?>
 
         <?php if ($_finalPrice == $_price): ?>
             <?php if ($this->helper('tax')->displayBothPrices()): ?>
@@ -203,14 +205,22 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <?php endif ?>
             <?php endif ?>
         <?php else: /* if ($_finalPrice == $_price): */ ?>
-            <?php $_originalWeeeTaxAmount = $_weeeHelper->getOriginalAmount($_product); ?>
-            <?php $_originalWeeeTaxAmount = $_store->roundPrice($_store->convertPrice($_originalWeeeTaxAmount)) ?>
+            <?php
+            // The old price carries the tax and the FPT in the same form as the special price below it.
+            $_originalWeeeTaxAmountSimpleTax = 0;
+            if ($_weeeInPrice) {
+                $_originalWeeeTaxAmountSimpleTax = $_simplePricesTax
+                    ? $_weeeHelper->getOriginalAmountInclTaxes($_product)
+                    : $_weeeHelper->getOriginalAmountForDisplay($_product);
+                $_originalWeeeTaxAmountSimpleTax = $_store->roundPrice($_store->convertPrice($_originalWeeeTaxAmountSimpleTax));
+            }
+            ?>
 
             <?php if ($_weeeTaxAmount && Mage::helper('weee')->typeOfDisplay($_product, 0)): // including ?>
                 <p class="old-price">
                     <span class="price-label"><?= $this->__('Regular Price:') ?></span>
                     <span class="price"
-                          id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_regularPrice + $_originalWeeeTaxAmount, true, false) ?></span>
+                          id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_regularPrice + $_originalWeeeTaxAmountSimpleTax, true, false) ?></span>
                 </p>
 
                 <?php if ($this->helper('tax')->displayBothPrices()): ?>
@@ -231,7 +241,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                     <p class="special-price">
                         <span class="price-label"><?= $this->__('Special Price:') ?></span>
                         <span class="price"
-                              id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_finalPrice + $_weeeTaxAmountInclTaxes, true, false) ?></span>
+                              id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_finalPriceSimpleTax + $_weeeTaxAmountSimpleTax, true, false) ?></span>
                     </p>
                 <?php endif ?>
 
@@ -239,7 +249,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <p class="old-price">
                     <span class="price-label"><?= $this->__('Regular Price:') ?></span>
                     <span class="price"
-                          id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_regularPrice + $_originalWeeeTaxAmount, true, false) ?></span>
+                          id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_regularPrice + $_originalWeeeTaxAmountSimpleTax, true, false) ?></span>
                 </p>
 
                 <p class="special-price">
@@ -268,7 +278,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 </span>
                 <?php else: ?>
                     <span class="price" id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
-                    <?= $_coreHelper->formatPrice($_finalPrice + $_weeeTaxAmountInclTaxes, false) ?>
+                    <?= $_coreHelper->formatPrice($_finalPriceSimpleTax + $_weeeTaxAmountSimpleTax, false) ?>
                 </span>
                     </p>
                     <span class="weee">(
@@ -285,7 +295,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <p class="old-price">
                     <span class="price-label"><?= $this->__('Regular Price:') ?></span>
                     <span class="price"
-                          id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_regularPrice + $_originalWeeeTaxAmount, true, false) ?></span>
+                          id="old-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_regularPrice + $_originalWeeeTaxAmountSimpleTax, true, false) ?></span>
                 </p>
 
                 <p class="special-price">
@@ -372,10 +382,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
 
         <?php if ($this->getDisplayMinimalPrice() && $_minimalPriceRounded && $_minimalPrice < $_finalPriceSimpleTax): ?>
 
-            <?php $_minimalPriceDisplayValue = $_minimalPrice; ?>
-            <?php if ($_weeeTaxAmount && Mage::helper('weee')->typeOfDisplay($_product, [0, 1, 4])): ?>
-                <?php $_minimalPriceDisplayValue = $_minimalPrice + $_weeeTaxAmount; ?>
-            <?php endif ?>
+            <?php $_minimalPriceDisplayValue = $_minimalPrice + ($_weeeInPrice ? $_weeeTaxAmountSimpleTax : 0); ?>
 
             <?php if ($this->getUseLinkForAsLowAs()): ?>
                 <a href="<?= $_product->getProductUrl() ?>" class="minimal-price-link">

--- a/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
@@ -31,8 +31,7 @@ $_minimalPriceValue = $_product->getMinimalPrice();
 $_minimalPriceValue = $_store->convertPrice($_minimalPriceValue);
 $_minimalPrice = $_taxHelper->getPrice($_product, $_minimalPriceValue, $_simplePricesTax);
 $_convertedFinalPrice = $_store->convertPrice($_product->getFinalPrice());
-// Visibility guards compare what the customer sees, so they use the rounded amount; the tax
-// helper keeps the full-precision one so it never adds tax to an already rounded base.
+// Rounded copy for the visibility checks; the tax helper needs the full-precision value.
 $_minimalPriceRounded = $_store->roundPrice($_minimalPriceValue);
 $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStoreLabel();
 ?>
@@ -58,6 +57,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
         <?php $_regularPrice = $_taxHelper->getPrice($_product, $_convertedPrice, $_simplePricesTax); ?>
         <?php $_finalPrice = $_taxHelper->getPrice($_product, $_convertedFinalPrice) ?>
         <?php $_finalPriceInclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, true) ?>
+        <?php $_finalPriceSimpleTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, $_simplePricesTax) ?>
         <?php $_weeeDisplayType = $_weeeHelper->getPriceDisplayType(); ?>
 
         <?php if ($_finalPrice == $_price): ?>
@@ -370,7 +370,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
 
         <?php endif /* if ($_finalPrice == $_price): */ ?>
 
-        <?php if ($this->getDisplayMinimalPrice() && $_minimalPriceRounded && $_minimalPriceRounded < $_product->getFinalPrice()): ?>
+        <?php if ($this->getDisplayMinimalPrice() && $_minimalPriceRounded && $_minimalPrice < $_finalPriceSimpleTax): ?>
 
             <?php $_minimalPriceDisplayValue = $_minimalPrice; ?>
             <?php if ($_weeeTaxAmount && Mage::helper('weee')->typeOfDisplay($_product, [0, 1, 4])): ?>

--- a/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
@@ -28,9 +28,9 @@ $_id = $_product->getId();
 $_weeeSeparator = '';
 $_simplePricesTax = ($_taxHelper->displayPriceIncludingTax() || $_taxHelper->displayBothPrices());
 $_minimalPriceValue = $_product->getMinimalPrice();
-$_minimalPriceValue = $_store->roundPrice($_store->convertPrice($_minimalPriceValue));
+$_minimalPriceValue = $_store->convertPrice($_minimalPriceValue);
 $_minimalPrice = $_taxHelper->getPrice($_product, $_minimalPriceValue, $_simplePricesTax);
-$_convertedFinalPrice = $_store->roundPrice($_store->convertPrice($_product->getFinalPrice()));
+$_convertedFinalPrice = $_store->convertPrice($_product->getFinalPrice());
 $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStoreLabel();
 ?>
 
@@ -50,7 +50,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
         <?php $_weeeTaxAmountInclTaxes = $_store->roundPrice($_store->convertPrice($_weeeTaxAmountInclTaxes)); ?>
 
         <div class="price-box">
-        <?php $_convertedPrice = $_store->roundPrice($_store->convertPrice($_product->getPrice())); ?>
+        <?php $_convertedPrice = $_store->convertPrice($_product->getPrice()); ?>
         <?php $_price = $_taxHelper->getPrice($_product, $_convertedPrice); ?>
         <?php $_regularPrice = $_taxHelper->getPrice($_product, $_convertedPrice, $_simplePricesTax); ?>
         <?php $_finalPrice = $_taxHelper->getPrice($_product, $_convertedFinalPrice) ?>

--- a/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
@@ -57,7 +57,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
         <?php $_regularPrice = $_taxHelper->getPrice($_product, $_convertedPrice, $_simplePricesTax); ?>
         <?php $_finalPrice = $_taxHelper->getPrice($_product, $_convertedFinalPrice) ?>
         <?php $_finalPriceInclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, true) ?>
-        <?php $_finalPriceSimpleTax = $_simplePricesTax ? $_finalPriceInclTax : $_taxHelper->getPrice($_product, $_convertedFinalPrice, false) ?>
+        <?php $_finalPriceSimpleTax = $_simplePricesTax ? $_finalPriceInclTax : $_finalPrice ?>
         <?php $_weeeDisplayType = $_weeeHelper->getPriceDisplayType(); ?>
         <?php $_weeeInPrice = $_weeeTaxAmount && $_weeeHelper->typeOfDisplay($_product, [0, 1, 4]); ?>
         <?php $_weeeTaxAmountSimpleTax = $_simplePricesTax ? $_weeeTaxAmountInclTaxes : $_weeeTaxAmount; ?>
@@ -153,13 +153,11 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                 <?php endif ?>
             <?php else: ?>
                 <?php if ($_weeeTaxAmount && Mage::helper('weee')->typeOfDisplay($_product, 0)): // including ?>
-                    <?php $weeeAmountToDisplay = $_taxHelper->displayPriceIncludingTax() ? $_weeeTaxAmountInclTaxes : $_weeeTaxAmount ?>
                     <span class="regular-price"
-                          id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_price + $weeeAmountToDisplay, true, true) ?></span>
+                          id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_price + $_weeeTaxAmountSimpleTax, true, true) ?></span>
                 <?php elseif ($_weeeTaxAmount && Mage::helper('weee')->typeOfDisplay($_product, 1)): // incl. + weee ?>
-                    <?php $weeeAmountToDisplay = $_taxHelper->displayPriceIncludingTax() ? $_weeeTaxAmountInclTaxes : $_weeeTaxAmount ?>
                     <span class="regular-price"
-                          id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_price + $weeeAmountToDisplay, true, true) ?></span>
+                          id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_price + $_weeeTaxAmountSimpleTax, true, true) ?></span>
                     <br>
                     <span class="weee">(<small>
                             <?php foreach ($_weeeTaxAttributes as $_weeeTaxAttribute): ?>
@@ -170,7 +168,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                         </small>)</span>
                 <?php elseif ($_weeeTaxAmount && Mage::helper('weee')->typeOfDisplay($_product, 4)): // incl. + weee ?>
                     <span class="regular-price"
-                          id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_price + $_weeeTaxAmount, true, true) ?></span>
+                          id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_price + $_weeeTaxAmountSimpleTax, true, true) ?></span>
                     <br>
                     <span class="weee">(<small>
                             <?php foreach ($_weeeTaxAttributes as $_weeeTaxAttribute): ?>
@@ -180,7 +178,6 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                             <?php endforeach ?>
                         </small>)</span>
                 <?php elseif ($_weeeTaxAmount && Mage::helper('weee')->typeOfDisplay($_product, 2)): // excl. + weee + final ?>
-                    <?php $weeeAmountToDisplay = $_taxHelper->displayPriceIncludingTax() ? $_weeeTaxAmountInclTaxes : $_weeeTaxAmount ?>
                     <span class="regular-price"><?= Mage::helper('core')->currency($_price, true, true) ?></span>
                     <br>
                     <?php foreach ($_weeeTaxAttributes as $_weeeTaxAttribute): ?>
@@ -193,7 +190,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
                         <br>
                     <?php endforeach ?>
                     <span class="regular-price"
-                          id="product-price-weee-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_price + $weeeAmountToDisplay, true, true) ?></span>
+                          id="product-price-weee-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_price + $_weeeTaxAmountSimpleTax, true, true) ?></span>
                 <?php else: ?>
                     <span class="regular-price" id="product-price-<?= $_id ?><?= $this->getIdSuffix() ?>">
                     <?php if ($_finalPrice == $_price): ?>
@@ -316,7 +313,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
             <span class="price-including-tax">
                 <span class="label"><?= Mage::helper('tax')->__('Incl. Tax:') ?></span>
                 <span class="price"
-                      id="price-including-tax-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_finalPriceInclTax + $_weeeTaxAmount, true, false) ?></span>
+                      id="price-including-tax-<?= $_id ?><?= $this->getIdSuffix() ?>"><?= Mage::helper('core')->currency($_finalPriceInclTax + $_weeeTaxAmountInclTaxes, true, false) ?></span>
             </span>
                 </p>
             <?php elseif ($_weeeTaxAmount && Mage::helper('weee')->typeOfDisplay($_product, 2)): // excl. + weee + final ?>

--- a/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
+++ b/app/design/frontend/base/default/template/catalog/rss/product/price.phtml
@@ -57,7 +57,7 @@ $_specialPriceStoreLabel = $this->getProductAttribute('special_price')->getStore
         <?php $_regularPrice = $_taxHelper->getPrice($_product, $_convertedPrice, $_simplePricesTax); ?>
         <?php $_finalPrice = $_taxHelper->getPrice($_product, $_convertedFinalPrice) ?>
         <?php $_finalPriceInclTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, true) ?>
-        <?php $_finalPriceSimpleTax = $_taxHelper->getPrice($_product, $_convertedFinalPrice, $_simplePricesTax) ?>
+        <?php $_finalPriceSimpleTax = $_simplePricesTax ? $_finalPriceInclTax : $_finalPrice ?>
         <?php $_weeeDisplayType = $_weeeHelper->getPriceDisplayType(); ?>
 
         <?php if ($_finalPrice == $_price): ?>

--- a/app/design/frontend/base/default/template/maho/giftcard/catalog/product/price.phtml
+++ b/app/design/frontend/base/default/template/maho/giftcard/catalog/product/price.phtml
@@ -21,7 +21,7 @@ $_hasPriceRange = $this->hasPriceRange();
 
 // Apply store currency conversion
 $_store = $_product->getStore();
-$_minPriceConverted = $_store->roundPrice($_store->convertPrice($_minPrice));
+$_minPriceConverted = $_store->convertPrice($_minPrice);
 
 // Calculate prices with/without tax
 $_minPriceTax = $_taxHelper->getPrice($_product, $_minPriceConverted);

--- a/tests/Frontend/Unit/Catalog/Block/Product/PriceTemplateTest.php
+++ b/tests/Frontend/Unit/Catalog/Block/Product/PriceTemplateTest.php
@@ -9,6 +9,23 @@ declare(strict_types=1);
 
 uses(Tests\MahoFrontendTestCase::class);
 
+$taxConfigPaths = ['tax/calculation/price_includes_tax', 'tax/display/type'];
+$originalTaxConfig = [];
+
+beforeEach(function () use ($taxConfigPaths, &$originalTaxConfig): void {
+    $store = Mage::app()->getStore();
+    foreach ($taxConfigPaths as $path) {
+        $originalTaxConfig[$path] = $store->getConfig($path);
+    }
+});
+
+afterEach(function () use (&$originalTaxConfig): void {
+    $store = Mage::app()->getStore();
+    foreach ($originalTaxConfig as $path => $value) {
+        $store->setConfig($path, $value);
+    }
+});
+
 /** Prices are stored excluding tax and displayed including tax, the setup that exposed the bug. */
 $vatStore = static function (): Mage_Core_Model_Store {
     $store = Mage::app()->getStore();
@@ -87,10 +104,39 @@ describe('catalog price templates tax rounding', function () use ($vatStore, $va
 
         expect($html)->toContain($money(13.00))->not->toContain($money(13.01));
     });
+
+    it('rounds the price of a product without a tax class on a tax-inclusive store', function () {
+        $store = Mage::app()->getStore();
+        $store->setConfig('tax/calculation/price_includes_tax', 1);
+        $store->setConfig('tax/display/type', (string) Mage_Tax_Model_Config::DISPLAY_TYPE_INCLUDING_TAX);
+
+        $product = Mage::getModel('catalog/product')
+            ->setId(1)
+            ->setTypeId(Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)
+            ->setStoreId($store->getId())
+            ->setTaxClassId(0);
+
+        expect(Mage::helper('tax')->getPrice($product, 10.665))->toBe(10.67);
+    });
 });
 
-describe('catalog/product/price.phtml minimal price visibility', function () use ($vatStore, $vatProduct, $render) {
-    it('hides the "From" price when it rounds to the same amount as the final price', function () use ($vatStore, $vatProduct, $render) {
+describe('catalog price templates minimal price visibility', function () use ($vatStore, $vatProduct, $render, $money) {
+    it('hides the "From" price when it displays the same amount as the final price', function () use ($vatStore, $vatProduct, $render) {
+        $store = $vatStore();
+        $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
+            'price' => 10.6557,
+            'final_price' => 10.6557,
+            'minimal_price' => 10.6550,
+        ]);
+
+        $html = $render('catalog/product_price', 'catalog/product/price.phtml', $product, [
+            'display_minimal_price' => true,
+        ]);
+
+        expect($html)->not->toContain('minimal-price-link');
+    });
+
+    it('shows the "From" price when it displays less, even though both amounts round alike before tax', function () use ($vatStore, $vatProduct, $render, $money) {
         $store = $vatStore();
         $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
             'price' => 10.66,
@@ -102,7 +148,7 @@ describe('catalog/product/price.phtml minimal price visibility', function () use
             'display_minimal_price' => true,
         ]);
 
-        expect($html)->not->toContain('minimal-price-link');
+        expect($html)->toContain('minimal-price-link')->toContain($money(13.00))->toContain($money(13.01));
     });
 
     it('shows the "From" price when it is genuinely lower', function () use ($vatStore, $vatProduct, $render) {
@@ -114,6 +160,21 @@ describe('catalog/product/price.phtml minimal price visibility', function () use
         ]);
 
         $html = $render('catalog/product_price', 'catalog/product/price.phtml', $product, [
+            'display_minimal_price' => true,
+        ]);
+
+        expect($html)->toContain('minimal-price-link');
+    });
+
+    it('applies the same "From" price guard in the rss price template', function () use ($vatStore, $vatProduct, $render) {
+        $store = $vatStore();
+        $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
+            'price' => 10.66,
+            'final_price' => 10.66,
+            'minimal_price' => 10.6557,
+        ]);
+
+        $html = $render('catalog/product_price', 'catalog/rss/product/price.phtml', $product, [
             'display_minimal_price' => true,
         ]);
 

--- a/tests/Frontend/Unit/Catalog/Block/Product/PriceTemplateTest.php
+++ b/tests/Frontend/Unit/Catalog/Block/Product/PriceTemplateTest.php
@@ -9,7 +9,11 @@ declare(strict_types=1);
 
 uses(Tests\MahoFrontendTestCase::class);
 
-$taxConfigPaths = ['tax/calculation/price_includes_tax', 'tax/display/type'];
+$taxConfigPaths = [
+    'tax/calculation/price_includes_tax',
+    'tax/calculation/cross_border_trade_enabled',
+    'tax/display/type',
+];
 $originalTaxConfig = [];
 
 beforeEach(function () use ($taxConfigPaths, &$originalTaxConfig): void {
@@ -118,6 +122,20 @@ describe('catalog price templates tax rounding', function () use ($vatStore, $va
 
         expect(Mage::helper('tax')->getPrice($product, 10.665))->toBe(10.67);
     });
+
+    it('backs the tax out to the same amount whether the caller asks explicitly or by display type', function () use ($vatProduct) {
+        $store = Mage::app()->getStore();
+        $store->setConfig('tax/calculation/price_includes_tax', 1);
+        $store->setConfig('tax/calculation/cross_border_trade_enabled', 1);
+        $store->setConfig('tax/display/type', (string) Mage_Tax_Model_Config::DISPLAY_TYPE_EXCLUDING_TAX);
+
+        $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, ['tax_class_id' => 2]);
+
+        $taxHelper = Mage::helper('tax');
+
+        expect($taxHelper->getPrice($product, 10.665, false))->toBe($taxHelper->getPrice($product, 10.665))
+            ->and($taxHelper->getPrice($product, 10.665, false))->toBe(8.75);
+    });
 });
 
 describe('catalog price templates minimal price visibility', function () use ($vatStore, $vatProduct, $render, $money) {
@@ -164,6 +182,26 @@ describe('catalog price templates minimal price visibility', function () use ($v
         ]);
 
         expect($html)->toContain('minimal-price-link');
+    });
+
+    it('hides the "From" price on a tax-inclusive store that displays prices excluding tax', function () use ($vatProduct, $render) {
+        $store = Mage::app()->getStore();
+        $store->setConfig('tax/calculation/price_includes_tax', 1);
+        $store->setConfig('tax/calculation/cross_border_trade_enabled', 1);
+        $store->setConfig('tax/display/type', (string) Mage_Tax_Model_Config::DISPLAY_TYPE_EXCLUDING_TAX);
+
+        $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
+            'tax_class_id' => 2,
+            'price' => 10.6557,
+            'final_price' => 10.6557,
+            'minimal_price' => 10.6557,
+        ]);
+
+        $html = $render('catalog/product_price', 'catalog/product/price.phtml', $product, [
+            'display_minimal_price' => true,
+        ]);
+
+        expect($html)->not->toContain('minimal-price-link');
     });
 
     it('applies the same "From" price guard in the rss price template', function () use ($vatStore, $vatProduct, $render) {

--- a/tests/Frontend/Unit/Catalog/Block/Product/PriceTemplateTest.php
+++ b/tests/Frontend/Unit/Catalog/Block/Product/PriceTemplateTest.php
@@ -181,3 +181,29 @@ describe('catalog price templates minimal price visibility', function () use ($v
         expect($html)->toContain('minimal-price-link');
     });
 });
+
+describe('catalog price templates discount badge', function () use ($vatStore, $vatProduct, $render, $money) {
+    it('hides the badge when the discount rounds to zero percent', function () use ($vatStore, $vatProduct, $render, $money) {
+        $store = $vatStore();
+        $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
+            'price' => 10.66,
+            'final_price' => 10.6557,
+        ]);
+
+        $html = $render('catalog/product_price', 'catalog/product/price.phtml', $product);
+
+        expect($html)->toContain($money(13.00))->toContain($money(13.01))->not->toContain('discount-percent');
+    });
+
+    it('shows the badge when the discount is at least one percent', function () use ($vatStore, $vatProduct, $render) {
+        $store = $vatStore();
+        $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
+            'price' => 10.66,
+            'final_price' => 8.00,
+        ]);
+
+        $html = $render('catalog/product_price', 'catalog/product/price.phtml', $product);
+
+        expect($html)->toContain('discount-percent')->toContain('-25%');
+    });
+});

--- a/tests/Frontend/Unit/Catalog/Block/Product/PriceTemplateTest.php
+++ b/tests/Frontend/Unit/Catalog/Block/Product/PriceTemplateTest.php
@@ -221,7 +221,7 @@ describe('catalog price templates minimal price visibility', function () use ($v
 });
 
 describe('catalog price templates discount badge', function () use ($vatStore, $vatProduct, $render, $money) {
-    it('hides the badge when the discount rounds to zero percent', function () use ($vatStore, $vatProduct, $render, $money) {
+    it('drops the regular price and the badge when the discount rounds to zero percent', function () use ($vatStore, $vatProduct, $render, $money) {
         $store = $vatStore();
         $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
             'price' => 10.66,
@@ -230,10 +230,13 @@ describe('catalog price templates discount badge', function () use ($vatStore, $
 
         $html = $render('catalog/product_price', 'catalog/product/price.phtml', $product);
 
-        expect($html)->toContain($money(13.00))->toContain($money(13.01))->not->toContain('discount-percent');
+        expect($html)->toContain($money(13.00))
+            ->not->toContain($money(13.01))
+            ->not->toContain('old-price')
+            ->not->toContain('discount-percent');
     });
 
-    it('shows the badge when the discount is at least one percent', function () use ($vatStore, $vatProduct, $render) {
+    it('shows the regular price and the badge when the discount is at least one percent', function () use ($vatStore, $vatProduct, $render, $money) {
         $store = $vatStore();
         $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
             'price' => 10.66,
@@ -242,6 +245,106 @@ describe('catalog price templates discount badge', function () use ($vatStore, $
 
         $html = $render('catalog/product_price', 'catalog/product/price.phtml', $product);
 
-        expect($html)->toContain('discount-percent')->toContain('-25%');
+        expect($html)->toContain('old-price')->toContain($money(13.01))
+            ->toContain('discount-percent')->toContain('-25%');
+    });
+});
+
+/** A store that prints both amounts, where the regular price is displayed including tax and the final price excluding it. */
+$bothPricesStore = static function (): Mage_Core_Model_Store {
+    $store = Mage::app()->getStore();
+    $store->setConfig('tax/calculation/price_includes_tax', 0);
+    $store->setConfig('tax/display/type', (string) Mage_Tax_Model_Config::DISPLAY_TYPE_BOTH);
+
+    return $store;
+};
+
+/** Stands in for a store with one 2.00 fixed product tax, taxed at 22%, printed inside the price. */
+class PriceTemplateTest_WeeeHelper extends Mage_Weee_Helper_Data
+{
+    public const AMOUNT = 2.00;
+    public const TAX_AMOUNT = 0.44;
+
+    #[\Override]
+    public function isEnabled($store = null): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function isTaxable($store = null): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function getPriceDisplayType($store = null): int
+    {
+        return 0;
+    }
+
+    #[\Override]
+    public function typeOfDisplay($product, $compareTo = null, $zone = null, $store = null)
+    {
+        if (is_null($compareTo)) {
+            return $this->getPriceDisplayType();
+        }
+        if (is_array($compareTo)) {
+            return in_array($this->getPriceDisplayType(), $compareTo);
+        }
+        return $this->getPriceDisplayType() == $compareTo;
+    }
+
+    #[\Override]
+    public function getProductWeeeAttributesForRenderer($product, $shipping = null, $billing = null, $website = null, $calculateTaxes = false): array
+    {
+        return [new Maho\DataObject([
+            'name' => 'FPT',
+            'amount' => self::AMOUNT,
+            'tax_amount' => self::TAX_AMOUNT,
+        ])];
+    }
+
+    #[\Override]
+    public function getAmountForDisplay($product): float
+    {
+        return self::AMOUNT;
+    }
+
+    #[\Override]
+    public function getOriginalAmountForDisplay(Mage_Catalog_Model_Product $product): float
+    {
+        return self::AMOUNT;
+    }
+
+    #[\Override]
+    public function getOriginalAmountInclTaxes(Mage_Catalog_Model_Product $product): float
+    {
+        return self::AMOUNT + self::TAX_AMOUNT;
+    }
+}
+
+describe('catalog price templates discount badge with a fixed product tax', function () use ($bothPricesStore, $vatProduct, $render, $money) {
+    beforeEach(function (): void {
+        Mage::unregister('_helper/weee');
+        Mage::register('_helper/weee', new PriceTemplateTest_WeeeHelper());
+    });
+
+    afterEach(function (): void {
+        Mage::unregister('_helper/weee');
+    });
+
+    it('reads the discount from the amounts it prints, not from two different tax conventions', function () use ($bothPricesStore, $vatProduct, $render, $money) {
+        $store = $bothPricesStore();
+        $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
+            'price' => 10.66,
+            'final_price' => 8.00,
+        ]);
+
+        $html = $render('catalog/product_price', 'catalog/product/price.phtml', $product);
+
+        // 13.01 + 2.44 against 9.76 + 2.44, both including tax, is a discount of 21 percent.
+        expect($html)->toContain($money(15.45))->toContain('-21%')
+            ->not->toContain($money(15.01))->not->toContain('-33%');
     });
 });

--- a/tests/Frontend/Unit/Catalog/Block/Product/PriceTemplateTest.php
+++ b/tests/Frontend/Unit/Catalog/Block/Product/PriceTemplateTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoFrontendTestCase::class);
+
+function renderPriceTemplate(float $price): string
+{
+    $store = Mage::app()->getStore();
+    $store->setConfig('tax/calculation/price_includes_tax', 0);
+    $store->setConfig('tax/display/type', (string) Mage_Tax_Model_Config::DISPLAY_TYPE_INCLUDING_TAX);
+
+    $product = Mage::getModel('catalog/product')
+        ->setId(1)
+        ->setTypeId(Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)
+        ->setStoreId($store->getId())
+        ->setPrice($price)
+        ->setFinalPrice($price)
+        ->setTaxPercent(22)
+        ->setAppliedRates([['percent' => 22]]);
+
+    return Mage::app()->getLayout()->createBlock('catalog/product_price')
+        ->setTemplate('catalog/product/price.phtml')
+        ->setProduct($product)
+        ->toHtml();
+}
+
+function formattedPrice(float $price): string
+{
+    return trim(strip_tags(Mage::helper('core')->formatPrice($price, false)));
+}
+
+describe('catalog/product/price.phtml tax rounding', function () {
+    it('adds tax to the full 4-decimal price instead of the price rounded to 2 decimals', function () {
+        $html = renderPriceTemplate(10.6557);
+
+        expect($html)->toContain(formattedPrice(13.00));
+        expect($html)->not->toContain(formattedPrice(13.01));
+    });
+
+    it('keeps prices with 2 decimals unchanged', function () {
+        $html = renderPriceTemplate(10.66);
+
+        expect($html)->toContain(formattedPrice(13.01));
+    });
+});

--- a/tests/Frontend/Unit/Catalog/Block/Product/PriceTemplateTest.php
+++ b/tests/Frontend/Unit/Catalog/Block/Product/PriceTemplateTest.php
@@ -9,43 +9,114 @@ declare(strict_types=1);
 
 uses(Tests\MahoFrontendTestCase::class);
 
-function renderPriceTemplate(float $price): string
-{
+/** Prices are stored excluding tax and displayed including tax, the setup that exposed the bug. */
+$vatStore = static function (): Mage_Core_Model_Store {
     $store = Mage::app()->getStore();
     $store->setConfig('tax/calculation/price_includes_tax', 0);
     $store->setConfig('tax/display/type', (string) Mage_Tax_Model_Config::DISPLAY_TYPE_INCLUDING_TAX);
 
-    $product = Mage::getModel('catalog/product')
-        ->setId(1)
-        ->setTypeId(Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)
-        ->setStoreId($store->getId())
-        ->setPrice($price)
-        ->setFinalPrice($price)
-        ->setTaxPercent(22)
-        ->setAppliedRates([['percent' => 22]]);
+    return $store;
+};
 
-    return Mage::app()->getLayout()->createBlock('catalog/product_price')
-        ->setTemplate('catalog/product/price.phtml')
+/** A product carrying a single 22% rate, so the templates never hit the database for one. */
+$vatProduct = static function (Mage_Core_Model_Store $store, string $typeId, array $data): Mage_Catalog_Model_Product {
+    return Mage::getModel('catalog/product')
+        ->setId(1)
+        ->setTypeId($typeId)
+        ->setStoreId($store->getId())
+        ->setTaxPercent(22)
+        ->setAppliedRates([['percent' => 22]])
+        ->addData($data);
+};
+
+$render = static function (string $blockAlias, string $template, Mage_Catalog_Model_Product $product, array $blockData = []): string {
+    return Mage::app()->getLayout()->createBlock($blockAlias)
+        ->addData($blockData)
+        ->setTemplate($template)
         ->setProduct($product)
         ->toHtml();
-}
+};
 
-function formattedPrice(float $price): string
-{
-    return trim(strip_tags(Mage::helper('core')->formatPrice($price, false)));
-}
+$money = static fn(float $price): string => trim(strip_tags(Mage::helper('core')->formatPrice($price, false)));
 
-describe('catalog/product/price.phtml tax rounding', function () {
-    it('adds tax to the full 4-decimal price instead of the price rounded to 2 decimals', function () {
-        $html = renderPriceTemplate(10.6557);
+describe('catalog price templates tax rounding', function () use ($vatStore, $vatProduct, $render, $money) {
+    it('adds tax to the full 4-decimal price instead of the price rounded to 2 decimals', function () use ($vatStore, $vatProduct, $render, $money) {
+        $store = $vatStore();
+        $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
+            'price' => 10.6557,
+            'final_price' => 10.6557,
+        ]);
 
-        expect($html)->toContain(formattedPrice(13.00));
-        expect($html)->not->toContain(formattedPrice(13.01));
+        $html = $render('catalog/product_price', 'catalog/product/price.phtml', $product);
+
+        expect($html)->toContain($money(13.00))->not->toContain($money(13.01));
     });
 
-    it('keeps prices with 2 decimals unchanged', function () {
-        $html = renderPriceTemplate(10.66);
+    it('keeps prices with 2 decimals unchanged', function () use ($vatStore, $vatProduct, $render, $money) {
+        $store = $vatStore();
+        $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
+            'price' => 10.66,
+            'final_price' => 10.66,
+        ]);
 
-        expect($html)->toContain(formattedPrice(13.01));
+        $html = $render('catalog/product_price', 'catalog/product/price.phtml', $product);
+
+        expect($html)->toContain($money(13.01));
+    });
+
+    it('applies the same rounding in the rss price template', function () use ($vatStore, $vatProduct, $render, $money) {
+        $store = $vatStore();
+        $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
+            'price' => 10.6557,
+            'final_price' => 10.6557,
+        ]);
+
+        $html = $render('catalog/product_price', 'catalog/rss/product/price.phtml', $product);
+
+        expect($html)->toContain($money(13.00))->not->toContain($money(13.01));
+    });
+
+    it('applies the same rounding in the gift card price template', function () use ($vatStore, $vatProduct, $render, $money) {
+        $store = $vatStore();
+        $product = $vatProduct($store, 'giftcard', [
+            'giftcard_type' => 'fixed',
+            'giftcard_amounts' => '10.6557,25',
+        ]);
+
+        $html = $render('giftcard/catalog_product_price', 'maho/giftcard/catalog/product/price.phtml', $product);
+
+        expect($html)->toContain($money(13.00))->not->toContain($money(13.01));
+    });
+});
+
+describe('catalog/product/price.phtml minimal price visibility', function () use ($vatStore, $vatProduct, $render) {
+    it('hides the "From" price when it rounds to the same amount as the final price', function () use ($vatStore, $vatProduct, $render) {
+        $store = $vatStore();
+        $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
+            'price' => 10.66,
+            'final_price' => 10.66,
+            'minimal_price' => 10.6557,
+        ]);
+
+        $html = $render('catalog/product_price', 'catalog/product/price.phtml', $product, [
+            'display_minimal_price' => true,
+        ]);
+
+        expect($html)->not->toContain('minimal-price-link');
+    });
+
+    it('shows the "From" price when it is genuinely lower', function () use ($vatStore, $vatProduct, $render) {
+        $store = $vatStore();
+        $product = $vatProduct($store, Mage_Catalog_Model_Product_Type::TYPE_SIMPLE, [
+            'price' => 10.66,
+            'final_price' => 10.66,
+            'minimal_price' => 5.00,
+        ]);
+
+        $html = $render('catalog/product_price', 'catalog/product/price.phtml', $product, [
+            'display_minimal_price' => true,
+        ]);
+
+        expect($html)->toContain('minimal-price-link');
     });
 });


### PR DESCRIPTION
Follow-up to #1263, reported [here](https://github.com/MahoCommerce/maho/pull/1263): a price stored as `10.6557` shows correctly in the admin but still displays `13.01` on the storefront with 22% VAT.

## Tax rounding on the storefront

The catalog price templates rounded the tax-exclusive price to 2 decimals *before* passing it to `Mage_Tax_Helper_Data::getPrice()`:

```php
$_convertedPrice = $_store->roundPrice($_store->convertPrice($_product->getPrice()));
```

`roundPrice()` is `round($price, 2)`, so the tax was applied to the wrong base:

```
10.6557 * 1.22 = 12.999954 -> 13.00   (correct)
10.66    * 1.22 = 13.0052   -> 13.01   (what was shown)
```

`getPrice()` already rounds its own result, so the extra rounding only destroyed precision. Removed it in `catalog/product/price.phtml`, `catalog/rss/product/price.phtml` and `maho/giftcard/catalog/product/price.phtml`. The `$_weeeTaxAmount` roundings stay: those values are printed directly, not fed to the tax helper.

Cart and checkout were never affected (`Mage_Tax_Model_Sales_Total_Quote_Tax` uses the unrounded value), which is why only the catalog page disagreed with the admin.

## Related fixes in the same templates

While aligning the templates on the unrounded base, the surrounding logic needed the same treatment:

- **Discount badge**: the percent is now computed from the amounts the page actually prints (tax and FPT included on both sides), and the old price + badge are hidden when the discount rounds to 0%. Before, a sub-cent difference could show a struck-through regular price with a "-0%" badge.
- **Minimal "From" price**: the visibility guards now compare the displayed (taxed, rounded) amounts, so the "From" line no longer appears when it would print the same figure as the final price, and still appears when the displayed figures differ.
- **FPT (Weee) amounts**: several spots mixed conventions, e.g. an excl-tax final price added to an incl-tax FPT (`$_finalPrice + $_weeeTaxAmountInclTaxes`), or printed the FPT without its tax next to incl-tax prices. New `Mage_Weee_Helper_Data::getOriginalAmountForDisplay()` / `getOriginalAmountInclTaxes()` provide the old-price FPT in the same convention as the special price below it.

## Tax helper

Two small `Mage_Tax_Helper_Data::getPrice()` changes so all branches agree to the cent:

- The explicit "excluding tax" branch now rounds the tax first, like the display-driven branch already did. Callers that pass `$roundPrice = false` (bundle, composite) are unaffected.
- The early return for products without a tax percent now honors `$roundPrice`, needed since the templates no longer pre-round.

## Tests

New Pest tests render the real templates with `10.6557` and 22% VAT; they fail against the unfixed code (`13.01`) and pass with the fix (`13.00`), and cover the discount badge, the "From" price guards, and the FPT discount computation.

The RSS template still uses the old `$_finalPrice == $_price` discount gate; deduplicating it against the main template is tracked in #1275.