### PR TITLE
Converted the Maho namespace magic accessors to real typed methods

### DIFF
--- a/app/code/core/Maho/Blog/Model/Category.php
+++ b/app/code/core/Maho/Blog/Model/Category.php
@@ -8,15 +8,6 @@
 
 declare(strict_types=1);
 
-/**
- * @method string getName()
- * @method string getUrlKey()
- * @method int getParentId()
- * @method string getPath()
- * @method int getLevel()
- * @method int getPosition()
- * @method int getIsActive()
- */
 class Maho_Blog_Model_Category extends Mage_Core_Model_Abstract
 {
     public const ENTITY = 'blog_category';
@@ -108,5 +99,47 @@ class Maho_Blog_Model_Category extends Mage_Core_Model_Abstract
             $this->setData('post_ids', $postIds);
         }
         return $this->getData('post_ids') ?: [];
+    }
+
+    public function getName(): ?string
+    {
+        $value = $this->getData('name');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getUrlKey(): ?string
+    {
+        $value = $this->getData('url_key');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getParentId(): ?int
+    {
+        $value = $this->getData('parent_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function getPath(): ?string
+    {
+        $value = $this->getData('path');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getLevel(): ?int
+    {
+        $value = $this->getData('level');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function getPosition(): ?int
+    {
+        $value = $this->getData('position');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function getIsActive(): ?int
+    {
+        $value = $this->getData('is_active');
+        return $value === null ? null : (int) $value;
     }
 }

--- a/app/code/core/Maho/Blog/Model/Post.php
+++ b/app/code/core/Maho/Blog/Model/Post.php
@@ -9,9 +9,6 @@
 declare(strict_types=1);
 
 /**
- * @method string getContent() Returns raw content. For frontend display, use getFilteredContent() instead.
- * @method string getPublishDate()
- * @method string getTitle()
  * @method string getImage()
  */
 class Maho_Blog_Model_Post extends Mage_Core_Model_Abstract
@@ -125,5 +122,26 @@ class Maho_Blog_Model_Post extends Mage_Core_Model_Abstract
         $helper = Mage::helper('cms');
 
         return $helper->getPageTemplateProcessor()->filter($content);
+    }
+
+    /**
+     * Returns raw content. For frontend display, use getFilteredContent() instead.
+     */
+    public function getContent(): ?string
+    {
+        $value = $this->getData('content');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getPublishDate(): ?string
+    {
+        $value = $this->getData('publish_date');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getTitle(): ?string
+    {
+        $value = $this->getData('title');
+        return $value === null ? null : (string) $value;
     }
 }

--- a/app/code/core/Maho/Blog/Model/Post.php
+++ b/app/code/core/Maho/Blog/Model/Post.php
@@ -8,9 +8,6 @@
 
 declare(strict_types=1);
 
-/**
- * @method string getImage()
- */
 class Maho_Blog_Model_Post extends Mage_Core_Model_Abstract
 {
     public const ENTITY = 'blog_post';
@@ -143,5 +140,20 @@ class Maho_Blog_Model_Post extends Mage_Core_Model_Abstract
     {
         $value = $this->getData('title');
         return $value === null ? null : (string) $value;
+    }
+
+    /**
+     * The admin file widget posts an array such as ['delete' => 1], which
+     * Maho_Blog_Model_Post_Attribute_Backend_Image consumes on save.
+     */
+    public function getImage(): string|array|null
+    {
+        $value = $this->getData('image');
+        return $value === null || is_array($value) ? $value : (string) $value;
+    }
+
+    public function setImage(string|array|null $value): static
+    {
+        return $this->setData('image', $value);
     }
 }

--- a/app/code/core/Maho/CustomerSegmentation/Model/EmailSequence.php
+++ b/app/code/core/Maho/CustomerSegmentation/Model/EmailSequence.php
@@ -15,31 +15,6 @@ declare(strict_types=1);
  * - Getter methods (getTemplate, getCouponSalesRule, getSegment): Return null if not found, log warning
  * - Validation methods (validate): Throw Mage_Core_Exception with user-friendly message
  * - Boolean checks (shouldGenerateCoupon): Return false on failure, never throw
- *
- * @method int getSegmentId()
- * @method string getTriggerEvent()
- * @method int getTemplateId()
- * @method int getStepNumber()
- * @method int getDelayMinutes()
- * @method bool getIsActive()
- * @method int getMaxSends()
- * @method bool getGenerateCoupon()
- * @method int|null getCouponSalesRuleId()
- * @method string|null getCouponPrefix()
- * @method int getCouponExpiresDays()
- * @method string getCreatedAt()
- * @method string getUpdatedAt()
- * @method Maho_CustomerSegmentation_Model_EmailSequence setSegmentId(int $value)
- * @method Maho_CustomerSegmentation_Model_EmailSequence setTriggerEvent(string $value)
- * @method Maho_CustomerSegmentation_Model_EmailSequence setTemplateId(int $value)
- * @method Maho_CustomerSegmentation_Model_EmailSequence setStepNumber(int $value)
- * @method Maho_CustomerSegmentation_Model_EmailSequence setDelayMinutes(int $value)
- * @method Maho_CustomerSegmentation_Model_EmailSequence setIsActive(bool $value)
- * @method Maho_CustomerSegmentation_Model_EmailSequence setMaxSends(int $value)
- * @method Maho_CustomerSegmentation_Model_EmailSequence setGenerateCoupon(bool $value)
- * @method Maho_CustomerSegmentation_Model_EmailSequence setCouponSalesRuleId(int|null $value)
- * @method Maho_CustomerSegmentation_Model_EmailSequence setCouponPrefix(string|null $value)
- * @method Maho_CustomerSegmentation_Model_EmailSequence setCouponExpiresDays(int $value)
  */
 class Maho_CustomerSegmentation_Model_EmailSequence extends Mage_Core_Model_Abstract
 {
@@ -214,8 +189,8 @@ class Maho_CustomerSegmentation_Model_EmailSequence extends Mage_Core_Model_Abst
             $this->setCouponPrefix(null);
         }
 
-        // Convert empty string to NULL for coupon_sales_rule_id (prevents FK constraint violation)
-        if ($this->getCouponSalesRuleId() === '' || $this->getCouponSalesRuleId() === 0) {
+        // Convert an empty selection to NULL for coupon_sales_rule_id (prevents FK constraint violation)
+        if ($this->getCouponSalesRuleId() === 0) {
             $this->setCouponSalesRuleId(null);
         }
 
@@ -228,7 +203,7 @@ class Maho_CustomerSegmentation_Model_EmailSequence extends Mage_Core_Model_Abst
                 $this->setTriggerEvent(self::TRIGGER_ENTER);
             }
             if (!$this->hasData('is_active')) {
-                $this->setIsActive(true);
+                $this->setIsActive(1);
             }
             if (!$this->hasData('max_sends')) {
                 $this->setMaxSends(1);
@@ -237,7 +212,7 @@ class Maho_CustomerSegmentation_Model_EmailSequence extends Mage_Core_Model_Abst
                 $this->setDelayMinutes(0);
             }
             if (!$this->hasData('generate_coupon')) {
-                $this->setGenerateCoupon(false);
+                $this->setGenerateCoupon(0);
             }
             if (!$this->hasData('coupon_expires_days')) {
                 $this->setCouponExpiresDays(30);
@@ -264,5 +239,138 @@ class Maho_CustomerSegmentation_Model_EmailSequence extends Mage_Core_Model_Abst
         }
 
         return $this;
+    }
+
+    public function getSegmentId(): ?int
+    {
+        $value = $this->getData('segment_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setSegmentId(?int $value): static
+    {
+        return $this->setData('segment_id', $value);
+    }
+
+    public function getTriggerEvent(): ?string
+    {
+        $value = $this->getData('trigger_event');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setTriggerEvent(?string $value): static
+    {
+        return $this->setData('trigger_event', $value);
+    }
+
+    public function getTemplateId(): ?int
+    {
+        $value = $this->getData('template_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setTemplateId(?int $value): static
+    {
+        return $this->setData('template_id', $value);
+    }
+
+    public function getStepNumber(): ?int
+    {
+        $value = $this->getData('step_number');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setStepNumber(?int $value): static
+    {
+        return $this->setData('step_number', $value);
+    }
+
+    public function getDelayMinutes(): ?int
+    {
+        $value = $this->getData('delay_minutes');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setDelayMinutes(?int $value): static
+    {
+        return $this->setData('delay_minutes', $value);
+    }
+
+    public function getIsActive(): ?int
+    {
+        $value = $this->getData('is_active');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setIsActive(?int $value): static
+    {
+        return $this->setData('is_active', $value);
+    }
+
+    public function getMaxSends(): ?int
+    {
+        $value = $this->getData('max_sends');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setMaxSends(?int $value): static
+    {
+        return $this->setData('max_sends', $value);
+    }
+
+    public function getGenerateCoupon(): ?int
+    {
+        $value = $this->getData('generate_coupon');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setGenerateCoupon(?int $value): static
+    {
+        return $this->setData('generate_coupon', $value);
+    }
+
+    public function getCouponSalesRuleId(): ?int
+    {
+        $value = $this->getData('coupon_sales_rule_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setCouponSalesRuleId(?int $value): static
+    {
+        return $this->setData('coupon_sales_rule_id', $value);
+    }
+
+    public function getCouponPrefix(): ?string
+    {
+        $value = $this->getData('coupon_prefix');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setCouponPrefix(?string $value): static
+    {
+        return $this->setData('coupon_prefix', $value);
+    }
+
+    public function getCouponExpiresDays(): ?int
+    {
+        $value = $this->getData('coupon_expires_days');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setCouponExpiresDays(?int $value): static
+    {
+        return $this->setData('coupon_expires_days', $value);
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        $value = $this->getData('created_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        $value = $this->getData('updated_at');
+        return $value === null ? null : (string) $value;
     }
 }

--- a/app/code/core/Maho/CustomerSegmentation/Model/Segment.php
+++ b/app/code/core/Maho/CustomerSegmentation/Model/Segment.php
@@ -9,36 +9,8 @@
 declare(strict_types=1);
 
 /**
- * @method string getName()
- * @method string getDescription()
- * @method int getIsActive()
- * @method string getConditionsSerialized()
- * @method string getWebsiteIds()
- * @method string getCustomerGroupIds()
- * @method string getCreatedAt()
- * @method string getUpdatedAt()
- * @method int getMatchedCustomersCount()
- * @method string getLastRefreshAt()
- * @method string getRefreshStatus()
- * @method string getRefreshMode()
- * @method int getPriority()
  * @method string getAutoEmailTrigger()
- * @method int getAutoEmailActive()
- * @method int getAllowOverlappingSequences()
- * @method Maho_CustomerSegmentation_Model_Segment setName(string $value)
- * @method Maho_CustomerSegmentation_Model_Segment setDescription(string $value)
- * @method Maho_CustomerSegmentation_Model_Segment setIsActive(int $value)
- * @method Maho_CustomerSegmentation_Model_Segment setConditionsSerialized(string $value)
- * @method Maho_CustomerSegmentation_Model_Segment setWebsiteIds(string $value)
- * @method Maho_CustomerSegmentation_Model_Segment setCustomerGroupIds(string $value)
- * @method Maho_CustomerSegmentation_Model_Segment setMatchedCustomersCount(int $value)
- * @method Maho_CustomerSegmentation_Model_Segment setLastRefreshAt(string $value)
- * @method Maho_CustomerSegmentation_Model_Segment setRefreshStatus(string $value)
- * @method Maho_CustomerSegmentation_Model_Segment setRefreshMode(string $value)
- * @method Maho_CustomerSegmentation_Model_Segment setPriority(int $value)
  * @method Maho_CustomerSegmentation_Model_Segment setAutoEmailTrigger(string $value)
- * @method Maho_CustomerSegmentation_Model_Segment setAutoEmailActive(int $value)
- * @method Maho_CustomerSegmentation_Model_Segment setAllowOverlappingSequences(int $value)
  * @method Maho_CustomerSegmentation_Model_Resource_Segment getResource()
  * @method Maho_CustomerSegmentation_Model_Resource_Segment _getResource()
  */
@@ -554,4 +526,152 @@ class Maho_CustomerSegmentation_Model_Segment extends Mage_Rule_Model_Abstract
         return $errors;
     }
 
+    public function getName(): ?string
+    {
+        $value = $this->getData('name');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setName(?string $value): static
+    {
+        return $this->setData('name', $value);
+    }
+
+    public function getDescription(): ?string
+    {
+        $value = $this->getData('description');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setDescription(?string $value): static
+    {
+        return $this->setData('description', $value);
+    }
+
+    public function getIsActive(): ?int
+    {
+        $value = $this->getData('is_active');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setIsActive(?int $value): static
+    {
+        return $this->setData('is_active', $value);
+    }
+
+    public function getConditionsSerialized(): ?string
+    {
+        $value = $this->getData('conditions_serialized');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setConditionsSerialized(?string $value): static
+    {
+        return $this->setData('conditions_serialized', $value);
+    }
+
+    public function setWebsiteIds(?string $value): static
+    {
+        return $this->setData('website_ids', $value);
+    }
+
+    public function getCustomerGroupIds(): ?string
+    {
+        $value = $this->getData('customer_group_ids');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setCustomerGroupIds(?string $value): static
+    {
+        return $this->setData('customer_group_ids', $value);
+    }
+
+    public function getMatchedCustomersCount(): ?int
+    {
+        $value = $this->getData('matched_customers_count');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setMatchedCustomersCount(?int $value): static
+    {
+        return $this->setData('matched_customers_count', $value);
+    }
+
+    public function getLastRefreshAt(): ?string
+    {
+        $value = $this->getData('last_refresh_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setLastRefreshAt(?string $value): static
+    {
+        return $this->setData('last_refresh_at', $value);
+    }
+
+    public function getRefreshStatus(): ?string
+    {
+        $value = $this->getData('refresh_status');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setRefreshStatus(?string $value): static
+    {
+        return $this->setData('refresh_status', $value);
+    }
+
+    public function getRefreshMode(): ?string
+    {
+        $value = $this->getData('refresh_mode');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setRefreshMode(?string $value): static
+    {
+        return $this->setData('refresh_mode', $value);
+    }
+
+    public function getPriority(): ?int
+    {
+        $value = $this->getData('priority');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setPriority(?int $value): static
+    {
+        return $this->setData('priority', $value);
+    }
+
+    public function getAutoEmailActive(): ?int
+    {
+        $value = $this->getData('auto_email_active');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setAutoEmailActive(?int $value): static
+    {
+        return $this->setData('auto_email_active', $value);
+    }
+
+    public function getAllowOverlappingSequences(): ?int
+    {
+        $value = $this->getData('allow_overlapping_sequences');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setAllowOverlappingSequences(?int $value): static
+    {
+        return $this->setData('allow_overlapping_sequences', $value);
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        $value = $this->getData('created_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        $value = $this->getData('updated_at');
+        return $value === null ? null : (string) $value;
+    }
 }

--- a/app/code/core/Maho/CustomerSegmentation/Model/Segment.php
+++ b/app/code/core/Maho/CustomerSegmentation/Model/Segment.php
@@ -9,8 +9,6 @@
 declare(strict_types=1);
 
 /**
- * @method string getAutoEmailTrigger()
- * @method Maho_CustomerSegmentation_Model_Segment setAutoEmailTrigger(string $value)
  * @method Maho_CustomerSegmentation_Model_Resource_Segment getResource()
  * @method Maho_CustomerSegmentation_Model_Resource_Segment _getResource()
  */

--- a/app/code/core/Maho/CustomerSegmentation/Model/Segment.php
+++ b/app/code/core/Maho/CustomerSegmentation/Model/Segment.php
@@ -568,18 +568,21 @@ class Maho_CustomerSegmentation_Model_Segment extends Mage_Rule_Model_Abstract
         return $this->setData('conditions_serialized', $value);
     }
 
-    public function setWebsiteIds(?string $value): static
+    /**
+     * The column stores a comma-separated list, but Mage_Rule_Model_Abstract::_beforeSave()
+     * and the admin multiselects both hand these two fields an array, so neither may cast.
+     */
+    public function setWebsiteIds(string|array|null $value): static
     {
         return $this->setData('website_ids', $value);
     }
 
-    public function getCustomerGroupIds(): ?string
+    public function getCustomerGroupIds(): string|array|null
     {
-        $value = $this->getData('customer_group_ids');
-        return $value === null ? null : (string) $value;
+        return $this->getData('customer_group_ids');
     }
 
-    public function setCustomerGroupIds(?string $value): static
+    public function setCustomerGroupIds(string|array|null $value): static
     {
         return $this->setData('customer_group_ids', $value);
     }

--- a/app/code/core/Maho/CustomerSegmentation/Model/SequenceProgress.php
+++ b/app/code/core/Maho/CustomerSegmentation/Model/SequenceProgress.php
@@ -10,26 +10,6 @@ declare(strict_types=1);
 
 /**
  * Sequence Progress Model - tracks customer progress through email sequences
- *
- * @method int getCustomerId()
- * @method int getSegmentId()
- * @method int getSequenceId()
- * @method int getQueueId()
- * @method int getStepNumber()
- * @method string getTriggerType()
- * @method string getScheduledAt()
- * @method string getSentAt()
- * @method string getStatus()
- * @method string getCreatedAt()
- * @method Maho_CustomerSegmentation_Model_SequenceProgress setCustomerId(int $value)
- * @method Maho_CustomerSegmentation_Model_SequenceProgress setSegmentId(int $value)
- * @method Maho_CustomerSegmentation_Model_SequenceProgress setSequenceId(int $value)
- * @method Maho_CustomerSegmentation_Model_SequenceProgress setQueueId(int $value)
- * @method Maho_CustomerSegmentation_Model_SequenceProgress setStepNumber(int $value)
- * @method Maho_CustomerSegmentation_Model_SequenceProgress setTriggerType(string $value)
- * @method Maho_CustomerSegmentation_Model_SequenceProgress setScheduledAt(string $value)
- * @method Maho_CustomerSegmentation_Model_SequenceProgress setSentAt(string $value)
- * @method Maho_CustomerSegmentation_Model_SequenceProgress setStatus(string $value)
  */
 class Maho_CustomerSegmentation_Model_SequenceProgress extends Mage_Core_Model_Abstract
 {
@@ -231,5 +211,110 @@ class Maho_CustomerSegmentation_Model_SequenceProgress extends Mage_Core_Model_A
         }
 
         return $this;
+    }
+
+    public function getCustomerId(): ?int
+    {
+        $value = $this->getData('customer_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setCustomerId(?int $value): static
+    {
+        return $this->setData('customer_id', $value);
+    }
+
+    public function getSegmentId(): ?int
+    {
+        $value = $this->getData('segment_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setSegmentId(?int $value): static
+    {
+        return $this->setData('segment_id', $value);
+    }
+
+    public function getSequenceId(): ?int
+    {
+        $value = $this->getData('sequence_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setSequenceId(?int $value): static
+    {
+        return $this->setData('sequence_id', $value);
+    }
+
+    public function getQueueId(): ?int
+    {
+        $value = $this->getData('queue_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setQueueId(?int $value): static
+    {
+        return $this->setData('queue_id', $value);
+    }
+
+    public function getStepNumber(): ?int
+    {
+        $value = $this->getData('step_number');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setStepNumber(?int $value): static
+    {
+        return $this->setData('step_number', $value);
+    }
+
+    public function getTriggerType(): ?string
+    {
+        $value = $this->getData('trigger_type');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setTriggerType(?string $value): static
+    {
+        return $this->setData('trigger_type', $value);
+    }
+
+    public function getScheduledAt(): ?string
+    {
+        $value = $this->getData('scheduled_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setScheduledAt(?string $value): static
+    {
+        return $this->setData('scheduled_at', $value);
+    }
+
+    public function getSentAt(): ?string
+    {
+        $value = $this->getData('sent_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setSentAt(?string $value): static
+    {
+        return $this->setData('sent_at', $value);
+    }
+
+    public function getStatus(): ?string
+    {
+        $value = $this->getData('status');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setStatus(?string $value): static
+    {
+        return $this->setData('status', $value);
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        $value = $this->getData('created_at');
+        return $value === null ? null : (string) $value;
     }
 }

--- a/app/code/core/Maho/CustomerSegmentation/controllers/Adminhtml/CustomerSegmentation_IndexController.php
+++ b/app/code/core/Maho/CustomerSegmentation/controllers/Adminhtml/CustomerSegmentation_IndexController.php
@@ -464,7 +464,7 @@ class Maho_CustomerSegmentation_Adminhtml_CustomerSegmentation_IndexController e
 
             $sequence->setSegmentId($segmentId);
             $sequence->setTriggerEvent($triggerEvent);
-            $sequence->setIsActive(true);
+            $sequence->setIsActive(1);
             $sequence->setDelayMinutes(0);
             $sequence->setCouponExpiresDays(30);
 

--- a/app/code/core/Maho/CustomerSegmentation/controllers/Adminhtml/CustomerSegmentation_IndexController.php
+++ b/app/code/core/Maho/CustomerSegmentation/controllers/Adminhtml/CustomerSegmentation_IndexController.php
@@ -422,7 +422,7 @@ class Maho_CustomerSegmentation_Adminhtml_CustomerSegmentation_IndexController e
     public function editSequenceAction(): void
     {
         $sequenceId = $this->getRequest()->getParam('id');
-        $segmentId = $this->getRequest()->getParam('segment_id');
+        $segmentId = (int) $this->getRequest()->getParam('segment_id') ?: null;
         $triggerEvent = $this->getRequest()->getParam('trigger_event');
 
         $sequence = Mage::getModel('customersegmentation/emailSequence');

--- a/app/code/core/Maho/FeedManager/Model/AttributeMapping.php
+++ b/app/code/core/Maho/FeedManager/Model/AttributeMapping.php
@@ -15,21 +15,6 @@ declare(strict_types=1);
  * - Getter methods (getConditionsArray, getTransformersArray): Return empty array if JSON invalid, never throw
  * - Setter methods (setConditionsArray, setTransformersArray): Encode to JSON, return self for chaining
  *
- * @method int getMappingId()
- * @method int getFeedId()
- * @method $this setFeedId(int $feedId)
- * @method string getPlatformAttribute()
- * @method $this setPlatformAttribute(string $attribute)
- * @method string getSourceType()
- * @method $this setSourceType(string $type)
- * @method string getSourceValue()
- * @method $this setSourceValue(string $value)
- * @method string|null getConditions()
- * @method $this setConditions(string|null $conditions)
- * @method string|null getTransformers()
- * @method $this setTransformers(string|null $transformers)
- * @method int getSortOrder()
- * @method $this setSortOrder(int $order)
  * @method Maho_FeedManager_Model_Resource_AttributeMapping getResource()
  * @method Maho_FeedManager_Model_Resource_AttributeMapping _getResource()
  */
@@ -105,5 +90,88 @@ class Maho_FeedManager_Model_AttributeMapping extends Mage_Core_Model_Abstract
             self::SOURCE_TYPE_COMBINED => $helper->__('Combined Template'),
             self::SOURCE_TYPE_TAXONOMY => $helper->__('Category Taxonomy'),
         ];
+    }
+
+    public function getMappingId(): ?int
+    {
+        $value = $this->getData('mapping_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function getFeedId(): ?int
+    {
+        $value = $this->getData('feed_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setFeedId(?int $value): static
+    {
+        return $this->setData('feed_id', $value);
+    }
+
+    public function getPlatformAttribute(): ?string
+    {
+        $value = $this->getData('platform_attribute');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setPlatformAttribute(?string $value): static
+    {
+        return $this->setData('platform_attribute', $value);
+    }
+
+    public function getSourceType(): ?string
+    {
+        $value = $this->getData('source_type');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setSourceType(?string $value): static
+    {
+        return $this->setData('source_type', $value);
+    }
+
+    public function getSourceValue(): ?string
+    {
+        $value = $this->getData('source_value');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setSourceValue(?string $value): static
+    {
+        return $this->setData('source_value', $value);
+    }
+
+    public function getConditions(): ?string
+    {
+        $value = $this->getData('conditions');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setConditions(?string $value): static
+    {
+        return $this->setData('conditions', $value);
+    }
+
+    public function getTransformers(): ?string
+    {
+        $value = $this->getData('transformers');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setTransformers(?string $value): static
+    {
+        return $this->setData('transformers', $value);
+    }
+
+    public function getSortOrder(): ?int
+    {
+        $value = $this->getData('sort_order');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setSortOrder(?int $value): static
+    {
+        return $this->setData('sort_order', $value);
     }
 }

--- a/app/code/core/Maho/FeedManager/Model/CategoryMapping.php
+++ b/app/code/core/Maho/FeedManager/Model/CategoryMapping.php
@@ -15,15 +15,6 @@ declare(strict_types=1);
  * - Getter methods (getCategory): Return null if category not found, never throw
  * - Load methods (loadByPlatformAndCategory): Return self even if not found (check getId())
  *
- * @method int getMappingId()
- * @method string getPlatform()
- * @method $this setPlatform(string $platform)
- * @method int getCategoryId()
- * @method $this setCategoryId(int $categoryId)
- * @method string getPlatformCategoryId()
- * @method $this setPlatformCategoryId(string $categoryId)
- * @method string getPlatformCategoryPath()
- * @method $this setPlatformCategoryPath(string $path)
  * @method Maho_FeedManager_Model_Resource_CategoryMapping getResource()
  * @method Maho_FeedManager_Model_Resource_CategoryMapping _getResource()
  */
@@ -56,5 +47,55 @@ class Maho_FeedManager_Model_CategoryMapping extends Mage_Core_Model_Abstract
             return null;
         }
         return Mage::getModel('catalog/category')->load($this->getCategoryId());
+    }
+
+    public function getMappingId(): ?int
+    {
+        $value = $this->getData('mapping_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function getPlatform(): ?string
+    {
+        $value = $this->getData('platform');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setPlatform(?string $value): static
+    {
+        return $this->setData('platform', $value);
+    }
+
+    public function getCategoryId(): ?int
+    {
+        $value = $this->getData('category_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setCategoryId(?int $value): static
+    {
+        return $this->setData('category_id', $value);
+    }
+
+    public function getPlatformCategoryId(): ?string
+    {
+        $value = $this->getData('platform_category_id');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setPlatformCategoryId(?string $value): static
+    {
+        return $this->setData('platform_category_id', $value);
+    }
+
+    public function getPlatformCategoryPath(): ?string
+    {
+        $value = $this->getData('platform_category_path');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setPlatformCategoryPath(?string $value): static
+    {
+        return $this->setData('platform_category_path', $value);
     }
 }

--- a/app/code/core/Maho/FeedManager/Model/Destination.php
+++ b/app/code/core/Maho/FeedManager/Model/Destination.php
@@ -305,9 +305,19 @@ class Maho_FeedManager_Model_Destination extends Mage_Core_Model_Abstract
         return $value === null ? null : (string) $value;
     }
 
+    public function setCreatedAt(?string $value): static
+    {
+        return $this->setData('created_at', $value);
+    }
+
     public function getUpdatedAt(): ?string
     {
         $value = $this->getData('updated_at');
         return $value === null ? null : (string) $value;
+    }
+
+    public function setUpdatedAt(?string $value): static
+    {
+        return $this->setData('updated_at', $value);
     }
 }

--- a/app/code/core/Maho/FeedManager/Model/Destination.php
+++ b/app/code/core/Maho/FeedManager/Model/Destination.php
@@ -16,21 +16,6 @@ declare(strict_types=1);
  * - Boolean checks (isEnabled, isSftp, isFtp): Return false on failure, never throw
  * - Connection testing: Throws Exception with descriptive message for caller to handle
  *
- * @method int getDestinationId()
- * @method string getName()
- * @method $this setName(string $name)
- * @method string getType()
- * @method $this setType(string $type)
- * @method string|null getConfig()
- * @method $this setConfig(string|null $config)
- * @method int getIsEnabled()
- * @method $this setIsEnabled(int $isEnabled)
- * @method string|null getLastUploadAt()
- * @method $this setLastUploadAt(string|null $datetime)
- * @method string|null getLastUploadStatus()
- * @method $this setLastUploadStatus(string|null $status)
- * @method string getCreatedAt()
- * @method string getUpdatedAt()
  * @method Maho_FeedManager_Model_Resource_Destination getResource()
  * @method Maho_FeedManager_Model_Resource_Destination _getResource()
  */
@@ -240,5 +225,89 @@ class Maho_FeedManager_Model_Destination extends Mage_Core_Model_Abstract
         $this->setUpdatedAt($now);
 
         return parent::_beforeSave();
+    }
+
+    public function getDestinationId(): ?int
+    {
+        $value = $this->getData('destination_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function getName(): ?string
+    {
+        $value = $this->getData('name');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setName(?string $value): static
+    {
+        return $this->setData('name', $value);
+    }
+
+    public function getType(): ?string
+    {
+        $value = $this->getData('type');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setType(?string $value): static
+    {
+        return $this->setData('type', $value);
+    }
+
+    public function getConfig(): ?string
+    {
+        $value = $this->getData('config');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setConfig(?string $value): static
+    {
+        return $this->setData('config', $value);
+    }
+
+    public function getIsEnabled(): ?int
+    {
+        $value = $this->getData('is_enabled');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setIsEnabled(?int $value): static
+    {
+        return $this->setData('is_enabled', $value);
+    }
+
+    public function getLastUploadAt(): ?string
+    {
+        $value = $this->getData('last_upload_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setLastUploadAt(?string $value): static
+    {
+        return $this->setData('last_upload_at', $value);
+    }
+
+    public function getLastUploadStatus(): ?string
+    {
+        $value = $this->getData('last_upload_status');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setLastUploadStatus(?string $value): static
+    {
+        return $this->setData('last_upload_status', $value);
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        $value = $this->getData('created_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        $value = $this->getData('updated_at');
+        return $value === null ? null : (string) $value;
     }
 }

--- a/app/code/core/Maho/FeedManager/Model/DynamicRule.php
+++ b/app/code/core/Maho/FeedManager/Model/DynamicRule.php
@@ -12,23 +12,6 @@ declare(strict_types=1);
  * Dynamic Attribute Rule Model
  *
  * Supports multiple condition→output cases with first-match-wins evaluation.
- *
- * @method string getName()
- * @method $this setName(string $name)
- * @method string getCode()
- * @method $this setCode(string $code)
- * @method string|null getDescription()
- * @method $this setDescription(?string $description)
- * @method int getIsSystem()
- * @method $this setIsSystem(int $isSystem)
- * @method int getIsEnabled()
- * @method $this setIsEnabled(int $isEnabled)
- * @method int getSortOrder()
- * @method $this setSortOrder(int $sortOrder)
- * @method string getCreatedAt()
- * @method $this setCreatedAt(string $createdAt)
- * @method string getUpdatedAt()
- * @method $this setUpdatedAt(string $updatedAt)
  */
 class Maho_FeedManager_Model_DynamicRule extends Mage_Core_Model_Abstract
 {
@@ -440,5 +423,93 @@ class Maho_FeedManager_Model_DynamicRule extends Mage_Core_Model_Abstract
         return $position === self::COMBINED_POSITION_PREFIX
             ? $staticValue . $attrValue
             : $attrValue . $staticValue;
+    }
+
+    public function getName(): ?string
+    {
+        $value = $this->getData('name');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setName(?string $value): static
+    {
+        return $this->setData('name', $value);
+    }
+
+    public function getCode(): ?string
+    {
+        $value = $this->getData('code');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setCode(?string $value): static
+    {
+        return $this->setData('code', $value);
+    }
+
+    public function getDescription(): ?string
+    {
+        $value = $this->getData('description');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setDescription(?string $value): static
+    {
+        return $this->setData('description', $value);
+    }
+
+    public function getIsSystem(): ?int
+    {
+        $value = $this->getData('is_system');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setIsSystem(?int $value): static
+    {
+        return $this->setData('is_system', $value);
+    }
+
+    public function getIsEnabled(): ?int
+    {
+        $value = $this->getData('is_enabled');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setIsEnabled(?int $value): static
+    {
+        return $this->setData('is_enabled', $value);
+    }
+
+    public function getSortOrder(): ?int
+    {
+        $value = $this->getData('sort_order');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setSortOrder(?int $value): static
+    {
+        return $this->setData('sort_order', $value);
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        $value = $this->getData('created_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setCreatedAt(?string $value): static
+    {
+        return $this->setData('created_at', $value);
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        $value = $this->getData('updated_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setUpdatedAt(?string $value): static
+    {
+        return $this->setData('updated_at', $value);
     }
 }

--- a/app/code/core/Maho/FeedManager/Model/Feed.php
+++ b/app/code/core/Maho/FeedManager/Model/Feed.php
@@ -566,6 +566,61 @@ class Maho_FeedManager_Model_Feed extends Mage_Rule_Model_Abstract
         return $this->setData('no_image_url', $value);
     }
 
+    public function getGzipCompression(): ?int
+    {
+        $value = $this->getData('gzip_compression');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setGzipCompression(?int $value): static
+    {
+        return $this->setData('gzip_compression', $value);
+    }
+
+    public function getNotificationMode(): ?string
+    {
+        $value = $this->getData('notification_mode');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setNotificationMode(?string $value): static
+    {
+        return $this->setData('notification_mode', $value);
+    }
+
+    public function getNotificationFrequency(): ?string
+    {
+        $value = $this->getData('notification_frequency');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setNotificationFrequency(?string $value): static
+    {
+        return $this->setData('notification_frequency', $value);
+    }
+
+    public function getNotificationEmail(): ?string
+    {
+        $value = $this->getData('notification_email');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setNotificationEmail(?string $value): static
+    {
+        return $this->setData('notification_email', $value);
+    }
+
+    public function getNotificationSent(): ?int
+    {
+        $value = $this->getData('notification_sent');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setNotificationSent(?int $value): static
+    {
+        return $this->setData('notification_sent', $value);
+    }
+
     public function getLastGeneratedAt(): ?string
     {
         $value = $this->getData('last_generated_at');
@@ -605,9 +660,19 @@ class Maho_FeedManager_Model_Feed extends Mage_Rule_Model_Abstract
         return $value === null ? null : (string) $value;
     }
 
+    public function setCreatedAt(?string $value): static
+    {
+        return $this->setData('created_at', $value);
+    }
+
     public function getUpdatedAt(): ?string
     {
         $value = $this->getData('updated_at');
         return $value === null ? null : (string) $value;
+    }
+
+    public function setUpdatedAt(?string $value): static
+    {
+        return $this->setData('updated_at', $value);
     }
 }

--- a/app/code/core/Maho/FeedManager/Model/Feed.php
+++ b/app/code/core/Maho/FeedManager/Model/Feed.php
@@ -17,89 +17,6 @@ declare(strict_types=1);
  * - Boolean checks (isEnabled, hasAttributeMappings): Return false on failure, never throw
  * - File operations (getOutputFilePath): Return path string, caller handles file existence
  *
- * @method int getFeedId()
- * @method string getName()
- * @method $this setName(string $name)
- * @method string getPlatform()
- * @method $this setPlatform(string $platform)
- * @method int getStoreId()
- * @method $this setStoreId(int $storeId)
- * @method int getIsEnabled()
- * @method $this setIsEnabled(int $isEnabled)
- * @method string getFilename()
- * @method $this setFilename(string $filename)
- * @method string getFileFormat()
- * @method $this setFileFormat(string $format)
- * @method string getGenerationTime()
- * @method $this setGenerationTime(string $time)
- * @method string getConfigurableMode()
- * @method $this setConfigurableMode(string $mode)
- * @method int|null getDestinationId()
- * @method $this setDestinationId(int|null $destinationId)
- * @method int getAutoUpload()
- * @method $this setAutoUpload(int $autoUpload)
- * @method string|null getSchedule()
- * @method $this setSchedule(string|null $schedule)
- * @method string|null getProductFilters()
- * @method $this setProductFilters(string|null $filters)
- * @method int getExcludeDisabled()
- * @method $this setExcludeDisabled(int $value)
- * @method int getExcludeOutOfStock()
- * @method $this setExcludeOutOfStock(int $value)
- * @method string|null getIncludeProductTypes()
- * @method $this setIncludeProductTypes(string|null $types)
- * @method string|null getFormatPreset()
- * @method $this setFormatPreset(string|null $preset)
- * @method string|null getPriceCurrency()
- * @method $this setPriceCurrency(string|null $currency)
- * @method int|null getPriceDecimals()
- * @method $this setPriceDecimals(int|null $decimals)
- * @method string|null getPriceDecimalPoint()
- * @method $this setPriceDecimalPoint(string|null $point)
- * @method string|null getPriceThousandsSep()
- * @method $this setPriceThousandsSep(string|null $sep)
- * @method string|null getTaxMode()
- * @method $this setTaxMode(string|null $mode)
- * @method int|null getUseParentValue()
- * @method $this setUseParentValue(int|null $value)
- * @method int|null getExcludeCategoryUrl()
- * @method $this setExcludeCategoryUrl(int|null $value)
- * @method string|null getNoImageUrl()
- * @method $this setNoImageUrl(string|null $url)
- * @method string|null getXmlHeader()
- * @method $this setXmlHeader(string|null $header)
- * @method string|null getXmlItemTemplate()
- * @method $this setXmlItemTemplate(string|null $template)
- * @method string|null getXmlFooter()
- * @method $this setXmlFooter(string|null $footer)
- * @method string|null getConditionGroups()
- * @method $this setConditionGroups(string|null $groups)
- * @method string|null getXmlItemTag()
- * @method $this setXmlItemTag(string|null $tag)
- * @method string|null getCsvColumns()
- * @method $this setCsvColumns(string|null $columns)
- * @method string|null getCsvDelimiter()
- * @method $this setCsvDelimiter(string|null $delimiter)
- * @method string|null getCsvEnclosure()
- * @method $this setCsvEnclosure(string|null $enclosure)
- * @method int|null getCsvIncludeHeader()
- * @method $this setCsvIncludeHeader(int|null $value)
- * @method string|null getJsonStructure()
- * @method $this setJsonStructure(string|null $structure)
- * @method string|null getJsonRootKey()
- * @method $this setJsonRootKey(string|null $key)
- * @method string|null getXmlStructure()
- * @method $this setXmlStructure(string|null $structure)
- * @method int getPriceCurrencySuffix()
- * @method $this setPriceCurrencySuffix(int $value)
- * @method string|null getLastGeneratedAt()
- * @method $this setLastGeneratedAt(string|null $datetime)
- * @method int|null getLastProductCount()
- * @method $this setLastProductCount(int|null $count)
- * @method int|null getLastFileSize()
- * @method $this setLastFileSize(int|null $size)
- * @method string getCreatedAt()
- * @method string getUpdatedAt()
  * @method Maho_FeedManager_Model_Resource_Feed getResource()
  * @method Maho_FeedManager_Model_Resource_Feed _getResource()
  */
@@ -234,5 +151,463 @@ class Maho_FeedManager_Model_Feed extends Mage_Rule_Model_Abstract
             self::CONFIGURABLE_MODE_CHILDREN_ONLY => 'Configurable children only (recommended)',
             self::CONFIGURABLE_MODE_BOTH => 'Both parent and children',
         ];
+    }
+
+    public function getFeedId(): ?int
+    {
+        $value = $this->getData('feed_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function getName(): ?string
+    {
+        $value = $this->getData('name');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setName(?string $value): static
+    {
+        return $this->setData('name', $value);
+    }
+
+    public function getPlatform(): ?string
+    {
+        $value = $this->getData('platform');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setPlatform(?string $value): static
+    {
+        return $this->setData('platform', $value);
+    }
+
+    public function getStoreId(): ?int
+    {
+        $value = $this->getData('store_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setStoreId(?int $value): static
+    {
+        return $this->setData('store_id', $value);
+    }
+
+    public function getIsEnabled(): ?int
+    {
+        $value = $this->getData('is_enabled');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setIsEnabled(?int $value): static
+    {
+        return $this->setData('is_enabled', $value);
+    }
+
+    public function getFilename(): ?string
+    {
+        $value = $this->getData('filename');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setFilename(?string $value): static
+    {
+        return $this->setData('filename', $value);
+    }
+
+    public function getFileFormat(): ?string
+    {
+        $value = $this->getData('file_format');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setFileFormat(?string $value): static
+    {
+        return $this->setData('file_format', $value);
+    }
+
+    public function getGenerationTime(): ?string
+    {
+        $value = $this->getData('generation_time');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setGenerationTime(?string $value): static
+    {
+        return $this->setData('generation_time', $value);
+    }
+
+    public function getConfigurableMode(): ?string
+    {
+        $value = $this->getData('configurable_mode');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setConfigurableMode(?string $value): static
+    {
+        return $this->setData('configurable_mode', $value);
+    }
+
+    public function getDestinationId(): ?int
+    {
+        $value = $this->getData('destination_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setDestinationId(?int $value): static
+    {
+        return $this->setData('destination_id', $value);
+    }
+
+    public function getAutoUpload(): ?int
+    {
+        $value = $this->getData('auto_upload');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setAutoUpload(?int $value): static
+    {
+        return $this->setData('auto_upload', $value);
+    }
+
+    public function getSchedule(): ?string
+    {
+        $value = $this->getData('schedule');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setSchedule(?string $value): static
+    {
+        return $this->setData('schedule', $value);
+    }
+
+    public function getProductFilters(): ?string
+    {
+        $value = $this->getData('product_filters');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setProductFilters(?string $value): static
+    {
+        return $this->setData('product_filters', $value);
+    }
+
+    public function getExcludeDisabled(): ?int
+    {
+        $value = $this->getData('exclude_disabled');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setExcludeDisabled(?int $value): static
+    {
+        return $this->setData('exclude_disabled', $value);
+    }
+
+    public function getExcludeOutOfStock(): ?int
+    {
+        $value = $this->getData('exclude_out_of_stock');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setExcludeOutOfStock(?int $value): static
+    {
+        return $this->setData('exclude_out_of_stock', $value);
+    }
+
+    public function getIncludeProductTypes(): ?string
+    {
+        $value = $this->getData('include_product_types');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setIncludeProductTypes(?string $value): static
+    {
+        return $this->setData('include_product_types', $value);
+    }
+
+    public function getConditionGroups(): ?string
+    {
+        $value = $this->getData('condition_groups');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setConditionGroups(?string $value): static
+    {
+        return $this->setData('condition_groups', $value);
+    }
+
+    public function getXmlHeader(): ?string
+    {
+        $value = $this->getData('xml_header');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setXmlHeader(?string $value): static
+    {
+        return $this->setData('xml_header', $value);
+    }
+
+    public function getXmlItemTemplate(): ?string
+    {
+        $value = $this->getData('xml_item_template');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setXmlItemTemplate(?string $value): static
+    {
+        return $this->setData('xml_item_template', $value);
+    }
+
+    public function getXmlFooter(): ?string
+    {
+        $value = $this->getData('xml_footer');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setXmlFooter(?string $value): static
+    {
+        return $this->setData('xml_footer', $value);
+    }
+
+    public function getXmlItemTag(): ?string
+    {
+        $value = $this->getData('xml_item_tag');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setXmlItemTag(?string $value): static
+    {
+        return $this->setData('xml_item_tag', $value);
+    }
+
+    public function getXmlStructure(): ?string
+    {
+        $value = $this->getData('xml_structure');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setXmlStructure(?string $value): static
+    {
+        return $this->setData('xml_structure', $value);
+    }
+
+    public function getCsvColumns(): ?string
+    {
+        $value = $this->getData('csv_columns');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setCsvColumns(?string $value): static
+    {
+        return $this->setData('csv_columns', $value);
+    }
+
+    public function getCsvDelimiter(): ?string
+    {
+        $value = $this->getData('csv_delimiter');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setCsvDelimiter(?string $value): static
+    {
+        return $this->setData('csv_delimiter', $value);
+    }
+
+    public function getCsvEnclosure(): ?string
+    {
+        $value = $this->getData('csv_enclosure');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setCsvEnclosure(?string $value): static
+    {
+        return $this->setData('csv_enclosure', $value);
+    }
+
+    public function getCsvIncludeHeader(): ?int
+    {
+        $value = $this->getData('csv_include_header');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setCsvIncludeHeader(?int $value): static
+    {
+        return $this->setData('csv_include_header', $value);
+    }
+
+    public function getJsonStructure(): ?string
+    {
+        $value = $this->getData('json_structure');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setJsonStructure(?string $value): static
+    {
+        return $this->setData('json_structure', $value);
+    }
+
+    public function getJsonRootKey(): ?string
+    {
+        $value = $this->getData('json_root_key');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setJsonRootKey(?string $value): static
+    {
+        return $this->setData('json_root_key', $value);
+    }
+
+    public function getFormatPreset(): ?string
+    {
+        $value = $this->getData('format_preset');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setFormatPreset(?string $value): static
+    {
+        return $this->setData('format_preset', $value);
+    }
+
+    public function getPriceCurrency(): ?string
+    {
+        $value = $this->getData('price_currency');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setPriceCurrency(?string $value): static
+    {
+        return $this->setData('price_currency', $value);
+    }
+
+    public function getPriceDecimals(): ?int
+    {
+        $value = $this->getData('price_decimals');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setPriceDecimals(?int $value): static
+    {
+        return $this->setData('price_decimals', $value);
+    }
+
+    public function getPriceDecimalPoint(): ?string
+    {
+        $value = $this->getData('price_decimal_point');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setPriceDecimalPoint(?string $value): static
+    {
+        return $this->setData('price_decimal_point', $value);
+    }
+
+    public function getPriceThousandsSep(): ?string
+    {
+        $value = $this->getData('price_thousands_sep');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setPriceThousandsSep(?string $value): static
+    {
+        return $this->setData('price_thousands_sep', $value);
+    }
+
+    public function getPriceCurrencySuffix(): ?int
+    {
+        $value = $this->getData('price_currency_suffix');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setPriceCurrencySuffix(?int $value): static
+    {
+        return $this->setData('price_currency_suffix', $value);
+    }
+
+    public function getTaxMode(): ?string
+    {
+        $value = $this->getData('tax_mode');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setTaxMode(?string $value): static
+    {
+        return $this->setData('tax_mode', $value);
+    }
+
+    public function getUseParentValue(): ?int
+    {
+        $value = $this->getData('use_parent_value');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setUseParentValue(?int $value): static
+    {
+        return $this->setData('use_parent_value', $value);
+    }
+
+    public function getExcludeCategoryUrl(): ?int
+    {
+        $value = $this->getData('exclude_category_url');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setExcludeCategoryUrl(?int $value): static
+    {
+        return $this->setData('exclude_category_url', $value);
+    }
+
+    public function getNoImageUrl(): ?string
+    {
+        $value = $this->getData('no_image_url');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setNoImageUrl(?string $value): static
+    {
+        return $this->setData('no_image_url', $value);
+    }
+
+    public function getLastGeneratedAt(): ?string
+    {
+        $value = $this->getData('last_generated_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setLastGeneratedAt(?string $value): static
+    {
+        return $this->setData('last_generated_at', $value);
+    }
+
+    public function getLastProductCount(): ?int
+    {
+        $value = $this->getData('last_product_count');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setLastProductCount(?int $value): static
+    {
+        return $this->setData('last_product_count', $value);
+    }
+
+    public function getLastFileSize(): ?int
+    {
+        $value = $this->getData('last_file_size');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setLastFileSize(?int $value): static
+    {
+        return $this->setData('last_file_size', $value);
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        $value = $this->getData('created_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        $value = $this->getData('updated_at');
+        return $value === null ? null : (string) $value;
     }
 }

--- a/app/code/core/Maho/FeedManager/Model/Generator/ProductWriterTrait.php
+++ b/app/code/core/Maho/FeedManager/Model/Generator/ProductWriterTrait.php
@@ -995,7 +995,7 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
             }
 
             $this->_log = Mage::getModel('feedmanager/log');
-            $this->_log->setFeedId($this->_feed->getId())
+            $this->_log->setFeedId((int) $this->_feed->getId())
                 ->setStatus(Maho_FeedManager_Model_Log::STATUS_RUNNING)
                 ->setStartedAt(Mage::app()->getLocale()->formatDateForDb('now'))
                 ->save();

--- a/app/code/core/Maho/FeedManager/Model/Log.php
+++ b/app/code/core/Maho/FeedManager/Model/Log.php
@@ -17,33 +17,6 @@ declare(strict_types=1);
  * - Recording methods (addError, recordUploadSuccess): Append to internal arrays, save on demand
  * - Duration methods (getDuration, getDurationFormatted): Return 0 or formatted string on failure
  *
- * @method int getLogId()
- * @method int getFeedId()
- * @method $this setFeedId(int $feedId)
- * @method string getStartedAt()
- * @method $this setStartedAt(string $datetime)
- * @method string|null getCompletedAt()
- * @method $this setCompletedAt(string|null $datetime)
- * @method string getStatus()
- * @method $this setStatus(string $status)
- * @method int|null getProductCount()
- * @method $this setProductCount(int|null $count)
- * @method int getErrorCount()
- * @method $this setErrorCount(int $count)
- * @method string|null getErrors()
- * @method $this setErrors(string|null $errors)
- * @method string|null getFilePath()
- * @method $this setFilePath(string|null $path)
- * @method int|null getFileSize()
- * @method $this setFileSize(int|null $size)
- * @method string|null getUploadStatus()
- * @method $this setUploadStatus(string|null $status)
- * @method string|null getUploadedAt()
- * @method $this setUploadedAt(string|null $datetime)
- * @method string|null getUploadMessage()
- * @method $this setUploadMessage(string|null $message)
- * @method int|null getDestinationId()
- * @method $this setDestinationId(int|null $id)
  * @method Maho_FeedManager_Model_Resource_Log getResource()
  * @method Maho_FeedManager_Model_Resource_Log _getResource()
  */
@@ -316,5 +289,154 @@ class Maho_FeedManager_Model_Log extends Mage_Core_Model_Abstract
         }
         $destination = Mage::getModel('feedmanager/destination')->load($this->getDestinationId());
         return $destination->getId() ? $destination->getName() : null;
+    }
+
+    public function getLogId(): ?int
+    {
+        $value = $this->getData('log_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function getFeedId(): ?int
+    {
+        $value = $this->getData('feed_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setFeedId(?int $value): static
+    {
+        return $this->setData('feed_id', $value);
+    }
+
+    public function getStartedAt(): ?string
+    {
+        $value = $this->getData('started_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setStartedAt(?string $value): static
+    {
+        return $this->setData('started_at', $value);
+    }
+
+    public function getCompletedAt(): ?string
+    {
+        $value = $this->getData('completed_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setCompletedAt(?string $value): static
+    {
+        return $this->setData('completed_at', $value);
+    }
+
+    public function getStatus(): ?string
+    {
+        $value = $this->getData('status');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setStatus(?string $value): static
+    {
+        return $this->setData('status', $value);
+    }
+
+    public function getProductCount(): ?int
+    {
+        $value = $this->getData('product_count');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setProductCount(?int $value): static
+    {
+        return $this->setData('product_count', $value);
+    }
+
+    public function getErrorCount(): ?int
+    {
+        $value = $this->getData('error_count');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setErrorCount(?int $value): static
+    {
+        return $this->setData('error_count', $value);
+    }
+
+    public function getErrors(): ?string
+    {
+        $value = $this->getData('errors');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setErrors(?string $value): static
+    {
+        return $this->setData('errors', $value);
+    }
+
+    public function getFilePath(): ?string
+    {
+        $value = $this->getData('file_path');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setFilePath(?string $value): static
+    {
+        return $this->setData('file_path', $value);
+    }
+
+    public function getFileSize(): ?int
+    {
+        $value = $this->getData('file_size');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setFileSize(?int $value): static
+    {
+        return $this->setData('file_size', $value);
+    }
+
+    public function getUploadStatus(): ?string
+    {
+        $value = $this->getData('upload_status');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setUploadStatus(?string $value): static
+    {
+        return $this->setData('upload_status', $value);
+    }
+
+    public function getUploadedAt(): ?string
+    {
+        $value = $this->getData('uploaded_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setUploadedAt(?string $value): static
+    {
+        return $this->setData('uploaded_at', $value);
+    }
+
+    public function getUploadMessage(): ?string
+    {
+        $value = $this->getData('upload_message');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setUploadMessage(?string $value): static
+    {
+        return $this->setData('upload_message', $value);
+    }
+
+    public function getDestinationId(): ?int
+    {
+        $value = $this->getData('destination_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setDestinationId(?int $value): static
+    {
+        return $this->setData('destination_id', $value);
     }
 }

--- a/app/code/core/Maho/FeedManager/controllers/Adminhtml/Feedmanager/FeedController.php
+++ b/app/code/core/Maho/FeedManager/controllers/Adminhtml/Feedmanager/FeedController.php
@@ -190,7 +190,7 @@ class Maho_FeedManager_Adminhtml_Feedmanager_FeedController extends Mage_Adminht
             }
 
             $mapping = Mage::getModel('feedmanager/attributeMapping');
-            $mapping->setFeedId($feed->getId())
+            $mapping->setFeedId((int) $feed->getId())
                 ->setFeedAttribute($feedAttribute)
                 ->setSourceType($config['source_type'])
                 ->setSourceValue($config['source_value'] ?? '')

--- a/app/code/core/Maho/Giftcard/Model/Giftcard.php
+++ b/app/code/core/Maho/Giftcard/Model/Giftcard.php
@@ -10,32 +10,6 @@ declare(strict_types=1);
 
 /**
  * Gift Card Model
- *
- * @method string getCode()
- * @method $this setCode(string $value)
- * @method string getStatus()
- * @method $this setStatus(string $value)
- * @method $this setBalance(float $value)
- * @method float getInitialBalance()
- * @method $this setInitialBalance(float $value)
- * @method string getRecipientName()
- * @method $this setRecipientName(string $value)
- * @method string getRecipientEmail()
- * @method $this setRecipientEmail(string $value)
- * @method string getSenderName()
- * @method $this setSenderName(string $value)
- * @method string getSenderEmail()
- * @method $this setSenderEmail(string $value)
- * @method string getMessage()
- * @method $this setMessage(string $value)
- * @method int getPurchaseOrderId()
- * @method $this setPurchaseOrderId(int $value)
- * @method int getPurchaseOrderItemId()
- * @method $this setPurchaseOrderItemId(int $value)
- * @method string getExpiresAt()
- * @method $this setExpiresAt(string $value)
- * @method string getCreatedAt()
- * @method string getUpdatedAt()
  */
 class Maho_Giftcard_Model_Giftcard extends Mage_Core_Model_Abstract
 {
@@ -482,5 +456,143 @@ class Maho_Giftcard_Model_Giftcard extends Mage_Core_Model_Abstract
         return Mage::getResourceModel('giftcard/history_collection')
             ->addFieldToFilter('giftcard_id', $this->getId())
             ->setOrder('created_at', 'DESC');
+    }
+
+    public function getCode(): ?string
+    {
+        $value = $this->getData('code');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setCode(?string $value): static
+    {
+        return $this->setData('code', $value);
+    }
+
+    public function getStatus(): ?string
+    {
+        $value = $this->getData('status');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setStatus(?string $value): static
+    {
+        return $this->setData('status', $value);
+    }
+
+    public function setBalance(?float $value): static
+    {
+        return $this->setData('balance', $value);
+    }
+
+    public function getInitialBalance(): ?float
+    {
+        $value = $this->getData('initial_balance');
+        return $value === null ? null : (float) $value;
+    }
+
+    public function setInitialBalance(?float $value): static
+    {
+        return $this->setData('initial_balance', $value);
+    }
+
+    public function getRecipientName(): ?string
+    {
+        $value = $this->getData('recipient_name');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setRecipientName(?string $value): static
+    {
+        return $this->setData('recipient_name', $value);
+    }
+
+    public function getRecipientEmail(): ?string
+    {
+        $value = $this->getData('recipient_email');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setRecipientEmail(?string $value): static
+    {
+        return $this->setData('recipient_email', $value);
+    }
+
+    public function getSenderName(): ?string
+    {
+        $value = $this->getData('sender_name');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setSenderName(?string $value): static
+    {
+        return $this->setData('sender_name', $value);
+    }
+
+    public function getSenderEmail(): ?string
+    {
+        $value = $this->getData('sender_email');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setSenderEmail(?string $value): static
+    {
+        return $this->setData('sender_email', $value);
+    }
+
+    public function getMessage(): ?string
+    {
+        $value = $this->getData('message');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setMessage(?string $value): static
+    {
+        return $this->setData('message', $value);
+    }
+
+    public function getPurchaseOrderId(): ?int
+    {
+        $value = $this->getData('purchase_order_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setPurchaseOrderId(?int $value): static
+    {
+        return $this->setData('purchase_order_id', $value);
+    }
+
+    public function getPurchaseOrderItemId(): ?int
+    {
+        $value = $this->getData('purchase_order_item_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setPurchaseOrderItemId(?int $value): static
+    {
+        return $this->setData('purchase_order_item_id', $value);
+    }
+
+    public function getExpiresAt(): ?string
+    {
+        $value = $this->getData('expires_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setExpiresAt(?string $value): static
+    {
+        return $this->setData('expires_at', $value);
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        $value = $this->getData('created_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        $value = $this->getData('updated_at');
+        return $value === null ? null : (string) $value;
     }
 }

--- a/app/code/core/Maho/Giftcard/Model/History.php
+++ b/app/code/core/Maho/Giftcard/Model/History.php
@@ -10,24 +10,6 @@ declare(strict_types=1);
 
 /**
  * Gift Card History Model
- *
- * @method int getGiftcardId()
- * @method $this setGiftcardId(int $value)
- * @method string getAction()
- * @method $this setAction(string $value)
- * @method float getBaseAmount()
- * @method $this setBaseAmount(float $value)
- * @method float getBalanceBefore()
- * @method $this setBalanceBefore(float $value)
- * @method float getBalanceAfter()
- * @method $this setBalanceAfter(float $value)
- * @method int getOrderId()
- * @method $this setOrderId(int $value)
- * @method int getAdminUserId()
- * @method $this setAdminUserId(int $value)
- * @method string getComment()
- * @method $this setComment(string $value)
- * @method string getCreatedAt()
  */
 class Maho_Giftcard_Model_History extends Mage_Core_Model_Abstract
 {
@@ -59,5 +41,99 @@ class Maho_Giftcard_Model_History extends Mage_Core_Model_Abstract
         }
 
         return Mage::getModel('sales/order')->load($this->getOrderId());
+    }
+
+    public function getGiftcardId(): ?int
+    {
+        $value = $this->getData('giftcard_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setGiftcardId(?int $value): static
+    {
+        return $this->setData('giftcard_id', $value);
+    }
+
+    public function getAction(): ?string
+    {
+        $value = $this->getData('action');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setAction(?string $value): static
+    {
+        return $this->setData('action', $value);
+    }
+
+    public function getBaseAmount(): ?float
+    {
+        $value = $this->getData('base_amount');
+        return $value === null ? null : (float) $value;
+    }
+
+    public function setBaseAmount(?float $value): static
+    {
+        return $this->setData('base_amount', $value);
+    }
+
+    public function getBalanceBefore(): ?float
+    {
+        $value = $this->getData('balance_before');
+        return $value === null ? null : (float) $value;
+    }
+
+    public function setBalanceBefore(?float $value): static
+    {
+        return $this->setData('balance_before', $value);
+    }
+
+    public function getBalanceAfter(): ?float
+    {
+        $value = $this->getData('balance_after');
+        return $value === null ? null : (float) $value;
+    }
+
+    public function setBalanceAfter(?float $value): static
+    {
+        return $this->setData('balance_after', $value);
+    }
+
+    public function getOrderId(): ?int
+    {
+        $value = $this->getData('order_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setOrderId(?int $value): static
+    {
+        return $this->setData('order_id', $value);
+    }
+
+    public function getAdminUserId(): ?int
+    {
+        $value = $this->getData('admin_user_id');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function setAdminUserId(?int $value): static
+    {
+        return $this->setData('admin_user_id', $value);
+    }
+
+    public function getComment(): ?string
+    {
+        $value = $this->getData('comment');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function setComment(?string $value): static
+    {
+        return $this->setData('comment', $value);
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        $value = $this->getData('created_at');
+        return $value === null ? null : (string) $value;
     }
 }

--- a/app/code/core/Maho/Queue/Model/Message.php
+++ b/app/code/core/Maho/Queue/Model/Message.php
@@ -13,18 +13,6 @@ use Maho\Queue\Transport\DbTransport;
 /**
  * Grid-backing model over the maho_queue_message table. Rows are written by
  * Maho\Queue\Transport\DbTransport, never through this model.
- *
- * @method string getQueue()
- * @method string getStatus()
- * @method string getMessageClass()
- * @method string getBody()
- * @method ?string getErrorMessage()
- * @method int getRetries()
- * @method string getAvailableAt()
- * @method ?string getClaimedAt()
- * @method ?string getProcessedAt()
- * @method string getCreatedAt()
- * @method string getUpdatedAt()
  */
 class Maho_Queue_Model_Message extends Mage_Core_Model_Abstract
 {
@@ -52,5 +40,71 @@ class Maho_Queue_Model_Message extends Mage_Core_Model_Abstract
             self::STATUS_FAILED => $helper->__('Failed'),
             self::STATUS_COMPLETED => $helper->__('Completed'),
         ];
+    }
+
+    public function getQueue(): ?string
+    {
+        $value = $this->getData('queue');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getStatus(): ?string
+    {
+        $value = $this->getData('status');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getMessageClass(): ?string
+    {
+        $value = $this->getData('message_class');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getBody(): ?string
+    {
+        $value = $this->getData('body');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        $value = $this->getData('error_message');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getRetries(): ?int
+    {
+        $value = $this->getData('retries');
+        return $value === null ? null : (int) $value;
+    }
+
+    public function getAvailableAt(): ?string
+    {
+        $value = $this->getData('available_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getClaimedAt(): ?string
+    {
+        $value = $this->getData('claimed_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getProcessedAt(): ?string
+    {
+        $value = $this->getData('processed_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        $value = $this->getData('created_at');
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        $value = $this->getData('updated_at');
+        return $value === null ? null : (string) $value;
     }
 }

--- a/tests/Backend/Unit/FeedManager/Model/GeneratorTest.php
+++ b/tests/Backend/Unit/FeedManager/Model/GeneratorTest.php
@@ -36,7 +36,7 @@ function createTestFeed(string $format): Maho_FeedManager_Model_Feed
 
     foreach ($mappings as $mappingData) {
         $mapping = Mage::getModel('feedmanager/attributeMapping');
-        $mapping->setFeedId($feed->getId());
+        $mapping->setFeedId((int) $feed->getId());
         foreach ($mappingData as $key => $value) {
             $mapping->setData($key, $value);
         }


### PR DESCRIPTION
Wave 1 of #1283. Replaces 312 magic accessors with real typed methods across the 14 models under
`app/code/core/Maho/`, leaving 15 annotations that are correct to keep.

`__call()` costs 6.7x a real method call (126.0 ns against 18.9 ns, measured over 3M calls). The
annotations also declared types the objects never held: `lib/Maho/Db/Adapter/Pdo/Mysql.php:266`
sets `PDO::ATTR_EMULATE_PREPARES = true`, so every column arrives as a string and
`@method int getStoreId()` described a value that was `'1'`.

Every method follows one shape:

```php
public function getStoreId(): ?int
{
    $value = $this->getData('store_id');
    return $value === null ? null : (int) $value;
}

public function setStoreId(?int $value): static
{
    return $this->setData('store_id', $value);
}
```

Types come from the column definition in each module's `sql/schema.php`, which loads in memory
with no database connection. Getters are nullable because a new unsaved model holds no data, so
even a `NOT NULL` column reads as `null` before the first save. Bodies call `getData()` and never
`_getData()`, so any ancestor override of `getData()` still runs.

Three findings came out of the conversion:

- `EmailSequence::_beforeSave()` tested `getCouponSalesRuleId() === '' || === 0`. With a typed
  getter the first branch is unreachable, and `=== 0` already covers it because `(int) '' === 0`.
  Collapsed to one branch, same behaviour.
- Three call sites passed a boolean into a `SMALLINT` column (`setIsActive(true)`,
  `setGenerateCoupon(false)`). Changed to `1` and `0`, which is what the column stores.
- `gzip_compression` on the feed table had no annotation but is read in six places, including
  `getOutputFilePath()` and `getOutputUrl()`. It and the four `notification_*` columns are now
  typed as well.

Two accessors were deliberately not generated:

- `Segment::getWebsiteIds()`. `Mage_Rule_Model_Abstract` implements it for real and lazy-loads
  through the resource, so generating over it would have shadowed that. Its `@method string`
  annotation was wrong (the method can return an array) and is removed, so static analysis now
  sees the inherited method instead.
- `conditions_serialized` on the feed table. It belongs to `Mage_Rule_Model_Abstract`, which
  declares it and drives it in `_beforeSave()` and `getConditions()`. Converting it on one of five
  children would put it at the wrong layer. It belongs in the wave that converts the parent.

The 15 remaining annotations are the `getResource()` / `_getResource()` pairs, which narrow the
return type of methods that already exist on `Mage_Core_Model_Abstract`, plus
`getAutoEmailTrigger` (no such column) and the blog post `getImage` EAV attribute.

`composer lint` passes: cs-fixer, rector, and PHPStan all clean, with no baseline changes.
Separately, a script re-derived every method from `sql/schema.php` and confirmed that each one
reads the column its name maps to under `_underscore()`, and that its cast matches the column
type. All 14 classes were then instantiated on a booted app to check the round trip on
database-shaped input: `'25.5000'` becomes `float(25.5)`, `'42'` becomes `int(42)`, and an unset
column stays `null`.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->