### PR TITLE
Kept the outgoing HTTP span open until the response body is read

### DIFF
--- a/.phpstan.dist.neon
+++ b/.phpstan.dist.neon
@@ -34,9 +34,3 @@ parameters:
 
     ignoreErrors:
         - identifier: missingType.iterableValue
-
-        # OpenTelemetry SDK is an optional dependency (in suggest, not require)
-        -
-            identifier: class.notFound
-            paths:
-                - app/code/core/Maho/OpenTelemetry/

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -363,7 +363,10 @@ class Mage_Core_Model_App
         } catch (Throwable $e) {
             $dispatchError = true;
             $rootSpan?->recordException($e);
-            $rootSpan?->setStatus('error', $e->getMessage());
+            // Class only, like the DB, HTTP and queue paths: a message can carry SQL,
+            // customer data or credentials, and trace lists show it unredacted
+            $rootSpan?->setAttribute('error.type', $e::class);
+            $rootSpan?->setStatus('error', $e::class);
             throw $e;
         } finally {
             // Telemetry ships after the response reached the client. On the error path do

--- a/app/code/core/Maho/OpenTelemetry/Model/Http/TracedClient.php
+++ b/app/code/core/Maho/OpenTelemetry/Model/Http/TracedClient.php
@@ -10,6 +10,8 @@
 
 declare(strict_types=1);
 
+use Symfony\Component\HttpClient\Response\ResponseStream;
+use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
@@ -79,11 +81,13 @@ class Maho_OpenTelemetry_Model_Http_TracedClient implements HttpClientInterface
         if (!empty($urlParts['port'])) {
             $attributes['server.port'] = $urlParts['port'];
         }
-        $span = $this->_tracer->startSpan($method, $attributes, 'client');
+        // Detached: the span outlives this call, so it must not adopt what the
+        // caller does between issuing the request and reading the response
+        $span = $this->_tracer->startDetachedSpan($method, $attributes, 'client');
 
         try {
             // Inject W3C Trace Context headers for distributed tracing
-            $propagationHeaders = $this->_tracer->getTracePropagationHeaders($urlParts['host'] ?? '');
+            $propagationHeaders = $this->_tracer->getTracePropagationHeaders($urlParts['host'] ?? '', $span);
             if (!empty($propagationHeaders)) {
                 $options['headers'] = array_merge(
                     $options['headers'] ?? [],
@@ -91,21 +95,18 @@ class Maho_OpenTelemetry_Model_Http_TracedClient implements HttpClientInterface
                 );
             }
 
-            $response = $this->_client->request($method, $url, $options);
-
-            // Add response data
-            $statusCode = $response->getStatusCode();
-            $span->setAttribute('http.response.status_code', $statusCode);
-            $span->setStatus($statusCode >= 500 ? 'error' : 'ok');
-
-            return $response;
+            // The response closes the span once the body is consumed. Reading the status
+            // here would stop the clock at the headers and serialize concurrent requests.
+            return new Maho_OpenTelemetry_Model_Http_TracedResponse(
+                $this->_client->request($method, $url, $options),
+                $span,
+            );
         } catch (\Throwable $e) {
             $span->recordException($e);
             $span->setAttribute('error.type', $e::class);
             $span->setStatus('error', $e::class);
-            throw $e;
-        } finally {
             $span->end();
+            throw $e;
         }
     }
 
@@ -119,7 +120,56 @@ class Maho_OpenTelemetry_Model_Http_TracedClient implements HttpClientInterface
             throw new \RuntimeException('TracedHttpClient not properly initialized');
         }
 
