### PR TITLE
Hid the checkout login and register links when customer accounts are disabled

### DIFF
--- a/app/design/frontend/base/default/template/checkout/onestep.phtml
+++ b/app/design/frontend/base/default/template/checkout/onestep.phtml
@@ -8,12 +8,13 @@
 /** @var Mage_Checkout_Block_Onepage $this */
 $isVirtual = $this->getQuote()->isVirtual();
 $isLoggedIn = $this->isCustomerLoggedIn();
+$showAccountLinks = !$isLoggedIn && Mage::getStoreConfigFlag('customer/account/enabled_in_frontend');
 ?>
 <div class="onestep-header">
     <div class="page-title">
         <h1><?= $this->__('Checkout') ?></h1>
     </div>
-    <?php if (!$isLoggedIn): ?>
+    <?php if ($showAccountLinks): ?>
     <div class="onestep-login-bar">
         <span class="onestep-login-text"><?= $this->__('Have an account?') ?></span>
         <a href="<?= $this->getUrl('customer/account/login', ['_secure' => true, 'referer' => base64_encode($this->getUrl('checkout/onepage'))]) ?>" class="button"><?= $this->__('Login') ?></a>

--- a/tests/Frontend/Integration/Checkout/OnestepAccountLinksTest.php
+++ b/tests/Frontend/Integration/Checkout/OnestepAccountLinksTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoFrontendTestCase::class);
+
+function onestepCheckoutHtml(): string
+{
+    return Mage::app()->getLayout()
+        ->createBlock('checkout/onepage')
+        ->setTemplate('checkout/onestep.phtml')
+        ->toHtml();
+}
+
+describe('One step checkout account links', function () {
+    it('shows the login and register links when customer accounts are enabled', function () {
+        Mage::app()->getStore()->setConfig('customer/account/enabled_in_frontend', '1');
+
+        $html = onestepCheckoutHtml();
+
+        expect($html)->toContain('customer/account/login');
+        expect($html)->toContain('customer/account/create');
+    });
+
+    it('hides the login and register links when customer accounts are disabled', function () {
+        Mage::app()->getStore()->setConfig('customer/account/enabled_in_frontend', '0');
+
+        $html = onestepCheckoutHtml();
+
+        expect($html)->not->toContain('customer/account/login');
+        expect($html)->not->toContain('customer/account/create');
+    });
+});


### PR DESCRIPTION
The one-step checkout rendered the "Have an account? Login / Register" bar even when `customer/account/enabled_in_frontend` was `No`. It now uses the same flag check as `page/html/header.phtml`.

Every other account link in the theme was already guarded with `ifconfig="customer/account/enabled_in_frontend"`, so this template was the only leak.

Fixes #1284

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->