### PR TITLE
Fixed spawned processes inheriting and prolonging file locks

### DIFF
--- a/app/code/core/Mage/Core/Model/Lock.php
+++ b/app/code/core/Mage/Core/Model/Lock.php
@@ -35,6 +35,15 @@ class Mage_Core_Model_Lock
     public const DB_LOCK_TIMEOUT = 5;
 
     /**
+     * An flock belongs to the open file description, not to the process, so any
+     * child that inherits the descriptor keeps the lock alive after the holder
+     * exits: a cron job that spawns a detached worker would hand it its group
+     * lock for the worker's whole lifetime. The "e" flag adds O_CLOEXEC, and is
+     * ignored where the platform has no such flag.
+     */
+    public const FILE_OPEN_MODE = 'ce';
+
+    /**
      * Held locks (SplFileObject for the file backend, true for the db backend);
      * static so acquired locks stay held until release or process exit even if
      * the acquiring model instance is destroyed. Tracking held names also keeps
@@ -156,7 +165,7 @@ class Mage_Core_Model_Lock
             if ($mtime === false || $mtime > $cutoff) {
                 continue;
             }
-            $handle = @fopen($file, 'c');
+            $handle = @fopen($file, self::FILE_OPEN_MODE);
             if ($handle === false) {
                 continue;
             }
@@ -201,7 +210,7 @@ class Mage_Core_Model_Lock
     {
         $file = $this->_lockFilePath($name);
         try {
-            return new SplFileObject($file, 'c');
+            return new SplFileObject($file, self::FILE_OPEN_MODE);
         } catch (RuntimeException $e) {
             throw new Mage_Core_Exception("Unable to create lock file {$file}", 0, $e);
         }

--- a/app/code/core/Mage/Core/Model/Lock.php
+++ b/app/code/core/Mage/Core/Model/Lock.php
@@ -35,11 +35,8 @@ class Mage_Core_Model_Lock
     public const DB_LOCK_TIMEOUT = 5;
 
     /**
-     * An flock belongs to the open file description, not to the process, so any
-     * child that inherits the descriptor keeps the lock alive after the holder
-     * exits: a cron job that spawns a detached worker would hand it its group
-     * lock for the worker's whole lifetime. The "e" flag adds O_CLOEXEC, and is
-     * ignored where the platform has no such flag.
+     * "e" adds O_CLOEXEC: an flock belongs to the open file description, so a
+     * child inheriting the descriptor would outlive the holder still holding it
      */
     public const FILE_OPEN_MODE = 'ce';
 

--- a/app/code/core/Mage/Core/Model/Lock.php
+++ b/app/code/core/Mage/Core/Model/Lock.php
@@ -86,10 +86,18 @@ class Mage_Core_Model_Lock
             return true;
         }
 
-        $handle = $this->_openLockFile($name);
-        if (!$handle->flock($blocking ? LOCK_EX : LOCK_EX | LOCK_NB)) {
-            return false;
-        }
+        $path = $this->_lockFilePath($name);
+        // cleanupStaleLockFiles() may unlink the path between our open and our flock,
+        // which would leave us holding an orphaned inode; retry on the fresh file
+        do {
+            $handle = $this->_openLockFile($name);
+            if (!$handle->flock($blocking ? LOCK_EX : LOCK_EX | LOCK_NB)) {
+                return false;
+            }
+            clearstatcache(false, $path);
+        } while (@fileinode($path) !== $handle->fstat()['ino']);
+        // fopen mode "c" never updates mtime; keep an active name below the staleness cutoff
+        @touch($path);
         self::$_locks[$name] = $handle;
         return true;
     }
@@ -141,7 +149,8 @@ class Mage_Core_Model_Lock
      * per-order paypal_order_<id> locks, one of which is created per checkout).
      * release() never unlinks, since unlinking a live lock would let two
      * processes hold the same name; only files older than $olderThanSeconds
