### PR TITLE
Updated TipTap to 3.30.1 and fixed the drag handle appearing over the admin header

### DIFF
--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions.js
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2025-2026 Maho <https://mahocommerce.com>
 // SPDX-License-Identifier: AFL-3.0
 
-import { Editor, Node, Mark, Extension, mergeAttributes, ResizableNodeView } from 'https://esm.sh/@tiptap/core@3.29.2';
-import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.29.2';
-import Image from 'https://esm.sh/@tiptap/extension-image@3.29.2';
-import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.29.2';
-import { Table, TableRow as BaseTableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.29.2';
-import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.29.2';
-import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.29.2';
+import { Editor, Node, Mark, Extension, mergeAttributes, ResizableNodeView } from 'https://esm.sh/@tiptap/core@3.30.1';
+import StarterKit from 'https://esm.sh/@tiptap/starter-kit@3.30.1';
+import Image from 'https://esm.sh/@tiptap/extension-image@3.30.1';
+import TextAlign from 'https://esm.sh/@tiptap/extension-text-align@3.30.1';
+import { Table, TableRow as BaseTableRow, TableCell, TableHeader } from 'https://esm.sh/@tiptap/extension-table@3.30.1';
+import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.30.1';
+import DragHandle from 'https://esm.sh/@tiptap/extension-drag-handle@3.30.1';
 import { MahoColumns, MahoColumn, COLUMN_PRESETS } from './extensions/columns.js';
 import { MahoBentoGrid, MahoBentoCell, BENTO_PRESETS } from './extensions/bento.js';
 import { MahoAccordion, MahoDetails, DetailsSummary, DetailsContent, ACCORDION_STYLES } from './extensions/details.js';

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/bento.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/bento.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
 // SPDX-License-Identifier: AFL-3.0
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.29.2';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.30.1';
 import { findParentNodeOfType, createGridNodeView } from './grid-utils.js';
 
 /**

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/columns.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025-2026 Maho <https://mahocommerce.com>
 // SPDX-License-Identifier: AFL-3.0
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.29.2';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.30.1';
 import { findParentNodeOfType, createGridNodeView } from './grid-utils.js';
 
 /**

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/details.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/extensions/details.js
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
 // SPDX-License-Identifier: AFL-3.0
 
-import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.29.2';
-import { Details, DetailsSummary, DetailsContent } from 'https://esm.sh/@tiptap/extension-details@3.29.2';
-import { Plugin, PluginKey } from 'https://esm.sh/@tiptap/pm@3.29.2/state';
+import { Node, mergeAttributes } from 'https://esm.sh/@tiptap/core@3.30.1';
+import { Details, DetailsSummary, DetailsContent } from 'https://esm.sh/@tiptap/extension-details@3.30.1';
+import { Plugin, PluginKey } from 'https://esm.sh/@tiptap/pm@3.30.1/state';
 import { createBadge, setBadgeLabel, findParentNodeOfType } from './grid-utils.js';
 
 export { DetailsSummary, DetailsContent };

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/setup.js
@@ -340,6 +340,8 @@ class tiptapWysiwygSetup {
                         const el = document.createElement('div');
                         el.classList.add('tiptap-drag-handle');
                         el.innerHTML = this.getIcon('drag-handle');
+                        // The extension only positions and reveals the handle on the first hover
+                        el.style.visibility = 'hidden';
                         return el;
                     },
                 }),

--- a/public/js/mage/adminhtml/wysiwyg/tiptap/tiptap.css
+++ b/public/js/mage/adminhtml/wysiwyg/tiptap/tiptap.css
@@ -53,6 +53,8 @@
     flex: 1;
     overflow-y: auto;
     min-height: 0;
+    /* offset parent for the absolutely positioned DragHandle wrapper appended here */
+    position: relative;
 }
 
 .tiptap-toolbar {


### PR DESCRIPTION
Fixes #1276.

**Drag handle position.** DragHandle appends a `position: absolute; top: 0; left: 0` wrapper into `editor.view.dom.parentElement`, which is `.tiptap-content`. That element was not positioned, so the wrapper anchored to the page and landed over the admin header. Added `position: relative`. It is also the scroll container, so the handle now stays correct while the content scrolls. Fullscreen mode never showed the bug because `.tiptap-fullscreen` is `position: fixed`.

The extension also only positions and reveals the handle on the first `mousemove`, so before that it rendered visible and unpositioned. The handle now starts `visibility: hidden`; the extension's own `showHandle()` clears that inline value on first hover.

**TipTap 3.29.2 → 3.30.1.** No code changes were needed. The new `addDecorations()` hook in 3.30.0 only replaces hand-written decoration plugins, and our single ProseMirror plugin uses `appendTransaction`. StarterKit now pins its bundled `@tiptap/*` versions exactly, and 3.30.0 fixes `insertContent`/`setContent` when prosemirror-model loads twice, which applies here because we import `@tiptap/pm/state` next to StarterKit. One behavior change to know about: `ListKeymap` now binds `Tab`, so Tab at the start of a paragraph after a list moves that paragraph into the list.

Verified in Chrome against 3.30.1: before, the handle sat at `top=3 left=0` and visible; after, it is hidden on load and hover still reveals it beside the correct paragraph.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->