### PR TITLE
Added REST v2 cart checkout setter endpoints and admin-gated custom item prices

### DIFF
--- a/app/code/core/Mage/Checkout/Api/Cart.php
+++ b/app/code/core/Mage/Checkout/Api/Cart.php
@@ -59,7 +59,7 @@ use Mage\Customer\Api\Address;
             // client sees the new item/total state in one round-trip.
             status: 200,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
-            description: 'Update item quantity in cart',
+            description: 'Update item quantity in cart. Body: qty, and an optional customPrice unit-price override (admin or carts/write tokens only)',
         ),
         new Delete(
             uriTemplate: '/carts/{id}/items/{itemId}',

--- a/app/code/core/Mage/Checkout/Api/Cart.php
+++ b/app/code/core/Mage/Checkout/Api/Cart.php
@@ -50,7 +50,7 @@ use Mage\Customer\Api\Address;
             // created addressable resource with a Location (which would be 201).
             status: 200,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
-            description: 'Add item to cart by numeric ID',
+            description: 'Add item to cart by numeric ID. Body: sku, qty, and an optional customPrice unit-price override (admin or carts/write tokens only)',
         ),
         new Put(
             uriTemplate: '/carts/{id}/items/{itemId}',
@@ -118,6 +118,32 @@ use Mage\Customer\Api\Address;
             name: 'get_my_payments',
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/read')",
             description: 'Get available payment methods for cart',
+        ),
+        // Step-wise checkout setters, the REST equivalents of the set*On GraphQL
+        // mutations. PUT because set is an idempotent replace, like gift-message.
+        new Put(
+            uriTemplate: '/carts/{id}/shipping-address',
+            name: 'set_my_shipping_address',
+            security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
+            description: 'Set the shipping address on the cart. Body: firstName, lastName, street[], city, region/regionId, postcode, countryId, telephone, company',
+        ),
+        new Put(
+            uriTemplate: '/carts/{id}/billing-address',
+            name: 'set_my_billing_address',
+            security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
+            description: 'Set the billing address on the cart. Same body as shipping-address, or {"sameAsShipping": true} to copy the shipping address',
+        ),
+        new Put(
+            uriTemplate: '/carts/{id}/shipping-method',
+            name: 'set_my_shipping_method',
+            security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
+            description: 'Select a shipping method on the cart. Body: carrierCode, methodCode (must be available for the current shipping address)',
+        ),
+        new Put(
+            uriTemplate: '/carts/{id}/payment-method',
+            name: 'set_my_payment_method',
+            security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
+            description: 'Select a payment method on the cart. Body: methodCode, optional additionalData',
         ),
         // Gift messages — cart-level and per-item, for both authenticated and
         // guest carts. PUT sets/updates (body: {sender, recipient, message});
@@ -262,6 +288,35 @@ use Mage\Customer\Api\Address;
             security: 'true',
             description: 'Get available payment methods for guest cart',
         ),
+        // Guest variants of the step-wise checkout setters
+        new Put(
+            uriTemplate: '/guest-carts/{id}/shipping-address',
+            name: 'set_guest_shipping_address',
+            uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
+            security: 'true',
+            description: 'Set the shipping address on a guest cart. Body: firstName, lastName, street[], city, region/regionId, postcode, countryId, telephone, company',
+        ),
+        new Put(
+            uriTemplate: '/guest-carts/{id}/billing-address',
+            name: 'set_guest_billing_address',
+            uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
+            security: 'true',
+            description: 'Set the billing address on a guest cart. Same body as shipping-address, or {"sameAsShipping": true} to copy the shipping address',
+        ),
+        new Put(
+            uriTemplate: '/guest-carts/{id}/shipping-method',
+            name: 'set_guest_shipping_method',
+            uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
+            security: 'true',
+            description: 'Select a shipping method on a guest cart. Body: carrierCode, methodCode (must be available for the current shipping address)',
+        ),
+        new Put(
+            uriTemplate: '/guest-carts/{id}/payment-method',
+            name: 'set_guest_payment_method',
+            uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
+            security: 'true',
+            description: 'Select a payment method on a guest cart. Body: methodCode, optional additionalData',
+        ),
     ],
     graphQlOperations: [
         new Query(
@@ -314,6 +369,7 @@ use Mage\Customer\Api\Address;
                 'giftcardRecipientEmail' => ['type' => 'String', 'description' => 'Gift card recipient email'],
                 'giftcardMessage' => ['type' => 'String', 'description' => 'Personal message'],
                 'giftcardDeliveryDate' => ['type' => 'String', 'description' => 'Scheduled delivery date (Y-m-d)'],
+                'customPrice' => ['type' => 'Float', 'description' => 'Unit price override in quote currency; requires admin or carts/write authorization'],
             ],
             description: 'Add item to cart',
         ),

--- a/app/code/core/Mage/Checkout/Api/Cart.php
+++ b/app/code/core/Mage/Checkout/Api/Cart.php
@@ -59,7 +59,7 @@ use Mage\Customer\Api\Address;
             // client sees the new item/total state in one round-trip.
             status: 200,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