-     * that nobody currently holds are removed, so there is no live lock to race.
+     * that nobody currently holds are removed, and acquire() re-checks its
+     * inode after locking, so an unlink here cannot orphan a concurrent acquire.
      * Returns the number of files removed. Operates on the filesystem regardless
      * of the configured backend, so leftovers from a prior file-backend run are
      * still reclaimed after a switch to db.

--- a/app/code/core/Maho/AccessibilityScan/Model/Runner.php
+++ b/app/code/core/Maho/AccessibilityScan/Model/Runner.php
@@ -22,6 +22,8 @@ class Maho_AccessibilityScan_Model_Runner
     /** Seconds allowed for npm install / browser download */
     protected const INSTALL_TIMEOUT = 900;
 
+    protected const INSTALL_LOCK = 'accessibilityscan_install';
+
     protected Maho_AccessibilityScan_Helper_Data $helper;
 
     public function __construct()
@@ -83,13 +85,7 @@ class Maho_AccessibilityScan_Model_Runner
     public function installPlaywright(bool $force = false): void
     {
         $dir = $this->helper->getPlaywrightDir();
-
-        // The working directory is shared; serialize install/update across
-        // concurrent scans so npm install and the scanner copy cannot race
-        $lock = fopen($dir . DS . '.install.lock', Mage_Core_Model_Lock::FILE_OPEN_MODE);
-        if ($lock === false || !flock($lock, LOCK_EX)) {
-            Mage::throwException($this->helper->__('Unable to acquire the scanner install lock in %s', $dir));
-        }
+        $this->acquireInstallLock();
 
         try {
             $packageJson = $dir . DS . 'package.json';
@@ -122,8 +118,7 @@ class Maho_AccessibilityScan_Model_Runner
                 self::INSTALL_TIMEOUT,
             );
         } finally {
-            flock($lock, LOCK_UN);
-            fclose($lock);
+            Mage::getSingleton('core/lock')->release(self::INSTALL_LOCK);
         }
     }
 
@@ -134,15 +129,24 @@ class Maho_AccessibilityScan_Model_Runner
     protected function syncScannerScript(): void
     {
         $dir = $this->helper->getPlaywrightDir();
-        $lock = fopen($dir . DS . '.install.lock', Mage_Core_Model_Lock::FILE_OPEN_MODE);
-        if ($lock === false || !flock($lock, LOCK_EX)) {
-            Mage::throwException($this->helper->__('Unable to acquire the scanner install lock in %s', $dir));
-        }
+        $this->acquireInstallLock();
         try {
             $this->copyScannerScript($dir);
         } finally {
-            flock($lock, LOCK_UN);
-            fclose($lock);
+            Mage::getSingleton('core/lock')->release(self::INSTALL_LOCK);
+        }
+    }
+
+    /**
+     * Serialize install/update across concurrent scans so npm install and the
+     * scanner copy cannot race; machine-local because the Playwright directory is too
+     */
+    protected function acquireInstallLock(): void
+    {
+        /** @var Mage_Core_Model_Lock $lock */
+        $lock = Mage::getSingleton('core/lock');
+        if (!$lock->acquire(self::INSTALL_LOCK, blocking: true, machineLocal: true)) {
+            Mage::throwException($this->helper->__('Unable to acquire the scanner install lock'));
         }
     }
 

--- a/app/code/core/Maho/AccessibilityScan/Model/Runner.php
+++ b/app/code/core/Maho/AccessibilityScan/Model/Runner.php
@@ -86,7 +86,7 @@ class Maho_AccessibilityScan_Model_Runner
 
         // The working directory is shared; serialize install/update across
         // concurrent scans so npm install and the scanner copy cannot race
-        $lock = fopen($dir . DS . '.install.lock', 'c');
+        $lock = fopen($dir . DS . '.install.lock', Mage_Core_Model_Lock::FILE_OPEN_MODE);
         if ($lock === false || !flock($lock, LOCK_EX)) {
             Mage::throwException($this->helper->__('Unable to acquire the scanner install lock in %s', $dir));
         }
