### PR TITLE
Fixed the singleton registry error that broke bootstrap when the OpenTelemetry module is active

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -473,7 +473,7 @@ final class Mage
     {
         $registryKey = "_singleton/$modelAlias";
         if (!isset(self::$_registry[$registryKey])) {
-            self::register($registryKey, self::getModel($modelAlias, $arguments));
+            self::register($registryKey, self::getModel($modelAlias, $arguments), $arguments === []);
         }
         return self::$_registry[$registryKey];
     }
@@ -525,7 +525,7 @@ final class Mage
     {
         $registryKey = "_resource_singleton/$modelAlias";
         if (!isset(self::$_registry[$registryKey])) {
-            self::register($registryKey, self::getResourceModel($modelAlias, $arguments));
+            self::register($registryKey, self::getResourceModel($modelAlias, $arguments), $arguments === []);
         }
         return self::$_registry[$registryKey];
     }
@@ -557,7 +557,7 @@ final class Mage
     {
         $registryKey = "_helper/$helperAlias";
         if (!isset(self::$_registry[$registryKey])) {
-            self::register($registryKey, self::getConfig()->getHelperInstance($helperAlias));
+            self::register($registryKey, self::getConfig()->getHelperInstance($helperAlias), true);
         }
         return self::$_registry[$registryKey];
     }
