### PR TITLE
Fixed the web installation wizard becoming unreachable after the Configuration step

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -717,8 +717,8 @@ final class Mage
             try {
                 self::dispatchEvent('mage_run_exception', ['exception' => $e]);
                 // Redirecting a request that already targets the installer would loop.
-                $path = (string) parse_url((string) ($_SERVER['REQUEST_URI'] ?? ''), PHP_URL_PATH);
-                if (!headers_sent() && !str_contains($path . '/', '/install/')) {
+                $path = self::$_app?->getRequest()->getOriginalPathInfo() ?? '';
+                if (!headers_sent() && !str_starts_with($path . '/', '/install/')) {
                     header('Location:' . self::getUrl('install'));
                 } else {
                     self::printException($e);

--- a/app/Mage.php
+++ b/app/Mage.php
@@ -716,7 +716,9 @@ final class Mage
             }
             try {
                 self::dispatchEvent('mage_run_exception', ['exception' => $e]);
-                if (!headers_sent()) {
+                // Redirecting a request that already targets the installer would loop.
+                $path = (string) parse_url((string) ($_SERVER['REQUEST_URI'] ?? ''), PHP_URL_PATH);
+                if (!headers_sent() && !str_contains($path . '/', '/install/')) {
                     header('Location:' . self::getUrl('install'));
                 } else {
                     self::printException($e);

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -447,9 +447,8 @@ class Mage_Core_Model_App
                     if ($this->_config->isLocalConfigLoaded() && !$this->_shouldSkipProcessModulesUpdates()) {
                         \Maho\Profiler::start('mage::app::init::apply_db_schema_updates');
                         // Setup scripts assume the declared tables exist, so they stay
-                        // on hold until the schema is converged by ./maho migrate, and until
-                        // the installer applies it to a mid-install database.
-                        if (Mage::isInstalled() && !$this->isSchemaUpdatePending()) {
+                        // on hold until the schema is converged by ./maho migrate.
+                        if (!$this->isSchemaUpdatePending()) {
                             Mage_Core_Model_Resource_Setup::applyAllUpdates();
                         }
                         \Maho\Profiler::stop('mage::app::init::apply_db_schema_updates');
@@ -472,8 +471,10 @@ class Mage_Core_Model_App
      */
     protected function _shouldSkipProcessModulesUpdates()
     {
+        // The installer applies setup scripts itself; a mid-install boot must
+        // not run them against the not-yet-populated database.
         if (!Mage::isInstalled()) {
-            return false;
+            return true;
         }
 
         $ignoreDevelopmentMode = (bool) (string) $this->_config->getNode(self::XML_PATH_IGNORE_DEV_MODE);

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -328,7 +328,7 @@ class Mage_Core_Model_App
         $this->_initModules();
         $this->loadAreaPart(Mage_Core_Model_App_Area::AREA_GLOBAL, Mage_Core_Model_App_Area::PART_EVENTS);
 
-        if ($this->_config->isLocalConfigLoaded()) {
+        if ($this->_config->isLocalConfigLoaded() && Mage::isInstalled()) {
             if ($this->isSchemaUpdatePending()) {
                 Maho::databaseUpdatePage();
             }
@@ -447,8 +447,9 @@ class Mage_Core_Model_App
                     if ($this->_config->isLocalConfigLoaded() && !$this->_shouldSkipProcessModulesUpdates()) {
                         \Maho\Profiler::start('mage::app::init::apply_db_schema_updates');
                         // Setup scripts assume the declared tables exist, so they stay
-                        // on hold until the schema is converged by ./maho migrate.
-                        if (!$this->isSchemaUpdatePending()) {
+                        // on hold until the schema is converged by ./maho migrate, and until
+                        // the installer applies it to a mid-install database.
+                        if (Mage::isInstalled() && !$this->isSchemaUpdatePending()) {
                             Mage_Core_Model_Resource_Setup::applyAllUpdates();
                         }
                         \Maho\Profiler::stop('mage::app::init::apply_db_schema_updates');

--- a/app/code/core/Mage/Install/Model/Installer.php
+++ b/app/code/core/Mage/Install/Model/Installer.php
@@ -158,6 +158,8 @@ class Mage_Install_Model_Installer extends Maho\DataObject
             $setupModel->setConfigData(Mage_Directory_Model_Currency::XML_PATH_CURRENCY_ALLOW, $locale['currency']);
         }
 
+        Mage_Core_Model_Resource_Setup::applyAllDataUpdates();
+
         return $this;
     }
 

--- a/app/code/core/Mage/Install/Model/Installer/Console.php
+++ b/app/code/core/Mage/Install/Model/Installer/Console.php
@@ -345,9 +345,6 @@ class Mage_Install_Model_Installer_Console extends Mage_Install_Model_Installer_
                 return false;
             }
 
-            // apply data updates
-            Mage_Core_Model_Resource_Setup::applyAllDataUpdates();
-
             /**
              * Validate entered data for administrator user
              */

--- a/app/code/core/Mage/Install/Model/Installer/SampleData.php
+++ b/app/code/core/Mage/Install/Model/Installer/SampleData.php
@@ -363,6 +363,10 @@ class Mage_Install_Model_Installer_SampleData
      */
     private function reindexAll(): void
     {
+        // Mid-install boots skip _initCurrentStore(), so load the stores the
+        // sample data import may have added or the indexers would run over none.
+        Mage::app()->reinitStores();
+
         /** @var Mage_Index_Model_Resource_Process_Collection $indexCollection */
         $indexCollection = Mage::getResourceModel('index/process_collection');
 

--- a/app/code/core/Mage/Install/controllers/WizardController.php
+++ b/app/code/core/Mage/Install/controllers/WizardController.php
@@ -300,6 +300,10 @@ class Mage_Install_WizardController extends Mage_Install_Controller_Action
         $this->getResponse()->setHeader('Content-Type', 'application/json', true);
 
         try {
+            // Mid-install boots skip _initCurrentStore(), so load the stores the
+            // installer just created or the indexers would run over none.
+            Mage::app()->reinitStores();
+
             /** @var Mage_Index_Model_Resource_Process_Collection $indexCollection */
             $indexCollection = Mage::getResourceModel('index/process_collection');
 

--- a/tests/Install/MidInstallBootTest.php
+++ b/tests/Install/MidInstallBootTest.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  * See https://github.com/MahoCommerce/maho/issues/1310
  */
 
+uses(Tests\MahoInstallTestCase::class);
+
 it('serves the wizard without touching the database while the store is not installed', function () {
     $varDir = sys_get_temp_dir() . '/maho-mid-install-' . getmypid();
     mkdir($varDir, 0777, true);

--- a/tests/Install/MidInstallBootTest.php
+++ b/tests/Install/MidInstallBootTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+/**
+ * The wizard writes app/etc/local.xml at the Configuration step, so from there until the last
+ * step the config is loaded while the store counts as not installed. The database is still empty
+ * at that point, so a boot that runs the setup scripts or reads the stores throws, and Mage::run()
+ * answers the exception with a redirect to the installer, which loops.
+ * See https://github.com/MahoCommerce/maho/issues/1310
+ */
+
+it('serves the wizard without touching the database while the store is not installed', function () {
+    $varDir = sys_get_temp_dir() . '/maho-mid-install-' . getmypid();
+    mkdir($varDir, 0777, true);
+
+    try {
+        $output = (string) shell_exec(sprintf(
+            '%s %s %s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg(__DIR__ . '/fixtures/mid-install-boot.php'),
+            escapeshellarg($varDir),
+        ));
+    } finally {
+        exec('rm -rf ' . escapeshellarg($varDir));
+    }
+
+    expect($output)->toContain('Maho Installation Wizard')
+        ->toContain('SETUP_SCRIPTS_APPLIED=0 STORES_LOADED=0');
+});

--- a/tests/Install/fixtures/mid-install-boot.php
+++ b/tests/Install/fixtures/mid-install-boot.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Boots Maho the way the wizard leaves it between the Configuration step and the last step:
+ * app/etc/local.xml is loaded, but the store does not count as installed yet.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+$root = dirname(__DIR__, 3);
+require $root . '/vendor/autoload.php';
+
+$_SERVER['REQUEST_METHOD'] = 'GET';
+$_SERVER['REQUEST_URI'] = '/install/wizard/license';
+$_SERVER['SCRIPT_NAME'] = '/index.php';
+$_SERVER['HTTP_HOST'] = 'localhost';
+
+Mage::setRoot($root);
+Mage::run('', 'store', ['is_installed' => false, 'var_dir' => $argv[1]]);
+
+$setupApplied = new ReflectionProperty(Mage_Core_Model_Resource_Setup::class, '_schemaUpdatesChecked');
+printf(
+    "\nSETUP_SCRIPTS_APPLIED=%d STORES_LOADED=%d\n",
+    (int) $setupApplied->getValue(),
+    count(Mage::app()->getStores(true)),
+);

--- a/tests/Install/fixtures/mid-install-boot.php
+++ b/tests/Install/fixtures/mid-install-boot.php
@@ -18,6 +18,8 @@ $_SERVER['REQUEST_METHOD'] = 'GET';
 $_SERVER['REQUEST_URI'] = '/install/wizard/license';
 $_SERVER['SCRIPT_NAME'] = '/index.php';
 $_SERVER['HTTP_HOST'] = 'localhost';
+$_SERVER['SERVER_PORT'] = '80';
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
 
 Mage::setRoot($root);
 Mage::run('', 'store', ['is_installed' => false, 'var_dir' => $argv[1]]);


### PR DESCRIPTION
Fixes #1310.

The Configuration step writes `app/etc/local.xml` with a placeholder install date, so the store does not count as installed while the database is still empty. `Mage_Core_Model_App` then ran the setup scripts and read the stores on every request. Since the declarative schema landed (#946), the setup scripts assume the declared tables exist, so the boot threw, `Mage::run()` answered with a redirect to the installer, and the redirect looped. Every `/install/*` URL returned 302 to `/install/`.

The boot no longer touches the database while the store is not installed. The wizard does not need it to: `Mage_Install_Model_Installer::installDb()` now applies the data scripts itself, which is the call `Mage_Install_Model_Installer_Console` already made right after it. That asymmetry is why the CLI installer worked and the web one did not, and why the EAV tables stayed empty and broke the sample data import with a foreign key error.

`Mage::run()` also reports the exception instead of redirecting when the request already targets the installer, so a future boot failure there shows the error rather than an endless redirect.

Verified against an empty SQLite database: the wizard runs end to end, `installDb` fills `eav_entity_type` and `eav_attribute` in the same request, and the sample data import completes with 593 products.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->