### PR TITLE
Excluded dev-only files from dist archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,16 @@
 # Make packagist / composer download smaller
+/.editorconfig export-ignore
+/.env.testing.dist export-ignore
 /.github export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.php-cs-fixer.php export-ignore
-/.phpcs.xml export-ignore
-/.phpstan.baseline.neon export-ignore
-/.phpstan.neon export-ignore
+/.phpstan.dist.baseline.neon export-ignore
+/.phpstan.dist.neon export-ignore
 /.rector.php export-ignore
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/composer.lock export-ignore
 /tests export-ignore
 /phpunit.xml export-ignore
 /README.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,8 +8,6 @@
 /.phpstan.dist.baseline.neon export-ignore
 /.phpstan.dist.neon export-ignore
 /.rector.php export-ignore
-/AGENTS.md export-ignore
-/CLAUDE.md export-ignore
 /composer.lock export-ignore
 /tests export-ignore
 /phpunit.xml export-ignore

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       all-dependencies:
         patterns:
@@ -12,6 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       all-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    cooldown:
-      default-days: 7
     groups:
       all-dependencies:
         patterns:
@@ -14,8 +12,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    cooldown:
-      default-days: 7
     groups:
       all-dependencies:
         patterns:


### PR DESCRIPTION
Acting on the dist-archive finding from https://plumbphp.dev/mahocommerce/maho (composite 89/100).

Three `export-ignore` entries pointed at files that no longer exist (`.phpcs.xml`, `.phpstan.neon`, `.phpstan.baseline.neon`), so the real PHPStan configs were shipping, the 925 KB baseline included. Added those plus `.editorconfig`, `.env.testing.dist` and `composer.lock`. Maho is always installed as a dependency of `maho-starter`, so its lock file is never read by Composer, and scanners pointed at a site's `vendor/` tree report advisories from it for packages that aren't actually installed. About 1.5 MB off every install.

`AGENTS.md` and `CLAUDE.md` deliberately stay in the archive: agents pick up nested convention files when reading sources under `vendor/`, so shipping them means an agent working on a Maho project gets Maho's conventions rather than guessing at Magento 1 idioms.

Plumb also flags a missing Dependabot cooldown and that we don't co-install with Symfony 8.1. The cooldown is being handled infra-wide with Terraform. The Symfony pin is deliberate (the `conflict` block holds the transitive packages at `<8.0`) and 7.4 has active support until 2028-11-30.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->