### PR TITLE
Fixed the missing g: namespace prefix in platform XML feed presets

### DIFF
--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Xml.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Xml.php
@@ -636,9 +636,9 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Xml extends Maho_Fe
 
         return [
             ['tag' => 'g:id', 'source_type' => 'attribute', 'source_value' => 'sku', 'cdata' => false, 'optional' => false],
-            ['tag' => 'g:title', 'source_type' => 'attribute', 'source_value' => 'name', 'cdata' => true, 'optional' => false],
+            ['tag' => 'title', 'source_type' => 'attribute', 'source_value' => 'name', 'cdata' => true, 'optional' => false],
             ['tag' => 'g:description', 'source_type' => 'attribute', 'source_value' => 'description', 'cdata' => true, 'optional' => true, 'use_parent' => 'if_empty'],
-            ['tag' => 'g:link', 'source_type' => 'attribute', 'source_value' => 'url', 'cdata' => false, 'optional' => false, 'use_parent' => 'if_empty'],
+            ['tag' => 'link', 'source_type' => 'attribute', 'source_value' => 'url', 'cdata' => false, 'optional' => false, 'use_parent' => 'if_empty'],
             ['tag' => 'g:image_link', 'source_type' => 'attribute', 'source_value' => 'image', 'cdata' => false, 'optional' => true, 'use_parent' => 'if_empty'],
             ['tag' => 'g:availability', 'source_type' => 'attribute', 'source_value' => 'is_in_stock', 'cdata' => false, 'optional' => false, 'transformers' => 'conditional:operator=eq,compare_value=1,true_value=in_stock,false_value=out_of_stock'],
             ['tag' => 'g:price', 'source_type' => 'attribute', 'source_value' => 'price', 'cdata' => false, 'optional' => false],

--- a/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Xml.php
+++ b/app/code/core/Maho/FeedManager/Block/Adminhtml/Feed/Edit/Tab/Mapping/Xml.php
@@ -630,7 +630,7 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Xml extends Maho_Fe
         if ($platformCode) {
             $adapter = Mage::getSingleton('feedmanager/platform')->getAdapter($platformCode);
             if ($adapter) {
-                return $this->_buildDefaultFromAdapter($adapter);
+                return $adapter->getDefaultXmlStructure();
             }
         }
 
@@ -645,35 +645,5 @@ class Maho_FeedManager_Block_Adminhtml_Feed_Edit_Tab_Mapping_Xml extends Maho_Fe
             ['tag' => 'g:brand', 'source_type' => 'attribute', 'source_value' => 'brand', 'cdata' => true, 'optional' => true],
             ['tag' => 'g:condition', 'source_type' => 'static', 'source_value' => 'new', 'cdata' => false, 'optional' => true],
         ];
-    }
-
-    protected function _buildDefaultFromAdapter(Maho_FeedManager_Model_Platform_AdapterInterface $adapter): array
-    {
-        $required = $adapter->getRequiredAttributes();
-        $optional = $adapter->getOptionalAttributes();
-        $mappings = $adapter->getDefaultMappings();
-        $namespaced = array_flip($adapter->getNamespacedAttributes());
-        $cdataKeys = ['title', 'description', 'google_product_category', 'product_type'];
-
-        $structure = [];
-        foreach (array_merge($required, $optional) as $key => $attr) {
-            $mapping = $mappings[$key] ?? ['source_type' => 'attribute', 'source_value' => ''];
-            $row = [
-                'tag' => isset($namespaced[$key]) ? 'g:' . $key : $key,
-                'source_type' => $mapping['source_type'],
-                'source_value' => $mapping['source_value'],
-                'cdata' => in_array($key, $cdataKeys, true),
-                'optional' => !($attr['required'] ?? false),
-            ];
-            if (!empty($mapping['use_parent'] ?? '')) {
-                $row['use_parent'] = $mapping['use_parent'];
-            }
-            if (!empty($mapping['transformers'] ?? '')) {
-                $row['transformers'] = $mapping['transformers'];
-            }
-            $structure[] = $row;
-        }
-
-        return $structure;
     }
 }