@@ -576,7 +576,7 @@ final class Mage
     {
         $registryKey = "_resource_helper/$moduleAlias";
         if (!isset(self::$_registry[$registryKey])) {
-            self::register($registryKey, self::getConfig()->getResourceHelperInstance($moduleAlias));
+            self::register($registryKey, self::getConfig()->getResourceHelperInstance($moduleAlias), true);
         }
         return self::$_registry[$registryKey];
     }

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -473,6 +473,8 @@ final class Mage
     {
         $registryKey = "_singleton/$modelAlias";
         if (!isset(self::$_registry[$registryKey])) {
+            // A constructor can re-enter its own alias and register it first; that
+            // instance wins. Arguments still fail loudly, the caller wants its own.
             self::register($registryKey, self::getModel($modelAlias, $arguments), $arguments === []);
         }
         return self::$_registry[$registryKey];

--- a/lib/Maho/Profiler.php
+++ b/lib/Maho/Profiler.php
@@ -97,27 +97,28 @@ class Profiler
     {
         self::resume($timerName);
 
+        // Match before asking for the tracer: booting one reads store config, and a
+        // 'CORE::create_object_of::' timer wraps the constructor that read re-enters.
+        $prefix = array_find(self::$_spanPrefixes, fn($candidate) => str_starts_with($timerName, $candidate));
+        if ($prefix === null) {
+            return;
+        }
+
         $tracer = \Mage::getTracer();
         if ($tracer === null || !$tracer->isRecording()) {
             return;
         }
-
-        foreach (self::$_spanPrefixes as $prefix) {
-            if (!str_starts_with($timerName, $prefix)) {
-                continue;
-            }
-            if ($prefix === 'BLOCK:' && !$tracer->isBlockTracingEnabled()) {
-                return;
-            }
-            if ($prefix === 'cache.' && !$tracer->isCacheTracingEnabled()) {
-                return;
-            }
-            self::$_spans[$timerName][] = $tracer->startSpan(
-                $timerName,
-                is_callable($attributes) ? $attributes() : $attributes,
-            );
+        if ($prefix === 'BLOCK:' && !$tracer->isBlockTracingEnabled()) {
             return;
         }
+        if ($prefix === 'cache.' && !$tracer->isCacheTracingEnabled()) {
+            return;
+        }
+
+        self::$_spans[$timerName][] = $tracer->startSpan(
+            $timerName,
+            is_callable($attributes) ? $attributes() : $attributes,
+        );
     }
 
     public static function pause(string $timerName): void

--- a/tests/Backend/Unit/Core/SingletonReentrancyTest.php
+++ b/tests/Backend/Unit/Core/SingletonReentrancyTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Mage_Core
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Fixtures whose construction reaches back into their own alias, the way
+ * Mage_Core_Model_Resource does during setup: Mage_Core_Model_Config profiles the
+ * construction, \Maho\Profiler::start() asks for the OpenTelemetry tracer, and
+ * initializing the tracer reads store config over 'core/resource'. Each records the
+ * instance the re-entrant call registered, so the tests can pin which one survives.
+ */
+class Maho_Test_Reentrancy_Model extends Mage_Core_Model_Abstract
+{
+    public static bool $reentered = false;
+    public static ?self $inner = null;
+
+    public function __construct(array $args = [])
+    {
+        if (!self::$reentered) {
+            self::$reentered = true;
+            self::$inner = Mage::getSingleton('mahotestreentrancy/model');
+        }
+        parent::__construct($args);
+    }
+}
+
+class Maho_Test_Reentrancy_Resource_Model
+{
+    public static bool $reentered = false;
+    public static ?self $inner = null;
+
+    public function __construct(array $args = [])
+    {
+        if (!self::$reentered) {
+            self::$reentered = true;
+            self::$inner = Mage::getResourceSingleton('mahotestreentrancy/model');
+        }
+    }
+}
+
+class Maho_Test_Reentrancy_Helper_Data extends Mage_Core_Helper_Abstract
+{
+    public static bool $reentered = false;
+    public static ?self $inner = null;
+
+    public function __construct()
+    {
+        if (!self::$reentered) {
+            self::$reentered = true;
+            self::$inner = Mage::helper('mahotestreentrancy');
+        }
+    }
+}
+
+class Maho_Test_Reentrancy_Resource_Helper extends Mage_Core_Model_Resource_Helper_Abstract
+{
+    public static bool $reentered = false;
+    public static ?self $inner = null;
+
+    public function __construct($module)
+    {
+        parent::__construct($module);
+        if (!self::$reentered) {
+            self::$reentered = true;
+            self::$inner = Mage::getResourceHelper('mahotestreentrancy');
+        }
+    }
+
+    #[\Override]
+    public function addLikeEscape($value, $options = [])
+    {
+        return $value;
+    }
+
+    #[\Override]
+    public function castField($field)
+    {
+        return $field;
+    }
+}
+
+beforeEach(function () {
+    Maho_Test_Reentrancy_Model::$reentered = false;
+    Maho_Test_Reentrancy_Model::$inner = null;
+    Maho_Test_Reentrancy_Resource_Model::$reentered = false;
+    Maho_Test_Reentrancy_Resource_Model::$inner = null;
+    Maho_Test_Reentrancy_Helper_Data::$reentered = false;
+    Maho_Test_Reentrancy_Helper_Data::$inner = null;
+    Maho_Test_Reentrancy_Resource_Helper::$reentered = false;
+    Maho_Test_Reentrancy_Resource_Helper::$inner = null;
+
+    $config = Mage::getConfig();
+    $config->setNode('global/models/mahotestreentrancy/class', 'Maho_Test_Reentrancy');
+    $config->setNode('global/models/mahotestreentrancy/resourceModel', 'mahotestreentrancy_resource');
+    $config->setNode('global/models/mahotestreentrancy_resource/class', 'Maho_Test_Reentrancy_Resource');
+    $config->setNode('global/helpers/mahotestreentrancy/class', 'Maho_Test_Reentrancy_Helper');
+
+    // The resource helper class name carries the connection engine, which differs per
+    // database backend, so bind the fixture to whatever name this backend resolves to.
+    $resourceHelperClass = $config->getResourceHelperClassName('mahotestreentrancy');
+    if (is_string($resourceHelperClass) && !class_exists($resourceHelperClass)) {
+        class_alias(Maho_Test_Reentrancy_Resource_Helper::class, $resourceHelperClass);
+    }
+});
+
+describe('a constructor that re-enters its own singleton', function () {
+    it('keeps the first instance for getSingleton()', function () {
+        $singleton = Mage::getSingleton('mahotestreentrancy/model');
+
+        expect(Maho_Test_Reentrancy_Model::$inner)->toBeInstanceOf(Maho_Test_Reentrancy_Model::class)
+            ->and($singleton)->toBe(Maho_Test_Reentrancy_Model::$inner)
+            ->and(Mage::getSingleton('mahotestreentrancy/model'))->toBe($singleton);
+    });
+
+    it('keeps the first instance for getResourceSingleton()', function () {
+        $singleton = Mage::getResourceSingleton('mahotestreentrancy/model');
+
+        expect(Maho_Test_Reentrancy_Resource_Model::$inner)->toBeInstanceOf(Maho_Test_Reentrancy_Resource_Model::class)
+            ->and($singleton)->toBe(Maho_Test_Reentrancy_Resource_Model::$inner)
+            ->and(Mage::getResourceSingleton('mahotestreentrancy/model'))->toBe($singleton);
+    });
+
+    it('keeps the first instance for helper()', function () {
+        $helper = Mage::helper('mahotestreentrancy');
+
+        expect(Maho_Test_Reentrancy_Helper_Data::$inner)->toBeInstanceOf(Maho_Test_Reentrancy_Helper_Data::class)
+            ->and($helper)->toBe(Maho_Test_Reentrancy_Helper_Data::$inner)
+            ->and(Mage::helper('mahotestreentrancy'))->toBe($helper);
+    });
+
+    it('keeps the first instance for getResourceHelper()', function () {
+        $helper = Mage::getResourceHelper('mahotestreentrancy');
+
+        expect(Maho_Test_Reentrancy_Resource_Helper::$inner)->toBeInstanceOf(Maho_Test_Reentrancy_Resource_Helper::class)
+            ->and($helper)->toBe(Maho_Test_Reentrancy_Resource_Helper::$inner)
+            ->and(Mage::getResourceHelper('mahotestreentrancy'))->toBe($helper);
+    });
+
+    it('still fails when the caller asked for constructor arguments', function () {
+        expect(fn() => Mage::getSingleton('mahotestreentrancy/model', ['foo' => 'bar']))
+            ->toThrow(Mage_Core_Exception::class, 'Mage registry key _singleton/mahotestreentrancy/model already exists');
+    });
+
+    it('still fails when the resource caller asked for constructor arguments', function () {
+        expect(fn() => Mage::getResourceSingleton('mahotestreentrancy/model', ['foo' => 'bar']))
+            ->toThrow(Mage_Core_Exception::class, 'Mage registry key _resource_singleton/mahotestreentrancy/model already exists');
+    });
+});

--- a/tests/Backend/Unit/Core/SingletonReentrancyTest.php
+++ b/tests/Backend/Unit/Core/SingletonReentrancyTest.php
@@ -12,10 +12,7 @@ uses(Tests\MahoBackendTestCase::class);
 
 /**
  * Fixtures whose construction reaches back into their own alias, the way
- * Mage_Core_Model_Resource does during setup: Mage_Core_Model_Config profiles the
- * construction, \Maho\Profiler::start() asks for the OpenTelemetry tracer, and
- * initializing the tracer reads store config over 'core/resource'. Each records the
- * instance the re-entrant call registered, so the tests can pin which one survives.
+ * Mage_Core_Model_Resource does when tracer init runs inside its constructor.
  */
 class Maho_Test_Reentrancy_Model extends Mage_Core_Model_Abstract
 {
@@ -103,8 +100,8 @@ beforeEach(function () {
     $config->setNode('global/models/mahotestreentrancy_resource/class', 'Maho_Test_Reentrancy_Resource');
     $config->setNode('global/helpers/mahotestreentrancy/class', 'Maho_Test_Reentrancy_Helper');
 
-    // The resource helper class name carries the connection engine, which differs per
-    // database backend, so bind the fixture to whatever name this backend resolves to.
+    // The resource helper class name carries the connection engine, so bind the
+    // fixture to whatever name this backend resolves to.
     $resourceHelperClass = $config->getResourceHelperClassName('mahotestreentrancy');
     if (is_string($resourceHelperClass) && !class_exists($resourceHelperClass)) {
         class_alias(Maho_Test_Reentrancy_Resource_Helper::class, $resourceHelperClass);

--- a/tests/Backend/Unit/OpenTelemetry/TracingSafetyTest.php
+++ b/tests/Backend/Unit/OpenTelemetry/TracingSafetyTest.php
@@ -69,6 +69,19 @@ it('profiler timers run cleanly without a tracer', function () {
     expect(true)->toBeTrue(); // reaching here without exceptions is the assertion
 });
 
+it('does not boot the tracer for a timer name that can never open a span', function () {
+    $cache = new ReflectionProperty(Mage::class, '_tracer');
+    $cache->setValue(null, null);
+
+    \Maho\Profiler::start('CORE::create_object_of::Mage_Core_Model_Resource');
+    \Maho\Profiler::stop('CORE::create_object_of::Mage_Core_Model_Resource');
+    expect($cache->getValue())->toBeNull();
+
+    \Maho\Profiler::start('mage::app::dispatch');
+    \Maho\Profiler::stop('mage::app::dispatch');
+    expect($cache->getValue())->toBeFalse();
+});
+
 it('commerce observers are no-ops without a tracer', function () {
     $observer = new Maho_OpenTelemetry_Model_Observer();
 


### PR DESCRIPTION
With `Maho_OpenTelemetry` active and the Configuration cache type disabled, every request after
the first one following a cache flush dies during bootstrap:

```
Mage registry key _singleton/core/resource already exists
#1 app/Mage.php(476): Mage::register('_singleton/core...', Object(Mage_Core_Model_Resource))
#2 app/code/core/Mage/Core/Model/Resource/Setup.php(127): Mage::getSingleton('core/resource')
#3 app/code/core/Mage/Core/Model/Resource/Setup.php(260): Mage_Core_Model_Resource_Setup->__construct('core_setup', 'Mage_Core')
#4 app/code/core/Mage/Core/Model/App.php(452): Mage_Core_Model_Resource_Setup::applyAllUpdates()
#5 app/code/core/Mage/Core/Model/App.php(328): Mage_Core_Model_App->_initModules()
#6 app/Mage.php(699): Mage_Core_Model_App->run(Array)
```

### Environment

| | |
| --- | --- |
| Maho | `963fad89d`, clean checkout, no local or community modules |
| PHP | 8.5.7 |
| Database | MySQL 8.4 |
| `open-telemetry/sdk` | 1.15.0, installed |

### Reproduce

Start from a working install of `963fad89d` with `Maho_OpenTelemetry` left at its shipped
`<active>true</active>`, tracing switched off (no `dev/opentelemetry/enabled`, no `OTEL_*`
variables) and nothing else customized.

1. Converge the declarative schema, so `isSchemaUpdatePending()` returns false. While it returns
   true, the 503 schema guard refuses requests before this bug can surface.

   ```
   ./maho migrate
   ```

2. Turn off the Configuration cache type, in System > Cache Management or directly:

   ```sql
   UPDATE core_cache_option SET value = 0 WHERE code = 'config';
   ```

3. Flush, so both the config cache and the cached schema verdict start cold.

   ```
   ./maho cache:flush
   ```

4. Request the same page twice, with a cache buster so no FPC or edge cache can answer.

   ```
   curl -s "https://example.test/?nocache=1" | head -3
   curl -s "https://example.test/?nocache=2" | head -3
   ```

Request 1 renders normally. Request 2 and every request after it dies with the trace above, until
the Configuration cache type is turned back on. Measured 1 pass then 3 failures over the 4
requests following a flush, then 5 failures out of 5 on a further round.

Read the response body, not the status code. A health check on `%{http_code}` alone reports the
site as fine: depending on the error display settings the failure is either 200 with the trace
inline, or 503 with a generic page whose real exception is in `var/report/`.

### Cause

`Mage::getSingleton()` builds the model first and registers it second, with nothing guarding the
window between. `Mage_Core_Model_Config::getModelInstance()` profiles the construction and
`\Maho\Profiler::start()` asks for the tracer before the object exists, so building
`core/resource` reaches back into `core/resource`:

```
Resource_Setup::applyAllUpdates()               App.php:452, sets update mode
  Mage::getSingleton('core/resource')           Setup.php:127, outer, key not registered yet
    \Maho\Profiler::start(...)                  Config.php:1407, before `new $className()`
      Mage::getTracer()                         Profiler.php:100
        Mage::helper('opentelemetry')           Tracer.php:144, the same window on helper()
        $helper->isEnabled() -> store config    Tracer.php:152
          Mage::getSingleton('core/resource')   inner, registers the key outer register() -> "already exists"
```

`Mage::$_tracerInitializing` only guards recursion back into `getTracer()` itself, not re-entry
into `getSingleton()`. The inner read runs long before the tracer can find out it is switched off,
because `isEnabled()` reads store config before `initialize()` reaches the
`class_exists(TracerProvider::class)` guard, and update mode is what lets that read reach the
database at all: it makes `getStore()` fall back to the default store rather than throw.

Two conditions have to line up, which is why the issue is normally hidden. First,
`getCacheSaveLock()` must return at Config.php:464 without registering `core/resource` at
line 468. This happens only when the Configuration cache type is disabled. Second,
`isSchemaUpdatePending()` must use its cached verdict rather than opening its own connection
at App.php:519. That is the state from the second request after a cache flush onward.

Although both conditions also apply to the CLI, the CLI does not hit the problematic path:
`Mage::app()` initializes through `Mage_Core_Model_Config::init()` and never calls
`_initModules()`, so schema updates are not applied during CLI bootstrap.