-            description: 'Update item quantity in cart. Body: qty, and an optional customPrice unit-price override (admin or carts/write tokens only)',
+            description: 'Update item quantity in cart. Body: qty (omit to keep the current quantity), and an optional customPrice unit-price override (admin or carts/write tokens only)',
         ),
         new Delete(
             uriTemplate: '/carts/{id}/items/{itemId}',

--- a/app/code/core/Mage/Checkout/Api/CartProcessor.php
+++ b/app/code/core/Mage/Checkout/Api/CartProcessor.php
@@ -318,7 +318,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
     {
         $args = $context['args']['input'] ?? [];
         $itemId = $args['itemId'] ?? $uriVariables['itemId'] ?? null;
-        $qty = (float) ($args['qty'] ?? 1);
+        $qty = isset($args['qty']) ? (float) $args['qty'] : null;
         $customPrice = $this->extractCustomPrice($args);
 
         if (!$itemId) {
@@ -395,6 +395,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
     private function setShippingAddressOnCart(array $context, array $uriVariables): Cart
     {
         $args = $context['args']['input'] ?? [];
+        $this->cartService->assertCompleteAddressInput($args);
 
         $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->setShippingAddress($quote, $this->cartService->mapAddressInput($args));
@@ -411,6 +412,9 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         // FILTER_VALIDATE_BOOLEAN also normalizes stringly-typed clients
         // ("true"/"false"/"1"/"0"), which strict_types would otherwise 500 on
         $sameAsShipping = filter_var($args['sameAsShipping'] ?? false, FILTER_VALIDATE_BOOLEAN);
+        if (!$sameAsShipping) {
+            $this->cartService->assertCompleteAddressInput($args);
+        }
 
         $quote = $this->resolveAndVerify($context, $uriVariables);
         $addressData = $sameAsShipping ? [] : $this->cartService->mapAddressInput($args);
@@ -459,9 +463,11 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $carrierCode = $args['carrierCode'] ?? '';
         $methodCode = $args['methodCode'] ?? '';
 
-        if (!$carrierCode || !$methodCode) {
+        if (!is_scalar($carrierCode) || !is_scalar($methodCode) || !$carrierCode || !$methodCode) {
             throw new BadRequestHttpException('Carrier code and method code are required');
         }
+        $carrierCode = (string) $carrierCode;
+        $methodCode = (string) $methodCode;
 
         $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->setShippingMethod($quote, $carrierCode, $methodCode);
@@ -478,9 +484,13 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $methodCode = $args['methodCode'] ?? '';
         $additionalData = $args['additionalData'] ?? null;
 
-        if (!$methodCode) {
+        if (!is_scalar($methodCode) || !$methodCode) {
             throw new BadRequestHttpException('Payment method code is required');
         }
+        if ($additionalData !== null && !is_array($additionalData)) {
+            throw new BadRequestHttpException('additionalData must be an object');
+        }
+        $methodCode = (string) $methodCode;
 
         $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->setPaymentMethod($quote, $methodCode, $additionalData);
@@ -524,16 +534,11 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         }
 
         // Customer self-assignment (merge guest cart)
-        $authenticatedCustomerId = $this->getAuthenticatedCustomerId();
-
         if (!$maskedId) {
             throw new BadRequestHttpException('Masked cart ID is required');
         }
-        if (!$authenticatedCustomerId) {
-            throw new AccessDeniedHttpException('Authentication required');
-        }
 
-        $customerId = (int) $authenticatedCustomerId;
+        $customerId = $this->requireCustomerId();
         if ($requestedCustomerId && (int) $requestedCustomerId !== $customerId) {
             throw new AccessDeniedHttpException('Cannot assign a different customer to this cart');
         }

--- a/app/code/core/Mage/Checkout/Api/CartProcessor.php
+++ b/app/code/core/Mage/Checkout/Api/CartProcessor.php
@@ -83,12 +83,12 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             'removeItemFrom', 'remove_guest_item', 'remove_cart_item' => $this->removeItemFromCart($context, $uriVariables),
             'applyCouponTo', 'apply_guest_coupon', 'apply_my_coupon' => $this->applyCouponToCart($context, $uriVariables),
             'removeCouponFrom', 'remove_guest_coupon', 'remove_my_coupon' => $this->removeCouponFromCart($context, $uriVariables),
-            'setShippingAddressOn' => $this->setShippingAddressOnCart($context, $uriVariables),
-            'setBillingAddressOn' => $this->setBillingAddressOnCart($context, $uriVariables),
+            'setShippingAddressOn', 'set_my_shipping_address', 'set_guest_shipping_address' => $this->setShippingAddressOnCart($context, $uriVariables),
+            'setBillingAddressOn', 'set_my_billing_address', 'set_guest_billing_address' => $this->setBillingAddressOnCart($context, $uriVariables),
             'get_guest_shipping' => $this->getShippingMethodsForCart($context, $uriVariables, focused: true),
             'get_my_shipping' => $this->getShippingMethodsForCart($context, $uriVariables, focused: false),
-            'setShippingMethodOn' => $this->setShippingMethodOnCart($context, $uriVariables),
-            'setPaymentMethodOn' => $this->setPaymentMethodOnCart($context, $uriVariables),
+            'setShippingMethodOn', 'set_my_shipping_method', 'set_guest_shipping_method' => $this->setShippingMethodOnCart($context, $uriVariables),
+            'setPaymentMethodOn', 'set_my_payment_method', 'set_guest_payment_method' => $this->setPaymentMethodOnCart($context, $uriVariables),
             'assignCustomerTo' => $this->assignCustomerToCart($context),
             'applyGiftcardTo', 'apply_guest_giftcard', 'apply_my_giftcard' => $this->applyGiftcardToCart($context, $uriVariables),
             'removeGiftcardFrom', 'remove_guest_giftcard', 'remove_my_giftcard' => $this->removeGiftcardFromCart($context, $uriVariables),
@@ -243,9 +243,18 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             }
         }
 
+        // Reject an unauthorized price override explicitly rather than silently dropping it
+        $customPrice = null;
+        if (isset($args['customPrice']) && $args['customPrice'] !== '') {
+            if (!$this->isPrivilegedCartActor()) {
+                throw new AccessDeniedHttpException('customPrice requires admin or carts/write authorization');
+            }
+            $customPrice = (float) $args['customPrice'];
+        }
+
         $recreated = false;
         $quote = $this->resolveCartForItemAdd($context, $uriVariables, $recreated);
-        $quote = $this->cartService->addItem($quote, $sku, $qty, $buyOptions);
+        $quote = $this->cartService->addItem($quote, $sku, $qty, $buyOptions, $customPrice);
 
         $cart = $this->cartMapper->mapQuoteToCart($quote, false);
         $cart->cartRecreated = $recreated;
@@ -436,7 +445,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $methodCode = $args['methodCode'] ?? '';
 
         if (!$carrierCode || !$methodCode) {
-            throw new \RuntimeException('Carrier code and method code are required');
+            throw new \Symfony\Component\HttpKernel\Exception\BadRequestHttpException('Carrier code and method code are required');
         }
 
         $quote = $this->resolveAndVerify($context, $uriVariables);
@@ -455,7 +464,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $additionalData = $args['additionalData'] ?? null;
 
         if (!$methodCode) {
-            throw new \RuntimeException('Payment method code is required');
+            throw new \Symfony\Component\HttpKernel\Exception\BadRequestHttpException('Payment method code is required');
         }
 
         $quote = $this->resolveAndVerify($context, $uriVariables);

--- a/app/code/core/Mage/Checkout/Api/CartProcessor.php
+++ b/app/code/core/Mage/Checkout/Api/CartProcessor.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Maho\ApiPlatform\Service\StoreContext;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -243,14 +244,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             }
         }
 
-        // Reject an unauthorized price override explicitly rather than silently dropping it
-        $customPrice = null;
-        if (isset($args['customPrice']) && $args['customPrice'] !== '') {
-            if (!$this->isPrivilegedCartActor()) {
-                throw new AccessDeniedHttpException('customPrice requires admin or carts/write authorization');
-            }
-            $customPrice = (float) $args['customPrice'];
-        }
+        $customPrice = $this->extractCustomPrice($args);
 
         $recreated = false;
         $quote = $this->resolveCartForItemAdd($context, $uriVariables, $recreated);
@@ -259,6 +253,24 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $cart = $this->cartMapper->mapQuoteToCart($quote, false);
         $cart->cartRecreated = $recreated;
         return $cart;
+    }
+
+    /**
+     * Read the optional customPrice override, rejecting an unauthorized or
+     * malformed value rather than silently dropping or coercing it.
+     */
+    private function extractCustomPrice(array $args): ?float
+    {
+        if (!isset($args['customPrice']) || $args['customPrice'] === '') {
+            return null;
+        }
+        if (!$this->isPrivilegedCartActor()) {
+            throw new AccessDeniedHttpException('customPrice requires admin or carts/write authorization');
+        }
+        if (!is_numeric($args['customPrice'])) {
+            throw new BadRequestHttpException('customPrice must be a number');
+        }
+        return (float) $args['customPrice'];
     }
 
     /**
@@ -307,13 +319,14 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $args = $context['args']['input'] ?? [];
         $itemId = $args['itemId'] ?? $uriVariables['itemId'] ?? null;
         $qty = (float) ($args['qty'] ?? 1);
+        $customPrice = $this->extractCustomPrice($args);
 
         if (!$itemId) {
-            throw new \RuntimeException('Item ID is required');
+            throw new BadRequestHttpException('Item ID is required');
         }
 
         $quote = $this->resolveAndVerify($context, $uriVariables);
-        $quote = $this->cartService->updateItem($quote, (int) $itemId, $qty);
+        $quote = $this->cartService->updateItem($quote, (int) $itemId, $qty, $customPrice);
 
         return $this->cartMapper->mapQuoteToCart($quote, false);
     }
@@ -327,7 +340,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $itemId = $args['itemId'] ?? $uriVariables['itemId'] ?? null;
 
         if (!$itemId) {
-            throw new \RuntimeException('Item ID is required');
+            throw new BadRequestHttpException('Item ID is required');
         }
 
         $quote = $this->resolveAndVerify($context, $uriVariables);
@@ -348,7 +361,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $couponCode = $args['couponCode'] ?? $args['code'] ?? '';
 
         if (!$couponCode) {
-            throw new \Symfony\Component\HttpKernel\Exception\BadRequestHttpException('Coupon code is required');
+            throw new BadRequestHttpException('Coupon code is required');
         }
 
         // Throttle anonymous/customer callers by IP: applying a coupon to a cart
@@ -395,7 +408,9 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
     private function setBillingAddressOnCart(array $context, array $uriVariables): Cart
     {
         $args = $context['args']['input'] ?? [];
-        $sameAsShipping = $args['sameAsShipping'] ?? false;
+        // FILTER_VALIDATE_BOOLEAN also normalizes stringly-typed clients
+        // ("true"/"false"/"1"/"0"), which strict_types would otherwise 500 on
+        $sameAsShipping = filter_var($args['sameAsShipping'] ?? false, FILTER_VALIDATE_BOOLEAN);
 
         $quote = $this->resolveAndVerify($context, $uriVariables);
         $addressData = $sameAsShipping ? [] : $this->cartService->mapAddressInput($args);
@@ -445,7 +460,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $methodCode = $args['methodCode'] ?? '';
 
         if (!$carrierCode || !$methodCode) {
-            throw new \Symfony\Component\HttpKernel\Exception\BadRequestHttpException('Carrier code and method code are required');
+            throw new BadRequestHttpException('Carrier code and method code are required');
         }
 
         $quote = $this->resolveAndVerify($context, $uriVariables);
@@ -464,7 +479,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $additionalData = $args['additionalData'] ?? null;
 
         if (!$methodCode) {
-            throw new \Symfony\Component\HttpKernel\Exception\BadRequestHttpException('Payment method code is required');
+            throw new BadRequestHttpException('Payment method code is required');
         }
 
         $quote = $this->resolveAndVerify($context, $uriVariables);
@@ -476,7 +491,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
     /**
      * Assign customer to cart (merge guest cart)
      */