-        return $this->_client->stream($responses, $timeout);
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
+
+        // The wrapped client only recognizes its own responses, so hand it the
+        // originals and map the chunks back to the decorators on the way out.
+        // $unwrapped keeps every inner response alive, so its object id stays its own.
+        $unwrapped = [];
+        $decorators = [];
+        foreach ($responses as $response) {
+            if ($response instanceof Maho_OpenTelemetry_Model_Http_TracedResponse) {
+                $inner = $response->getWrappedResponse();
+                $decorators[spl_object_id($inner)] = $response;
+                $unwrapped[] = $inner;
+            } else {
+                $unwrapped[] = $response;
+            }
+        }
+
+        return new ResponseStream(
+            self::_mapChunks($this->_client->stream($unwrapped, $timeout), $decorators),
+        );
+    }
+
+    /**
+     * Re-key the wrapped client's chunks onto the decorators, closing each span
+     * when its response completes or fails
+     *
+     * @param array<int, Maho_OpenTelemetry_Model_Http_TracedResponse> $decorators By inner response object id
+     * @return \Generator<ResponseInterface, ChunkInterface, mixed, void>
+     */
+    private static function _mapChunks(ResponseStreamInterface $stream, array $decorators): \Generator
+    {
+        foreach ($stream as $response => $chunk) {
+            $decorator = $decorators[spl_object_id($response)] ?? null;
+
+            try {
+                $isLast = $chunk->isLast();
+            } catch (\Throwable $e) {
+                // An error chunk throws on every accessor
+                $decorator?->closeSpan($e);
+                throw $e;
+            }
+
+            if ($isLast) {
+                $decorator?->closeSpan();
+            }
+
+            yield ($decorator ?? $response) => $chunk;
+        }
     }
 
     /**

--- a/app/code/core/Maho/OpenTelemetry/Model/Http/TracedResponse.php
+++ b/app/code/core/Maho/OpenTelemetry/Model/Http/TracedResponse.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Symfony HTTP response decorator that keeps the client span open until the body is consumed.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Maho_OpenTelemetry
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpClient\Response\StreamableInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Symfony responses are lazy: the body is transferred during getContent()/toArray()/
+ * stream(), which is also where a transport failure surfaces. Ending the span at
+ * request() would time the connection alone and miss those failures.
+ */
+class Maho_OpenTelemetry_Model_Http_TracedResponse implements ResponseInterface, StreamableInterface
+{
+    private bool $_closed = false;
+
+    public function __construct(
+        private readonly ResponseInterface $_response,
+        private readonly Maho_OpenTelemetry_Model_Span $_span,
+    ) {}
+
+    /**
+     * The decorated response, for handing back to the client's stream()
+     */
+    public function getWrappedResponse(): ResponseInterface
+    {
+        return $this->_response;
+    }
+
+    /**
+     * End the span, recording the outcome. Idempotent: body consumption,
+     * cancellation, stream completion and destruction all call it.
+     */
+    public function closeSpan(?\Throwable $error = null): void
+    {
+        if ($this->_closed) {
+            return;
+        }
+        $this->_closed = true;
+
+        // Non-blocking, unlike getStatusCode(): 0 until the headers arrived
+        $statusCode = (int) ($this->_response->getInfo('http_code') ?: 0);
+        if ($statusCode > 0) {
+            $this->_span->setAttribute('http.response.status_code', $statusCode);
+        }
+
+        if ($error !== null) {
+            $this->_span->recordException($error);
+            $this->_span->setAttribute('error.type', $error::class);
+            $this->_span->setStatus('error', $error::class);
+        } elseif ($statusCode >= 500) {
+            $this->_span->setStatus('error', 'HTTP ' . $statusCode);
+        } elseif ($statusCode > 0) {
+            $this->_span->setStatus('ok');
+        }
+        // Abandoned before its headers arrived: status stays unset
+
+        $this->_span->end();
+    }
+
+    #[\Override]
+    public function getStatusCode(): int
+    {
+        return $this->_response->getStatusCode();
+    }
+
+    #[\Override]
+    public function getHeaders(bool $throw = true): array
+    {
+        return $this->_response->getHeaders($throw);
+    }
+
+    #[\Override]
+    public function getContent(bool $throw = true): string
+    {
+        try {
+            $content = $this->_response->getContent($throw);
+        } catch (\Throwable $e) {
+            $this->closeSpan($e);
+            throw $e;
+        }
+
+        $this->closeSpan();
+        return $content;
+    }
+
+    #[\Override]
+    public function toArray(bool $throw = true): array
+    {
+        try {
+            $data = $this->_response->toArray($throw);
+        } catch (\Throwable $e) {
+            $this->closeSpan($e);
+            throw $e;
+        }
+
+        $this->closeSpan();
+        return $data;
+    }
+
+    #[\Override]
+    public function cancel(): void
+    {
+        $this->_response->cancel();
+        $this->closeSpan();
+    }
+
+    #[\Override]
+    public function getInfo(?string $type = null): mixed
+    {
+        return $this->_response->getInfo($type);
+    }
+
+    /**
+     * @return resource
+     */
+    #[\Override]
+    public function toStream(bool $throw = true)
+    {
+        if (!$this->_response instanceof StreamableInterface) {
+            throw new \LogicException(sprintf('%s cannot be converted to a stream.', get_debug_type($this->_response)));
+        }
+
+        return $this->_response->toStream($throw);
+    }
+
+    public function __destruct()
+    {
+        $this->closeSpan();
+    }
+}

--- a/app/code/core/Maho/OpenTelemetry/Model/Span.php
+++ b/app/code/core/Maho/OpenTelemetry/Model/Span.php
@@ -42,11 +42,17 @@ class Maho_OpenTelemetry_Model_Span
      * Activation is required so that child spans created later will automatically
      * be nested under this span. Without activation, all spans appear as root spans.
      *
+     * @param bool $activate False for a span ended after this call returns, so the
+     *        unrelated work done meanwhile is not nested under it
      * @return $this
      */