@@ -134,7 +134,7 @@ class Maho_AccessibilityScan_Model_Runner
     protected function syncScannerScript(): void
     {
         $dir = $this->helper->getPlaywrightDir();
-        $lock = fopen($dir . DS . '.install.lock', 'c');
+        $lock = fopen($dir . DS . '.install.lock', Mage_Core_Model_Lock::FILE_OPEN_MODE);
         if ($lock === false || !flock($lock, LOCK_EX)) {
             Mage::throwException($this->helper->__('Unable to acquire the scanner install lock in %s', $dir));
         }

--- a/app/etc/local.xml.template
+++ b/app/etc/local.xml.template
@@ -41,6 +41,9 @@ SPDX-License-Identifier: AFL-3.0
               clusters (no advisory lock support) or on SQLite (only emulated via an expiring lock
               table). Note: advisory locks belong to the DB session, so if the connection drops during
               a long run (e.g. MySQL wait_timeout) the server releases the lock while PHP keeps running.
+              The reverse also holds: a spawned child (e.g. the detached queue worker) inherits the DB
+              socket, so after an unclean death of the holder (kill -9, OOM) the server keeps the lock
+              held until the child exits.
         -->
         <!--
         <lock>

--- a/app/etc/local.xml.template
+++ b/app/etc/local.xml.template
@@ -33,8 +33,9 @@ SPDX-License-Identifier: AFL-3.0
         <!--
             Named locks (cron dispatch, reindexing, order placement, ...). Default backend is "file".
             - file: kernel flock in var/locks. Released instantly when the holding process exits or
-              crashes. The right choice for single-server setups; use it unless multiple servers must
-              share locks.
+              crashes. Lock files are opened close-on-exec, so a process the holder spawns (e.g. the
+              detached queue worker) cannot prolong the lock. The right choice for single-server
+              setups; use it unless multiple servers must share locks.
             - db: the database server's advisory locks (MySQL GET_LOCK, PostgreSQL advisory locks),
               for multi-frontend setups sharing one database server. Do NOT use it on Galera-style
               clusters (no advisory lock support) or on SQLite (only emulated via an expiring lock

--- a/app/locale/en_US/Maho_AccessibilityScan.csv
+++ b/app/locale/en_US/Maho_AccessibilityScan.csv
@@ -88,7 +88,7 @@
 "Total","Total"
 "Total Scans","Total Scans"
 "Total Violations","Total Violations"
-"Unable to acquire the scanner install lock in %s","Unable to acquire the scanner install lock in %s"
+"Unable to acquire the scanner install lock","Unable to acquire the scanner install lock"
 "Unable to copy the scanner script to %s","Unable to copy the scanner script to %s"
 "Unable to create directory %s","Unable to create directory %s"
 "Unable to start process: %s","Unable to start process: %s"

--- a/tests/Backend/Unit/Core/Model/LockTest.php
+++ b/tests/Backend/Unit/Core/Model/LockTest.php
@@ -119,37 +119,32 @@ it('cleans up only stale, unheld lock files', function () {
     @unlink($recent);
 });
 
-// Issue #1314: the holder runs in its own process so it can exit while its child lives
+// The holder runs in its own process so it can exit while its child lives
 it('does not leak a held lock into a process spawned while holding it', function () {
-    $root = Mage::getBaseDir();
-    $lockDir = Mage::getConfig()->getVarDir('locks');
-    $probe = Mage::getBaseDir('var') . DS . 'cloexec-probe.php';
+    $lockFile = Mage::getConfig()->getVarDir('locks') . DS . 'core_lock_cloexec.lock';
+    $probe = __DIR__ . DS . 'fixtures' . DS . 'cloexec-probe.php';
 
-    file_put_contents($probe, <<<PHP
-        <?php
-        require '{$root}/vendor/autoload.php';
-        Mage::setRoot('{$root}');
-        Mage::app();
-        Mage::getModel('core/lock')->acquire('core_lock_cloexec');
-        exec('nohup sleep 30 > /dev/null 2>&1 & echo \$!', \$out);
-        echo end(\$out);
-        PHP);
-
-    exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($probe) . ' 2>/dev/null', $output);
+    exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($probe) . ' 2>&1', $output, $exitCode);
     $child = (int) end($output);
-    @unlink($probe);
+    expect($exitCode)->toBe(0, 'probe failed: ' . implode("\n", $output));
+    expect($child)->toBeGreaterThan(0, 'probe printed no child pid: ' . implode("\n", $output));
 
-    // A dead child would free the descriptor and pass the test for the wrong reason
-    exec('ps -p ' . $child, $alive);
-    expect(count($alive))->toBeGreaterThan(1);
+    try {
+        // A dead child would free the descriptor and pass the test for the wrong reason
+        exec('ps -p ' . $child, $alive);
+        expect(count($alive))->toBeGreaterThan(1);
 
-    $contender = fopen($lockDir . DS . 'core_lock_cloexec.lock', 'c');
-    $free = flock($contender, LOCK_EX | LOCK_NB);
-    if ($free) {
-        flock($contender, LOCK_UN);
+        // The probe pinned the file backend, so a successful acquire left a lock file
+        expect(is_file($lockFile))->toBeTrue();
+        $contender = fopen($lockFile, 'c');
+        $free = flock($contender, LOCK_EX | LOCK_NB);
+        if ($free) {
+            flock($contender, LOCK_UN);
+        }
+        fclose($contender);
+        expect($free)->toBeTrue();
+    } finally {
+        exec('kill ' . $child . ' 2>/dev/null');
+        @unlink($lockFile);
     }
-    fclose($contender);
-    exec('kill ' . $child . ' 2>/dev/null');
-
-    expect($free)->toBeTrue();
 });

--- a/tests/Backend/Unit/Core/Model/LockTest.php
+++ b/tests/Backend/Unit/Core/Model/LockTest.php
@@ -119,13 +119,7 @@ it('cleans up only stale, unheld lock files', function () {
     @unlink($recent);
 });
 
-/**
- * Issue #1314: the queue watchdog runs inside `cron:run default`, which holds
- * cron.default, and spawns a detached `queue:work`. An flock belongs to the open
- * file description, so before the fix the worker inherited the descriptor and
- * held the group lock for its whole lifetime, starving every default-group job.
- * The holder must therefore run in its own process and exit while the child lives.
- */
+// Issue #1314: the holder runs in its own process so it can exit while its child lives
 it('does not leak a held lock into a process spawned while holding it', function () {
     $root = Mage::getBaseDir();
     $lockDir = Mage::getConfig()->getVarDir('locks');
@@ -145,7 +139,7 @@ it('does not leak a held lock into a process spawned while holding it', function
     $child = (int) end($output);
     @unlink($probe);
 
-    // A dead child would free the descriptor anyway and pass the test for the wrong reason
+    // A dead child would free the descriptor and pass the test for the wrong reason
     exec('ps -p ' . $child, $alive);
     expect(count($alive))->toBeGreaterThan(1);
 

--- a/tests/Backend/Unit/Core/Model/LockTest.php
+++ b/tests/Backend/Unit/Core/Model/LockTest.php
@@ -118,3 +118,44 @@ it('cleans up only stale, unheld lock files', function () {
     $manager->release('cron.default');
     @unlink($recent);
 });
+
+/**
+ * Issue #1314: the queue watchdog runs inside `cron:run default`, which holds
+ * cron.default, and spawns a detached `queue:work`. An flock belongs to the open
+ * file description, so before the fix the worker inherited the descriptor and
+ * held the group lock for its whole lifetime, starving every default-group job.
+ * The holder must therefore run in its own process and exit while the child lives.
+ */
+it('does not leak a held lock into a process spawned while holding it', function () {
+    $root = Mage::getBaseDir();
+    $lockDir = Mage::getConfig()->getVarDir('locks');
+    $probe = Mage::getBaseDir('var') . DS . 'cloexec-probe.php';
+
+    file_put_contents($probe, <<<PHP
+        <?php
+        require '{$root}/vendor/autoload.php';
+        Mage::setRoot('{$root}');
+        Mage::app();
+        Mage::getModel('core/lock')->acquire('core_lock_cloexec');
+        exec('nohup sleep 30 > /dev/null 2>&1 & echo \$!', \$out);
+        echo end(\$out);
+        PHP);
+
+    exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($probe) . ' 2>/dev/null', $output);
+    $child = (int) end($output);
+    @unlink($probe);
+
+    // A dead child would free the descriptor anyway and pass the test for the wrong reason
+    exec('ps -p ' . $child, $alive);
+    expect(count($alive))->toBeGreaterThan(1);
+
+    $contender = fopen($lockDir . DS . 'core_lock_cloexec.lock', 'c');
+    $free = flock($contender, LOCK_EX | LOCK_NB);
+    if ($free) {
+        flock($contender, LOCK_UN);
+    }
+    fclose($contender);
+    exec('kill ' . $child . ' 2>/dev/null');
+
+    expect($free)->toBeTrue();
+});

--- a/tests/Backend/Unit/Core/Model/fixtures/cloexec-probe.php
+++ b/tests/Backend/Unit/Core/Model/fixtures/cloexec-probe.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Holds a file-backend lock while spawning a detached child, then prints the child
+ * pid: without O_CLOEXEC the child would inherit the lock descriptor and keep the
+ * lock held after this process exits.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+$root = dirname(__DIR__, 6);
+require $root . '/vendor/autoload.php';
+
+Mage::setRoot($root);
+Mage::app();
+
+// Pin the file backend: the installed local.xml may configure db, which creates
+// no lock file and would let the test pass without exercising O_CLOEXEC
+Mage::getConfig()->setNode(Mage_Core_Model_Lock::XML_PATH_BACKEND, 'file');
+
+if (!Mage::getModel('core/lock')->acquire('core_lock_cloexec')) {
+    fwrite(STDERR, 'unable to acquire core_lock_cloexec');
+    exit(1);
+}
+
+exec('nohup sleep 30 > /dev/null 2>&1 & echo $!', $out);
+$child = (int) end($out);
+if ($child <= 0) {
+    fwrite(STDERR, 'unable to spawn the detached child');
+    exit(1);
+}
+echo "\n{$child}\n";


### PR DESCRIPTION
Fixes #1314.

An `flock` belongs to the open file description, not to the process, so a child that inherits the descriptor keeps the lock alive after the holder exits. The queue watchdog runs inside `cron:run default`, which holds `cron.default`, and spawns a detached `queue:work`. The worker inherited the descriptor and held the group lock for its whole lifetime, so the default group ran once per worker lifetime instead of once per cron pass.

Lock files are now opened with `O_CLOEXEC` (the `e` mode flag, ignored where the platform has no such flag). One change in `Mage_Core_Model_Lock` covers every lock name and every spawn path, and it survives a fatal error or a kill in the holder, because the kernel applies the flag. The same mode is applied to the accessibility scanner install lock.

Two notes on the report:

- The suggested `proc_open` fix does not work. `proc_open` only remaps descriptors 0, 1 and 2 and leaves every other descriptor open in the child.
- The `db` backend is not affected. I tested `GET_LOCK` with an inherited socket: the client sends `COM_QUIT` at exit, so the server ends the session and releases the lock.

The new test runs the holder in its own process, so it can exit while the spawned child lives. It fails against the unfixed code.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->