-    private function assignCustomerToCart(array $context, array $uriVariables = []): Cart
+    private function assignCustomerToCart(array $context): Cart
     {
         $args = $context['args']['input'] ?? [];
         $cartId = $args['cartId'] ?? null;
@@ -486,20 +501,20 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         // Admin/POS users can assign any customer to any cart
         if ($this->isPrivilegedCartActor()) {
             if (!$requestedCustomerId) {
-                throw new \RuntimeException('Customer ID is required');
+                throw new BadRequestHttpException('Customer ID is required');
             }
             $quote = $this->cartService->getCart(
                 $cartId ? (int) $cartId : null,
                 $maskedId,
             );
             if (!$quote) {
-                throw new \RuntimeException('Cart not found');
+                throw new NotFoundHttpException('Cart not found');
             }
 
             $customerId = (int) $requestedCustomerId;
             $customer = \Mage::getModel('customer/customer')->load($customerId);
             if (!$customer->getId()) {
-                throw new \RuntimeException('Customer not found');
+                throw new NotFoundHttpException('Customer not found');
             }
 
             $quote->assignCustomer($customer);
@@ -512,15 +527,15 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $authenticatedCustomerId = $this->getAuthenticatedCustomerId();
 
         if (!$maskedId) {
-            throw new \RuntimeException('Masked cart ID is required');
+            throw new BadRequestHttpException('Masked cart ID is required');
         }
         if (!$authenticatedCustomerId) {
-            throw new \RuntimeException('Authentication required');
+            throw new AccessDeniedHttpException('Authentication required');
         }
 
         $customerId = (int) $authenticatedCustomerId;
         if ($requestedCustomerId && (int) $requestedCustomerId !== $customerId) {
-            throw new \RuntimeException('Cannot assign a different customer to this cart');
+            throw new AccessDeniedHttpException('Cannot assign a different customer to this cart');
         }
 
         $quote = $this->cartService->mergeCarts($maskedId, $customerId);

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -440,6 +440,12 @@ class CartService
         }
 
         if ($customPrice !== null) {
+            // A persisted id means addProduct() merged into an existing line, and the
+            // override would apply to units already in the cart at another price
+            $existingOverride = $result->getOriginalCustomPrice();
+            if ($result->getId() && ($existingOverride === null || (float) $existingOverride !== $customPrice)) {
+                throw new BadRequestHttpException('customPrice would reprice units already in the cart; update the existing item instead');
+            }
             $result->setCustomPrice($customPrice);
             $result->setOriginalCustomPrice($customPrice);
         }
@@ -457,8 +463,9 @@ class CartService
      * @param \Mage_Sales_Model_Quote $quote Quote
      * @param int $itemId Item ID
      * @param float $qty New quantity
+     * @param float|null $customPrice New unit price override in quote currency (caller must authorize)
      */
-    public function updateItem(\Mage_Sales_Model_Quote $quote, int $itemId, float $qty): \Mage_Sales_Model_Quote
+    public function updateItem(\Mage_Sales_Model_Quote $quote, int $itemId, float $qty, ?float $customPrice = null): \Mage_Sales_Model_Quote
     {
         // Validate quantity
         if ($qty <= 0) {
@@ -466,6 +473,9 @@ class CartService
         }
         if ($qty > self::MAX_ITEM_QTY) {
             throw new BadRequestHttpException('Quantity cannot exceed 10,000');
+        }
+        if ($customPrice !== null && $customPrice < 0) {
+            throw new BadRequestHttpException('Custom price cannot be negative');
         }
 
         $item = $quote->getItemById($itemId);
@@ -475,6 +485,10 @@ class CartService
         }
 
         $item->setQty($qty);
+        if ($customPrice !== null) {
+            $item->setCustomPrice($customPrice);
+            $item->setOriginalCustomPrice($customPrice);
+        }
 
         $this->collectAndVerifyTotals($quote);
 
@@ -899,6 +913,9 @@ class CartService
     {
         if ($sameAsShipping) {
             $shippingAddress = $quote->getShippingAddress();
+            if (!$shippingAddress->getCountryId()) {
+                throw new BadRequestHttpException('Cart has no shipping address to copy');
+            }
             $addressData = StoreDefaults::extractAddressFields($shippingAddress);
         } else {
             $addressData = $this->sanitizeAddressData($addressData);

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -234,8 +234,9 @@ class CartService
      * @param string $sku Product SKU
      * @param float $qty Quantity
      * @param array $options Custom options (option_id => value)
+     * @param float|null $customPrice Unit price override in quote currency (caller must authorize)
      */
-    public function addItem(\Mage_Sales_Model_Quote $quote, string $sku, float $qty, array $options = []): \Mage_Sales_Model_Quote
+    public function addItem(\Mage_Sales_Model_Quote $quote, string $sku, float $qty, array $options = [], ?float $customPrice = null): \Mage_Sales_Model_Quote
     {
         // Validate quantity
         if ($qty <= 0) {
@@ -243,6 +244,9 @@ class CartService
         }
         if ($qty > self::MAX_ITEM_QTY) {
             throw new BadRequestHttpException('Quantity cannot exceed 10,000');
+        }
+        if ($customPrice !== null && $customPrice < 0) {
+            throw new BadRequestHttpException('Custom price cannot be negative');
         }
 
         // First find product ID by SKU
@@ -433,6 +437,11 @@ class CartService
         if (is_string($result)) {
             $this->logDebug("Failed to add product: {$result}");
             throw new BadRequestHttpException("Failed to add product: {$result}");
+        }
+
+        if ($customPrice !== null) {
+            $result->setCustomPrice($customPrice);
+            $result->setOriginalCustomPrice($customPrice);
         }
 
         $this->collectAndVerifyTotals($quote);

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -442,8 +442,9 @@ class CartService
         if ($customPrice !== null) {
             // A persisted id means addProduct() merged into an existing line, and the
             // override would apply to units already in the cart at another price
+            // (compared at the column's DECIMAL(12,4) scale, so a re-add of the same value passes)
             $existingOverride = $result->getOriginalCustomPrice();
-            if ($result->getId() && ($existingOverride === null || (float) $existingOverride !== $customPrice)) {
+            if ($result->getId() && ($existingOverride === null || round((float) $existingOverride, 4) !== round($customPrice, 4))) {
                 throw new BadRequestHttpException('customPrice would reprice units already in the cart; update the existing item instead');
             }
             $result->setCustomPrice($customPrice);
@@ -462,18 +463,11 @@ class CartService
      *
      * @param \Mage_Sales_Model_Quote $quote Quote
      * @param int $itemId Item ID
-     * @param float $qty New quantity
+     * @param float|null $qty New quantity, null keeps the current one
      * @param float|null $customPrice New unit price override in quote currency (caller must authorize)
      */
-    public function updateItem(\Mage_Sales_Model_Quote $quote, int $itemId, float $qty, ?float $customPrice = null): \Mage_Sales_Model_Quote
+    public function updateItem(\Mage_Sales_Model_Quote $quote, int $itemId, ?float $qty, ?float $customPrice = null): \Mage_Sales_Model_Quote
     {
-        // Validate quantity
-        if ($qty <= 0) {
-            throw new BadRequestHttpException('Quantity must be greater than zero');
-        }
-        if ($qty > self::MAX_ITEM_QTY) {
-            throw new BadRequestHttpException('Quantity cannot exceed 10,000');
-        }
         if ($customPrice !== null && $customPrice < 0) {
             throw new BadRequestHttpException('Custom price cannot be negative');
         }
@@ -482,6 +476,16 @@ class CartService
 
         if (!$item) {
             throw new \Symfony\Component\HttpKernel\Exception\NotFoundHttpException("Cart item with ID '{$itemId}' not found");
+        }
+
+        $qty ??= (float) $item->getQty();
+
+        // Validate quantity
+        if ($qty <= 0) {
+            throw new BadRequestHttpException('Quantity must be greater than zero');
+        }
+        if ($qty > self::MAX_ITEM_QTY) {
+            throw new BadRequestHttpException('Quantity cannot exceed 10,000');
         }
 
         $item->setQty($qty);
@@ -835,6 +839,25 @@ class CartService
             throw new NotFoundHttpException('Cart item not found');
         }
         return $item;
+    }
+
+    /**
+     * Reject a partial payload on the checkout address setters. GraphQL declares
+     * these fields non-null; the REST bodies carry no schema, so without this a
+     * `{}` PUT blanks an already-valid address and only fails at order placement.
+     */
+    public function assertCompleteAddressInput(array $input): void
+    {
+        $missing = [];
+        foreach (['firstName', 'lastName', 'street', 'city', 'postcode', 'countryId', 'telephone'] as $field) {
+            $value = $input[$field] ?? null;
+            if ($value === null || $value === '' || $value === []) {
+                $missing[] = $field;
+            }
+        }
+        if ($missing) {
+            throw new BadRequestHttpException('Missing required address fields: ' . implode(', ', $missing));
+        }
     }
 
     /**

--- a/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
+++ b/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
@@ -71,6 +71,12 @@ class CartMutationHandler
         $qty = $variables['qty'] ?? $variables['input']['qty'] ?? 1;
         // Admin-only surface (AdminAcl gate above), so no extra gate on the price override
         $customPrice = $variables['customPrice'] ?? $variables['input']['customPrice'] ?? null;
+        if ($customPrice === '') {
+            $customPrice = null;
+        }
+        if ($customPrice !== null && !is_numeric($customPrice)) {
+            throw ValidationException::invalidValue('customPrice', 'must be a number');
+        }
 
         if (!$cartId) {
             throw ValidationException::requiredField('cartId');

--- a/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
+++ b/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
@@ -69,6 +69,8 @@ class CartMutationHandler
         $cartId = $variables['cartId'] ?? $variables['input']['cartId'] ?? null;
         $sku = $variables['sku'] ?? $variables['input']['sku'] ?? null;
         $qty = $variables['qty'] ?? $variables['input']['qty'] ?? 1;
+        // Admin-only surface (AdminAcl gate above), so no extra gate on the price override
+        $customPrice = $variables['customPrice'] ?? $variables['input']['customPrice'] ?? null;
 
         if (!$cartId) {
             throw ValidationException::requiredField('cartId');
@@ -80,7 +82,7 @@ class CartMutationHandler
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
-        $quote = $this->cartService->addItem($quote, $sku, (float) $qty);
+        $quote = $this->cartService->addItem($quote, $sku, (float) $qty, [], $customPrice !== null ? (float) $customPrice : null);
 
         return ['addToCart' => $this->mapCart($quote)];
     }

--- a/app/code/core/Mage/Sales/Api/Order.php
+++ b/app/code/core/Mage/Sales/Api/Order.php
@@ -63,7 +63,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
             uriTemplate: '/orders',
             name: 'place_order',
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('orders/create')",
-            description: 'Place a new order from an authenticated customer cart',
+            description: 'Place a new order from an authenticated customer cart. Body: cartId, plus the full checkout state in one shot: shippingAddress, billingAddress, guestEmail, paymentMethod, paymentData, shippingMethod (carrier_method), orderNote',
         ),
         new Post(
             // The placeholder is named `maskedQuoteId` rather than `id` so
@@ -77,7 +77,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
             ],
             requirements: ['maskedQuoteId' => '[a-f0-9]{32}'],
             security: 'true',
-            description: 'Place order from guest cart',
+            description: 'Place order from guest cart. Body carries the full checkout state in one shot: shippingAddress, billingAddress, guestEmail, paymentMethod, paymentData, shippingMethod (carrier_method), orderNote',
         ),
         new Post(
             // Authenticated counterpart to place_guest_order: place an order from
@@ -89,7 +89,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
             name: 'place_customer_order',
             requirements: ['id' => '\d+'],
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('orders/create')",
-            description: 'Place order from the authenticated customer cart',
+            description: 'Place order from the authenticated customer cart. Body carries the full checkout state in one shot: shippingAddress, billingAddress, guestEmail, paymentMethod, paymentData, shippingMethod (carrier_method), orderNote',
         ),
         // Order lifecycle actions. hold/unhold and comments are management
         // operations (admin or orders/write grant); cancel additionally lets a

--- a/tests/Api/V2/Write/CartCheckoutSettersTest.php
+++ b/tests/Api/V2/Write/CartCheckoutSettersTest.php
@@ -83,6 +83,13 @@ describe('guest cart step-wise checkout setters', function (): void {
         expect($copied['json']['billingAddress']['postcode'])->toBe('90210');
     });
 
+    it('rejects an incomplete address payload with a 400', function (): void {
+        [$maskedId] = makeGuestSetterCart();
+
+        expect(apiPut("/api/rest/v2/guest-carts/{$maskedId}/shipping-address", [])['status'])->toBe(400);
+        expect(apiPut("/api/rest/v2/guest-carts/{$maskedId}/billing-address", ['city' => 'Los Angeles'])['status'])->toBe(400);
+    });
+
     it('rejects sameAsShipping when the cart has no shipping address', function (): void {
         [$maskedId] = makeGuestSetterCart();
 

--- a/tests/Api/V2/Write/CartCheckoutSettersTest.php
+++ b/tests/Api/V2/Write/CartCheckoutSettersTest.php
@@ -83,6 +83,14 @@ describe('guest cart step-wise checkout setters', function (): void {
         expect($copied['json']['billingAddress']['postcode'])->toBe('90210');
     });
 
+    it('rejects sameAsShipping when the cart has no shipping address', function (): void {
+        [$maskedId] = makeGuestSetterCart();
+
+        $response = apiPut("/api/rest/v2/guest-carts/{$maskedId}/billing-address", ['sameAsShipping' => true]);
+
+        expect($response['status'])->toBe(400);
+    });
+
     it('selects a shipping method', function (): void {
         [$maskedId] = makeGuestSetterCart();
 

--- a/tests/Api/V2/Write/CartCheckoutSettersTest.php
+++ b/tests/Api/V2/Write/CartCheckoutSettersTest.php
@@ -1,0 +1,224 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+/**
+ * API v2 Step-Wise Cart Checkout Setter Tests (WRITE)
+ *
+ * PUT shipping-address / billing-address / shipping-method / payment-method
+ * on /carts/{id} and /guest-carts/{id} (issue #1309).
+ *
+ * @group write
+ */
+
+afterAll(function (): void {
+    cleanupTestData();
+});
+
+/**
+ * A complete US checkout address in the API camelCase shape.
+ */
+function checkoutSetterAddress(): array
+{
+    return [
+        'firstName' => 'Step',
+        'lastName' => 'Wise',
+        'street' => ['123 Setter St'],
+        'city' => 'Los Angeles',
+        'region' => 'California',
+        'postcode' => '90210',
+        'countryId' => 'US',
+        'telephone' => '5550100',
+    ];
+}
+
+/**
+ * Create a guest cart with one item. Returns [maskedId, numeric id].
+ */
+function makeGuestSetterCart(): array
+{
+    $create = apiPost('/api/rest/v2/guest-carts', []);
+    expect($create['status'])->toBeIn([200, 201]);
+    $maskedId = $create['json']['maskedId'];
+    $cartId = (int) $create['json']['id'];
+    trackCreated('quote', $cartId);
+
+    $add = apiPost("/api/rest/v2/guest-carts/{$maskedId}/items", [
+        'sku' => fixtures('write_test_sku'),
+        'qty' => 1,
+    ]);
+    expect($add['status'])->toBe(200);
+
+    return [$maskedId, $cartId];
+}
+
+describe('guest cart step-wise checkout setters', function (): void {
+
+    it('sets the shipping address', function (): void {
+        [$maskedId] = makeGuestSetterCart();
+
+        $response = apiPut("/api/rest/v2/guest-carts/{$maskedId}/shipping-address", checkoutSetterAddress());
+
+        expect($response['status'])->toBe(200);
+        expect($response['json']['shippingAddress']['city'])->toBe('Los Angeles');
+        expect($response['json']['shippingAddress']['postcode'])->toBe('90210');
+    });
+
+    it('sets the billing address, including sameAsShipping', function (): void {
+        [$maskedId] = makeGuestSetterCart();
+
+        $direct = apiPut("/api/rest/v2/guest-carts/{$maskedId}/billing-address", checkoutSetterAddress());
+        expect($direct['status'])->toBe(200);
+        expect($direct['json']['billingAddress']['city'])->toBe('Los Angeles');
+
+        apiPut("/api/rest/v2/guest-carts/{$maskedId}/shipping-address", checkoutSetterAddress());
+        $copied = apiPut("/api/rest/v2/guest-carts/{$maskedId}/billing-address", ['sameAsShipping' => true]);
+        expect($copied['status'])->toBe(200);
+        expect($copied['json']['billingAddress']['postcode'])->toBe('90210');
+    });
+
+    it('selects a shipping method', function (): void {
+        [$maskedId] = makeGuestSetterCart();
+
+        $withAddress = apiPut("/api/rest/v2/guest-carts/{$maskedId}/shipping-address", checkoutSetterAddress());
+        expect($withAddress['status'])->toBe(200);
+
+        $available = $withAddress['json']['availableShippingMethods'] ?? [];
+        $free = array_values(array_filter($available, fn($m) => $m['carrierCode'] === 'freeshipping'));
+        if (empty($free)) {
+            $this->markTestSkipped('freeshipping is not available in this store');
+        }
+
+        $response = apiPut("/api/rest/v2/guest-carts/{$maskedId}/shipping-method", [
+            'carrierCode' => 'freeshipping',
+            'methodCode' => 'freeshipping',
+        ]);
+
+        expect($response['status'])->toBe(200);
+        expect($response['json']['selectedShippingMethod']['carrierCode'])->toBe('freeshipping');
+    });
+
+    it('selects a payment method', function (): void {
+        [$maskedId] = makeGuestSetterCart();
+
+        apiPut("/api/rest/v2/guest-carts/{$maskedId}/shipping-address", checkoutSetterAddress());
+
+        $cart = apiGet("/api/rest/v2/guest-carts/{$maskedId}");
+        $available = array_column($cart['json']['availablePaymentMethods'] ?? [], 'code');
+        if (!in_array('cashondelivery', $available, true)) {
+            $this->markTestSkipped('cashondelivery is not available in this store');
+        }
+
+        $response = apiPut("/api/rest/v2/guest-carts/{$maskedId}/payment-method", [
+            'methodCode' => 'cashondelivery',
+        ]);
+
+        expect($response['status'])->toBe(200);
+        expect($response['json']['selectedPaymentMethod']['code'])->toBe('cashondelivery');
+    });
+
+    it('rejects an unavailable shipping method with a 400', function (): void {
+        [$maskedId] = makeGuestSetterCart();
+
+        apiPut("/api/rest/v2/guest-carts/{$maskedId}/shipping-address", checkoutSetterAddress());
+
+        $response = apiPut("/api/rest/v2/guest-carts/{$maskedId}/shipping-method", [
+            'carrierCode' => 'notacarrier',
+            'methodCode' => 'notamethod',
+        ]);
+
+        expect($response['status'])->toBe(400);
+    });
+
+    it('rejects a shipping method without codes with a 400', function (): void {
+        [$maskedId] = makeGuestSetterCart();
+
+        $response = apiPut("/api/rest/v2/guest-carts/{$maskedId}/shipping-method", []);
+
+        expect($response['status'])->toBe(400);
+    });
+
+    it('completes the full step-wise checkout and places the order', function (): void {
+        [$maskedId] = makeGuestSetterCart();
+
+        expect(apiPut("/api/rest/v2/guest-carts/{$maskedId}/shipping-address", checkoutSetterAddress())['status'])->toBe(200);
+        expect(apiPut("/api/rest/v2/guest-carts/{$maskedId}/billing-address", ['sameAsShipping' => true])['status'])->toBe(200);
+
+        $shipping = apiPut("/api/rest/v2/guest-carts/{$maskedId}/shipping-method", [
+            'carrierCode' => 'freeshipping',
+            'methodCode' => 'freeshipping',
+        ]);
+        $payment = apiPut("/api/rest/v2/guest-carts/{$maskedId}/payment-method", [
+            'methodCode' => 'cashondelivery',
+        ]);
+        if ($shipping['status'] !== 200 || $payment['status'] !== 200) {
+            $this->markTestSkipped('freeshipping or cashondelivery is not available in this store');
+        }
+
+        $order = apiPost("/api/rest/v2/guest-carts/{$maskedId}/place-order", [
+            'guestEmail' => 'stepwise-buyer@example.com',
+        ]);
+
+        expect($order['status'])->toBeLessThan(500);
+        if ($order['status'] >= 400) {
+            $this->markTestSkipped(
+                'Checkout could not complete in this store (status ' . $order['status'] . '): '
+                . ($order['json']['message'] ?? $order['json']['error'] ?? 'unknown'),
+            );
+        }
+
+        if (!empty($order['json']['id'])) {
+            trackCreated('order', (int) $order['json']['id']);
+        }
+        expect($order['json']['incrementId'])->not->toBeEmpty();
+    });
+
+});
+
+describe('authenticated cart step-wise checkout setters', function (): void {
+
+    it('sets the shipping address for the owner', function (): void {
+        $create = apiPost('/api/rest/v2/carts', [], customerToken());
+        expect($create['status'])->toBeIn([200, 201]);
+        $cartId = (int) $create['json']['id'];
+        trackCreated('quote', $cartId);
+        apiPost("/api/rest/v2/carts/{$cartId}/items", [
+            'sku' => fixtures('write_test_sku'),
+            'qty' => 1,
+        ], customerToken());
+
+        $response = apiPut("/api/rest/v2/carts/{$cartId}/shipping-address", checkoutSetterAddress(), customerToken());
+
+        expect($response['status'])->toBe(200);
+        expect($response['json']['shippingAddress']['city'])->toBe('Los Angeles');
+    });
+
+    it('requires authentication', function (): void {
+        expect(apiPut('/api/rest/v2/carts/1/shipping-address', checkoutSetterAddress())['status'])->toBeUnauthorized();
+        expect(apiPut('/api/rest/v2/carts/1/billing-address', checkoutSetterAddress())['status'])->toBeUnauthorized();
+        expect(apiPut('/api/rest/v2/carts/1/shipping-method', ['carrierCode' => 'x', 'methodCode' => 'y'])['status'])->toBeUnauthorized();
+        expect(apiPut('/api/rest/v2/carts/1/payment-method', ['methodCode' => 'x'])['status'])->toBeUnauthorized();
+    });
+
+    it('does not let another customer set an address on the cart', function (): void {
+        $create = apiPost('/api/rest/v2/carts', [], customerToken());
+        expect($create['status'])->toBeIn([200, 201]);
+        $cartId = (int) $create['json']['id'];
+        trackCreated('quote', $cartId);
+
+        $response = apiPut(
+            "/api/rest/v2/carts/{$cartId}/shipping-address",
+            checkoutSetterAddress(),
+            customerToken(fixtures('invalid_customer_id')),
+        );
+
+        expect($response['status'])->toBeGreaterThanOrEqual(400);
+    });
+
+});

--- a/tests/Api/V2/Write/CartItemCustomPriceTest.php
+++ b/tests/Api/V2/Write/CartItemCustomPriceTest.php
@@ -205,6 +205,32 @@ describe('customPrice on add-to-cart', function (): void {
         expect((float) $update['json']['prices']['subtotal'])->toBe(7.50);
     });
 
+    it('keeps the quantity when the update body carries only a customPrice', function (): void {
+        $sku = fixtures('write_test_sku');
+        expect($sku)->not->toBeEmpty();
+
+        $token = serviceToken(['carts/write']);
+        $cartId = makeCustomPriceCart($token);
+        expect($cartId)->not->toBeNull();
+
+        $add = apiPost("/api/rest/v2/carts/{$cartId}/items", [
+            'sku' => $sku,
+            'qty' => 4,
+            'customPrice' => 2.00,
+        ], $token);
+        expect($add['status'])->toBe(200);
+        $itemId = (int) $add['json']['items'][0]['id'];
+
+        $update = apiPut("/api/rest/v2/carts/{$cartId}/items/{$itemId}", [
+            'customPrice' => 3.00,
+        ], $token);
+
+        expect($update['status'])->toBe(200);
+        expect((float) $update['json']['items'][0]['qty'])->toBe(4.0);
+        expect((float) $update['json']['items'][0]['price'])->toBe(3.00);
+        expect((float) $update['json']['prices']['subtotal'])->toBe(12.00);
+    });
+
     it('rejects a customer token sending customPrice on item update', function (): void {
         $sku = fixtures('write_test_sku');
         expect($sku)->not->toBeEmpty();

--- a/tests/Api/V2/Write/CartItemCustomPriceTest.php
+++ b/tests/Api/V2/Write/CartItemCustomPriceTest.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+/**
+ * API v2 Cart Item Custom Price Tests (WRITE)
+ *
+ * Optional customPrice on add-to-cart (issue #1309), honoured only for admin
+ * or carts/write service tokens; storefront and guest callers are rejected.
+ *
+ * @group write
+ */
+
+afterAll(function (): void {
+    cleanupTestData();
+});
+
+/**
+ * Create a cart with the privileged service token. Returns the numeric id.
+ */
+function makeCustomPriceCart(string $token): ?int
+{
+    $create = apiPost('/api/rest/v2/carts', [], $token);
+    if (!in_array($create['status'], [200, 201], true) || empty($create['json']['id'])) {
+        return null;
+    }
+    $cartId = (int) $create['json']['id'];
+    trackCreated('quote', $cartId);
+    return $cartId;
+}
+
+describe('customPrice on add-to-cart', function (): void {
+
+    it('lets a carts/write service token add an item at a custom price', function (): void {
+        $sku = fixtures('write_test_sku');
+        expect($sku)->not->toBeEmpty();
+
+        $token = serviceToken(['carts/write']);
+        $cartId = makeCustomPriceCart($token);
+        expect($cartId)->not->toBeNull();
+
+        $response = apiPost("/api/rest/v2/carts/{$cartId}/items", [
+            'sku' => $sku,
+            'qty' => 1,
+            'customPrice' => 1.23,
+        ], $token);
+
+        expect($response['status'])->toBe(200);
+        expect($response['json']['items'])->not->toBeEmpty();
+        expect((float) $response['json']['items'][0]['price'])->toBe(1.23);
+        expect((float) $response['json']['prices']['subtotal'])->toBe(1.23);
+    });
+
+    it('keeps the custom price across a quantity update', function (): void {
+        $sku = fixtures('write_test_sku');
+        expect($sku)->not->toBeEmpty();
+
+        $token = serviceToken(['carts/write']);
+        $cartId = makeCustomPriceCart($token);
+        expect($cartId)->not->toBeNull();
+
+        $add = apiPost("/api/rest/v2/carts/{$cartId}/items", [
+            'sku' => $sku,
+            'qty' => 1,
+            'customPrice' => 2.50,
+        ], $token);
+        expect($add['status'])->toBe(200);
+        $itemId = (int) $add['json']['items'][0]['id'];
+
+        $update = apiPut("/api/rest/v2/carts/{$cartId}/items/{$itemId}", [
+            'qty' => 3,
+        ], $token);
+
+        expect($update['status'])->toBe(200);
+        expect((float) $update['json']['items'][0]['price'])->toBe(2.50);
+        expect((float) $update['json']['prices']['subtotal'])->toBe(7.50);
+    });
+
+    it('rejects a guest sending customPrice', function (): void {
+        $sku = fixtures('write_test_sku');
+        expect($sku)->not->toBeEmpty();
+
+        $create = apiPost('/api/rest/v2/guest-carts', []);
+        expect($create['status'])->toBeIn([200, 201]);
+        $maskedId = $create['json']['maskedId'];
+        if (!empty($create['json']['id'])) {
+            trackCreated('quote', (int) $create['json']['id']);
+        }
+
+        $response = apiPost("/api/rest/v2/guest-carts/{$maskedId}/items", [
+            'sku' => $sku,
+            'qty' => 1,
+            'customPrice' => 0.01,
+        ]);
+
+        // The firewall turns the anonymous access-denied into a 401 challenge
+        expect($response['status'])->toBeIn([401, 403]);
+    });
+
+    it('rejects a customer token sending customPrice', function (): void {
+        $sku = fixtures('write_test_sku');
+        expect($sku)->not->toBeEmpty();
+
+        $create = apiPost('/api/rest/v2/carts', [], customerToken());
+        expect($create['status'])->toBeIn([200, 201]);
+        $cartId = (int) $create['json']['id'];
+        trackCreated('quote', $cartId);
+
+        $response = apiPost("/api/rest/v2/carts/{$cartId}/items", [
+            'sku' => $sku,
+            'qty' => 1,
+            'customPrice' => 0.01,
+        ], customerToken());
+
+        expect($response['status'])->toBe(403);
+    });
+
+    it('rejects a negative customPrice', function (): void {
+        $sku = fixtures('write_test_sku');
+        expect($sku)->not->toBeEmpty();
+
+        $token = serviceToken(['carts/write']);
+        $cartId = makeCustomPriceCart($token);
+        expect($cartId)->not->toBeNull();
+
+        $response = apiPost("/api/rest/v2/carts/{$cartId}/items", [
+            'sku' => $sku,
+            'qty' => 1,
+            'customPrice' => -5,
+        ], $token);
+
+        expect($response['status'])->toBe(400);
+    });
+
+    it('carries the custom price through to the placed order', function (): void {
+        $sku = fixtures('write_test_sku');
+        expect($sku)->not->toBeEmpty();
+
+        $token = serviceToken(['carts/write', 'orders/create']);
+        $cartId = makeCustomPriceCart($token);
+        expect($cartId)->not->toBeNull();
+
+        $add = apiPost("/api/rest/v2/carts/{$cartId}/items", [
+            'sku' => $sku,
+            'qty' => 2,
+            'customPrice' => 4.56,
+        ], $token);
+        expect($add['status'])->toBe(200);
+
+        $address = [
+            'firstName' => 'Marketplace',
+            'lastName' => 'Buyer',
+            'street' => ['123 Test St'],
+            'city' => 'Los Angeles',
+            'region' => 'California',
+            'postcode' => '90210',
+            'countryId' => 'US',
+            'telephone' => '5550100',
+        ];
+
+        $order = apiPost('/api/rest/v2/orders', [
+            'cartId' => $cartId,
+            'guestEmail' => 'marketplace-buyer@example.com',
+            'shippingAddress' => $address,
+            'billingAddress' => $address,
+            'paymentMethod' => 'cashondelivery',
+            'shippingMethod' => 'freeshipping_freeshipping',
+        ], $token);
+
+        expect($order['status'])->toBeLessThan(500);
+        if ($order['status'] >= 400) {
+            $this->markTestSkipped(
+                'Checkout could not complete in this store (status ' . $order['status'] . '): '
+                . ($order['json']['message'] ?? $order['json']['error'] ?? 'unknown'),
+            );
+        }
+
+        if (!empty($order['json']['id'])) {
+            trackCreated('order', (int) $order['json']['id']);
+        }
+
+        expect($order['json']['items'])->not->toBeEmpty();
+        expect((float) $order['json']['items'][0]['price'])->toBe(4.56);
+        expect((float) $order['json']['prices']['subtotal'])->toBe(9.12);
+    });
+
+});

--- a/tests/Api/V2/Write/CartItemCustomPriceTest.php
+++ b/tests/Api/V2/Write/CartItemCustomPriceTest.php
@@ -138,6 +138,97 @@ describe('customPrice on add-to-cart', function (): void {
         expect($response['status'])->toBe(400);
     });
 
+    it('rejects a non-numeric customPrice', function (): void {
+        $sku = fixtures('write_test_sku');
+        expect($sku)->not->toBeEmpty();
+
+        $token = serviceToken(['carts/write']);
+        $cartId = makeCustomPriceCart($token);
+        expect($cartId)->not->toBeNull();
+
+        $response = apiPost("/api/rest/v2/carts/{$cartId}/items", [
+            'sku' => $sku,
+            'qty' => 1,
+            'customPrice' => 'abc',
+        ], $token);
+
+        expect($response['status'])->toBe(400);
+    });
+
+    it('rejects re-adding the same SKU at a different customPrice', function (): void {
+        $sku = fixtures('write_test_sku');
+        expect($sku)->not->toBeEmpty();
+
+        $token = serviceToken(['carts/write']);
+        $cartId = makeCustomPriceCart($token);
+        expect($cartId)->not->toBeNull();
+
+        $add = apiPost("/api/rest/v2/carts/{$cartId}/items", [
+            'sku' => $sku,
+            'qty' => 1,
+            'customPrice' => 10.00,
+        ], $token);
+        expect($add['status'])->toBe(200);
+
+        $repriced = apiPost("/api/rest/v2/carts/{$cartId}/items", [
+            'sku' => $sku,
+            'qty' => 1,
+            'customPrice' => 2.00,
+        ], $token);
+
+        expect($repriced['status'])->toBe(400);
+    });
+
+    it('lets a privileged token change the custom price via item update', function (): void {
+        $sku = fixtures('write_test_sku');
+        expect($sku)->not->toBeEmpty();
+
+        $token = serviceToken(['carts/write']);
+        $cartId = makeCustomPriceCart($token);
+        expect($cartId)->not->toBeNull();
+
+        $add = apiPost("/api/rest/v2/carts/{$cartId}/items", [
+            'sku' => $sku,
+            'qty' => 1,
+            'customPrice' => 2.50,
+        ], $token);
+        expect($add['status'])->toBe(200);
+        $itemId = (int) $add['json']['items'][0]['id'];
+
+        $update = apiPut("/api/rest/v2/carts/{$cartId}/items/{$itemId}", [
+            'qty' => 2,
+            'customPrice' => 3.75,
+        ], $token);
+
+        expect($update['status'])->toBe(200);
+        expect((float) $update['json']['items'][0]['price'])->toBe(3.75);
+        expect((float) $update['json']['prices']['subtotal'])->toBe(7.50);
+    });
+
+    it('rejects a customer token sending customPrice on item update', function (): void {
+        $sku = fixtures('write_test_sku');
+        expect($sku)->not->toBeEmpty();
+
+        $create = apiPost('/api/rest/v2/carts', [], customerToken());
+        expect($create['status'])->toBeIn([200, 201]);
+        $cartId = (int) $create['json']['id'];
+        trackCreated('quote', $cartId);
+
+        $add = apiPost("/api/rest/v2/carts/{$cartId}/items", [
+            'sku' => $sku,
+            'qty' => 1,
+        ], customerToken());
+        expect($add['status'])->toBe(200);
+        $itemId = (int) $add['json']['items'][0]['id'];
+
+        $update = apiPut("/api/rest/v2/carts/{$cartId}/items/{$itemId}", [
+            'qty' => 2,
+            'customPrice' => 0.01,
+        ], customerToken());
+
+        expect($update['status'])->toBe(403);
+    });
+
     it('carries the custom price through to the placed order', function (): void {
         $sku = fixtures('write_test_sku');
         expect($sku)->not->toBeEmpty();


### PR DESCRIPTION
Fixes #1309.

REST v2 could not mutate a cart's addresses, shipping method, or payment method step by step: the setters existed only as GraphQL mutations, and the one-shot place-order body was undocumented. Marketplace middleware also had no way to record an item at the external sale price.

- New `PUT` sub-resources on `/carts/{id}` and `/guest-carts/{id}`: `shipping-address`, `billing-address`, `shipping-method`, `payment-method`. They route to the existing `CartService` setters shared with GraphQL, so validation and ownership checks are identical.
- Optional `customPrice` on add-to-cart (REST, GraphQL, admin GraphQL). Only admin or `carts/write` service tokens may use it; guests and customer tokens receive an explicit 401/403 instead of a silent drop. The price persists on the quote item and flows into the placed order.
- Documented the one-shot place-order body fields (`shippingAddress`, `billingAddress`, `guestEmail`, `paymentMethod`, `paymentData`, `shippingMethod`, `orderNote`) in the OpenAPI operation descriptions, since they were undiscoverable.
- Missing carrier/method codes on the setters now return 400 instead of 500.

Covered by two new Api write test files (16 tests), including a full step-wise guest checkout through order placement and an end-to-end order at a custom price.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->