-    public function setSdkSpan(SpanInterface $span): self
+    public function setSdkSpan(SpanInterface $span, bool $activate = true): self
     {
         $this->_sdkSpan = $span;
+
+        if (!$activate) {
+            return $this;
+        }
 
         // Activate the span so child spans are nested correctly
         try {

--- a/app/code/core/Maho/OpenTelemetry/Model/Tracer.php
+++ b/app/code/core/Maho/OpenTelemetry/Model/Tracer.php
@@ -28,8 +28,10 @@ use OpenTelemetry\SDK\Propagation\PropagatorFactory;
 use OpenTelemetry\SDK\Trace\SamplerFactory;
 use OpenTelemetry\Contrib\Otlp\Protocols;
 use OpenTelemetry\SDK\Logs\LoggerProvider;
+use OpenTelemetry\SDK\Logs\LoggerProviderInterface;
 use OpenTelemetry\SDK\Logs\Processor\BatchLogRecordProcessor;
 use OpenTelemetry\SDK\Metrics\MeterProvider;
+use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
 use OpenTelemetry\SDK\Metrics\MetricReader\ExportingReader;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Trace\TracerProvider;
@@ -52,6 +54,13 @@ class Maho_OpenTelemetry_Model_Tracer
      * Active span stack
      */
     private array $_spanStack = [];
+
+    /**
+     * Spans that outlive the call which started them, closed by flush() if still open
+     *
+     * @var array<int, Maho_OpenTelemetry_Model_Span>
+     */
+    private array $_detachedSpans = [];
 
     /**
      * Is tracer enabled and initialized
@@ -103,12 +112,12 @@ class Maho_OpenTelemetry_Model_Tracer
     /**
      * OpenTelemetry LoggerProvider for OTLP log export (null unless enabled)
      */
-    private ?LoggerProvider $_loggerProvider = null;
+    private ?LoggerProviderInterface $_loggerProvider = null;
 
     /**
      * OpenTelemetry MeterProvider for OTLP metric export (null unless enabled)
      */
-    private ?MeterProvider $_meterProvider = null;
+    private ?MeterProviderInterface $_meterProvider = null;
 
     /**
      * Histogram for http.server.request.duration (lazily created)
@@ -313,6 +322,25 @@ class Maho_OpenTelemetry_Model_Tracer
      */
     public function startSpan(string $name, array $attributes = [], ?string $kind = null): Maho_OpenTelemetry_Model_Span
     {
+        return $this->_startChildSpan($name, $attributes, $kind, detached: false);
+    }
+
+    /**
+     * Start a child span the caller ends after this call has returned
+     *
+     * Keeps the parent it is created with, but is not made the current span: an HTTP
+     * body is consumed later, and the caller's work meanwhile must not nest under the
+     * request. flush() closes any still open when the request ends.
+     *
+     * @param string|null $kind Span kind: 'server', 'client', 'producer', 'consumer' or null for internal
+     */
+    public function startDetachedSpan(string $name, array $attributes = [], ?string $kind = null): Maho_OpenTelemetry_Model_Span
+    {
+        return $this->_startChildSpan($name, $attributes, $kind, detached: true);
+    }
+
+    private function _startChildSpan(string $name, array $attributes, ?string $kind, bool $detached): Maho_OpenTelemetry_Model_Span
+    {
         if (!$this->_enabled || !$this->_tracer || !$this->_rootStarted) {
             return $this->_createNullSpan();
         }
@@ -331,8 +359,12 @@ class Maho_OpenTelemetry_Model_Tracer
             $sdkSpan = $spanBuilder->startSpan();
 
             // Wrap in our Span model
-            $span = $this->_createSpan($sdkSpan);
-            $this->_spanStack[] = $span;
+            $span = $this->_createSpan($sdkSpan, activate: !$detached);
+            if ($detached) {
+                $this->_detachedSpans[] = $span;
+            } else {
+                $this->_spanStack[] = $span;
+            }
 
             return $span;
         } catch (\Throwable $e) {
@@ -400,7 +432,7 @@ class Maho_OpenTelemetry_Model_Tracer
     /**
      * Get the LoggerProvider for OTLP log export (null unless log export is enabled)
      */
-    public function getLoggerProvider(): ?LoggerProvider
+    public function getLoggerProvider(): ?LoggerProviderInterface
     {
         return $this->_loggerProvider;
     }
@@ -490,8 +522,11 @@ class Maho_OpenTelemetry_Model_Tracer
     /**
      * Build an OTLP transport for one signal, honoring OTEL_EXPORTER_OTLP_PROTOCOL.
      * maxRetries 1: exports are request-scoped, so a retry only holds the worker.
+     * Protected so the export pipeline can be exercised without a collector.
+     *
+     * @return TransportInterface<string>
      */
-    private function _createTransport(string $endpoint, string $signal): TransportInterface
+    protected function _createTransport(string $endpoint, string $signal): TransportInterface
     {
         $helper = Mage::helper('opentelemetry');
         $protocol = $helper->getProtocol($signal);
@@ -542,6 +577,8 @@ class Maho_OpenTelemetry_Model_Tracer
 
     /**
      * Map a span kind string to the SDK SpanKind constant
+     *
+     * @return SpanKind::KIND_*
      */
     private function _mapSpanKind(?string $kind): int
     {
@@ -573,14 +610,16 @@ class Maho_OpenTelemetry_Model_Tracer
      * Get W3C Trace Context propagation headers
      *
      * @param string $host Destination host; baggage only goes to listed ones
+     * @param Maho_OpenTelemetry_Model_Span|null $span Span the receiver should parent to,
+     *        defaulting to the active one. A detached client span is not the active one.
      */
-    public function getTracePropagationHeaders(string $host = ''): array
+    public function getTracePropagationHeaders(string $host = '', ?Maho_OpenTelemetry_Model_Span $span = null): array
     {
         if (!$this->_enabled) {
             return [];
         }
 
-        $sdkSpan = $this->getActiveSpan()?->getSdkSpan();
+        $sdkSpan = ($span ?? $this->getActiveSpan())?->getSdkSpan();
         if (!$sdkSpan || !$this->_propagator || !$sdkSpan->getContext()->isValid()) {
             return [];
         }
@@ -619,6 +658,18 @@ class Maho_OpenTelemetry_Model_Tracer
     {
         if (!$this->_enabled || !$this->_tracerProvider) {
             return;
+        }
+
+        // A response the caller never consumed still holds an open span, and its
+        // object may not be collected before the process ends
+        $detached = $this->_detachedSpans;
+        $this->_detachedSpans = [];
+        foreach ($detached as $span) {
+            try {
+                $span->end();
+            } catch (\Throwable) {
+                // Ignore errors ending unfinished spans
+            }
         }
 
         // End any remaining spans in reverse order (child spans first)
@@ -683,24 +734,31 @@ class Maho_OpenTelemetry_Model_Tracer
         for ($i = count($this->_spanStack) - 1; $i >= 0; $i--) {
             if ($this->_spanStack[$i] === $span) {
                 array_splice($this->_spanStack, $i, 1);
-                break;
+
+                // Root closed: shutdown functions must not open a new orphan trace
+                if ($this->_spanStack === []) {
+                    $this->_rootStarted = false;
+                }
+                return;
             }
         }
 
-        // Root closed: shutdown functions must not open a new orphan trace
-        if ($this->_spanStack === []) {
-            $this->_rootStarted = false;
+        foreach ($this->_detachedSpans as $i => $detached) {
+            if ($detached === $span) {
+                unset($this->_detachedSpans[$i]);
+                return;
+            }
         }
     }
 
     /**
      * Create a span wrapping an SDK span
      */
-    private function _createSpan(SpanInterface $sdkSpan): Maho_OpenTelemetry_Model_Span
+    private function _createSpan(SpanInterface $sdkSpan, bool $activate = true): Maho_OpenTelemetry_Model_Span
     {
         // Instantiate directly to avoid Profiler::start() → startSpan() recursion
         $span = new Maho_OpenTelemetry_Model_Span();
-        $span->setSdkSpan($sdkSpan);
+        $span->setSdkSpan($sdkSpan, $activate);
         $span->setTracer($this);
         return $span;
     }

--- a/app/code/core/Maho/OpenTelemetry/README.md
+++ b/app/code/core/Maho/OpenTelemetry/README.md
@@ -42,7 +42,7 @@ Traces appear in Grafana at http://localhost:3000 (Explore → Tempo).
 | `{METHOD} {module/controller/action}` | SERVER | Request root span, renamed after routing |
 | `{METHOD} {api_route}` | SERVER | Same for `/api/*`: the API Platform route name (REST, GraphQL, MCP) or `api/{type}` for the legacy servers |
 | `{OPERATION} {table}` | CLIENT | Every DB query. `db.query.text` carries the statement as executed (see Data safety) and can be switched off |
-| `{METHOD}` (HTTP client) | CLIENT | Outgoing requests via `\Maho\Http\Client::create()`; `url.full` is stripped of query string, fragment and userinfo |
+| `{METHOD}` (HTTP client) | CLIENT | Outgoing requests via `\Maho\Http\Client::create()`; `url.full` is stripped of query string, fragment and userinfo. Spans the whole exchange, from the request being issued to the body being read, so a failure raised while consuming the response lands on the span rather than after it |
 | `process {MessageClass}` | CONSUMER | One span per queue message, continuing the trace of the request that dispatched it; the payload is never recorded |
 | `BLOCK:*`, `OBSERVER:*`, `cron.job*`, `email.send`, `image.process`, `index.reindex`, `payment.*` | INTERNAL | High-level profiler timers |
 | `cache.*` | INTERNAL | Cache reads and writes, off by default |
@@ -134,6 +134,12 @@ or warning/notice-level PHP error messages (only fatal-class errors include the
 message text). Logged-in customers and admin users are identified by id alone
 (`enduser.id`), never by name or email. Credentials for the OTLP endpoint itself
 are stored encrypted (Authorization Header field).
+
+A failed span carries the exception class in `error.type` and in its status
+description, never the message. The `exception` event that accompanies it is the
+standard OTel one, so it does carry `exception.message` and
+`exception.stacktrace`: an unhandled failure is worth the detail, but treat the
+backend as holding whatever your code puts in exception messages.
 
 Two settings do export more, and both are named for what they do:
 

--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,9 @@
         "laminas/laminas-soap": "^2.10",
         "laminas/laminas-xmlrpc": "^3.0",
         "symfony/mcp-bundle": "^0.12",
-        "nyholm/psr7": "^1.8"
+        "nyholm/psr7": "^1.8",
+        "open-telemetry/sdk": "^1.15",
+        "open-telemetry/exporter-otlp": "^1.4"
     },
     "suggest": {
         "ext-pdo_pgsql": "Required for PostgreSQL database support",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d81973774b0af272d6dd05240603f7b",
+    "content-hash": "a8e4413b991c58352edbd5ae7e60a246",
     "packages": [
         {
             "name": "altcha-org/altcha",
@@ -9233,6 +9233,50 @@
             "time": "2026-07-30T15:46:02+00:00"
         },
         {
+            "name": "google/protobuf",
+            "version": "v5.35.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/protocolbuffers/protobuf-php.git",
+                "reference": "55bb4a7d6739b5af0927b96213c1371a3afb7cfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/55bb4a7d6739b5af0927b96213c1371a3afb7cfb",
+                "reference": "55bb4a7d6739b5af0927b96213c1371a3afb7cfb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=11.5.0 <12.0.0"
+            },
+            "suggest": {
+                "ext-bcmath": "Need to support JSON deserialization"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\Protobuf\\": "src/Google/Protobuf",
+                    "GPBMetadata\\Google\\Protobuf\\": "src/GPBMetadata/Google/Protobuf"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "proto library for PHP",
+            "homepage": "https://developers.google.com/protocol-buffers/",
+            "keywords": [
+                "proto"
+            ],
+            "support": {
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v5.35.1"
+            },
+            "time": "2026-06-11T21:19:23+00:00"
+        },
+        {
             "name": "jean85/pretty-package-versions",
             "version": "2.1.1",
             "source": {
@@ -10869,6 +10913,485 @@
                 }
             ],
             "time": "2024-09-09T07:06:30+00:00"
+        },
+        {
+            "name": "nyholm/psr7-server",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Nyholm/psr7-server.git",
+                "reference": "4335801d851f554ca43fa6e7d2602141538854dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Nyholm/psr7-server/zipball/4335801d851f554ca43fa6e7d2602141538854dc",
+                "reference": "4335801d851f554ca43fa6e7d2602141538854dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "nyholm/nsa": "^1.1",
+                "nyholm/psr7": "^1.3",
+                "phpunit/phpunit": "^7.0 || ^8.5 || ^9.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Nyholm\\Psr7Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                },
+                {
+                    "name": "Martijn van der Ven",
+                    "email": "martijn@vanderven.se"
+                }
+            ],
+            "description": "Helper classes to handle PSR-7 server requests",
+            "homepage": "http://tnyholm.se",
+            "keywords": [
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/Nyholm/psr7-server/issues",
+                "source": "https://github.com/Nyholm/psr7-server/tree/1.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Zegnat",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-11-08T09:30:43+00:00"
+        },
+        {
+            "name": "open-telemetry/api",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/api.git",
+                "reference": "7c029c4a6fd457094a20569bf98f93d95e9a7559"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/7c029c4a6fd457094a20569bf98f93d95e9a7559",
+                "reference": "7c029c4a6fd457094a20569bf98f93d95e9a7559",
+                "shasum": ""
+            },
+            "require": {
+                "open-telemetry/context": "^1.4",
+                "php": "^8.1",
+                "psr/log": "^1.1|^2.0|^3.0",
+                "symfony/polyfill-php82": "^1.26"
+            },
+            "conflict": {
+                "open-telemetry/sdk": "<=1.11"
+            },
+            "type": "library",
+            "extra": {
+                "spi": {
+                    "OpenTelemetry\\API\\Instrumentation\\AutoInstrumentation\\HookManagerInterface": [
+                        "OpenTelemetry\\API\\Instrumentation\\AutoInstrumentation\\ExtensionHookManager"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "1.8.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Trace/functions.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\API\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "API for OpenTelemetry PHP.",
+            "keywords": [
+                "Metrics",
+                "api",
+                "apm",
+                "logging",
+                "opentelemetry",
+                "otel",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/languages/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2026-07-06T12:28:04+00:00"
+        },
+        {
+            "name": "open-telemetry/context",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/context.git",
+                "reference": "3c414b246e0dabb7d6145404e6a5e4536ca18d07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/context/zipball/3c414b246e0dabb7d6145404e6a5e4536ca18d07",
+                "reference": "3c414b246e0dabb7d6145404e6a5e4536ca18d07",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "symfony/polyfill-php82": "^1.26"
+            },
+            "suggest": {
+                "ext-ffi": "To allow context switching in Fibers"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "fiber/initialize_fiber_handler.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\Context\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "Context implementation for OpenTelemetry PHP.",
+            "keywords": [
+                "Context",
+                "opentelemetry",
+                "otel"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/languages/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2025-10-19T06:44:33+00:00"
+        },
+        {
+            "name": "open-telemetry/exporter-otlp",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/exporter-otlp.git",
+                "reference": "283a0d66522f2adc6d8d7debfd7686be91c282be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/exporter-otlp/zipball/283a0d66522f2adc6d8d7debfd7686be91c282be",
+                "reference": "283a0d66522f2adc6d8d7debfd7686be91c282be",
+                "shasum": ""
+            },
+            "require": {
+                "open-telemetry/api": "^1.0",
+                "open-telemetry/gen-otlp-protobuf": "^1.1",
+                "open-telemetry/sdk": "^1.0",
+                "php": "^8.1",
+                "php-http/discovery": "^1.14"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "_register.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\Contrib\\Otlp\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "OTLP exporter for OpenTelemetry.",
+            "keywords": [
+                "Metrics",
+                "exporter",
+                "gRPC",
+                "http",
+                "opentelemetry",
+                "otel",
+                "otlp",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/languages/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2026-02-05T09:44:52+00:00"
+        },
+        {
+            "name": "open-telemetry/gen-otlp-protobuf",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/gen-otlp-protobuf.git",
+                "reference": "66f04d0e448ad333033bfc7baae1aa56330be088"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/gen-otlp-protobuf/zipball/66f04d0e448ad333033bfc7baae1aa56330be088",
+                "reference": "66f04d0e448ad333033bfc7baae1aa56330be088",
+                "shasum": ""
+            },
+            "require": {
+                "google/protobuf": "^3.22 || ^4.0 || ^5.0",
+                "php": "^8.0"
+            },
+            "suggest": {
+                "ext-protobuf": "For better performance, when dealing with the protobuf format"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opentelemetry\\Proto\\": "Opentelemetry/Proto/",
+                    "GPBMetadata\\Opentelemetry\\": "GPBMetadata/Opentelemetry/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "PHP protobuf files for communication with OpenTelemetry OTLP collectors/servers.",
+            "keywords": [
+                "Metrics",
+                "apm",
+                "gRPC",
+                "logging",
+                "opentelemetry",
+                "otel",
+                "otlp",
+                "protobuf",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/languages/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2026-06-17T12:06:32+00:00"
+        },
+        {
+            "name": "open-telemetry/sdk",
+            "version": "1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/sdk.git",
+                "reference": "77e1aa73850154abb86937d52a70883edc3b4547"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/77e1aa73850154abb86937d52a70883edc3b4547",
+                "reference": "77e1aa73850154abb86937d52a70883edc3b4547",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "nyholm/psr7-server": "^1.1",
+                "open-telemetry/api": "^1.8",
+                "open-telemetry/context": "^1.4",
+                "open-telemetry/sem-conv": "^1.38.0",
+                "php": "^8.1",
+                "php-http/discovery": "^1.14",
+                "psr/http-client": "^1.0",
+                "psr/http-client-implementation": "^1.0",
+                "psr/http-factory-implementation": "^1.0",
+                "psr/http-message": "^1.0.1|^2.0",
+                "psr/log": "^1.1|^2.0|^3.0",
+                "ramsey/uuid": "^3.0 || ^4.0",
+                "symfony/polyfill-mbstring": "^1.23",
+                "symfony/polyfill-php82": "^1.26",
+                "tbachert/spi": "^1.0.5"
+            },
+            "suggest": {
+                "ext-gmp": "To support unlimited number of synchronous metric readers",
+                "ext-mbstring": "To increase performance of string operations",
+                "open-telemetry/sdk-configuration": "File-based OpenTelemetry SDK configuration"
+            },
+            "type": "library",
+            "extra": {
+                "spi": {
+                    "OpenTelemetry\\API\\Configuration\\ConfigEnv\\EnvComponentLoader": [
+                        "OpenTelemetry\\API\\Instrumentation\\Configuration\\General\\ConfigEnv\\EnvComponentLoaderHttpConfig",
+                        "OpenTelemetry\\API\\Instrumentation\\Configuration\\General\\ConfigEnv\\EnvComponentLoaderPeerConfig",
+                        "OpenTelemetry\\SDK\\ConfigEnv\\Trace\\SpanSuppressionStrategySemConv",
+                        "OpenTelemetry\\SDK\\ConfigEnv\\Trace\\SpanSuppressionStrategySpanKind",
+                        "OpenTelemetry\\SDK\\ConfigEnv\\Distribution\\DistributionConfigurationSdk"
+                    ],
+                    "OpenTelemetry\\SDK\\Common\\Configuration\\Resolver\\ResolverInterface": [
+                        "OpenTelemetry\\SDK\\Common\\Configuration\\Resolver\\SdkConfigurationResolver"
+                    ],
+                    "OpenTelemetry\\API\\Instrumentation\\AutoInstrumentation\\HookManagerInterface": [
+                        "OpenTelemetry\\API\\Instrumentation\\AutoInstrumentation\\ExtensionHookManager"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "1.14.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Common/Util/functions.php",
+                    "Logs/Exporter/_register.php",
+                    "Metrics/MetricExporter/_register.php",
+                    "Propagation/_register.php",
+                    "Trace/SpanExporter/_register.php",
+                    "Common/Dev/Compatibility/_load.php",
+                    "_autoload.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\SDK\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "SDK for OpenTelemetry PHP.",
+            "keywords": [
+                "Metrics",
+                "apm",
+                "logging",
+                "opentelemetry",
+                "otel",
+                "sdk",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/languages/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2026-07-14T13:09:54+00:00"
+        },
+        {
+            "name": "open-telemetry/sem-conv",
+            "version": "1.38.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/sem-conv.git",
+                "reference": "e613bc640a407def4991b8a936a9b27edd9a3240"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/e613bc640a407def4991b8a936a9b27edd9a3240",
+                "reference": "e613bc640a407def4991b8a936a9b27edd9a3240",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenTelemetry\\SemConv\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "Semantic conventions for OpenTelemetry PHP.",
+            "keywords": [
+                "Metrics",
+                "apm",
+                "logging",
+                "opentelemetry",
+                "otel",
+                "semantic conventions",
+                "semconv",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/languages/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2026-01-21T04:14:03+00:00"
         },
         {
             "name": "opis/json-schema",
@@ -12849,6 +13372,160 @@
                 "source": "https://github.com/bobthecow/psysh/tree/v0.12.24"
             },
             "time": "2026-06-29T15:41:09+00:00"
+        },
+        {
+            "name": "ramsey/collection",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/collection.git",
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/collection/zipball/344572933ad0181accbf4ba763e85a0306a8c5e2",
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "captainhook/plugin-composer": "^5.3",
+                "ergebnis/composer-normalize": "^2.45",
+                "fakerphp/faker": "^1.24",
+                "hamcrest/hamcrest-php": "^2.0",
+                "jangregor/phpstan-prophecy": "^2.1",
+                "mockery/mockery": "^1.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpspec/prophecy-phpunit": "^2.3",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-mockery": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5",
+                "ramsey/coding-standard": "^2.3",
+                "ramsey/conventional-commits": "^1.6",
+                "roave/security-advisories": "dev-latest"
+            },
+            "type": "library",
+            "extra": {
+                "captainhook": {
+                    "force-install": true
+                },
+                "ramsey/conventional-commits": {
+                    "configFile": "conventional-commits.json"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Collection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                }
+            ],
+            "description": "A PHP library for representing and manipulating collections.",
+            "keywords": [
+                "array",
+                "collection",
+                "hash",
+                "map",
+                "queue",
+                "set"
+            ],
+            "support": {
+                "issues": "https://github.com/ramsey/collection/issues",
+                "source": "https://github.com/ramsey/collection/tree/2.1.1"
+            },
+            "time": "2025-03-22T05:38:12+00:00"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "4.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/1df15849d00943a67d677dc9cfd80795f038c9f8",
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": ">=0.8.16 <=0.18",
+                "php": "^8.0",
+                "ramsey/collection": "^1.2 || ^2.0"
+            },
+            "replace": {
+                "rhumsaa/uuid": "self.version"
+            },
+            "require-dev": {
+                "captainhook/captainhook": "^5.25",
+                "captainhook/plugin-composer": "^5.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "ergebnis/composer-normalize": "^2.47",
+                "mockery/mockery": "^1.6",
+                "paragonie/random-lib": "^2",
+                "php-mock/php-mock": "^2.6",
+                "php-mock/php-mock-mockery": "^1.5",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpbench/phpbench": "^1.2.14",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-mockery": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "slevomat/coding-standard": "^8.18",
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "suggest": {
+                "ext-bcmath": "Enables faster math with arbitrary-precision integers using BCMath.",
+                "ext-gmp": "Enables faster math with arbitrary-precision integers using GMP.",
+                "ext-uuid": "Enables the use of PeclUuidTimeGenerator and PeclUuidRandomGenerator.",
+                "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
+                "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
+            },
+            "type": "library",
+            "extra": {
+                "captainhook": {
+                    "force-install": true
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP library for generating and working with universally unique identifiers (UUIDs).",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "support": {
+                "issues": "https://github.com/ramsey/uuid/issues",
+                "source": "https://github.com/ramsey/uuid/tree/4.9.3"
+            },
+            "time": "2026-06-18T03:57:49+00:00"
         },
         {
             "name": "react/cache",
@@ -15002,6 +15679,58 @@
             "time": "2026-02-17T17:25:14+00:00"
         },
         {
+            "name": "tbachert/spi",
+            "version": "v1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Nevay/spi.git",
+                "reference": "e7078767866d0a9e0f91d3f9d42a832df5e39002"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Nevay/spi/zipball/e7078767866d0a9e0f91d3f9d42a832df5e39002",
+                "reference": "e7078767866d0a9e0f91d3f9d42a832df5e39002",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "composer/semver": "^1.0 || ^2.0 || ^3.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "infection/infection": "^0.27.9",
+                "phpunit/phpunit": "^10.5",
+                "psalm/phar": "^5.18"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Nevay\\SPI\\Composer\\Plugin",
+                "branch-alias": {
+                    "dev-main": "1.0.x-dev"
+                },
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nevay\\SPI\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Service provider loading facility",
+            "keywords": [
+                "service provider"
+            ],
+            "support": {
+                "issues": "https://github.com/Nevay/spi/issues",
+                "source": "https://github.com/Nevay/spi/tree/v1.0.5"
+            },
+            "time": "2025-06-29T15:42:06+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "2.0.1",
             "source": {
@@ -15154,5 +15883,5 @@
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/Backend/Unit/OpenTelemetry/ExportTest.php
+++ b/tests/Backend/Unit/OpenTelemetry/ExportTest.php
@@ -1,0 +1,301 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Maho_OpenTelemetry
+ */
+
+declare(strict_types=1);
+
+use OpenTelemetry\SDK\Common\Export\TransportInterface;
+use OpenTelemetry\SDK\Common\Future\CancellationInterface;
+use OpenTelemetry\SDK\Common\Future\CompletedFuture;
+use OpenTelemetry\SDK\Common\Future\FutureInterface;
+use Opentelemetry\Proto\Trace\V1\Status\StatusCode;
+use Symfony\Component\HttpClient\Exception\ClientException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * The export path with the SDK actually installed: spans built by the real
+ * tracer, serialized by the OTLP exporter, captured off the transport. Asserts
+ * on the payload that would leave the server rather than on our own wrappers.
+ */
+
+/**
+ * Stands in for the OTLP HTTP transport, keeping every payload the exporter sends.
+ * Declaring JSON makes the exporter serialize OTLP/JSON, which the assertions read
+ * directly instead of decoding protobuf.
+ */
+final class MahoTestOtlpTransport implements TransportInterface
+{
+    /** @var list<string> */
+    public array $payloads = [];
+
+    #[\Override]
+    public function contentType(): string
+    {
+        return 'application/json';
+    }
+
+    #[\Override]
+    public function send(string $payload, ?CancellationInterface $cancellation = null): FutureInterface
+    {
+        $this->payloads[] = $payload;
+        return new CompletedFuture(null);
+    }
+
+    #[\Override]
+    public function shutdown(?CancellationInterface $cancellation = null): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function forceFlush(?CancellationInterface $cancellation = null): bool
+    {
+        return true;
+    }
+}
+
+final class MahoTestTracer extends Maho_OpenTelemetry_Model_Tracer
+{
+    public MahoTestOtlpTransport $transport;
+
+    public function __construct()
+    {
+        $this->transport = new MahoTestOtlpTransport();
+    }
+
+    #[\Override]
+    protected function _createTransport(string $endpoint, string $signal): TransportInterface
+    {
+        return $this->transport;
+    }
+}
+
+afterEach(function () {
+    foreach (array_keys($_SERVER) as $key) {
+        if (str_starts_with((string) $key, 'OTEL_')) {
+            unset($_SERVER[$key]);
+        }
+    }
+    Mage::app()->getStore()->setConfig('dev/opentelemetry/sampling_rate', '0.1');
+});
+
+/**
+ * A tracer wired to the SDK and sampling everything, so assertions never race
+ * the sampler
+ */
+function otelExportTracer(): MahoTestTracer
+{
+    $_SERVER['OTEL_EXPORTER_OTLP_ENDPOINT'] = 'http://collector.invalid:4318';
+    Mage::app()->getStore()->setConfig('dev/opentelemetry/sampling_rate', '1');
+
+    $tracer = new MahoTestTracer();
+    expect($tracer->initialize())->not->toBeFalse();
+
+    return $tracer;
+}
+
+/**
+ * Every span in an OTLP/JSON payload, flattened
+ *
+ * @return list<array<string, mixed>>
+ */
+function otelSpansIn(string $payload): array
+{
+    $decoded = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
+
+    $spans = [];
+    foreach ($decoded['resourceSpans'] ?? [] as $resourceSpans) {
+        foreach ($resourceSpans['scopeSpans'] ?? [] as $scopeSpans) {
+            foreach ($scopeSpans['spans'] ?? [] as $span) {
+                $spans[] = $span;
+            }
+        }
+    }
+
+    return $spans;
+}
+
+/**
+ * @param list<array<string, mixed>> $spans
+ * @return array<string, mixed>
+ */
+function otelSpanNamed(array $spans, string $name): array
+{
+    foreach ($spans as $span) {
+        if (($span['name'] ?? null) === $name) {
+            return $span;
+        }
+    }
+
+    throw new RuntimeException("No exported span named \"$name\" (got: "
+        . implode(', ', array_column($spans, 'name')) . ')');
+}
+
+/**
+ * OTLP attributes as a plain map. Scalars arrive wrapped in a one-key type
+ * envelope, and integers as strings, so callers cast what they compare.
+ *
+ * @param array<string, mixed> $span
+ * @return array<string, mixed>
+ */
+function otelAttributesOf(array $span): array
+{
+    $attributes = [];
+    foreach ($span['attributes'] ?? [] as $attribute) {
+        $attributes[$attribute['key']] = array_values($attribute['value'])[0] ?? null;
+    }
+
+    return $attributes;
+}
+
+it('holds spans until flush, then serializes the hierarchy into one OTLP payload', function () {
+    $tracer = otelExportTracer();
+
+    $root = $tracer->startRootSpan('POST', ['http.request.method' => 'POST'], 'server');
+    $query = $tracer->startSpan('SELECT catalog_product_entity', ['db.system.name' => 'mysql'], 'client');
+    $query->end();
+    $root->end();
+
+    // Deferred by the batch processor: nothing may reach the collector mid-request
+    expect($tracer->transport->payloads)->toBeEmpty();
+
+    $tracer->flush();
+
+    expect($tracer->transport->payloads)->toHaveCount(1);
+    $spans = otelSpansIn($tracer->transport->payloads[0]);
+    expect($spans)->toHaveCount(2);
+
+    $rootSpan = otelSpanNamed($spans, 'POST');
+    $querySpan = otelSpanNamed($spans, 'SELECT catalog_product_entity');
+
+    expect($rootSpan['parentSpanId'] ?? '')->toBe('')
+        ->and($querySpan['traceId'])->toBe($rootSpan['traceId'])
+        ->and($querySpan['parentSpanId'])->toBe($rootSpan['spanId'])
+        ->and(otelAttributesOf($querySpan)['db.system.name'])->toBe('mysql');
+});
+
+it('continues the dispatching trace on the queue consumer span', function () {
+    $tracer = otelExportTracer();
+
+    $request = $tracer->startRootSpan('POST', [], 'server');
+    $carrier = $tracer->getTracePropagationHeaders();
+    expect($carrier)->toHaveKey('traceparent')
+        ->and($carrier['traceparent'])->toContain($request->getTraceId())
+        ->and($carrier['traceparent'])->toContain($request->getSpanId());
+    $request->end();
+
+    // What TraceMessageListener hands back from the stamp QueueManager wrote
+    $consumer = $tracer->startRootSpan('process My_Module_Model_Message', [], 'consumer', $carrier);
+    expect($consumer->getTraceId())->toBe($request->getTraceId());
+    $consumer->end();
+
+    $tracer->flush();
+    $spans = otelSpansIn($tracer->transport->payloads[0]);
+
+    expect(otelSpanNamed($spans, 'process My_Module_Model_Message')['parentSpanId'])
+        ->toBe($request->getSpanId());
+});
+
+it('spans the outgoing HTTP request until its body is consumed', function () {
+    $tracer = otelExportTracer();
+    $root = $tracer->startRootSpan('POST', [], 'server');
+
+    $client = new Maho_OpenTelemetry_Model_Http_TracedClient();
+    $client->setClient(new MockHttpClient(new MockResponse('{"ok":true}', ['http_code' => 201])));
+    $client->setTracer($tracer);
+
+    $response = $client->request('GET', 'https://api.example.com/orders?token=secret#frag');
+
+    // Work done while the response is in flight belongs to the caller, so it must
+    // stay a sibling of the HTTP span rather than be adopted by it
+    $tracer->startSpan('SELECT sales_order', [], 'client')->end();
+
+    expect($response->toArray())->toBe(['ok' => true]);
+
+    $root->end();
+    $tracer->flush();
+    $spans = otelSpansIn($tracer->transport->payloads[0]);
+
+    $rootSpan = otelSpanNamed($spans, 'POST');
+    $httpSpan = otelSpanNamed($spans, 'GET');
+    $attributes = otelAttributesOf($httpSpan);
+
+    expect($httpSpan['parentSpanId'])->toBe($rootSpan['spanId'])
+        ->and(otelSpanNamed($spans, 'SELECT sales_order')['parentSpanId'])->toBe($rootSpan['spanId'])
+        ->and($attributes['url.full'])->toBe('https://api.example.com/orders')
+        ->and((int) $attributes['http.response.status_code'])->toBe(201)
+        ->and($httpSpan['status']['code'] ?? null)->toBe(StatusCode::STATUS_CODE_OK);
+});
+
+it('records a failure raised while the response body is read', function () {
+    $tracer = otelExportTracer();
+    $root = $tracer->startRootSpan('POST', [], 'server');
+
+    $client = new Maho_OpenTelemetry_Model_Http_TracedClient();
+    $client->setClient(new MockHttpClient(new MockResponse('gone', ['http_code' => 404])));
+    $client->setTracer($tracer);
+
+    // Symfony defers 4xx/5xx to the moment the body is read, which used to be
+    // after the span had already been closed as a success
+    $response = $client->request('GET', 'https://api.example.com/missing');
+    expect(fn() => $response->getContent())->toThrow(ClientException::class);
+
+    $root->end();
+    $tracer->flush();
+
+    $httpSpan = otelSpanNamed(otelSpansIn($tracer->transport->payloads[0]), 'GET');
+
+    expect($httpSpan['status']['code'] ?? null)->toBe(StatusCode::STATUS_CODE_ERROR)
+        ->and(otelAttributesOf($httpSpan)['error.type'])->toBe(ClientException::class)
+        ->and(array_column($httpSpan['events'] ?? [], 'name'))->toContain('exception');
+});
+
+it('exports the span of a response nobody consumed', function () {
+    $tracer = otelExportTracer();
+    $root = $tracer->startRootSpan('POST', [], 'server');
+
+    $client = new Maho_OpenTelemetry_Model_Http_TracedClient();
+    $client->setClient(new MockHttpClient(new MockResponse('never read')));
+    $client->setTracer($tracer);
+    $client->request('GET', 'https://api.example.com/fire-and-forget');
+
+    $root->end();
+    $tracer->flush();
+
+    expect(array_column(otelSpansIn($tracer->transport->payloads[0]), 'name'))->toContain('GET');
+});
+
+it('propagates trace context to the outgoing request headers', function () {
+    $tracer = otelExportTracer();
+    $root = $tracer->startRootSpan('POST', [], 'server');
+
+    $sent = [];
+    $client = new Maho_OpenTelemetry_Model_Http_TracedClient();
+    $client->setClient(new MockHttpClient(function (string $method, string $url, array $options) use (&$sent) {
+        $sent = $options['headers'] ?? [];
+        return new MockResponse('{}');
+    }));
+    $client->setTracer($tracer);
+
+    $client->request('GET', 'https://api.example.com/orders')->getContent();
+
+    $traceparent = array_values(array_filter(
+        $sent,
+        static fn(string $header): bool => str_starts_with(strtolower($header), 'traceparent:'),
+    ));
+
+    $root->end();
+    $tracer->flush();
+    $httpSpan = otelSpanNamed(otelSpansIn($tracer->transport->payloads[0]), 'GET');
+
+    // The receiver parents to the client span, not to the request that issued it
+    expect($traceparent)->toHaveCount(1)
+        ->and($traceparent[0])->toBe("traceparent: 00-{$httpSpan['traceId']}-{$httpSpan['spanId']}-01");
+});


### PR DESCRIPTION
Superseded: these commits went straight onto the `opentelemetry` branch, so they are part of #350.

Follow-up to the review on #350.

**HTTP client spans covered only the connection.** Symfony's client is lazy: `request()` returns as soon as the request is issued and the body is transferred later, so ending the span after `getStatusCode()` timed the connection alone, missed the failures Symfony raises from `getContent()`/`toArray()`/`stream()`, and blocked every request on its headers even when the caller meant to run them concurrently. The span now travels with a response decorator that closes it when the body is consumed, the response is cancelled, its stream ends or the object is dropped; `flush()` closes whatever is still open at the end of the request. It starts detached: parented where it was created but never made the current span, so the caller's work while the response is in flight is not nested under the request. The `traceparent` handed to the remote service still names that client span.

**Exception messages on the request span.** `Mage_Core_Model_App::run()` was the only error path putting `$e->getMessage()` in a span status description; the DB, HTTP and queue paths all use the class. It now matches them, since a message can carry SQL, customer data or credentials and trace lists show it unredacted. The OTel `exception` event still carries message and stack trace, per semconv; the README's Data safety section now says so instead of leaving it implied.

**No SDK-backed tests.** `open-telemetry/sdk` and `open-telemetry/exporter-otlp` move into `require-dev`, so CI installs them. That retires the phpstan ignore that had hidden the whole module from analysis (five pre-existing typing errors surfaced and are fixed). A new `ExportTest` drives the real tracer through a recording transport and asserts trace hierarchy, OTLP serialization, deferred flushing, queue trace continuation and W3C propagation against the payload that would leave the server.

A fourth review point, that existing queue installs need a version bump and an upgrade migration for `trace_context`, does not apply: `maho_queue_message` is declared in `sql/schema.php`, and `Maho\Db\Schema\Status` fingerprints every module's schema file, so a changed declaration flips `isSchemaUpdatePending()` and web entry points serve the database-update page until `./maho migrate` converges. Adding the column to `schema.php` is the migration.