### PR TITLE
Added a 301 redirect from /index.php URLs to the clean URL

### DIFF
--- a/app/code/core/Mage/Core/Helper/Url.php
+++ b/app/code/core/Mage/Core/Helper/Url.php
@@ -227,8 +227,9 @@ class Mage_Core_Helper_Url extends Mage_Core_Helper_Abstract
      */
     public function addTrailingSlash(string $url): string
     {
-        // Parse URL and remove all trailing slashes from path
-        $parts = parse_url($url);
+        // Parse URL and remove all trailing slashes from path.
+        // parse_url() rejects some path-only inputs (e.g. "/a:1/b"); treat those as a plain path.
+        $parts = parse_url($url) ?: ['path' => $url];
         $parts['path'] = rtrim($parts['path'] ?? '', '/');
 
         // Only add trailing slashes for pages without an extension
@@ -244,8 +245,9 @@ class Mage_Core_Helper_Url extends Mage_Core_Helper_Abstract
      */
     public function removeTrailingSlash(string $url): string
     {
-        // Parse URL and remove all trailing slashes from path
-        $parts = parse_url($url);
+        // Parse URL and remove all trailing slashes from path.
+        // parse_url() rejects some path-only inputs (e.g. "/a:1/b"); treat those as a plain path.
+        $parts = parse_url($url) ?: ['path' => $url];
         $parts['path'] = rtrim($parts['path'] ?? '', '/');
 
         // Add a trailing slash to the root domain

--- a/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
+++ b/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
@@ -9,7 +9,7 @@
 class Mage_Core_Model_Controller_Front_Observer
 {
     /**
-     * Run pre-dispatch checks in order: base URL, trailing slash, store resolution,
+     * Run pre-dispatch checks in order: base URL, canonical URI, store resolution,
      * URL rewrite, config rewrite, HTTPS enforcement.
      *
      * Each step short-circuits the chain if a redirect has been set.
@@ -24,7 +24,7 @@ class Mage_Core_Model_Controller_Front_Observer
 
         $steps = [
             $this->checkBaseUrl(...),
-            $this->checkTrailingSlash(...),
+            $this->checkCanonicalUri(...),
             $this->rewriteDb(...),
             $this->rewriteConfig(...),
             $this->enforceHttps(...),
@@ -76,7 +76,11 @@ class Mage_Core_Model_Controller_Front_Observer
         }
     }
 
-    private function checkTrailingSlash(Mage_Core_Controller_Request_Http $request, Mage_Core_Controller_Response_Http $response): void
+    /**
+     * Redirect to the canonical form of the request URI: no front-controller script,
+     * no repeated slashes, and the configured trailing-slash style.
+     */
+    private function checkCanonicalUri(Mage_Core_Controller_Request_Http $request, Mage_Core_Controller_Response_Http $response): void
     {
         if (!Mage::isInstalled() || $request->getPost() || strtolower($request->getMethod()) === 'post') {
             return;
@@ -86,8 +90,21 @@ class Mage_Core_Model_Controller_Front_Observer
             return;
         }
 
-        $requestUri = $request->getRequestUri();
-        $canonicalUri = preg_replace('#/{2,}#', '/', $requestUri);
+        $requestUri = (string) $request->getRequestUri();
+        $canonicalUri = $requestUri;
+
+        // Maho never generates URLs holding index.php, but the front controller stays reachable
+        // at its own path on every web server, serving the whole storefront a second time.
+        $baseUrl = $request->getBaseUrl();
+        if (str_ends_with($baseUrl, '/index.php')) {
+            $rest = substr($requestUri, strlen($baseUrl));
+            if (!str_starts_with($rest, '/')) {
+                $rest = '/' . $rest;
+            }
+            $canonicalUri = substr($baseUrl, 0, -strlen('/index.php')) . $rest;
+        }
+
+        $canonicalUri = preg_replace('#/{2,}#', '/', $canonicalUri);
         $canonicalUri = Mage::helper('core/url')->addOrRemoveTrailingSlash($canonicalUri);
 
         if ($canonicalUri !== $requestUri) {

--- a/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
+++ b/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
@@ -91,20 +91,20 @@ class Mage_Core_Model_Controller_Front_Observer
         }
 
         $requestUri = (string) $request->getRequestUri();
-        $queryPos = strpos($requestUri, '?');
-        $path = $queryPos === false ? $requestUri : substr($requestUri, 0, $queryPos);
-        $query = $queryPos === false ? '' : substr($requestUri, $queryPos);
+        $parts = explode('?', $requestUri, 2);
+        $path = $parts[0];
+        $query = isset($parts[1]) ? '?' . $parts[1] : '';
 
         $baseUrl = $request->getBaseUrl();
         if (str_ends_with($baseUrl, '/index.php') && str_starts_with($path, $baseUrl)) {
-            $path = dirname($baseUrl) . '/' . substr($path, strlen($baseUrl));
+            $path = dirname($baseUrl) . substr($path, strlen($baseUrl));
         }
 
-        // Leading slashes and backslashes go too: a Location of "//host" or "/\host" is another origin.
-        $path = preg_replace('#/{2,}#', '/', '/' . ltrim($path, '/\\'));
+        // A leading "//" or "/\" makes the browser read the Location as another origin.
+        $path = '/' . ltrim(preg_replace('#/{2,}#', '/', $path), '/\\');
         $path = Mage::helper('core/url')->addOrRemoveTrailingSlash($path);
-        $canonicalUri = $path . $query;
 
+        $canonicalUri = $path . $query;
         if ($canonicalUri !== $requestUri) {
             $response->setRedirect($canonicalUri, 301);
         }

--- a/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
+++ b/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
@@ -66,11 +66,14 @@ class Mage_Core_Model_Controller_Front_Observer
 
         $uri = @parse_url($baseUrl);
         $requestUri = $request->getRequestUri() ?: '/';
+        // The slash keeps "/shop" (the base path without its trailing slash) inside the
+        // base URL; redirecting it would ping-pong with checkCanonicalUri on "remove" mode.
+        $requestPath = explode('?', $requestUri, 2)[0] . '/';
 
         if (
             (isset($uri['scheme']) && $uri['scheme'] !== $request->getScheme())
             || (isset($uri['host']) && $uri['host'] !== $request->getHttpHost())
-            || (isset($uri['path']) && !str_contains($requestUri, $uri['path']))
+            || (isset($uri['path']) && !str_contains($requestPath, $uri['path']))
         ) {
             $response->setRedirect($baseUrl, $redirectCode);
         }
@@ -90,12 +93,18 @@ class Mage_Core_Model_Controller_Front_Observer
             return;
         }
 
+        // Legacy API clients (SOAP/XML-RPC) do not follow redirects reliably.
+        if (str_starts_with($request->getPathInfo() . '/', '/api/')) {
+            return;
+        }
+
         $requestUri = (string) $request->getRequestUri();
         $path = explode('?', $requestUri, 2)[0];
         $query = substr($requestUri, strlen($path));
 
+        // Strip the script only at a path boundary: "/index.php.bak" is a 404, not a redirect.
         $baseUrl = $request->getBaseUrl();
-        if (str_ends_with($baseUrl, '/index.php') && str_starts_with($path, $baseUrl)) {
+        if (str_ends_with($baseUrl, '/index.php') && ($path === $baseUrl || str_starts_with($path, $baseUrl . '/'))) {
             $path = dirname($baseUrl) . substr($path, strlen($baseUrl));
         }
 

--- a/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
+++ b/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
@@ -91,25 +91,23 @@ class Mage_Core_Model_Controller_Front_Observer
         }
 
         $requestUri = (string) $request->getRequestUri();
-        $canonicalUri = $requestUri;
+        [$path, $query] = array_pad(explode('?', $requestUri, 2), 2, null);
 
-        // Maho never generates URLs holding index.php, but the front controller stays reachable
-        // at its own path on every web server, serving the whole storefront a second time.
         $baseUrl = $request->getBaseUrl();
-        if (str_ends_with($baseUrl, '/index.php')) {
-            $rest = substr($requestUri, strlen($baseUrl));
-            if (!str_starts_with($rest, '/')) {
-                $rest = '/' . $rest;
-            }
-            $canonicalUri = substr($baseUrl, 0, -strlen('/index.php')) . $rest;
+        if (str_ends_with($baseUrl, '/index.php') && str_starts_with($path, $baseUrl)) {
+            $path = dirname($baseUrl) . '/' . substr($path, strlen($baseUrl));
         }
 
-        $canonicalUri = preg_replace('#/{2,}#', '/', $canonicalUri);
-        $canonicalUri = Mage::helper('core/url')->addOrRemoveTrailingSlash($canonicalUri);
+        $path = preg_replace('#/{2,}#', '/', $path);
+        $path = Mage::helper('core/url')->addOrRemoveTrailingSlash($path);
+        $canonicalUri = $query === null ? $path : $path . '?' . $query;
 
-        if ($canonicalUri !== $requestUri) {
-            $response->setRedirect($canonicalUri, 301);
+        // A Location the browser reads as another origin ("/\host") or as an absolute URL is not a local path.
+        if ($canonicalUri === $requestUri || !str_starts_with($path, '/') || str_starts_with($path, '/\\')) {
+            return;
         }
+
+        $response->setRedirect($canonicalUri, 301);
     }
 
     private function rewriteDb(Mage_Core_Controller_Request_Http $request, Mage_Core_Controller_Response_Http $response): void

--- a/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
+++ b/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
@@ -91,9 +91,8 @@ class Mage_Core_Model_Controller_Front_Observer
         }
 
         $requestUri = (string) $request->getRequestUri();
-        $parts = explode('?', $requestUri, 2);
-        $path = $parts[0];
-        $query = isset($parts[1]) ? '?' . $parts[1] : '';
+        $path = explode('?', $requestUri, 2)[0];
+        $query = substr($requestUri, strlen($path));
 
         $baseUrl = $request->getBaseUrl();
         if (str_ends_with($baseUrl, '/index.php') && str_starts_with($path, $baseUrl)) {

--- a/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
+++ b/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
@@ -91,7 +91,9 @@ class Mage_Core_Model_Controller_Front_Observer
         }
 
         $requestUri = (string) $request->getRequestUri();
-        [$path, $query] = array_pad(explode('?', $requestUri, 2), 2, null);
+        $queryPos = strpos($requestUri, '?');
+        $path = $queryPos === false ? $requestUri : substr($requestUri, 0, $queryPos);
+        $query = $queryPos === false ? '' : substr($requestUri, $queryPos);
 
         $baseUrl = $request->getBaseUrl();
         if (str_ends_with($baseUrl, '/index.php') && str_starts_with($path, $baseUrl)) {
@@ -101,7 +103,7 @@ class Mage_Core_Model_Controller_Front_Observer
         // Leading slashes and backslashes go too: a Location of "//host" or "/\host" is another origin.
         $path = preg_replace('#/{2,}#', '/', '/' . ltrim($path, '/\\'));
         $path = Mage::helper('core/url')->addOrRemoveTrailingSlash($path);
-        $canonicalUri = $query === null ? $path : $path . '?' . $query;
+        $canonicalUri = $path . $query;
 
         if ($canonicalUri !== $requestUri) {
             $response->setRedirect($canonicalUri, 301);

--- a/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
+++ b/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
@@ -67,13 +67,13 @@ class Mage_Core_Model_Controller_Front_Observer
         $uri = @parse_url($baseUrl);
         $requestUri = $request->getRequestUri() ?: '/';
         // The slash keeps "/shop" (the base path without its trailing slash) inside the
-        // base URL; redirecting it would ping-pong with checkCanonicalUri on "remove" mode.
+        // base URL; checkCanonicalUri redirects it to "/shop/" locally.
         $requestPath = explode('?', $requestUri, 2)[0] . '/';
 
         if (
             (isset($uri['scheme']) && $uri['scheme'] !== $request->getScheme())
             || (isset($uri['host']) && $uri['host'] !== $request->getHttpHost())
-            || (isset($uri['path']) && !str_contains($requestPath, $uri['path']))
+            || (isset($uri['path']) && !str_starts_with($requestPath, $uri['path']))
         ) {
             $response->setRedirect($baseUrl, $redirectCode);
         }
@@ -89,12 +89,15 @@ class Mage_Core_Model_Controller_Front_Observer
             return;
         }
 
-        if (Mage::helper('adminhtml')->isAdminFrontNameMatched($request->getPathInfo())) {
+        // Collapse repeated slashes before the exemptions so "//api/soap" still matches.
+        $pathInfo = preg_replace('#/{2,}#', '/', $request->getPathInfo());
+
+        if (Mage::helper('adminhtml')->isAdminFrontNameMatched($pathInfo)) {
             return;
         }
 
         // Legacy API clients (SOAP/XML-RPC) do not follow redirects reliably.
-        if (str_starts_with($request->getPathInfo() . '/', '/api/')) {
+        if (str_starts_with($pathInfo . '/', '/api/')) {
             return;
         }
 
@@ -103,14 +106,24 @@ class Mage_Core_Model_Controller_Front_Observer
         $query = substr($requestUri, strlen($path));
 
         // Strip the script only at a path boundary: "/index.php.bak" is a 404, not a redirect.
+        // getBaseUrl() returns the prefix as percent-encoded in REQUEST_URI, so decode to compare.
         $baseUrl = $request->getBaseUrl();
-        if (str_ends_with($baseUrl, '/index.php') && ($path === $baseUrl || str_starts_with($path, $baseUrl . '/'))) {
-            $path = dirname($baseUrl) . substr($path, strlen($baseUrl));
+        if (str_ends_with(rawurldecode($baseUrl), '/index.php') && ($path === $baseUrl || str_starts_with($path, $baseUrl . '/'))) {
+            $path = substr($baseUrl, 0, (int) strrpos($baseUrl, '/')) . substr($path, strlen($baseUrl));
         }
 
         // A leading "//" or "/\" makes the browser read the Location as another origin.
         $path = '/' . ltrim(preg_replace('#/{2,}#', '/', $path), '/\\');
         $path = Mage::helper('core/url')->addOrRemoveTrailingSlash($path);
+
+        // The base path keeps its trailing slash: "/shop" resolves outside the base URL and 404s.
+        $basePath = rtrim((string) parse_url(Mage::getBaseUrl(
+            Mage_Core_Model_Store::URL_TYPE_WEB,
+            Mage::app()->isCurrentlySecure(),
+        ), PHP_URL_PATH), '/');
+        if ($basePath !== '' && rtrim($path, '/') === $basePath) {
+            $path = $basePath . '/';
+        }
 
         $canonicalUri = $path . $query;
         if ($canonicalUri !== $requestUri) {

--- a/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
+++ b/app/code/core/Mage/Core/Model/Controller/Front/Observer.php
@@ -98,16 +98,14 @@ class Mage_Core_Model_Controller_Front_Observer
             $path = dirname($baseUrl) . '/' . substr($path, strlen($baseUrl));
         }
 
-        $path = preg_replace('#/{2,}#', '/', $path);
+        // Leading slashes and backslashes go too: a Location of "//host" or "/\host" is another origin.
+        $path = preg_replace('#/{2,}#', '/', '/' . ltrim($path, '/\\'));
         $path = Mage::helper('core/url')->addOrRemoveTrailingSlash($path);
         $canonicalUri = $query === null ? $path : $path . '?' . $query;
 
-        // A Location the browser reads as another origin ("/\host") or as an absolute URL is not a local path.
-        if ($canonicalUri === $requestUri || !str_starts_with($path, '/') || str_starts_with($path, '/\\')) {
-            return;
+        if ($canonicalUri !== $requestUri) {
+            $response->setRedirect($canonicalUri, 301);
         }
-
-        $response->setRedirect($canonicalUri, 301);
     }
 
     private function rewriteDb(Mage_Core_Controller_Request_Http $request, Mage_Core_Controller_Response_Http $response): void

--- a/tests/Backend/Unit/Maho/Routing/CanonicalUriTest.php
+++ b/tests/Backend/Unit/Maho/Routing/CanonicalUriTest.php
@@ -111,6 +111,18 @@ describe('Front observer canonical URI', function () {
         expect(canonicalUriLocation($response))->toBe('/shop/customer/account/login');
     });
 
+    it('leaves a path that only starts with the front controller name alone', function () {
+        $response = canonicalUriDispatch('/index.php.bak');
+
+        expect($response->isRedirect())->toBeFalse();
+    });
+
+    it('leaves a legacy API request alone, since SOAP clients may not follow redirects', function () {
+        $response = canonicalUriDispatch('/index.php/api/soap?wsdl=1');
+
+        expect($response->isRedirect())->toBeFalse();
+    });
+
     it('leaves a rewritten URL alone', function () {
         $response = canonicalUriDispatch('/catalog/category/view/id/3');
 

--- a/tests/Backend/Unit/Maho/Routing/CanonicalUriTest.php
+++ b/tests/Backend/Unit/Maho/Routing/CanonicalUriTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * `Mage_Core_Model_Controller_Front_Observer::checkCanonicalUri()` sends the front
+ * controller's own path back to the storefront root. Maho never generates a URL
+ * holding `index.php`, but every web server keeps `/index.php` reachable, which
+ * serves the whole catalog a second time under duplicate URLs.
+ *
+ * The script segment is detected through the request base URL, the same value the
+ * router already strips to build the path info, so a store installed in a
+ * subdirectory keeps its prefix.
+ */
+function canonicalUriConfig(): void
+{
+    $config = Mage::getConfig();
+    // `checkBaseUrl` runs before the canonical-URI step and would redirect first
+    // on the host mismatch between the test URI and the installed base URL.
+    $config->saveConfig('web/url/redirect_to_base', '0');
+    $config->saveConfig('web/url/trailing_slash_behavior', 'leave');
+    Mage::app()->cleanCache([Mage_Core_Model_Config::CACHE_TAG]);
+    $config->reinit();
+    Mage::app()->reinitStores();
+}
+
+function canonicalUriResetConfig(): void
+{
+    $config = Mage::getConfig();
+    $config->deleteConfig('web/url/redirect_to_base');
+    $config->deleteConfig('web/url/trailing_slash_behavior');
+    Mage::app()->cleanCache([Mage_Core_Model_Config::CACHE_TAG]);
+    $config->reinit();
+    Mage::app()->reinitStores();
+}
+
+function canonicalUriDispatch(string $uri, string $script = '/index.php', string $method = 'GET', array $postData = []): Mage_Core_Controller_Response_Http
+{
+    $server = ['SCRIPT_NAME' => $script, 'SCRIPT_FILENAME' => $script, 'PHP_SELF' => $script];
+    $symfonyRequest = SymfonyRequest::create('http://localhost' . $uri, $method, $postData, [], [], $server);
+
+    $request = new Mage_Core_Controller_Request_Http($symfonyRequest);
+    // The URL-rewrite lookup runs after this step and would redirect on its own
+    // when no canonical redirect is expected.
+    $request->isStraight(true);
+
+    $response = new Mage_Core_Controller_Response_Http();
+
+    Mage::app()->setRequest($request);
+    Mage::app()->setResponse($response);
+
+    $front = new Mage_Core_Controller_Varien_Front();
+    $event = new \Maho\Event\Observer();
+    $event->setData('front', $front);
+
+    (new Mage_Core_Model_Controller_Front_Observer())->onDispatchBefore($event);
+
+    return $response;
+}
+
+function canonicalUriLocation(Mage_Core_Controller_Response_Http $response): ?string
+{
+    foreach ($response->getHeaders() as $header) {
+        if (strcasecmp($header['name'], 'Location') === 0) {
+            return $header['value'];
+        }
+    }
+    return null;
+}
+
+describe('Front observer canonical URI', function () {
+    beforeEach(function () {
+        canonicalUriConfig();
+        Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
+    });
+
+    afterEach(fn() => canonicalUriResetConfig());
+
+    it('redirects the bare front controller to the storefront root', function () {
+        $response = canonicalUriDispatch('/index.php');
+
+        expect($response->isRedirect())->toBeTrue();
+        expect(canonicalUriLocation($response))->toBe('/');
+    });
+
+    it('keeps the query string when redirecting the bare front controller', function () {
+        $response = canonicalUriDispatch('/index.php?utm_source=newsletter');
+
+        expect(canonicalUriLocation($response))->toBe('/?utm_source=newsletter');
+    });
+
+    it('redirects a path served through the front controller', function () {
+        $response = canonicalUriDispatch('/index.php/catalog/category/view/id/3');
+
+        expect(canonicalUriLocation($response))->toBe('/catalog/category/view/id/3');
+    });
+
+    it('keeps the subdirectory prefix of a store installed below the document root', function () {
+        $response = canonicalUriDispatch('/shop/index.php/customer/account/login', '/shop/index.php');
+
+        expect(canonicalUriLocation($response))->toBe('/shop/customer/account/login');
+    });
+
+    it('leaves a rewritten URL alone', function () {
+        $response = canonicalUriDispatch('/catalog/category/view/id/3');
+
+        expect($response->isRedirect())->toBeFalse();
+    });
+
+    it('does not redirect a POST, which would lose the submitted body', function () {
+        $response = canonicalUriDispatch('/index.php', '/index.php', 'POST', ['form_key' => 'x']);
+
+        expect($response->isRedirect())->toBeFalse();
+    });
+});

--- a/tests/Backend/Unit/Maho/Routing/CanonicalUriTest.php
+++ b/tests/Backend/Unit/Maho/Routing/CanonicalUriTest.php
@@ -11,12 +11,27 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 uses(Tests\MahoBackendTestCase::class);
 
-function canonicalUriConfig(string $trailingSlash = 'leave'): void
+/**
+ * Original base URL captured before this file mutates it, so the reset restores the
+ * real installed value (persisted config leaks across the shared test DB).
+ */
+function canonicalUriOriginalBaseUrl(): string
 {
+    static $orig = null;
+    $orig ??= (string) Mage::getStoreConfig('web/unsecure/base_url');
+    return $orig;
+}
+
+function canonicalUriConfig(string $trailingSlash = 'leave', ?string $baseUrl = null): void
+{
+    canonicalUriOriginalBaseUrl();
     $config = Mage::getConfig();
     // `checkBaseUrl` runs first and would redirect on the host mismatch with the installed base URL.
     $config->saveConfig('web/url/redirect_to_base', '0');
     $config->saveConfig('web/url/trailing_slash_behavior', $trailingSlash);
+    if ($baseUrl !== null) {
+        $config->saveConfig('web/unsecure/base_url', $baseUrl);
+    }
     Mage::app()->cleanCache([Mage_Core_Model_Config::CACHE_TAG]);
     $config->reinit();
     Mage::app()->reinitStores();
@@ -27,6 +42,7 @@ function canonicalUriResetConfig(): void
     $config = Mage::getConfig();
     $config->deleteConfig('web/url/redirect_to_base');
     $config->deleteConfig('web/url/trailing_slash_behavior');
+    $config->saveConfig('web/unsecure/base_url', canonicalUriOriginalBaseUrl());
     Mage::app()->cleanCache([Mage_Core_Model_Config::CACHE_TAG]);
     $config->reinit();
     Mage::app()->reinitStores();
@@ -43,12 +59,8 @@ function canonicalUriDispatch(string $uri, string $script = '/index.php', string
         'REQUEST_METHOD' => $method,
         'HTTP_HOST' => 'localhost',
     ];
-    $query = [];
-    $queryPos = strpos($uri, '?');
-    if ($queryPos !== false) {
-        parse_str(substr($uri, $queryPos + 1), $query);
-    }
-    $symfonyRequest = new SymfonyRequest($query, $postData, [], [], [], $server);
+    // The observer only reads REQUEST_URI; the query bag is never consulted on this path.
+    $symfonyRequest = new SymfonyRequest([], $postData, [], [], [], $server);
 
     $request = new Mage_Core_Controller_Request_Http($symfonyRequest);
     // The URL-rewrite lookup runs after this step and would redirect on its own.
@@ -70,12 +82,7 @@ function canonicalUriDispatch(string $uri, string $script = '/index.php', string
 
 function canonicalUriLocation(Mage_Core_Controller_Response_Http $response): ?string
 {
-    foreach ($response->getHeaders() as $header) {
-        if (strcasecmp($header['name'], 'Location') === 0) {
-            return $header['value'];
-        }
-    }
-    return null;
+    return $response->getSymfonyResponse()->headers->get('Location');
 }
 
 describe('Front observer canonical URI', function () {
@@ -121,6 +128,42 @@ describe('Front observer canonical URI', function () {
         $response = canonicalUriDispatch('/index.php/api/soap?wsdl=1');
 
         expect($response->isRedirect())->toBeFalse();
+    });
+
+    it('exempts a legacy API request even with a doubled slash', function () {
+        $response = canonicalUriDispatch('//api/soap?wsdl=1');
+
+        expect($response->isRedirect())->toBeFalse();
+    });
+
+    it('strips a percent-encoded front controller script', function () {
+        $response = canonicalUriDispatch('/%69ndex.php/catalog/category/view/id/3');
+
+        expect(canonicalUriLocation($response))->toBe('/catalog/category/view/id/3');
+    });
+
+    it('leaves a path parse_url cannot parse intact', function () {
+        canonicalUriConfig('add');
+
+        $response = canonicalUriDispatch('/product/sku:123/');
+
+        expect($response->isRedirect())->toBeFalse();
+    });
+
+    it('keeps the trailing slash on the root of a store installed below the document root', function () {
+        canonicalUriConfig('remove', 'http://localhost/shop/');
+
+        $response = canonicalUriDispatch('/shop/', '/shop/index.php');
+
+        expect($response->isRedirect())->toBeFalse();
+    });
+
+    it('redirects the slashless subdirectory root to the storefront root', function () {
+        canonicalUriConfig('remove', 'http://localhost/shop/');
+
+        $response = canonicalUriDispatch('/shop', '/shop/index.php');
+
+        expect(canonicalUriLocation($response))->toBe('/shop/');
     });
 
     it('leaves a rewritten URL alone', function () {

--- a/tests/Backend/Unit/Maho/Routing/CanonicalUriTest.php
+++ b/tests/Backend/Unit/Maho/Routing/CanonicalUriTest.php
@@ -128,7 +128,7 @@ describe('Front observer canonical URI', function () {
 
         $response = canonicalUriDispatch('/\\example.com/x');
 
-        expect($response->isRedirect())->toBeFalse();
+        expect(canonicalUriLocation($response))->toBe('/example.com/x/');
     });
 
     it('does not redirect a POST, which would lose the submitted body', function () {

--- a/tests/Backend/Unit/Maho/Routing/CanonicalUriTest.php
+++ b/tests/Backend/Unit/Maho/Routing/CanonicalUriTest.php
@@ -11,23 +11,12 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 uses(Tests\MahoBackendTestCase::class);
 
-/**
- * `Mage_Core_Model_Controller_Front_Observer::checkCanonicalUri()` sends the front
- * controller's own path back to the storefront root. Maho never generates a URL
- * holding `index.php`, but every web server keeps `/index.php` reachable, which
- * serves the whole catalog a second time under duplicate URLs.
- *
- * The script segment is detected through the request base URL, the same value the
- * router already strips to build the path info, so a store installed in a
- * subdirectory keeps its prefix.
- */
-function canonicalUriConfig(): void
+function canonicalUriConfig(string $trailingSlash = 'leave'): void
 {
     $config = Mage::getConfig();
-    // `checkBaseUrl` runs before the canonical-URI step and would redirect first
-    // on the host mismatch between the test URI and the installed base URL.
+    // `checkBaseUrl` runs first and would redirect on the host mismatch with the installed base URL.
     $config->saveConfig('web/url/redirect_to_base', '0');
-    $config->saveConfig('web/url/trailing_slash_behavior', 'leave');
+    $config->saveConfig('web/url/trailing_slash_behavior', $trailingSlash);
     Mage::app()->cleanCache([Mage_Core_Model_Config::CACHE_TAG]);
     $config->reinit();
     Mage::app()->reinitStores();
@@ -45,12 +34,24 @@ function canonicalUriResetConfig(): void
 
 function canonicalUriDispatch(string $uri, string $script = '/index.php', string $method = 'GET', array $postData = []): Mage_Core_Controller_Response_Http
 {
-    $server = ['SCRIPT_NAME' => $script, 'SCRIPT_FILENAME' => $script, 'PHP_SELF' => $script];
-    $symfonyRequest = SymfonyRequest::create('http://localhost' . $uri, $method, $postData, [], [], $server);
+    // `SymfonyRequest::create()` validates the URI, so it cannot express what a web server hands over.
+    $server = [
+        'SCRIPT_NAME' => $script,
+        'SCRIPT_FILENAME' => $script,
+        'PHP_SELF' => $script,
+        'REQUEST_URI' => $uri,
+        'REQUEST_METHOD' => $method,
+        'HTTP_HOST' => 'localhost',
+    ];
+    $query = [];
+    $queryPos = strpos($uri, '?');
+    if ($queryPos !== false) {
+        parse_str(substr($uri, $queryPos + 1), $query);
+    }
+    $symfonyRequest = new SymfonyRequest($query, $postData, [], [], [], $server);
 
     $request = new Mage_Core_Controller_Request_Http($symfonyRequest);
-    // The URL-rewrite lookup runs after this step and would redirect on its own
-    // when no canonical redirect is expected.
+    // The URL-rewrite lookup runs after this step and would redirect on its own.
     $request->isStraight(true);
 
     $response = new Mage_Core_Controller_Response_Http();
@@ -112,6 +113,20 @@ describe('Front observer canonical URI', function () {
 
     it('leaves a rewritten URL alone', function () {
         $response = canonicalUriDispatch('/catalog/category/view/id/3');
+
+        expect($response->isRedirect())->toBeFalse();
+    });
+
+    it('leaves a query string holding a URL untouched', function () {
+        $response = canonicalUriDispatch('/catalog/category/view/id/3?back=https://example.com/x');
+
+        expect($response->isRedirect())->toBeFalse();
+    });
+
+    it('never sends a Location the browser reads as another origin', function () {
+        canonicalUriConfig('add');
+
+        $response = canonicalUriDispatch('/\\example.com/x');
 
         expect($response->isRedirect())->toBeFalse();
     });

--- a/tests/Backend/Unit/Maho/Routing/HttpsEnforcementTest.php
+++ b/tests/Backend/Unit/Maho/Routing/HttpsEnforcementTest.php
@@ -49,7 +49,7 @@ function httpsConfig(string $unsecure, string $secure, string $useInAdmin, strin
     // Disable base-URL auto-redirect so `checkBaseUrl` doesn't fire before
     // `enforceHttps`. We're testing the HTTPS step, not base-URL redirection.
     $config->saveConfig('web/url/redirect_to_base', '0');
-    // Likewise `checkTrailingSlash` would 301-redirect to add/remove the
+    // Likewise `checkCanonicalUri` would 301-redirect to add/remove the
     // trailing slash before `enforceHttps` runs. Disable here.
     $config->saveConfig('web/url/trailing_slash_behavior', 'leave');
     // Drop the `store_global_config_cache` entry so fresh store instances


### PR DESCRIPTION
Every store answered each page twice: once at the clean URL (`/customer/account/login`) and once through the front controller script (`/index.php/customer/account/login`). Both returned 200, so search engines indexed duplicate content. Maho never links to the `/index.php` form, but old backlinks and crawlers still hit it.

Now the request answers with a single 301 to the clean URL:

| Request | Redirect |
|---|---|
| `/index.php` | `/` |
| `/index.php?utm_source=x` | `/?utm_source=x` |
| `/index.php/catalog/category/view/id/3` | `/catalog/category/view/id/3` |
| `/shop/index.php/customer/account/login` | `/shop/customer/account/login` |

The redirect lives in the front controller observer, in the same step that already collapsed repeated slashes and applied the trailing-slash setting (`checkTrailingSlash`, renamed `checkCanonicalUri`). Doing it in PHP instead of `.htaccess` covers Apache, nginx, Caddy, and FrankenPHP with no web server configuration.

Excluded: POST requests, admin URLs, and the legacy `/api/` endpoints, because SOAP/XML-RPC clients do not follow redirects.

Edge cases covered by the review pass, with tests for each:

- A subdirectory store root (`/shop`) redirects to `/shop/` instead of a 404.
- Paths that `parse_url()` rejects (for example `/product/sku:123`) no longer collapse to `/`.
- A doubled slash (`//api/soap`) or an encoded script name (`/%69ndex.php/...`) cannot bypass the redirect or the exclusions.
- The redirect never emits a protocol-relative `//host` Location.

Documented in https://mahocommerce.com/hosting/web-server/.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->
