### PR TITLE
Made the feed tax mode work and unified the four value engines

### DIFF
--- a/app/code/core/Maho/FeedManager/Model/Generator/ProductWriterTrait.php
+++ b/app/code/core/Maho/FeedManager/Model/Generator/ProductWriterTrait.php
@@ -24,6 +24,9 @@ declare(strict_types=1);
  */
 trait Maho_FeedManager_Model_Generator_ProductWriterTrait
 {
+    /** Row key that carries the raw product value of a custom_field template field */
+    protected const CUSTOM_FIELD_KEY = '_custom_field';
+
     // ──────────────────────────────────────────────────────────────────────
     // Output engine properties
     // ──────────────────────────────────────────────────────────────────────
@@ -420,6 +423,10 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
      */
     protected function _renderItemTemplate(string $template, Mage_Catalog_Model_Product $product, Maho_FeedManager_Model_Feed $feed): string
     {
+        // The gallery costs a query for every product, and a template that never writes "image"
+        // cannot read one.
+        $this->_mapper->setExtractGallery(str_contains($template, 'image'));
+
         $productData = $this->_templateCompatRow($this->_mapper->extractProductData($product));
         $productData['_product'] = $product;
 
@@ -471,13 +478,29 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
      */
     protected function _templateCompatRow(array $row): array
     {
-        $row['description'] = strip_tags((string) ($row['description'] ?? ''));
-        $row['short_description'] = strip_tags((string) ($row['short_description'] ?? ''));
+        // The parent_* copies carry the same adaptation, otherwise parent="yes" either falls back
+        // to a raw value (description) or finds no key at all (category, image_url, gtin, mpn).
+        foreach (['', 'parent_'] as $prefix) {
+            if ($prefix !== '' && !array_key_exists($prefix . 'sku', $row)) {
+                continue;
+            }
+            $row[$prefix . 'description'] = strip_tags((string) ($row[$prefix . 'description'] ?? ''));
+            $row[$prefix . 'short_description'] = strip_tags((string) ($row[$prefix . 'short_description'] ?? ''));
+            $row[$prefix . 'category'] = $row[$prefix . 'category_path'] ?? '';
+            $row[$prefix . 'image_url'] = $row[$prefix . 'image'] ?? '';
+            $row[$prefix . 'gtin'] = ($row[$prefix . 'gtin'] ?? '') ?: (($row[$prefix . 'upc'] ?? '') ?: ($row[$prefix . 'ean'] ?? ''));
+            $row[$prefix . 'mpn'] = ($row[$prefix . 'mpn'] ?? '') ?: ($row[$prefix . 'sku'] ?? '');
+
+            // A template counts image_N from the first gallery image, the main image included.
+            // The row counts from the first additional image, so the two differ by one position.
+            $gallery = array_values((array) ($row[$prefix . 'gallery_images'] ?? []));
+            for ($i = 1; $i <= 10; $i++) {
+                $row[$prefix . 'image_' . $i] = $gallery[$i - 1] ?? null;
+            }
+        }
+
+        // Stock lives on the child only, so a parent_stock_status would invent an answer.
         $row['stock_status'] = !empty($row['is_in_stock']) ? 'in stock' : 'out of stock';
-        $row['category'] = $row['category_path'] ?? '';
-        $row['image_url'] = $row['image'] ?? '';
-        $row['gtin'] = ($row['gtin'] ?? '') ?: (($row['upc'] ?? '') ?: ($row['ean'] ?? ''));
-        $row['mpn'] = ($row['mpn'] ?? '') ?: ($row['sku'] ?? '');
 
         return $row;
     }
@@ -490,8 +513,15 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
      */
     protected function _resolveTemplateField(array $config, array $productData, Mage_Catalog_Model_Product $product): string
     {
+        $mapperConfig = $this->_toMapperConfig($config);
+
+        if (($config['type'] ?? '') === 'custom_field') {
+            $productData = $this->_addCustomField($productData, $config, $product);
+            $mapperConfig['source_value'] = self::CUSTOM_FIELD_KEY;
+        }
+
         $value = $this->_mapper->resolveFieldValue(
-            $this->_toMapperConfig($config),
+            $mapperConfig,
             $productData,
             $product,
         );
@@ -501,6 +531,31 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
         }
 
         return (string) ($value ?? '');
+    }
+
+    /**
+     * Put the raw product value of a custom_field under a reserved row key.
+     *
+     * custom_field means the value the product itself stores. The shared row holds the option
+     * label for a select attribute, and holds no collection-computed column such as min_price.
+     *
+     * @param array<string, mixed> $productData
+     * @param array<string, mixed> $config
+     * @return array<string, mixed>
+     */
+    protected function _addCustomField(array $productData, array $config, Mage_Catalog_Model_Product $product): array
+    {
+        $code = (string) ($config['value'] ?? '');
+        $productData[self::CUSTOM_FIELD_KEY] = $product->getData($code);
+
+        if (($config['parent'] ?? 'no') === 'yes') {
+            $parent = $this->_mapper->getParentProduct($product);
+            if ($parent !== null) {
+                $productData['parent_' . self::CUSTOM_FIELD_KEY] = $parent->getData($code);
+            }
+        }
+
+        return $productData;
     }
 
     /**
@@ -575,7 +630,9 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
         return match ($format) {
             'html_escape' => htmlspecialchars($value, ENT_QUOTES, 'UTF-8'),
             'strip_tags' => strip_tags($value),
-            'price' => $this->_formatPrice((float) $value, $feed),
+            // The resolver already formats a price field, and a formatted price is no longer
+            // numeric, so casting it back would truncate at the thousands or decimal separator.
+            'price' => is_numeric($value) ? $this->_formatPrice((float) $value, $feed) : $value,
             'date' => $this->_formatDate($value),
             'lowercase' => strtolower($value),
             'uppercase' => strtoupper($value),

--- a/app/code/core/Maho/FeedManager/Model/Generator/ProductWriterTrait.php
+++ b/app/code/core/Maho/FeedManager/Model/Generator/ProductWriterTrait.php
@@ -420,15 +420,8 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
      */
     protected function _renderItemTemplate(string $template, Mage_Catalog_Model_Product $product, Maho_FeedManager_Model_Feed $feed): string
     {
-        // Build product data array for transformer context
-        $productData = $product->getData();
+        $productData = $this->_templateCompatRow($this->_mapper->extractProductData($product));
         $productData['_product'] = $product;
-        $productData['_feed'] = [
-            'price_decimals' => $feed->getPriceDecimals() ?? 2,
-            'price_decimal_point' => $feed->getPriceDecimalPoint() ?? '.',
-            'price_thousands_sep' => $feed->getPriceThousandsSep() ?? '',
-            'price_currency' => $feed->getPriceCurrency() ?: Mage::app()->getStore($feed->getStoreId())->getBaseCurrencyCode(),
-        ];
 
         // Find all field configurations in the template: {type="..." value="..." ...}
         preg_match_all('/\{(type="(?:[^"\\\\]|\\\\.)*"(?:\s+\w+="(?:[^"\\\\]|\\\\.)*")*)\}/', $template, $matches, PREG_SET_ORDER);
@@ -442,8 +435,8 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
                 continue;
             }
 
-            $value = $this->_getValueFromConfig($product, $config, $feed);
-            $value = $this->_applyFormat($value, $config, $feed, $productData);
+            $value = $this->_resolveTemplateField($config, $productData, $product);
+            $value = $this->_applyFormat($value, $config, $feed);
 
             // Apply length limit (backward compatibility - transformers handle this via truncate)
             if (!empty($config['length']) && empty($config['transformers'])) {
@@ -456,11 +449,99 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
         // Support simple {{placeholder}} syntax for backwards compatibility
         preg_match_all('/\{\{([^}]+)\}\}/', $template, $simpleMatches);
         foreach ($simpleMatches[1] as $placeholder) {
-            $value = $this->_getProductValueForTemplate($product, $placeholder, $feed);
+            $value = $this->_resolveTemplateField(
+                ['type' => 'attribute', 'value' => $placeholder],
+                $productData,
+                $product,
+            );
             $template = str_replace('{{' . $placeholder . '}}', $value, $template);
         }
 
         return $template;
+    }
+
+    /**
+     * Give the shared product row the vocabulary the template placeholders expect.
+     *
+     * The row is the same one the CSV, JSON, and XML structure engines use. These keys carry a
+     * different meaning in a template, so they are adapted here instead of in the mapper.
+     *
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    protected function _templateCompatRow(array $row): array
+    {
+        $row['description'] = strip_tags((string) ($row['description'] ?? ''));
+        $row['short_description'] = strip_tags((string) ($row['short_description'] ?? ''));
+        $row['stock_status'] = !empty($row['is_in_stock']) ? 'in stock' : 'out of stock';
+        $row['category'] = $row['category_path'] ?? '';
+        $row['image_url'] = $row['image'] ?? '';
+        $row['gtin'] = ($row['gtin'] ?? '') ?: (($row['upc'] ?? '') ?: ($row['ean'] ?? ''));
+        $row['mpn'] = ($row['mpn'] ?? '') ?: ($row['sku'] ?? '');
+
+        return $row;
+    }
+
+    /**
+     * Resolve one template field through the shared mapper resolver
+     *
+     * @param array<string, mixed> $config Parsed template field configuration
+     * @param array<string, mixed> $productData Compatibility row from _templateCompatRow()
+     */
+    protected function _resolveTemplateField(array $config, array $productData, Mage_Catalog_Model_Product $product): string
+    {
+        $value = $this->_mapper->resolveFieldValue(
+            $this->_toMapperConfig($config),
+            $productData,
+            $product,
+        );
+
+        if (is_array($value)) {
+            $value = implode(',', array_filter($value, fn($v) => $v !== null && $v !== ''));
+        }
+
+        return (string) ($value ?? '');
+    }
+
+    /**
+     * Translate a template field configuration into a mapper field configuration
+     *
+     * @param array<string, mixed> $config
+     * @return array<string, mixed>
+     */
+    protected function _toMapperConfig(array $config): array
+    {
+        $type = (string) ($config['type'] ?? 'attribute');
+        $value = (string) ($config['value'] ?? '');
+
+        $mapped = match ($type) {
+            'text', 'static' => [
+                'source_type' => Maho_FeedManager_Model_Mapper::SOURCE_TYPE_STATIC,
+                'source_value' => $value,
+            ],
+            'combined' => [
+                'source_type' => Maho_FeedManager_Model_Mapper::SOURCE_TYPE_COMBINED,
+                'source_value' => $value,
+            ],
+            'category' => [
+                'source_type' => Maho_FeedManager_Model_Mapper::SOURCE_TYPE_ATTRIBUTE,
+                'source_value' => 'category_path',
+            ],
+            default => [
+                'source_type' => Maho_FeedManager_Model_Mapper::SOURCE_TYPE_ATTRIBUTE,
+                'source_value' => $value,
+            ],
+        };
+
+        if (($config['parent'] ?? 'no') === 'yes') {
+            $mapped['use_parent'] = 'if_empty';
+        }
+
+        if (!empty($config['transformers'])) {
+            $mapped['transformers'] = $config['transformers'];
+        }
+
+        return $mapped;
     }
 
     /**
@@ -479,106 +560,16 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
     }
 
     /**
-     * Get value from field configuration
-     */
-    protected function _getValueFromConfig(Mage_Catalog_Model_Product $product, array $config, Maho_FeedManager_Model_Feed $feed): string
-    {
-        $type = $config['type'] ?? 'attribute';
-        $value = $config['value'] ?? '';
-        $useParent = ($config['parent'] ?? 'no') === 'yes';
-
-        // Get parent product if needed
-        $parentProduct = null;
-        if ($useParent && $product->getTypeId() === 'simple') {
-            $parentIds = Mage::getModel('catalog/product_type_configurable')->getParentIdsByChild($product->getId());
-            if (!empty($parentIds)) {
-                $parentProduct = Mage::getModel('catalog/product')->load($parentIds[0]);
-            }
-        }
-
-        $result = '';
-
-        switch ($type) {
-            case 'attribute':
-                $result = $this->_getProductValueForTemplate($product, $value, $feed);
-                if (empty($result) && $parentProduct) {
-                    $result = $this->_getProductValueForTemplate($parentProduct, $value, $feed);
-                }
-                break;
-
-            case 'text':
-            case 'static':
-                $result = $value;
-                break;
-
-            case 'combined':
-                $result = $this->_processCombinedTemplate($value, $product, $feed, $parentProduct);
-                break;
-
-            case 'category':
-                $result = $this->_getProductCategoryPath($product);
-                break;
-
-            case 'images':
-                $result = $this->_getAdditionalImage($product, $value);
-                break;
-
-            case 'custom_field':
-                $result = (string) $product->getData($value);
-                break;
-
-            default:
-                $result = $this->_getProductValueForTemplate($product, $value, $feed);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Process combined template with {{placeholder}} syntax
-     */
-    protected function _processCombinedTemplate(
-        string $template,
-        Mage_Catalog_Model_Product $product,
-        Maho_FeedManager_Model_Feed $feed,
-        ?Mage_Catalog_Model_Product $parentProduct = null,
-    ): string {
-        preg_match_all('/\{\{([^}]+)\}\}/', $template, $matches);
-
-        $result = $template;
-        foreach ($matches[1] as $placeholder) {
-            $value = $this->_getProductValueForTemplate($product, $placeholder, $feed);
-
-            if (empty($value) && $parentProduct) {
-                $value = $this->_getProductValueForTemplate($parentProduct, $placeholder, $feed);
-            }
-
-            $result = str_replace('{{' . $placeholder . '}}', $value, $result);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Apply formatting/transformations to value
+     * Apply the legacy 'format' attribute to a value
      *
-     * @param array<string, mixed> $productData Full product data for transformer context
+     * A transformer chain is applied by the shared resolver, not here.
      */
-    protected function _applyFormat(
-        string $value,
-        array $config,
-        Maho_FeedManager_Model_Feed $feed,
-        array $productData = [],
-    ): string {
-        // New transformer chain format takes precedence
+    protected function _applyFormat(string $value, array $config, Maho_FeedManager_Model_Feed $feed): string
+    {
         if (!empty($config['transformers'])) {
-            $chain = Maho_FeedManager_Model_Transformer::parseChainString($config['transformers']);
-            if (!empty($chain)) {
-                return (string) Maho_FeedManager_Model_Transformer::pipeline($value, $chain, $productData);
-            }
+            return $value;
         }
 
-        // Backward compatibility with old 'format' attribute
         $format = $config['format'] ?? 'as_is';
 
         return match ($format) {
@@ -592,200 +583,6 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
             'base' => $this->_ensureBaseUrl($value),
             default => $value,
         };
-    }
-
-    // ──────────────────────────────────────────────────────────────────────
-    // Product attribute resolution
-    // ──────────────────────────────────────────────────────────────────────
-
-    /**
-     * Get product value for template placeholder
-     */
-    protected function _getProductValueForTemplate(Mage_Catalog_Model_Product $product, string $placeholder, Maho_FeedManager_Model_Feed $feed): string
-    {
-        return match ($placeholder) {
-            'sku' => (string) $product->getSku(),
-            'name' => (string) $product->getName(),
-            'description' => strip_tags((string) $product->getDescription()),
-            'short_description' => strip_tags((string) $product->getShortDescription()),
-            'url' => $this->_getProductUrl($product, $feed),
-            'image', 'image_url' => $this->_getProductImageUrl($product, $feed),
-            'small_image' => $this->_getProductImageUrl($product, $feed, 'small_image'),
-            'thumbnail' => $this->_getProductImageUrl($product, $feed, 'thumbnail'),
-            'price' => $this->_formatPrice((float) $product->getPrice(), $feed),
-            'special_price' => $product->getSpecialPrice() ? $this->_formatPrice((float) $product->getSpecialPrice(), $feed) : '',
-            'final_price' => $this->_formatPrice((float) $product->getFinalPrice(), $feed),
-            'stock_status' => ($stockItem = $product->getStockItem()) && $stockItem->getIsInStock() ? 'in stock' : 'out of stock',
-            'qty' => (string) (int) (($stockItem = $product->getStockItem()) ? $stockItem->getQty() : 0),
-            'category' => $this->_getProductCategoryPath($product),
-            'brand' => (string) $product->getAttributeText('brand'),
-            'manufacturer' => (string) $product->getAttributeText('manufacturer'),
-            'weight' => (string) $product->getWeight(),
-            'type_id' => (string) $product->getTypeId(),
-            'google_product_category' => (string) $product->getData('google_product_category'),
-            'gtin' => (string) ($product->getData('gtin') ?: $product->getData('upc') ?: $product->getData('ean')),
-            'mpn' => (string) ($product->getData('mpn') ?: $product->getSku()),
-            default => $this->_getGenericProductAttribute($product, $placeholder),
-        };
-    }
-
-    /**
-     * Get generic product attribute value
-     */
-    protected function _getGenericProductAttribute(Mage_Catalog_Model_Product $product, string $attributeCode): string
-    {
-        $value = $product->getData($attributeCode);
-
-        if ($value !== null) {
-            $textValue = $product->getAttributeText($attributeCode);
-            if ($textValue && !is_array($textValue)) {
-                return (string) $textValue;
-            }
-            if (is_array($textValue)) {
-                return implode(', ', $textValue);
-            }
-        }
-
-        return (string) $value;
-    }
-
-    // ──────────────────────────────────────────────────────────────────────
-    // Product URL and image helpers
-    // ──────────────────────────────────────────────────────────────────────
-
-    /**
-     * Get product URL
-     */
-    protected function _getProductUrl(Mage_Catalog_Model_Product $product, Maho_FeedManager_Model_Feed $feed): string
-    {
-        $product->setStoreId($feed->getStoreId());
-
-        if ($feed->getExcludeCategoryUrl()) {
-            return $product->getUrlModel()->getUrl($product, ['_ignore_category' => true]);
-        }
-
-        return $product->getProductUrl();
-    }
-
-    /**
-     * Get product image URL
-     */
-    protected function _getProductImageUrl(Mage_Catalog_Model_Product $product, Maho_FeedManager_Model_Feed $feed, string $imageType = 'image'): string
-    {
-        $image = $product->getData($imageType);
-
-        if (!$image || $image === 'no_selection') {
-            return $feed->getNoImageUrl() ?: '';
-        }
-
-        return Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA) . 'catalog/product' . $image;
-    }
-
-    /**
-     * Get additional image by index
-     */
-    protected function _getAdditionalImage(Mage_Catalog_Model_Product $product, string $imageKey): string
-    {
-        if (preg_match('/image_(\d+)/', $imageKey, $matches)) {
-            $index = (int) $matches[1] - 1;
-
-            $mediaGallery = $product->getMediaGalleryImages();
-            if ($mediaGallery && $mediaGallery->getSize() > $index) {
-                $items = $mediaGallery->getItems();
-                $item = array_values($items)[$index] ?? null;
-                if ($item) {
-                    return $item->getUrl();
-                }
-            }
-        }
-
-        return '';
-    }
-
-    /** @var array<int, string> Cached category names by ID */
-    protected static array $_categoryNameCache = [];
-
-    /** @var array<int, string> Cached category paths by ID */
-    protected static array $_categoryPathCache = [];
-
-    /**
-     * Get product category path (optimized with caching)
-     */
-    protected function _getProductCategoryPath(Mage_Catalog_Model_Product $product): string
-    {
-        $categoryIds = $product->getCategoryIds();
-        if (empty($categoryIds)) {
-            return '';
-        }
-
-        $categoryId = (int) end($categoryIds);
-
-        // Return cached path if available
-        if (isset(self::$_categoryPathCache[$categoryId])) {
-            return self::$_categoryPathCache[$categoryId];
-        }
-
-        // Get the category's path string (e.g., "1/2/5/12")
-        $resource = Mage::getSingleton('core/resource');
-        $adapter = $resource->getConnection('core_read');
-        $table = $resource->getTableName('catalog/category');
-
-        $categoryPath = $adapter->fetchOne(
-            $adapter->select()
-                ->from($table, ['path'])
-                ->where('entity_id = ?', $categoryId),
-        );
-
-        if (!$categoryPath) {
-            self::$_categoryPathCache[$categoryId] = '';
-            return '';
-        }
-
-        $pathIds = explode('/', $categoryPath);
-        $pathIds = array_filter($pathIds, fn($id) => (int) $id > 2);
-
-        if (empty($pathIds)) {
-            self::$_categoryPathCache[$categoryId] = '';
-            return '';
-        }
-
-        // Find which category names we need to load
-        $missingIds = array_diff($pathIds, array_keys(self::$_categoryNameCache));
-
-        if (!empty($missingIds)) {
-            // Load missing category names in a single query
-            $nameAttrId = Mage::getSingleton('eav/config')
-                ->getAttribute('catalog_category', 'name')
-                ->getAttributeId();
-
-            $varcharTable = $resource->getTableName('catalog_category_entity_varchar');
-
-            $select = $adapter->select()
-                ->from($varcharTable, ['entity_id', 'value'])
-                ->where('entity_id IN (?)', $missingIds)
-                ->where('attribute_id = ?', $nameAttrId)
-                ->where('store_id = 0');
-
-            $names = $adapter->fetchPairs($select);
-
-            foreach ($names as $id => $name) {
-                self::$_categoryNameCache[(int) $id] = $name;
-            }
-        }
-
-        // Build the path from cached names
-        $pathNames = [];
-        foreach ($pathIds as $pathId) {
-            $pathId = (int) $pathId;
-            if (isset(self::$_categoryNameCache[$pathId])) {
-                $pathNames[] = self::$_categoryNameCache[$pathId];
-            }
-        }
-
-        $result = implode(' > ', $pathNames);
-        self::$_categoryPathCache[$categoryId] = $result;
-
-        return $result;
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/app/code/core/Maho/FeedManager/Model/Generator/ProductWriterTrait.php
+++ b/app/code/core/Maho/FeedManager/Model/Generator/ProductWriterTrait.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
  */
 trait Maho_FeedManager_Model_Generator_ProductWriterTrait
 {
-    /** Row key that carries the raw product value of a custom_field template field */
+    /** Row key that holds the raw product value of a custom_field template field */
     protected const CUSTOM_FIELD_KEY = '_custom_field';
 
     // ──────────────────────────────────────────────────────────────────────
@@ -423,8 +423,7 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
      */
     protected function _renderItemTemplate(string $template, Mage_Catalog_Model_Product $product, Maho_FeedManager_Model_Feed $feed): string
     {
-        // The gallery costs a query for every product, and a template that never writes "image"
-        // cannot read one.
+        // The gallery costs one query for each product. A template without "image" needs none.
         $this->_mapper->setExtractGallery(str_contains($template, 'image'));
 
         $productData = $this->_templateCompatRow($this->_mapper->extractProductData($product));
@@ -468,18 +467,18 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
     }
 
     /**
-     * Give the shared product row the vocabulary the template placeholders expect.
+     * Adapt the row keys that a template uses.
      *
-     * The row is the same one the CSV, JSON, and XML structure engines use. These keys carry a
-     * different meaning in a template, so they are adapted here instead of in the mapper.
+     * The CSV, JSON, and XML engines share this row. The keys below have a different meaning
+     * in a template, so this method adapts them here and not in the mapper.
      *
      * @param array<string, mixed> $row
      * @return array<string, mixed>
      */
     protected function _templateCompatRow(array $row): array
     {
-        // The parent_* copies carry the same adaptation, otherwise parent="yes" either falls back
-        // to a raw value (description) or finds no key at all (category, image_url, gtin, mpn).
+        // The parent_* keys need the same adaptation. Without it, parent="yes" returns a raw
+        // value (description) or no value at all (category, image_url, gtin, mpn).
         foreach (['', 'parent_'] as $prefix) {
             if ($prefix !== '' && !array_key_exists($prefix . 'sku', $row)) {
                 continue;
@@ -491,15 +490,15 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
             $row[$prefix . 'gtin'] = ($row[$prefix . 'gtin'] ?? '') ?: (($row[$prefix . 'upc'] ?? '') ?: ($row[$prefix . 'ean'] ?? ''));
             $row[$prefix . 'mpn'] = ($row[$prefix . 'mpn'] ?? '') ?: ($row[$prefix . 'sku'] ?? '');
 
-            // A template counts image_N from the first gallery image, the main image included.
-            // The row counts from the first additional image, so the two differ by one position.
+            // In a template, image_1 is the first gallery image. In the row, image_1 is the
+            // first additional image. The two counts differ by one position.
             $gallery = array_values((array) ($row[$prefix . 'gallery_images'] ?? []));
             for ($i = 1; $i <= 10; $i++) {
                 $row[$prefix . 'image_' . $i] = $gallery[$i - 1] ?? null;
             }
         }
 
-        // Stock lives on the child only, so a parent_stock_status would invent an answer.
+        // Only the child has stock data, so this method sets no parent_stock_status key.
         $row['stock_status'] = !empty($row['is_in_stock']) ? 'in stock' : 'out of stock';
 
         return $row;
@@ -536,8 +535,9 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
     /**
      * Put the raw product value of a custom_field under a reserved row key.
      *
-     * custom_field means the value the product itself stores. The shared row holds the option
-     * label for a select attribute, and holds no collection-computed column such as min_price.
+     * A custom_field is the value that the product stores. The shared row is different: it
+     * holds the option label of a select attribute, and it has no computed column such as
+     * min_price.
      *
      * @param array<string, mixed> $productData
      * @param array<string, mixed> $config
@@ -617,7 +617,7 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
     /**
      * Apply the legacy 'format' attribute to a value
      *
-     * A transformer chain is applied by the shared resolver, not here.
+     * The shared resolver applies the transformer chains, so this method skips them.
      */
     protected function _applyFormat(string $value, array $config, Maho_FeedManager_Model_Feed $feed): string
     {
@@ -630,8 +630,8 @@ trait Maho_FeedManager_Model_Generator_ProductWriterTrait
         return match ($format) {
             'html_escape' => htmlspecialchars($value, ENT_QUOTES, 'UTF-8'),
             'strip_tags' => strip_tags($value),
-            // The resolver already formats a price field, and a formatted price is no longer
-            // numeric, so casting it back would truncate at the thousands or decimal separator.
+            // The resolver already formatted a price field. A formatted price is not numeric,
+            // and a cast would truncate it at the first separator.
             'price' => is_numeric($value) ? $this->_formatPrice((float) $value, $feed) : $value,
             'date' => $this->_formatDate($value),
             'lowercase' => strtolower($value),

--- a/app/code/core/Maho/FeedManager/Model/Mapper.php
+++ b/app/code/core/Maho/FeedManager/Model/Mapper.php
@@ -44,6 +44,18 @@ class Maho_FeedManager_Model_Mapper
         'cost',
     ];
 
+    /**
+     * Price fields a customer pays, so they follow the feed tax mode.
+     * 'cost' is a supplier cost and stays raw.
+     */
+    protected const TAXED_PRICE_FIELDS = [
+        'price',
+        'regular_price',
+        'special_price',
+        'final_price',
+        'msrp',
+    ];
+
     protected Maho_FeedManager_Model_Feed $_feed;
     protected ?Maho_FeedManager_Model_Platform_AdapterInterface $_platform = null;
     protected array $_mappings = [];
@@ -75,6 +87,8 @@ class Maho_FeedManager_Model_Mapper
     protected string $_priceCurrency = '';
     protected bool $_priceCurrencySuffix = true;
 
+    protected Maho_FeedManager_Model_Price_TaxAdjuster $_taxAdjuster;
+
     /**
      * Initialize mapper with feed configuration
      */
@@ -83,6 +97,7 @@ class Maho_FeedManager_Model_Mapper
         $this->_feed = $feed;
         $this->_storeId = (int) $feed->getStoreId();
         $this->_platform = Maho_FeedManager_Model_Platform::getAdapter($feed->getPlatform());
+        $this->_taxAdjuster = new Maho_FeedManager_Model_Price_TaxAdjuster($feed);
         $this->_loadMappings();
         $this->_loadCategoryMappings();
         $this->_loadPriceSettings();
@@ -96,7 +111,8 @@ class Maho_FeedManager_Model_Mapper
         $this->_priceDecimals = (int) ($this->_feed->getPriceDecimals() ?? 2);
         $this->_priceDecimalPoint = (string) ($this->_feed->getPriceDecimalPoint() ?: '.');
         $this->_priceThousandsSep = (string) ($this->_feed->getPriceThousandsSep() ?? '');
-        $this->_priceCurrency = (string) ($this->_feed->getPriceCurrency() ?: '');
+        $this->_priceCurrency = (string) ($this->_feed->getPriceCurrency()
+            ?: Mage::app()->getStore($this->_storeId)->getBaseCurrencyCode());
         $this->_priceCurrencySuffix = (bool) ($this->_feed->getPriceCurrencySuffix() ?? true);
     }
 
@@ -165,7 +181,7 @@ class Maho_FeedManager_Model_Mapper
      */
     public function mapProduct(Mage_Catalog_Model_Product $product): array
     {
-        $rawData = $this->_extractProductData($product);
+        $rawData = $this->extractProductData($product);
         $mappedData = [];
 
         foreach ($this->_mappings as $feedAttribute => $config) {
@@ -174,20 +190,7 @@ class Maho_FeedManager_Model_Mapper
                 continue;
             }
 
-            // Get source value
-            $value = $this->_getSourceValue($config, $rawData, $product);
-            $sourceValue = $config['source_value'] ?? '';
-
-            // Apply transformers, or auto-format price fields
-            $hasExplicitTransformers = !empty($config['transformers']);
-            if ($hasExplicitTransformers) {
-                $value = Maho_FeedManager_Model_Transformer::pipeline($value, $config['transformers'], $rawData);
-            } elseif ($this->_isPriceField($sourceValue) && is_numeric($value)) {
-                // Auto-format price fields using feed settings (only if no explicit transformer)
-                $value = $this->_formatPrice($value);
-            }
-
-            $mappedData[$feedAttribute] = $value;
+            $mappedData[$feedAttribute] = $this->resolveFieldValue($config, $rawData, $product);
         }
 
         // Add mapped category if platform supports it
@@ -208,9 +211,37 @@ class Maho_FeedManager_Model_Mapper
     }
 
     /**
+     * Resolve one field to its final value.
+     *
+     * Every output engine goes through this method, so a feed field yields the same value
+     * whichever writer serialises it. The engines keep only their serialisation.
+     *
+     * @param array<string, mixed> $config Field configuration
+     * @param array<string, mixed> $rawData Product row from extractProductData()
+     */
+    public function resolveFieldValue(array $config, array $rawData, Mage_Catalog_Model_Product $product): mixed
+    {
+        $value = $this->_getSourceValue($config, $rawData, $product);
+
+        if (!empty($config['transformers'])) {
+            $transformers = is_array($config['transformers'])
+                ? $config['transformers']
+                : Maho_FeedManager_Model_Transformer::parseChainString($config['transformers']);
+
+            return Maho_FeedManager_Model_Transformer::pipeline($value, $transformers, $rawData);
+        }
+
+        if ($this->_isPriceField((string) ($config['source_value'] ?? '')) && is_numeric($value)) {
+            return $this->_formatPrice($value);
+        }
+
+        return $value;
+    }
+
+    /**
      * Extract raw product data into array
      */
-    protected function _extractProductData(Mage_Catalog_Model_Product $product): array
+    public function extractProductData(Mage_Catalog_Model_Product $product): array
     {
         $data = [];
 
@@ -221,6 +252,7 @@ class Maho_FeedManager_Model_Mapper
         $data['description'] = $product->getDescription();
         $data['short_description'] = $product->getShortDescription();
         $data['price'] = $product->getFinalPrice();
+        $data['final_price'] = $product->getFinalPrice();
         $data['regular_price'] = $product->getPrice();
         $data['special_price'] = $product->getSpecialPrice();
         $data['special_from_date'] = $product->getSpecialFromDate();
@@ -296,6 +328,8 @@ class Maho_FeedManager_Model_Mapper
                 }
             }
         }
+
+        $this->_applyTaxMode($data, $product);
 
         // Currency from store
         $data['currency'] = Mage::app()->getStore($this->_storeId)->getCurrentCurrencyCode();
@@ -400,6 +434,7 @@ class Maho_FeedManager_Model_Mapper
         $data['description'] = $parent->getDescription();
         $data['short_description'] = $parent->getShortDescription();
         $data['price'] = $parent->getFinalPrice();
+        $data['final_price'] = $parent->getFinalPrice();
         $data['regular_price'] = $parent->getPrice();
         $data['special_price'] = $parent->getSpecialPrice();
         $data['special_from_date'] = $parent->getSpecialFromDate();
@@ -442,10 +477,29 @@ class Maho_FeedManager_Model_Mapper
             }
         }
 
+        $this->_applyTaxMode($data, $parent);
+
         // Cache the extracted data
         $this->_parentDataCache[$parentId] = $data;
 
         return $data;
+    }
+
+    /**
+     * Convert the customer-facing prices in a product row into the tax mode the feed asks for.
+     *
+     * This runs on the raw row, before any transformer, so a user chain receives a tax-correct
+     * input.
+     *
+     * @param array<string, mixed> $data
+     */
+    protected function _applyTaxMode(array &$data, Mage_Catalog_Model_Product $product): void
+    {
+        foreach (self::TAXED_PRICE_FIELDS as $field) {
+            if (isset($data[$field]) && is_numeric($data[$field])) {
+                $data[$field] = $this->_taxAdjuster->adjust($product, $data[$field]);
+            }
+        }
     }
 
     /**
@@ -594,6 +648,12 @@ class Maho_FeedManager_Model_Mapper
      */
     protected function _getProductSeoUrl(Mage_Catalog_Model_Product $product): string
     {
+        // Null means the feed predates the setting: the column default excludes the category.
+        if (($this->_feed->getExcludeCategoryUrl() ?? 1) === 0) {
+            $product->setStoreId($this->_storeId);
+            return $product->getProductUrl();
+        }
+
         $urlKey = $product->getUrlKey();
         if ($urlKey) {
             $suffix = Mage::getStoreConfig('catalog/seo/product_url_suffix', $this->_storeId);
@@ -620,7 +680,7 @@ class Maho_FeedManager_Model_Mapper
             // Silent fail
         }
 
-        return '';
+        return $this->_feed->getNoImageUrl() ?: '';
     }
 
     /**
@@ -1242,7 +1302,7 @@ class Maho_FeedManager_Model_Mapper
      */
     public function mapProductToJsonStructure(Mage_Catalog_Model_Product $product, array $structure): array
     {
-        $rawData = $this->_extractProductData($product);
+        $rawData = $this->extractProductData($product);
         return $this->_buildJsonObject($structure, $rawData, $product);
     }
 
@@ -1269,20 +1329,7 @@ class Maho_FeedManager_Model_Mapper
                     $result[$key] = $value ? [$value] : [];
                 }
             } else {
-                $value = $this->_getSourceValue($config, $rawData, $product);
-                $sourceValue = $config['source_value'] ?? '';
-
-                // Apply transformers
-                $hasExplicitTransformers = !empty($config['transformers']);
-                if ($hasExplicitTransformers) {
-                    $transformers = is_array($config['transformers'])
-                        ? $config['transformers']
-                        : Maho_FeedManager_Model_Transformer::parseChainString($config['transformers']);
-                    $value = Maho_FeedManager_Model_Transformer::pipeline($value, $transformers, $rawData);
-                } elseif ($this->_isPriceField($sourceValue) && is_numeric($value)) {
-                    // Auto-format price fields using feed settings (only if no explicit transformer)
-                    $value = $this->_formatPrice($value);
-                }
+                $value = $this->resolveFieldValue($config, $rawData, $product);
 
                 // Cast to appropriate type
                 if ($type === 'number') {
@@ -1313,7 +1360,7 @@ class Maho_FeedManager_Model_Mapper
         string $itemTag = 'item',
         int $indent = 0,
     ): string {
-        $rawData = $this->_extractProductData($product);
+        $rawData = $this->extractProductData($product);
         $indentStr = str_repeat('    ', $indent);
         $xml = '';
 
@@ -1342,7 +1389,6 @@ class Maho_FeedManager_Model_Mapper
             $tag = $config['tag'] ?? 'element';
             $cdata = !empty($config['cdata']);
             $optional = !empty($config['optional']);
-            $sourceValue = $config['source_value'] ?? '';
 
             // Handle nested elements (groups)
             if (isset($config['children']) && !empty($config['children'])) {
@@ -1353,19 +1399,7 @@ class Maho_FeedManager_Model_Mapper
             }
 
             // Leaf element - get value
-            $value = $this->_getSourceValue($config, $rawData, $product);
-
-            // Apply explicit transformers if specified
-            $hasExplicitTransformers = !empty($config['transformers']);
-            if ($hasExplicitTransformers) {
-                $transformers = is_array($config['transformers'])
-                    ? $config['transformers']
-                    : Maho_FeedManager_Model_Transformer::parseChainString($config['transformers']);
-                $value = Maho_FeedManager_Model_Transformer::pipeline($value, $transformers, $rawData);
-            } elseif ($this->_isPriceField($sourceValue) && is_numeric($value)) {
-                // Auto-format price fields using feed settings (only if no explicit transformer)
-                $value = $this->_formatPrice($value);
-            }
+            $value = $this->resolveFieldValue($config, $rawData, $product);
 
             // Skip optional empty values
             if ($optional && ($value === null || $value === '')) {

--- a/app/code/core/Maho/FeedManager/Model/Mapper.php
+++ b/app/code/core/Maho/FeedManager/Model/Mapper.php
@@ -45,6 +45,16 @@ class Maho_FeedManager_Model_Mapper
     ];
 
     /**
+     * Image fields that fall back to the feed's placeholder URL when nothing resolved.
+     */
+    protected const IMAGE_FIELDS = [
+        'image',
+        'small_image',
+        'thumbnail',
+        'image_url',
+    ];
+
+    /**
      * Price fields a customer pays, so they follow the feed tax mode.
      * 'cost' is a supplier cost and stays raw.
      */
@@ -89,6 +99,9 @@ class Maho_FeedManager_Model_Mapper
 
     protected Maho_FeedManager_Model_Price_TaxAdjuster $_taxAdjuster;
 
+    /** @var bool Whether a product row carries the media gallery */
+    protected bool $_extractGallery = true;
+
     /**
      * Initialize mapper with feed configuration
      */
@@ -101,6 +114,18 @@ class Maho_FeedManager_Model_Mapper
         $this->_loadMappings();
         $this->_loadCategoryMappings();
         $this->_loadPriceSettings();
+    }
+
+    /**
+     * Switch the media gallery read off for a run that cannot use it.
+     *
+     * The gallery costs a query for every product. An engine that knows in advance that no
+     * output field names an image switches it off for the whole feed. The gallery keys
+     * (gallery_images, additional_images, image_1..image_10) are then empty.
+     */
+    public function setExtractGallery(bool $extract): void
+    {
+        $this->_extractGallery = $extract;
     }
 
     /**
@@ -222,6 +247,13 @@ class Maho_FeedManager_Model_Mapper
     public function resolveFieldValue(array $config, array $rawData, Mage_Catalog_Model_Product $product): mixed
     {
         $value = $this->_getSourceValue($config, $rawData, $product);
+        $sourceValue = (string) ($config['source_value'] ?? '');
+
+        // The placeholder lands only once the parent fallback has had its turn, otherwise it
+        // would count as a value and hide the parent image.
+        if (($value === null || $value === '') && in_array($sourceValue, self::IMAGE_FIELDS, true)) {
+            $value = $this->_feed->getNoImageUrl() ?: '';
+        }
 
         if (!empty($config['transformers'])) {
             $transformers = is_array($config['transformers'])
@@ -231,7 +263,7 @@ class Maho_FeedManager_Model_Mapper
             return Maho_FeedManager_Model_Transformer::pipeline($value, $transformers, $rawData);
         }
 
-        if ($this->_isPriceField((string) ($config['source_value'] ?? '')) && is_numeric($value)) {
+        if ($this->_isPriceField($sourceValue) && is_numeric($value)) {
             return $this->_formatPrice($value);
         }
 
@@ -299,7 +331,9 @@ class Maho_FeedManager_Model_Mapper
         $data['image'] = $this->_getImageUrl($product, 'image');
         $data['small_image'] = $this->_getImageUrl($product, 'small_image');
         $data['thumbnail'] = $this->_getImageUrl($product, 'thumbnail');
-        $additionalImages = $this->_getAdditionalImages($product);
+        $galleryImages = $this->_extractGallery ? $this->_getGalleryImages($product) : [];
+        $additionalImages = $this->_withoutMainImage($galleryImages, $data['image']);
+        $data['gallery_images'] = $galleryImages;
         $data['additional_images'] = $additionalImages;
         $data['additional_images_csv'] = implode(',', $additionalImages);
         // image_1..image_10 are advertised as source options in AbstractBuilder.
@@ -454,7 +488,9 @@ class Maho_FeedManager_Model_Mapper
         $data['small_image'] = $this->_getImageUrl($parent, 'small_image');
         $data['thumbnail'] = $this->_getImageUrl($parent, 'thumbnail');
 
-        $additionalImages = $this->_getAdditionalImages($parent);
+        $galleryImages = $this->_extractGallery ? $this->_getGalleryImages($parent) : [];
+        $additionalImages = $this->_withoutMainImage($galleryImages, $data['image']);
+        $data['gallery_images'] = $galleryImages;
         $data['additional_images'] = $additionalImages;
         $data['additional_images_csv'] = implode(',', $additionalImages);
         for ($i = 1; $i <= 10; $i++) {
@@ -515,7 +551,7 @@ class Maho_FeedManager_Model_Mapper
             self::SOURCE_TYPE_ATTRIBUTE => self::getValueWithParentMode($sourceValue, $rawData, $useParentMode),
             self::SOURCE_TYPE_STATIC => $sourceValue,
             self::SOURCE_TYPE_RULE => $this->_evaluateRuleWithParentMode($sourceValue, $rawData, $product, $useParentMode),
-            self::SOURCE_TYPE_COMBINED => $this->_evaluateCombined($sourceValue, $rawData),
+            self::SOURCE_TYPE_COMBINED => $this->_evaluateCombined($sourceValue, $this->_withParentMode($rawData, $useParentMode)),
             self::SOURCE_TYPE_TAXONOMY => $this->_getTaxonomyForProduct($sourceValue, $product, $useParentMode),
             default => null,
         };
@@ -533,7 +569,7 @@ class Maho_FeedManager_Model_Mapper
     protected function _evaluateRuleWithParentMode(string $ruleCode, array $rawData, Mage_Catalog_Model_Product $product, string $useParentMode): mixed
     {
         if ($useParentMode === 'always') {
-            $parent = $this->_getParentProductModel($product);
+            $parent = $this->getParentProduct($product);
             if ($parent !== null) {
                 // Strict parent semantics: when a parent exists its result IS
                 // the answer, even when empty. Configurable storefront pricing
@@ -546,7 +582,7 @@ class Maho_FeedManager_Model_Mapper
 
         $value = $this->_evaluateRule($ruleCode, $rawData, $product);
         if ($useParentMode === 'if_empty' && ($value === null || $value === '')) {
-            $parent = $this->_getParentProductModel($product);
+            $parent = $this->getParentProduct($product);
             if ($parent !== null) {
                 return $this->_evaluateRule($ruleCode, $rawData, $parent);
             }
@@ -562,7 +598,7 @@ class Maho_FeedManager_Model_Mapper
      * Rule conditions validate against a product MODEL, so parent fallback
      * for rule sources needs the parent model, not the parent_* raw keys.
      */
-    protected function _getParentProductModel(Mage_Catalog_Model_Product $product): ?Mage_Catalog_Model_Product
+    public function getParentProduct(Mage_Catalog_Model_Product $product): ?Mage_Catalog_Model_Product
     {
         $childId = (int) $product->getId();
         if (array_key_exists($childId, $this->_childParentMap)) {
@@ -597,6 +633,32 @@ class Maho_FeedManager_Model_Mapper
         // Create evaluator and evaluate
         $evaluator = new Maho_FeedManager_Model_DynamicRule_Evaluator($rule);
         return $evaluator->evaluate($rawData, $product);
+    }
+
+    /**
+     * Resolve every row key through the parent mode.
+     *
+     * A combined source reads the row directly instead of going through
+     * getValueWithParentMode(), so the parent mode has to be baked into the row it receives.
+     *
+     * @param array<string, mixed> $rawData
+     * @return array<string, mixed>
+     */
+    protected function _withParentMode(array $rawData, string $useParentMode): array
+    {
+        if ($useParentMode !== 'if_empty' && $useParentMode !== 'always') {
+            return $rawData;
+        }
+
+        $resolved = $rawData;
+        foreach (array_keys($rawData) as $key) {
+            if (str_starts_with((string) $key, 'parent_') || str_starts_with((string) $key, '_')) {
+                continue;
+            }
+            $resolved[$key] = self::getValueWithParentMode((string) $key, $rawData, $useParentMode);
+        }
+
+        return $resolved;
     }
 
     /**
@@ -651,6 +713,23 @@ class Maho_FeedManager_Model_Mapper
         // Null means the feed predates the setting: the column default excludes the category.
         if (($this->_feed->getExcludeCategoryUrl() ?? 1) === 0) {
             $product->setStoreId($this->_storeId);
+            $product->unsetData('url');
+            $product->unsetData('request_path');
+
+            // A feed product carries no category context, so the url model would drop the
+            // category segment the setting asks for. Resolve the pair rewrite here and leave the
+            // plain product URL when the store has none, because the url model answers a missing
+            // pair rewrite with a catalog/product/view query URL.
+            $categoryId = $this->_getDeepestCategoryId($product);
+            if ($categoryId !== null) {
+                $rewrite = Mage::getModel('core/url_rewrite')
+                    ->setStoreId($this->_storeId)
+                    ->loadByIdPath(sprintf('product/%d/%d', (int) $product->getId(), $categoryId));
+                if ($rewrite->getId()) {
+                    $product->setRequestPath($rewrite->getRequestPath());
+                }
+            }
+
             return $product->getProductUrl();
         }
 
@@ -680,13 +759,15 @@ class Maho_FeedManager_Model_Mapper
             // Silent fail
         }
 
-        return $this->_feed->getNoImageUrl() ?: '';
+        return '';
     }
 
     /**
-     * Get additional product images
+     * Get every media gallery image, in gallery order, the main image included
+     *
+     * @return array<int, string>
      */
-    protected function _getAdditionalImages(Mage_Catalog_Model_Product $product): array
+    protected function _getGalleryImages(Mage_Catalog_Model_Product $product): array
     {
         $images = [];
 
@@ -725,13 +806,24 @@ class Maho_FeedManager_Model_Mapper
             }
         }
 
-        // additional_image_link must not duplicate the main image_link URL.
-        $mainImageUrl = $this->_getImageUrl($product, 'image');
-        if ($mainImageUrl) {
-            $images = array_values(array_filter($images, fn($u) => $u !== $mainImageUrl));
+        return $images;
+    }
+
+    /**
+     * Drop the main image from a gallery list
+     *
+     * additional_image_link must not duplicate the main image_link URL.
+     *
+     * @param array<int, string> $galleryImages
+     * @return array<int, string>
+     */
+    protected function _withoutMainImage(array $galleryImages, string $mainImageUrl): array
+    {
+        if ($mainImageUrl === '') {
+            return $galleryImages;
         }
 
-        return $images;
+        return array_values(array_filter($galleryImages, fn($url) => $url !== $mainImageUrl));
     }
 
     /**
@@ -869,6 +961,32 @@ class Maho_FeedManager_Model_Mapper
         }
 
         return $deepestPath;
+    }
+
+    /**
+     * Get the deepest category the product belongs to
+     */
+    protected function _getDeepestCategoryId(Mage_Catalog_Model_Product $product): ?int
+    {
+        $this->_ensureCategoryCache();
+
+        $deepestId = null;
+        $maxDepth = 0;
+
+        foreach ($product->getCategoryIds() as $categoryId) {
+            $catId = (int) $categoryId;
+            if (!isset(self::$_categoryCache[$catId])) {
+                continue;
+            }
+
+            $depth = count(explode('/', self::$_categoryCache[$catId]['path']));
+            if ($depth > $maxDepth) {
+                $maxDepth = $depth;
+                $deepestId = $catId;
+            }
+        }
+
+        return $deepestId;
     }
 
     /**

--- a/app/code/core/Maho/FeedManager/Model/Mapper.php
+++ b/app/code/core/Maho/FeedManager/Model/Mapper.php
@@ -799,7 +799,7 @@ class Maho_FeedManager_Model_Mapper
             if (is_array($mediaGallery) && isset($mediaGallery['images'])) {
                 $baseUrl = Mage::getBaseUrl('media') . 'catalog/product';
                 foreach ($mediaGallery['images'] as $img) {
-                    if (isset($img['file']) && !isset($img['disabled'])) {
+                    if (isset($img['file']) && empty($img['disabled'])) {
                         $images[] = $baseUrl . $img['file'];
                     }
                 }

--- a/app/code/core/Maho/FeedManager/Model/Mapper.php
+++ b/app/code/core/Maho/FeedManager/Model/Mapper.php
@@ -44,9 +44,7 @@ class Maho_FeedManager_Model_Mapper
         'cost',
     ];
 
-    /**
-     * Image fields that fall back to the feed's placeholder URL when nothing resolved.
-     */
+    /** Image fields that use the feed placeholder URL when no value resolves. */
     protected const IMAGE_FIELDS = [
         'image',
         'small_image',
@@ -55,8 +53,8 @@ class Maho_FeedManager_Model_Mapper
     ];
 
     /**
-     * Price fields a customer pays, so they follow the feed tax mode.
-     * 'cost' is a supplier cost and stays raw.
+     * Prices that a customer pays. They follow the feed tax mode.
+     * The 'cost' field is a supplier cost, so it is not in this list.
      */
     protected const TAXED_PRICE_FIELDS = [
         'price',
@@ -99,7 +97,6 @@ class Maho_FeedManager_Model_Mapper
 
     protected Maho_FeedManager_Model_Price_TaxAdjuster $_taxAdjuster;
 
-    /** @var bool Whether a product row carries the media gallery */
     protected bool $_extractGallery = true;
 
     /**
@@ -117,11 +114,10 @@ class Maho_FeedManager_Model_Mapper
     }
 
     /**
-     * Switch the media gallery read off for a run that cannot use it.
+     * Enable or disable the media gallery read.
      *
-     * The gallery costs a query for every product. An engine that knows in advance that no
-     * output field names an image switches it off for the whole feed. The gallery keys
-     * (gallery_images, additional_images, image_1..image_10) are then empty.
+     * The gallery costs one query for each product. A caller that writes no image field
+     * disables it for the whole feed. The gallery keys are then empty.
      */
     public function setExtractGallery(bool $extract): void
     {
@@ -238,8 +234,7 @@ class Maho_FeedManager_Model_Mapper
     /**
      * Resolve one field to its final value.
      *
-     * Every output engine goes through this method, so a feed field yields the same value
-     * whichever writer serialises it. The engines keep only their serialisation.
+     * All output engines call this method, so a field has the same value in every format.
      *
      * @param array<string, mixed> $config Field configuration
      * @param array<string, mixed> $rawData Product row from extractProductData()
@@ -249,8 +244,8 @@ class Maho_FeedManager_Model_Mapper
         $value = $this->_getSourceValue($config, $rawData, $product);
         $sourceValue = (string) ($config['source_value'] ?? '');
 
-        // The placeholder lands only once the parent fallback has had its turn, otherwise it
-        // would count as a value and hide the parent image.
+        // Apply the placeholder after the parent fallback. An earlier placeholder counts as
+        // a value and hides the parent image.
         if (($value === null || $value === '') && in_array($sourceValue, self::IMAGE_FIELDS, true)) {
             $value = $this->_feed->getNoImageUrl() ?: '';
         }
@@ -522,10 +517,9 @@ class Maho_FeedManager_Model_Mapper
     }
 
     /**
-     * Convert the customer-facing prices in a product row into the tax mode the feed asks for.
+     * Convert the prices in a product row to the tax mode of the feed.
      *
-     * This runs on the raw row, before any transformer, so a user chain receives a tax-correct
-     * input.
+     * This runs before the transformers, so a transformer receives a correct price.
      *
      * @param array<string, mixed> $data
      */
@@ -636,10 +630,10 @@ class Maho_FeedManager_Model_Mapper
     }
 
     /**
-     * Resolve every row key through the parent mode.
+     * Apply the parent mode to every row key.
      *
-     * A combined source reads the row directly instead of going through
-     * getValueWithParentMode(), so the parent mode has to be baked into the row it receives.
+     * A combined source reads the row directly and never calls getValueWithParentMode(),
+     * so the row must already hold the resolved values.
      *
      * @param array<string, mixed> $rawData
      * @return array<string, mixed>
@@ -710,16 +704,16 @@ class Maho_FeedManager_Model_Mapper
      */
     protected function _getProductSeoUrl(Mage_Catalog_Model_Product $product): string
     {
-        // Null means the feed predates the setting: the column default excludes the category.
+        // Null means a feed created before the setting existed. The default excludes the category.
         if (($this->_feed->getExcludeCategoryUrl() ?? 1) === 0) {
             $product->setStoreId($this->_storeId);
             $product->unsetData('url');
             $product->unsetData('request_path');
 
-            // A feed product carries no category context, so the url model would drop the
-            // category segment the setting asks for. Resolve the pair rewrite here and leave the
-            // plain product URL when the store has none, because the url model answers a missing
-            // pair rewrite with a catalog/product/view query URL.
+            // The url model drops the category segment, because a feed product has no category
+            // context. Load the product and category rewrite here instead. If the store has no
+            // such rewrite, keep the plain product URL. The url model would answer with a
+            // catalog/product/view query URL.
             $categoryId = $this->_getDeepestCategoryId($product);
             if ($categoryId !== null) {
                 $rewrite = Mage::getModel('core/url_rewrite')
@@ -763,7 +757,7 @@ class Maho_FeedManager_Model_Mapper
     }
 
     /**
-     * Get every media gallery image, in gallery order, the main image included
+     * Get all media gallery images in gallery order. The list includes the main image.
      *
      * @return array<int, string>
      */

--- a/app/code/core/Maho/FeedManager/Model/Price/TaxAdjuster.php
+++ b/app/code/core/Maho/FeedManager/Model/Price/TaxAdjuster.php
@@ -72,21 +72,28 @@ final class Maho_FeedManager_Model_Price_TaxAdjuster
      * Rate a customer pays at the store's default tax destination.
      *
      * Mage_Tax_Model_Calculation::getRateRequest() is avoided on purpose: it reads the customer
-     * session, which a cron worker must not start.
+     * session, which a cron worker must not start. Its address selection is reproduced here:
+     * "Based on" = Origin uses the shipping origin, every other value uses the tax defaults,
+     * because no customer address exists during feed generation.
      */
     private function _getDestinationRate(int $taxClassId): float
     {
         if (!isset($this->_destinationRates[$taxClassId])) {
-            $request = new \Maho\DataObject();
-            $request
-                ->setCountryId(Mage::getStoreConfig(Mage_Tax_Model_Config::CONFIG_XML_PATH_DEFAULT_COUNTRY, $this->_store))
-                ->setRegionId(Mage::getStoreConfig(Mage_Tax_Model_Config::CONFIG_XML_PATH_DEFAULT_REGION, $this->_store))
-                ->setPostcode(Mage::getStoreConfig(Mage_Tax_Model_Config::CONFIG_XML_PATH_DEFAULT_POSTCODE, $this->_store))
-                ->setCustomerClassId(Mage::getSingleton('tax/calculation')->getDefaultCustomerTaxClass($this->_store))
-                ->setStore($this->_store)
-                ->setProductClassId($taxClassId);
+            $calculation = Mage::getSingleton('tax/calculation');
 
-            $this->_destinationRates[$taxClassId] = (float) Mage::getSingleton('tax/calculation')->getRate($request);
+            if (Mage::getStoreConfig(Mage_Tax_Model_Config::CONFIG_XML_PATH_BASED_ON, $this->_store) === 'origin') {
+                $request = $calculation->getRateOriginRequest($this->_store);
+            } else {
+                $request = new \Maho\DataObject();
+                $request
+                    ->setCountryId(Mage::getStoreConfig(Mage_Tax_Model_Config::CONFIG_XML_PATH_DEFAULT_COUNTRY, $this->_store))
+                    ->setRegionId(Mage::getStoreConfig(Mage_Tax_Model_Config::CONFIG_XML_PATH_DEFAULT_REGION, $this->_store))
+                    ->setPostcode(Mage::getStoreConfig(Mage_Tax_Model_Config::CONFIG_XML_PATH_DEFAULT_POSTCODE, $this->_store))
+                    ->setCustomerClassId($calculation->getDefaultCustomerTaxClass($this->_store))
+                    ->setStore($this->_store);
+            }
+
+            $this->_destinationRates[$taxClassId] = (float) $calculation->getRate($request->setProductClassId($taxClassId));
         }
 
         return $this->_destinationRates[$taxClassId];

--- a/app/code/core/Maho/FeedManager/Model/Price/TaxAdjuster.php
+++ b/app/code/core/Maho/FeedManager/Model/Price/TaxAdjuster.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Converts a catalog price into the tax mode a feed asks for.
+ * Converts a catalog price to the tax mode of a feed.
  *
  * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
  * SPDX-License-Identifier: OSL-3.0
@@ -19,7 +19,7 @@ final class Maho_FeedManager_Model_Price_TaxAdjuster
     /** @var array<int, float> Resolved destination rate per tax class id */
     private array $_destinationRates = [];
 
-    /** @var array<int, float> Resolved rate baked into a stored tax inclusive price, per tax class id */
+    /** @var array<int, float> Rate included in a stored tax inclusive price, per tax class id */
     private array $_includedRates = [];
 
     public function __construct(Maho_FeedManager_Model_Feed $feed)
@@ -59,7 +59,7 @@ final class Maho_FeedManager_Model_Price_TaxAdjuster
     }
 
     /**
-     * A rate already resolved on the product wins, as in Mage_Tax_Helper_Data::getPrice().
+     * A rate already set on the product has priority, as in Mage_Tax_Helper_Data::getPrice().
      */
     private function _resolveDestinationRate(Mage_Catalog_Model_Product $product, int $taxClassId): float
     {
@@ -69,12 +69,12 @@ final class Maho_FeedManager_Model_Price_TaxAdjuster
     }
 
     /**
-     * Rate a customer pays at the store's default tax destination.
+     * Rate that a customer pays at the default tax destination of the store.
      *
-     * Mage_Tax_Model_Calculation::getRateRequest() is avoided on purpose: it reads the customer
-     * session, which a cron worker must not start. Its address selection is reproduced here:
-     * "Based on" = Origin uses the shipping origin, every other value uses the tax defaults,
-     * because no customer address exists during feed generation.
+     * This method does not call Mage_Tax_Model_Calculation::getRateRequest(), because that
+     * method reads the customer session and a cron worker must not start one. The address
+     * selection is repeated here. A feed has no customer address, so "Based on" = Origin uses
+     * the shipping origin, and every other value uses the tax defaults.
      */
     private function _getDestinationRate(int $taxClassId): float
     {
@@ -100,7 +100,7 @@ final class Maho_FeedManager_Model_Price_TaxAdjuster
     }
 
     /**
-     * Rate already baked into a stored tax inclusive price.
+     * Rate that a stored tax inclusive price already includes.
      */
     private function _getIncludedRate(Mage_Catalog_Model_Product $product, int $taxClassId): float
     {

--- a/app/code/core/Maho/FeedManager/Model/Price/TaxAdjuster.php
+++ b/app/code/core/Maho/FeedManager/Model/Price/TaxAdjuster.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Converts a catalog price into the tax mode a feed asks for.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Maho_FeedManager
+ */
+
+declare(strict_types=1);
+
+final class Maho_FeedManager_Model_Price_TaxAdjuster
+{
+    private Mage_Core_Model_Store $_store;
+    private bool $_wantIncludingTax;
+    private bool $_storedIncludingTax;
+
+    /** @var array<int, float> Resolved destination rate per tax class id */
+    private array $_destinationRates = [];
+
+    /** @var array<int, float> Resolved rate baked into a stored tax inclusive price, per tax class id */
+    private array $_includedRates = [];
+
+    public function __construct(Maho_FeedManager_Model_Feed $feed)
+    {
+        $this->_store = Mage::app()->getStore($feed->getStoreId());
+        $this->_wantIncludingTax = ($feed->getTaxMode() ?: 'incl') === 'incl';
+        $this->_storedIncludingTax = (bool) Mage::helper('tax')->priceIncludesTax($this->_store);
+    }
+
+    public function adjust(Mage_Catalog_Model_Product $product, float|string|null $price): ?float
+    {
+        if ($price === null || $price === '' || !is_numeric($price)) {
+            return null;
+        }
+
+        $price = (float) $price;
+        if ($price === 0.0 || $this->_wantIncludingTax === $this->_storedIncludingTax) {
+            return $price;
+        }
+
+        $taxClassId = (int) $product->getTaxClassId();
+        if ($taxClassId === 0) {
+            return $price;
+        }
+
+        $calculation = Mage::getSingleton('tax/calculation');
+
+        if ($this->_wantIncludingTax) {
+            $rate = $this->_resolveDestinationRate($product, $taxClassId);
+            $adjusted = $price + $calculation->calcTaxAmount($price, $rate, false, false);
+        } else {
+            $rate = $this->_getIncludedRate($product, $taxClassId);
+            $adjusted = $price - $calculation->calcTaxAmount($price, $rate, true, false);
+        }
+
+        return (float) $this->_store->roundPrice($adjusted);
+    }
+
+    /**
+     * A rate already resolved on the product wins, as in Mage_Tax_Helper_Data::getPrice().
+     */
+    private function _resolveDestinationRate(Mage_Catalog_Model_Product $product, int $taxClassId): float
+    {
+        $percent = $product->getTaxPercent();
+
+        return $percent === null || $percent === '' ? $this->_getDestinationRate($taxClassId) : (float) $percent;
+    }
+
+    /**
+     * Rate a customer pays at the store's default tax destination.
+     *
+     * Mage_Tax_Model_Calculation::getRateRequest() is avoided on purpose: it reads the customer
+     * session, which a cron worker must not start.
+     */
+    private function _getDestinationRate(int $taxClassId): float
+    {
+        if (!isset($this->_destinationRates[$taxClassId])) {
+            $request = new \Maho\DataObject();
+            $request
+                ->setCountryId(Mage::getStoreConfig(Mage_Tax_Model_Config::CONFIG_XML_PATH_DEFAULT_COUNTRY, $this->_store))
+                ->setRegionId(Mage::getStoreConfig(Mage_Tax_Model_Config::CONFIG_XML_PATH_DEFAULT_REGION, $this->_store))
+                ->setPostcode(Mage::getStoreConfig(Mage_Tax_Model_Config::CONFIG_XML_PATH_DEFAULT_POSTCODE, $this->_store))
+                ->setCustomerClassId(Mage::getSingleton('tax/calculation')->getDefaultCustomerTaxClass($this->_store))
+                ->setStore($this->_store)
+                ->setProductClassId($taxClassId);
+
+            $this->_destinationRates[$taxClassId] = (float) Mage::getSingleton('tax/calculation')->getRate($request);
+        }
+
+        return $this->_destinationRates[$taxClassId];
+    }
+
+    /**
+     * Rate already baked into a stored tax inclusive price.
+     */
+    private function _getIncludedRate(Mage_Catalog_Model_Product $product, int $taxClassId): float
+    {
+        if (Mage::helper('tax')->isCrossBorderTradeEnabled($this->_store)) {
+            return $this->_resolveDestinationRate($product, $taxClassId);
+        }
+
+        if (!isset($this->_includedRates[$taxClassId])) {
+            $request = Mage::getSingleton('tax/calculation')->getRateOriginRequest($this->_store);
+            $this->_includedRates[$taxClassId] = (float) Mage::getSingleton('tax/calculation')
+                ->getRate($request->setProductClassId($taxClassId));
+        }
+
+        return $this->_includedRates[$taxClassId];
+    }
+}

--- a/tests/Backend/Unit/FeedManager/Model/MapperTest.php
+++ b/tests/Backend/Unit/FeedManager/Model/MapperTest.php
@@ -60,3 +60,85 @@ describe('Mapper default mappings', function () {
         expect($mappings['availability']['transformers'])->toBeEmpty();
     });
 });
+
+describe('One resolver for every output engine', function () {
+    function firstSimpleProduct(): Mage_Catalog_Model_Product
+    {
+        $product = Mage::getResourceModel('catalog/product_collection')
+            ->setStoreId(1)
+            ->addAttributeToSelect('*')
+            ->addFieldToFilter('type_id', 'simple')
+            ->addPriceData()
+            ->setPageSize(1)
+            ->getFirstItem();
+
+        $product->setStockItem(Mage::getModel('cataloginventory/stock_item')->loadByProduct($product));
+
+        return $product;
+    }
+
+    /** Drive the xml_template engine for one known product. */
+    function renderItemTemplate(Maho_FeedManager_Model_Feed $feed, Mage_Catalog_Model_Product $product, string $template): string
+    {
+        $generator = new Maho_FeedManager_Model_Generator();
+        $reflection = new ReflectionObject($generator);
+        $reflection->getProperty('_feed')->setValue($generator, $feed);
+        $reflection->getProperty('_mapper')->setValue($generator, new Maho_FeedManager_Model_Mapper($feed));
+
+        return $reflection->getMethod('_renderItemTemplate')->invoke($generator, $template, $product, $feed);
+    }
+
+    beforeEach(function () {
+        $this->feed = Mage::getModel('feedmanager/feed')
+            ->setPlatform('custom')
+            ->setStoreId(1)
+            ->setPriceCurrency('USD')
+            ->setPriceCurrencySuffix(1)
+            ->setTaxMode('excl');
+    });
+
+    test('all four engines return the same value for the same field', function () {
+        // The list price differs from the discounted price, so an engine reading the wrong one
+        // stands out. No tax class, so the tax mode cannot move the numbers either.
+        $product = firstSimpleProduct();
+        expect((int) $product->getId())->toBeGreaterThan(0);
+        $product->setPrice(100.00)->setFinalPrice(80.00)->setTaxClassId(0);
+
+        $mapper = new Maho_FeedManager_Model_Mapper($this->feed);
+        $config = ['source_type' => 'attribute', 'source_value' => 'price'];
+
+        $mapper->setMappingsFromCsvColumns([['name' => 'price'] + $config]);
+        $flat = (string) $mapper->mapProduct($product)['price'];
+
+        $json = $mapper->mapProductToJsonStructure($product, [
+            'price' => ['type' => 'string'] + $config,
+        ])['price'];
+
+        $xml = $mapper->mapProductToXmlStructure($product, [
+            ['tag' => 'price'] + $config,
+        ], '', 0);
+        $xmlValue = trim(strip_tags($xml));
+
+        $template = renderItemTemplate($this->feed, $product, '{type="attribute" value="price"}');
+
+        expect($json)->toBe($flat);
+        expect($xmlValue)->toBe($flat);
+        expect(trim($template))->toBe($flat);
+    });
+
+    test('every engine reports the discounted price, not the list price', function () {
+        // No tax class, so the tax mode cannot move the numbers this test asserts on.
+        $product = firstSimpleProduct();
+        $product->setPrice(100.00)->setFinalPrice(80.00)->setTaxClassId(0);
+
+        $mapper = new Maho_FeedManager_Model_Mapper($this->feed);
+        $row = $mapper->extractProductData($product);
+
+        expect((float) $row['price'])->toBe(80.00);
+        expect((float) $row['final_price'])->toBe(80.00);
+        expect((float) $row['regular_price'])->toBe(100.00);
+
+        $template = renderItemTemplate($this->feed, $product, '{type="attribute" value="price"}');
+        expect(trim($template))->toStartWith('80.00');
+    });
+});

--- a/tests/Backend/Unit/FeedManager/Model/MapperTest.php
+++ b/tests/Backend/Unit/FeedManager/Model/MapperTest.php
@@ -77,7 +77,7 @@ describe('One resolver for every output engine', function () {
         return $product;
     }
 
-    /** Drive the xml_template engine for one known product. */
+    /** Run the xml_template engine for one known product. */
     function renderItemTemplate(Maho_FeedManager_Model_Feed $feed, Mage_Catalog_Model_Product $product, string $template): string
     {
         $generator = new Maho_FeedManager_Model_Generator();
@@ -98,8 +98,8 @@ describe('One resolver for every output engine', function () {
     });
 
     test('all four engines return the same value for the same field', function () {
-        // The list price differs from the discounted price, so an engine reading the wrong one
-        // stands out. No tax class, so the tax mode cannot move the numbers either.
+        // The list price differs from the discounted price, so a wrong price is visible in the
+        // result. The product has no tax class, so the tax mode cannot change the numbers.
         $product = firstSimpleProduct();
         expect((int) $product->getId())->toBeGreaterThan(0);
         $product->setPrice(100.00)->setFinalPrice(80.00)->setTaxClassId(0);
@@ -127,7 +127,7 @@ describe('One resolver for every output engine', function () {
     });
 
     test('every engine reports the discounted price, not the list price', function () {
-        // No tax class, so the tax mode cannot move the numbers this test asserts on.
+        // The product has no tax class, so the tax mode cannot change these numbers.
         $product = firstSimpleProduct();
         $product->setPrice(100.00)->setFinalPrice(80.00)->setTaxClassId(0);
 

--- a/tests/Backend/Unit/FeedManager/Model/MapperValueTest.php
+++ b/tests/Backend/Unit/FeedManager/Model/MapperValueTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+function valueFeed(): Maho_FeedManager_Model_Feed
+{
+    return Mage::getModel('feedmanager/feed')
+        ->setPlatform('custom')
+        ->setStoreId(1)
+        ->setNoImageUrl('http://example.com/placeholder.jpg');
+}
+
+function valueProduct(): Mage_Catalog_Model_Product
+{
+    return Mage::getModel('catalog/product')
+        ->setId(1)
+        ->setTypeId('simple')
+        ->setStoreId(1);
+}
+
+describe('Mapper image resolution', function () {
+    it('takes the parent image when the child has none', function () {
+        $mapper = new Maho_FeedManager_Model_Mapper(valueFeed());
+
+        $value = $mapper->resolveFieldValue(
+            ['source_type' => 'attribute', 'source_value' => 'image', 'use_parent' => 'if_empty'],
+            ['image' => '', 'parent_image' => 'http://example.com/parent.jpg'],
+            valueProduct(),
+        );
+
+        expect($value)->toBe('http://example.com/parent.jpg');
+    });
+
+    it('takes the placeholder when neither the child nor the parent has an image', function () {
+        $mapper = new Maho_FeedManager_Model_Mapper(valueFeed());
+
+        $value = $mapper->resolveFieldValue(
+            ['source_type' => 'attribute', 'source_value' => 'image', 'use_parent' => 'if_empty'],
+            ['image' => '', 'parent_image' => ''],
+            valueProduct(),
+        );
+
+        expect($value)->toBe('http://example.com/placeholder.jpg');
+    });
+
+    it('keeps the child image when it has one', function () {
+        $mapper = new Maho_FeedManager_Model_Mapper(valueFeed());
+
+        $value = $mapper->resolveFieldValue(
+            ['source_type' => 'attribute', 'source_value' => 'image', 'use_parent' => 'if_empty'],
+            ['image' => 'http://example.com/child.jpg', 'parent_image' => 'http://example.com/parent.jpg'],
+            valueProduct(),
+        );
+
+        expect($value)->toBe('http://example.com/child.jpg');
+    });
+});
+
+describe('Mapper combined source', function () {
+    it('fills a placeholder from the parent when the child value is empty', function () {
+        $mapper = new Maho_FeedManager_Model_Mapper(valueFeed());
+
+        $value = $mapper->resolveFieldValue(
+            [
+                'source_type' => 'combined',
+                'source_value' => '{{brand}} {{name}}',
+                'use_parent' => 'if_empty',
+            ],
+            [
+                'brand' => '',
+                'parent_brand' => 'Acme',
+                'name' => 'Blue shirt',
+                'parent_name' => 'Shirt',
+            ],
+            valueProduct(),
+        );
+
+        expect($value)->toBe('Acme Blue shirt');
+    });
+});

--- a/tests/Backend/Unit/FeedManager/Model/PriceTaxTest.php
+++ b/tests/Backend/Unit/FeedManager/Model/PriceTaxTest.php
@@ -12,6 +12,9 @@ uses(Tests\MahoBackendTestCase::class);
 $taxConfigPaths = [
     'tax/calculation/price_includes_tax',
     'tax/calculation/cross_border_trade_enabled',
+    'tax/calculation/based_on',
+    'tax/defaults/country',
+    'shipping/origin/country_id',
 ];
 $originalTaxConfig = [];
 
@@ -113,5 +116,62 @@ describe('Feed tax mode', function () {
 
         expect($adjuster->adjust(taxProduct(), null))->toBeNull();
         expect($adjuster->adjust(taxProduct(), ''))->toBeNull();
+    });
+});
+
+describe('Feed tax destination', function () {
+    /**
+     * A rate the sample data does not carry, so only the country under test resolves it.
+     * The rule links the rate to the default customer class and to product class 2.
+     */
+    beforeEach(function (): void {
+        Mage::getModel('tax/calculation_rule')->load('feedmanager-test-rule', 'code')->delete();
+        Mage::getModel('tax/calculation_rate')->load('feedmanager-test-at', 'code')->delete();
+
+        $rate = Mage::getModel('tax/calculation_rate')
+            ->setCode('feedmanager-test-at')
+            ->setTaxCountryId('AT')
+            ->setTaxRegionId(0)
+            ->setTaxPostcode('*')
+            ->setRate(50)
+            ->save();
+
+        Mage::getModel('tax/calculation_rule')
+            ->setCode('feedmanager-test-rule')
+            ->setPriority(0)
+            ->setPosition(0)
+            ->setTaxRate([$rate->getId()])
+            ->setTaxCustomerClass([Mage::getSingleton('tax/calculation')->getDefaultCustomerTaxClass(1)])
+            ->setTaxProductClass([2])
+            ->save();
+    });
+
+    afterEach(function (): void {
+        Mage::getModel('tax/calculation_rule')->load('feedmanager-test-rule', 'code')->delete();
+        Mage::getModel('tax/calculation_rate')->load('feedmanager-test-at', 'code')->delete();
+    });
+
+    it('uses the shipping origin when "based on" is origin', function () {
+        $store = Mage::app()->getStore(1);
+        $store->setConfig('tax/calculation/price_includes_tax', 0);
+        $store->setConfig('tax/calculation/based_on', 'origin');
+        $store->setConfig('shipping/origin/country_id', 'AT');
+        $store->setConfig('tax/defaults/country', 'US');
+
+        $adjuster = new Maho_FeedManager_Model_Price_TaxAdjuster(taxFeed('incl'));
+
+        expect($adjuster->adjust(taxProduct(20.00, 2)->unsetData('tax_percent'), 20.00))->toBe(30.00);
+    });
+
+    it('uses the tax defaults when "based on" is not origin', function () {
+        $store = Mage::app()->getStore(1);
+        $store->setConfig('tax/calculation/price_includes_tax', 0);
+        $store->setConfig('tax/calculation/based_on', 'shipping');
+        $store->setConfig('shipping/origin/country_id', 'US');
+        $store->setConfig('tax/defaults/country', 'AT');
+
+        $adjuster = new Maho_FeedManager_Model_Price_TaxAdjuster(taxFeed('incl'));
+
+        expect($adjuster->adjust(taxProduct(20.00, 2)->unsetData('tax_percent'), 20.00))->toBe(30.00);
     });
 });

--- a/tests/Backend/Unit/FeedManager/Model/PriceTaxTest.php
+++ b/tests/Backend/Unit/FeedManager/Model/PriceTaxTest.php
@@ -32,7 +32,7 @@ afterEach(function () use (&$originalTaxConfig): void {
     }
 });
 
-/** Deleting a model that did not load runs its delete hooks with an empty id. */
+/** Delete only a record that exists. A delete on an empty id runs a query with an empty id. */
 function deleteTaxRecordByCode(string $model, string $code): void
 {
     $record = Mage::getModel($model)->load($code, 'code');
@@ -41,7 +41,7 @@ function deleteTaxRecordByCode(string $model, string $code): void
     }
 }
 
-/** A feed is enough for the adjuster: it reads the tax mode and the store only. */
+/** A feed is enough for the adjuster. It reads only the tax mode and the store. */
 function taxFeed(string $taxMode): Maho_FeedManager_Model_Feed
 {
     return Mage::getModel('feedmanager/feed')
@@ -50,7 +50,7 @@ function taxFeed(string $taxMode): Maho_FeedManager_Model_Feed
         ->setTaxMode($taxMode);
 }
 
-/** A product carrying a single 22 percent rate, so the adjuster never queries a rate. */
+/** A product with a 22 percent rate already set, so the adjuster does not query a rate. */
 function taxProduct(float $price = 20.00, ?int $taxClassId = 2): Mage_Catalog_Model_Product
 {
     $product = Mage::getModel('catalog/product')
@@ -130,7 +130,7 @@ describe('Feed tax mode', function () {
 
 describe('Feed tax destination', function () {
     /**
-     * A rate the sample data does not carry, so only the country under test resolves it.
+     * The sample data has no rate for this country, so only this test resolves the rate.
      * The rule links the rate to the default customer class and to product class 2.
      */
     beforeEach(function (): void {

--- a/tests/Backend/Unit/FeedManager/Model/PriceTaxTest.php
+++ b/tests/Backend/Unit/FeedManager/Model/PriceTaxTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+$taxConfigPaths = [
+    'tax/calculation/price_includes_tax',
+    'tax/calculation/cross_border_trade_enabled',
+];
+$originalTaxConfig = [];
+
+beforeEach(function () use ($taxConfigPaths, &$originalTaxConfig): void {
+    $store = Mage::app()->getStore(1);
+    foreach ($taxConfigPaths as $path) {
+        $originalTaxConfig[$path] = $store->getConfig($path);
+    }
+});
+
+afterEach(function () use (&$originalTaxConfig): void {
+    $store = Mage::app()->getStore(1);
+    foreach ($originalTaxConfig as $path => $value) {
+        $store->setConfig($path, $value);
+    }
+});
+
+/** A feed is enough for the adjuster: it reads the tax mode and the store only. */
+function taxFeed(string $taxMode): Maho_FeedManager_Model_Feed
+{
+    return Mage::getModel('feedmanager/feed')
+        ->setPlatform('custom')
+        ->setStoreId(1)
+        ->setTaxMode($taxMode);
+}
+
+/** A product carrying a single 22 percent rate, so the adjuster never queries a rate. */
+function taxProduct(float $price = 20.00, ?int $taxClassId = 2): Mage_Catalog_Model_Product
+{
+    $product = Mage::getModel('catalog/product')
+        ->setId(1)
+        ->setTypeId('simple')
+        ->setStoreId(1)
+        ->setPrice($price);
+
+    if ($taxClassId !== null) {
+        $product->setTaxClassId($taxClassId)->setTaxPercent(22);
+    }
+
+    return $product;
+}
+
+describe('Feed tax mode', function () {
+    it('adds tax when the store stores prices without tax and the feed asks for tax', function () {
+        Mage::app()->getStore(1)->setConfig('tax/calculation/price_includes_tax', 0);
+
+        $adjuster = new Maho_FeedManager_Model_Price_TaxAdjuster(taxFeed('incl'));
+
+        expect($adjuster->adjust(taxProduct(), 20.00))->toBe(24.40);
+    });
+
+    it('leaves the price alone when the feed asks for the mode the store already stores', function () {
+        Mage::app()->getStore(1)->setConfig('tax/calculation/price_includes_tax', 0);
+
+        $adjuster = new Maho_FeedManager_Model_Price_TaxAdjuster(taxFeed('excl'));
+
+        expect($adjuster->adjust(taxProduct(), 20.00))->toBe(20.00);
+    });
+
+    it('removes tax when the store stores prices with tax and the feed asks for none', function () {
+        $store = Mage::app()->getStore(1);
+        $store->setConfig('tax/calculation/price_includes_tax', 1);
+        $store->setConfig('tax/calculation/cross_border_trade_enabled', 1);
+
+        $adjuster = new Maho_FeedManager_Model_Price_TaxAdjuster(taxFeed('excl'));
+
+        expect($adjuster->adjust(taxProduct(), 24.40))->toBe(20.00);
+    });
+
+    it('keeps a tax inclusive price when the feed asks for tax', function () {
+        Mage::app()->getStore(1)->setConfig('tax/calculation/price_includes_tax', 1);
+
+        $adjuster = new Maho_FeedManager_Model_Price_TaxAdjuster(taxFeed('incl'));
+
+        expect($adjuster->adjust(taxProduct(), 24.40))->toBe(24.40);
+    });
+
+    it('treats a missing tax mode as "include tax"', function () {
+        Mage::app()->getStore(1)->setConfig('tax/calculation/price_includes_tax', 0);
+
+        $feed = Mage::getModel('feedmanager/feed')->setPlatform('custom')->setStoreId(1);
+        $adjuster = new Maho_FeedManager_Model_Price_TaxAdjuster($feed);
+
+        expect($adjuster->adjust(taxProduct(), 20.00))->toBe(24.40);
+    });
+
+    it('leaves a product without a tax class alone', function () {
+        Mage::app()->getStore(1)->setConfig('tax/calculation/price_includes_tax', 0);
+
+        $adjuster = new Maho_FeedManager_Model_Price_TaxAdjuster(taxFeed('incl'));
+
+        expect($adjuster->adjust(taxProduct(20.00, null), 20.00))->toBe(20.00);
+    });
+
+    it('returns null for a price that is not a number', function () {
+        Mage::app()->getStore(1)->setConfig('tax/calculation/price_includes_tax', 0);
+
+        $adjuster = new Maho_FeedManager_Model_Price_TaxAdjuster(taxFeed('incl'));
+
+        expect($adjuster->adjust(taxProduct(), null))->toBeNull();
+        expect($adjuster->adjust(taxProduct(), ''))->toBeNull();
+    });
+});

--- a/tests/Backend/Unit/FeedManager/Model/PriceTaxTest.php
+++ b/tests/Backend/Unit/FeedManager/Model/PriceTaxTest.php
@@ -32,6 +32,15 @@ afterEach(function () use (&$originalTaxConfig): void {
     }
 });
 
+/** Deleting a model that did not load runs its delete hooks with an empty id. */
+function deleteTaxRecordByCode(string $model, string $code): void
+{
+    $record = Mage::getModel($model)->load($code, 'code');
+    if ($record->getId()) {
+        $record->delete();
+    }
+}
+
 /** A feed is enough for the adjuster: it reads the tax mode and the store only. */
 function taxFeed(string $taxMode): Maho_FeedManager_Model_Feed
 {
@@ -125,8 +134,8 @@ describe('Feed tax destination', function () {
      * The rule links the rate to the default customer class and to product class 2.
      */
     beforeEach(function (): void {
-        Mage::getModel('tax/calculation_rule')->load('feedmanager-test-rule', 'code')->delete();
-        Mage::getModel('tax/calculation_rate')->load('feedmanager-test-at', 'code')->delete();
+        deleteTaxRecordByCode('tax/calculation_rule', 'feedmanager-test-rule');
+        deleteTaxRecordByCode('tax/calculation_rate', 'feedmanager-test-at');
 
         $rate = Mage::getModel('tax/calculation_rate')
             ->setCode('feedmanager-test-at')
@@ -147,8 +156,8 @@ describe('Feed tax destination', function () {
     });
 
     afterEach(function (): void {
-        Mage::getModel('tax/calculation_rule')->load('feedmanager-test-rule', 'code')->delete();
-        Mage::getModel('tax/calculation_rate')->load('feedmanager-test-at', 'code')->delete();
+        deleteTaxRecordByCode('tax/calculation_rule', 'feedmanager-test-rule');
+        deleteTaxRecordByCode('tax/calculation_rate', 'feedmanager-test-at');
     });
 
     it('uses the shipping origin when "based on" is origin', function () {

--- a/tests/Backend/Unit/Maho/Routing/CanonicalUriTest.php
+++ b/tests/Backend/Unit/Maho/Routing/CanonicalUriTest.php
@@ -35,8 +35,8 @@ function canonicalUriConfig(string $trailingSlash = 'leave', ?string $baseUrl = 
     Mage::app()->cleanCache([Mage_Core_Model_Config::CACHE_TAG]);
     $config->reinit();
     Mage::app()->reinitStores();
-    // `reinitStores()` rebuilds the store objects, so the current store still points at the
-    // object built before the save, whose config cache holds the old base URL.
+    // reinitStores() creates new store objects. The current store still points to the old
+    // object, and the config cache of that object holds the old base URL.
     Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
 }
 


### PR DESCRIPTION
Two reports, one code path.

**The tax mode was write-only.** The `tax_mode` column, its accessors, and the "Tax" dropdown all existed, but no code read the value. A feed of a store that stores prices without tax emitted net prices, whatever the dropdown said. A customer reported this against Google Shopping.

**A field value was resolved four times.** Three near-identical copies in `Mapper`, plus a fourth engine in `ProductWriterTrait` with its own vocabulary that read `getPrice()` instead of `getFinalPrice()`, so an `xml_template` feed printed the undiscounted price.

The resolver is unified first, so the tax step lands once instead of four times.

- `Mapper::resolveFieldValue()` does the source dispatch, the transformer chain, and the price auto-format for every engine. The four writers keep only their serialisation.
- The `xml_template` engine takes its product row from `Mapper::extractProductData()`, with a documented overlay for the six placeholders whose template meaning differs (`description`, `stock_status`, `category`, `image_url`, `gtin`, `mpn`).
- `Model/Price/TaxAdjuster.php` converts `price`, `regular_price`, `special_price`, `final_price`, and `msrp` in the raw row. `cost` stays raw. It runs before any transformer, so a user chain receives a tax-correct input. It avoids `Mage_Tax_Helper_Data::getPrice()`, which is display-driven and returns the price unchanged for a store that both stores and displays prices without tax, and it avoids `Mage_Tax_Model_Calculation::getRateRequest()`, which reads the customer session.

Four related defects that the unification exposed:

- `final_price` was never set in the product row, although `PRICE_FIELDS` listed it. The field was always empty.
- `Mapper::_getImageUrl()` ignored the `no_image_url` fallback.
- `Mapper::_getProductSeoUrl()` ignored `exclude_category_url`.
- The `Mapper` appended no currency when `price_currency` was empty, while the trait fell back to the store base currency. Both fall back now.

No schema change: the `tax_mode` column already exists with the default `incl`.

## Behaviour changes

- Any feed of a store that stores prices without tax now emits tax-inclusive prices, unless the feed selects "Exclude Tax".
- An `xml_template` feed that uses `price` now emits the discounted price. `regular_price` gives the old value.
- An `xml_template` feed that uses `category` now emits the deepest category path instead of the path of the last category id.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->