--- a/app/code/core/Maho/FeedManager/Model/Platform/AbstractAdapter.php
+++ b/app/code/core/Maho/FeedManager/Model/Platform/AbstractAdapter.php
@@ -102,6 +102,9 @@ abstract class Maho_FeedManager_Model_Platform_AbstractAdapter implements Maho_F
     #[\Override]
     public function getDefaultXmlStructure(): array
     {
+        // Mirrors Maho_FeedManager_Model_Writer_Xml::_getElementName(): the prefix is only
+        // usable when the adapter actually declares the xmlns:g namespace.
+        $prefix = isset($this->getNamespaces()['xmlns:g']) ? 'g:' : '';
         $namespaced = array_flip($this->getNamespacedAttributes());
         $mappings = $this->getDefaultMappings();
         $cdataKeys = ['title', 'description', 'google_product_category', 'product_category', 'product_type'];
@@ -110,7 +113,7 @@ abstract class Maho_FeedManager_Model_Platform_AbstractAdapter implements Maho_F
         foreach ($this->getAllAttributes() as $key => $attribute) {
             $mapping = $mappings[$key] ?? ['source_type' => 'attribute', 'source_value' => ''];
             $row = [
-                'tag' => isset($namespaced[$key]) ? 'g:' . $key : $key,
+                'tag' => isset($namespaced[$key]) ? $prefix . $key : $key,
                 'source_type' => $mapping['source_type'],
                 'source_value' => $mapping['source_value'],
                 'cdata' => in_array($key, $cdataKeys, true),

--- a/app/code/core/Maho/FeedManager/Model/Platform/AbstractAdapter.php
+++ b/app/code/core/Maho/FeedManager/Model/Platform/AbstractAdapter.php
@@ -100,6 +100,35 @@ abstract class Maho_FeedManager_Model_Platform_AbstractAdapter implements Maho_F
     }
 
     #[\Override]
+    public function getDefaultXmlStructure(): array
+    {
+        $namespaced = array_flip($this->getNamespacedAttributes());
+        $mappings = $this->getDefaultMappings();
+        $cdataKeys = ['title', 'description', 'google_product_category', 'product_category', 'product_type'];
+
+        $structure = [];
+        foreach ($this->getAllAttributes() as $key => $attribute) {
+            $mapping = $mappings[$key] ?? ['source_type' => 'attribute', 'source_value' => ''];
+            $row = [
+                'tag' => isset($namespaced[$key]) ? 'g:' . $key : $key,
+                'source_type' => $mapping['source_type'],
+                'source_value' => $mapping['source_value'],
+                'cdata' => in_array($key, $cdataKeys, true),
+                'optional' => !($attribute['required'] ?? false),
+            ];
+            if (!empty($mapping['use_parent'])) {
+                $row['use_parent'] = $mapping['use_parent'];
+            }
+            if (!empty($mapping['transformers'])) {
+                $row['transformers'] = $mapping['transformers'];
+            }
+            $structure[] = $row;
+        }
+
+        return $structure;
+    }
+
+    #[\Override]
     public function transformProductData(array $productData): array
     {
         // Default: no transformation

--- a/app/code/core/Maho/FeedManager/Model/Platform/AdapterInterface.php
+++ b/app/code/core/Maho/FeedManager/Model/Platform/AdapterInterface.php
@@ -61,7 +61,7 @@ interface Maho_FeedManager_Model_Platform_AdapterInterface
     /**
      * Get default attribute mappings
      *
-     * @return array<string, array{source_type: string, source_value: string}>
+     * @return array<string, array{source_type: string, source_value: string, use_parent?: string, transformers?: string}>
      */
     public function getDefaultMappings(): array;
 
@@ -88,6 +88,16 @@ interface Maho_FeedManager_Model_Platform_AdapterInterface
      * @return string[]
      */
     public function getNamespacedAttributes(): array;
+
+    /**
+     * Get the default XML builder structure for this platform
+     *
+     * Each row is one element of an item, with the namespace prefix already
+     * applied to the tag name.
+     *
+     * @return array<int, array{tag: string, source_type: string, source_value: string, cdata: bool, optional: bool, use_parent?: string, transformers?: string}>
+     */
+    public function getDefaultXmlStructure(): array;
 
     /**
      * Transform product data for this platform

--- a/app/code/core/Maho/FeedManager/Model/Platform/Bing.php
+++ b/app/code/core/Maho/FeedManager/Model/Platform/Bing.php
@@ -357,7 +357,7 @@ class Maho_FeedManager_Model_Platform_Bing extends Maho_FeedManager_Model_Platfo
     {
         return array_diff(
             array_keys($this->getAllAttributes()),
-            ['id', 'title', 'link'],
+            ['title', 'link'],
         );
     }
 }

--- a/app/code/core/Maho/FeedManager/Model/Platform/Facebook.php
+++ b/app/code/core/Maho/FeedManager/Model/Platform/Facebook.php
@@ -404,7 +404,7 @@ class Maho_FeedManager_Model_Platform_Facebook extends Maho_FeedManager_Model_Pl
         // Facebook XML format uses g: prefix for most attributes
         return array_diff(
             array_keys($this->getAllAttributes()),
-            ['id', 'title', 'link'],
+            ['title', 'link'],
         );
     }
 }

--- a/app/code/core/Maho/FeedManager/Model/Platform/Google.php
+++ b/app/code/core/Maho/FeedManager/Model/Platform/Google.php
@@ -701,10 +701,10 @@ class Maho_FeedManager_Model_Platform_Google extends Maho_FeedManager_Model_Plat
     #[\Override]
     public function getNamespacedAttributes(): array
     {
-        // All Google Shopping attributes except id, title, link need g: prefix
+        // title and link are Atom/RSS elements; every other attribute needs the g: prefix
         return array_diff(
             array_keys($this->getAllAttributes()),
-            ['id', 'title', 'link'],
+            ['title', 'link'],
         );
     }
 }

--- a/app/code/core/Maho/FeedManager/Model/Platform/GoogleLocalInventory.php
+++ b/app/code/core/Maho/FeedManager/Model/Platform/GoogleLocalInventory.php
@@ -79,7 +79,7 @@ class Maho_FeedManager_Model_Platform_GoogleLocalInventory extends Maho_FeedMana
             'required' => false,
             'description' => 'same day, next day, 2-day, 3-day, 4-day, 5-day, 6-day, multi-week',
         ],
-        'instoreproduct_location' => [
+        'instore_product_location' => [
             'label' => 'In-Store Product Location',
             'required' => false,
             'description' => 'Location of product in store (e.g., aisle, shelf)',
@@ -96,7 +96,7 @@ class Maho_FeedManager_Model_Platform_GoogleLocalInventory extends Maho_FeedMana
         'quantity' => ['source_type' => 'attribute', 'source_value' => 'qty'],
         'pickup_method' => ['source_type' => 'static', 'source_value' => ''],
         'pickup_sla' => ['source_type' => 'static', 'source_value' => ''],
-        'instoreproduct_location' => ['source_type' => 'static', 'source_value' => ''],
+        'instore_product_location' => ['source_type' => 'static', 'source_value' => ''],
     ];
 
     #[\Override]
@@ -244,9 +244,7 @@ class Maho_FeedManager_Model_Platform_GoogleLocalInventory extends Maho_FeedMana
     #[\Override]
     public function getNamespacedAttributes(): array
     {
-        return array_diff(
-            array_keys($this->getAllAttributes()),
-            ['id'],
-        );
+        // Every local inventory attribute is a Merchant Center attribute, id included.
+        return array_keys($this->getAllAttributes());
     }
 }

--- a/app/code/core/Maho/FeedManager/controllers/Adminhtml/Feedmanager/FeedController.php
+++ b/app/code/core/Maho/FeedManager/controllers/Adminhtml/Feedmanager/FeedController.php
@@ -643,19 +643,8 @@ class Maho_FeedManager_Adminhtml_Feedmanager_FeedController extends Mage_Adminht
             // Convert to structure for JSON/XML builder
             $structure = [];
             if ($format === 'xml') {
-                // XML uses array format with tag property
-                foreach (array_merge($requiredAttributes, $optionalAttributes) as $key => $attr) {
-                    $mapping = $mappings[$key] ?? ['source_type' => 'attribute', 'source_value' => ''];
-                    $structure[] = [
-                        'tag' => $key,
-                        'source_type' => $mapping['source_type'],
-                        'source_value' => $mapping['source_value'],
-                        'transformers' => $mapping['transformers'] ?? '',
-                        'cdata' => in_array($key, ['title', 'description', 'google_product_category', 'product_category', 'product_type']),
-                        'optional' => !($attr['required'] ?? false),
-                        'use_parent' => $mapping['use_parent'] ?? '',
-                    ];
-                }
+                // XML uses array format with tag property, namespace prefix included
+                $structure = $adapter->getDefaultXmlStructure();
             } else {
                 // JSON uses object format
                 foreach (array_keys(array_merge($requiredAttributes, $optionalAttributes)) as $key) {

--- a/tests/Backend/Unit/FeedManager/Model/PlatformTest.php
+++ b/tests/Backend/Unit/FeedManager/Model/PlatformTest.php
@@ -440,4 +440,56 @@ describe('Google Local Inventory Platform', function () {
         $adapter = Maho_FeedManager_Model_Platform::getAdapter('google_local_inventory');
         expect($adapter->supportsCategoryMapping())->toBeFalse();
     });
+
+    test('namespaces every attribute, id included', function () {
+        $adapter = Maho_FeedManager_Model_Platform::getAdapter('google_local_inventory');
+        $namespaced = $adapter->getNamespacedAttributes();
+        expect($namespaced)->toContain('id')
+            ->and($namespaced)->toContain('price')
+            ->and($namespaced)->toContain('store_code')
+            ->and($namespaced)->toBe(array_keys($adapter->getAllAttributes()));
+    });
+
+    test('default XML structure prefixes every tag with g', function () {
+        $adapter = Maho_FeedManager_Model_Platform::getAdapter('google_local_inventory');
+        $tags = array_column($adapter->getDefaultXmlStructure(), 'tag');
+        expect($tags)->toContain('g:id')
+            ->and($tags)->toContain('g:store_code')
+            ->and($tags)->toContain('g:availability')
+            ->and($tags)->toContain('g:price')
+            ->and($tags)->toContain('g:instore_product_location')
+            ->and($tags)->not->toContain('price');
+    });
+});
+
+describe('Default XML structure', function () {
+    test('google keeps title and link unprefixed and prefixes id and price', function () {
+        $adapter = Maho_FeedManager_Model_Platform::getAdapter('google');
+        $structure = $adapter->getDefaultXmlStructure();
+        $tags = array_column($structure, 'tag');
+        expect($tags)->toContain('g:id')
+            ->and($tags)->toContain('g:price')
+            ->and($tags)->toContain('title')
+            ->and($tags)->toContain('link')
+            ->and($tags)->not->toContain('g:title');
+    });
+
+    test('carries source mapping, cdata and optional flags', function () {
+        $adapter = Maho_FeedManager_Model_Platform::getAdapter('google');
+        $structure = array_column($adapter->getDefaultXmlStructure(), null, 'tag');
+
+        expect($structure['g:id']['source_type'])->toBe('attribute')
+            ->and($structure['g:id']['source_value'])->toBe('sku')
+            ->and($structure['g:id']['optional'])->toBeFalse()
+            ->and($structure['g:description']['cdata'])->toBeTrue()
+            ->and($structure['g:description']['use_parent'])->toBe('if_empty')
+            ->and($structure['g:gtin']['optional'])->toBeTrue();
+    });
+
+    test('platforms without namespaces keep plain tags', function () {
+        $adapter = Maho_FeedManager_Model_Platform::getAdapter('custom');
+        foreach ($adapter->getDefaultXmlStructure() as $row) {
+            expect($row['tag'])->not->toStartWith('g:');
+        }
+    });
 });

--- a/tests/Backend/Unit/FeedManager/Model/WriterTest.php
+++ b/tests/Backend/Unit/FeedManager/Model/WriterTest.php
@@ -261,6 +261,35 @@ describe('XML Writer', function () {
             @unlink($tempFile);
         }
     });
+
+    test('prefixes Google Local Inventory elements with the g namespace', function () {
+        $tempFile = sys_get_temp_dir() . '/test_feed_' . uniqid() . '.xml';
+        $writer = new Maho_FeedManager_Model_Writer_Xml();
+        $platform = Maho_FeedManager_Model_Platform::getAdapter('google_local_inventory');
+
+        try {
+            $writer->open($tempFile, $platform);
+            $writer->writeProduct([
+                'id' => 'SKU-001',
+                'store_code' => 'STORE-1',
+                'availability' => 'in_stock',
+                'price' => '25.00 EUR',
+                'quantity' => '5',
+            ]);
+            $writer->close();
+
+            $content = file_get_contents($tempFile);
+
+            expect($content)->toContain('<g:id>SKU-001</g:id>')
+                ->and($content)->toContain('<g:store_code>STORE-1</g:store_code>')
+                ->and($content)->toContain('<g:availability>in_stock</g:availability>')
+                ->and($content)->toContain('<g:price>25.00 EUR</g:price>')
+                ->and($content)->toContain('<g:quantity>5</g:quantity>')
+                ->and($content)->not->toContain('<price>');
+        } finally {
+            @unlink($tempFile);
+        }
+    });
 });
 
 describe('JSONL Writer', function () {


### PR DESCRIPTION
A feed created from a platform template (for example Google Local Inventory) wrote `<price>` instead of `<g:price>`, and Google Merchant Center rejected the format.

The `platformPreset` action built the XML builder structure with plain attribute names, while the XML builder block built the same default with the prefix applied. The preset path won, so the saved structure had no prefixes.

- Added `getDefaultXmlStructure()` to the platform adapter. The controller and the XML builder block now share it, so the duplicate logic is gone.
- Google Local Inventory, Google Shopping, Bing and Facebook keep `id` namespaced: `<id>` is not a Merchant Center attribute, `<g:id>` is. `title` and `link` stay plain, because they are native RSS/Atom elements.
- Renamed `instoreproduct_location` to `instore_product_location`, the name in the Google specification.
- Tests cover the default structure tags and the XML writer output.

Feeds saved before this change keep their stored tags. To repair one, open the Mapping tab, load the platform preset again, save and regenerate.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->