### PR TITLE
Stripped 4-byte characters from the search query text

### DIFF
--- a/app/code/core/Mage/CatalogSearch/Helper/Data.php
+++ b/app/code/core/Mage/CatalogSearch/Helper/Data.php
@@ -113,6 +113,13 @@ class Mage_CatalogSearch_Helper_Data extends Mage_Core_Helper_Abstract
                 $this->_queryText = is_array($this->_queryText) ? ''
                     : $stringHelper->cleanString(trim($this->_queryText));
 
+                // 4-byte characters do not fit the utf8mb3 column the query is saved in, and
+                // an unhandled insert failure would take the whole result page down with it
+                $stripped = preg_replace('/[\x{10000}-\x{10FFFF}]/u', '', $this->_queryText);
+                if ($stripped !== null) {
+                    $this->_queryText = trim($stripped);
+                }
+
                 $maxQueryLength = $this->getMaxQueryLength();
                 if ($maxQueryLength !== '' && $stringHelper->strlen($this->_queryText) > $maxQueryLength) {
                     $this->_queryText = $stringHelper->substr($this->_queryText, 0, $maxQueryLength);

--- a/tests/Frontend/Unit/CatalogSearch/Helper/DataTest.php
+++ b/tests/Frontend/Unit/CatalogSearch/Helper/DataTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoFrontendTestCase::class);
+
+function searchHelperForQuery(string $queryText): Mage_CatalogSearch_Helper_Data
+{
+    Mage::app()->getRequest()->setParam(Mage_CatalogSearch_Helper_Data::QUERY_VAR_NAME, $queryText);
+    return new Mage_CatalogSearch_Helper_Data();
+}
+
+describe('getQueryText', function () {
+    it('removes 4-byte characters that the query column cannot store', function () {
+        $helper = searchHelperForQuery("\u{1F449}\u{1F3FB} acc6.top \u{1F448}\u{1F3FB} comprar");
+
+        expect($helper->getQueryText())->toBe('acc6.top  comprar');
+    });
+
+    it('returns an empty query when the text is only 4-byte characters', function () {
+        $helper = searchHelperForQuery("\u{1F449}\u{1F3FB}");
+
+        expect($helper->getQueryText())->toBe('');
+    });
+
+    it('keeps accented and non-latin characters', function () {
+        $helper = searchHelperForQuery('membresía Ελλάδα');
+
+        expect($helper->getQueryText())->toBe('membresía Ελλάδα');
+    });
+});


### PR DESCRIPTION
A search for a string with an emoji returned a 500 page. The query reaches the insert into `catalogsearch_query`, whose `query_text` column is `utf8mb3`, and MySQL raises `SQLSTATE[HY000] 1366` inside `Mage_CatalogSearch_Model_Query::prepare()`. The exception is unhandled, so the result page dies before it renders.

Found on a live shop, where a spam bot hit `/catalogsearch/result` with emoji-wrapped advertisement text. Any customer who types an emoji in the search box gets the same 500.

`Mage_CatalogSearch_Helper_Data::getQueryText()` now removes characters outside the BMP, next to the `cleanString()` and max-length normalization it already does. A query made only of such characters becomes empty and takes the normal empty-search path.

This does not touch the database charset. That is a separate decision, and it needs the connection charset too (`Maho\Db\Adapter\Pdo\Mysql` defaults it to `utf8`).

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->