### PR TITLE
Added a health check for cron declarations left behind by uninstalled modules

### DIFF
--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -228,9 +228,7 @@ class HealthCheck extends BaseMahoCommand
                 }
                 $moduleName = $parts[3] . '_' . $parts[4];
 
-                libxml_use_internal_errors(true);
-                $xml = simplexml_load_file($file->getPathname());
-                libxml_clear_errors();
+                $xml = self::loadXmlFile($file->getPathname());
                 if ($xml === false) {
                     continue;
                 }
@@ -313,7 +311,7 @@ class HealthCheck extends BaseMahoCommand
     {
         $config = Mage::getConfig();
         $findings = ['orphans' => [], 'stale' => [], 'disabled' => [], 'dead' => []];
-        $paths = self::findCronConfigPaths();
+        ['paths' => $paths, 'declaring' => $declaringPaths] = self::findCronConfigPaths();
 
         // A code named by a config_path is owned too: rows saved there are overrides.
         $claimed = [];
@@ -322,22 +320,30 @@ class HealthCheck extends BaseMahoCommand
             $claimed[$jobCode] = true;
             self::claimCronConfigPath($claimed, (string) ($jobDef['config_path'] ?? ''));
 
+            $alias = (string) ($jobDef['alias'] ?? '');
+            $method = (string) ($jobDef['method'] ?? '');
+
             // A disabled module's alias cannot resolve even when its code is there.
             $module = (string) ($jobDef['module'] ?? '');
-            if ($module !== ''
-                && $config->getNode('modules/' . $module) !== false
-                && !Mage::helper('core')->isModuleEnabled($module)
-            ) {
-                $findings['disabled'][] = [
+            if ($module !== '' && !Mage::helper('core')->isModuleEnabled($module)) {
+                if ($config->getNode('modules/' . $module) !== false) {
+                    $findings['disabled'][] = [
+                        'job_code' => $jobCode,
+                        'module' => $module,
+                        'paths' => $paths[$jobCode] ?? [],
+                    ];
+                    continue;
+                }
+                // Undeclared module: the scheduler skips the job even when its code
+                // still loads, and recompiling drops it from the registry.
+                $findings['stale'][] = [
                     'job_code' => $jobCode,
-                    'module' => $module,
-                    'paths' => $paths[$jobCode] ?? [],
+                    'model' => $alias . '::' . $method,
+                    'reason' => sprintf('module %s is no longer declared under app/etc/modules', $module),
                 ];
                 continue;
             }
 
-            $alias = (string) ($jobDef['alias'] ?? '');
-            $method = (string) ($jobDef['method'] ?? '');
             $reason = self::findMissingCronCallback($alias, $method);
             if ($reason !== null) {
                 $findings['stale'][] = [
@@ -348,26 +354,32 @@ class HealthCheck extends BaseMahoCommand
             }
         }
 
-        // The database rows arrive here: loadToXml() merges core_config_data paths
-        // into the config tree under `default/`. XML wins over `default/`, matching
-        // the precedence dispatch() resolves a job's run config with.
+        // The database rows arrive here: loadToXml() merges default-scope core_config_data
+        // paths into the config tree under `default/`. Node precedence matches dispatch():
+        // the XML node wins only when it carries a non-empty <run>; otherwise dispatch()
+        // falls back to the whole `default/` node, so the health check must too.
         $declared = [];
         foreach (['default/crontab/jobs', 'crontab/jobs'] as $path) {
             $node = $config->getNode($path);
-            if ($node instanceof \Maho\Simplexml\Element) {
-                $jobs = $node->asArray();
-                if (is_array($jobs)) {
-                    $declared = array_replace_recursive($declared, $jobs);
+            if (!$node instanceof \Maho\Simplexml\Element) {
+                continue;
+            }
+            $jobs = $node->asArray();
+            if (!is_array($jobs)) {
+                continue;
+            }
+            foreach ($jobs as $jobCode => $jobConfig) {
+                if (is_array($jobConfig)) {
+                    $configPath = $jobConfig['schedule']['config_path'] ?? '';
+                    self::claimCronConfigPath($claimed, is_scalar($configPath) ? (string) $configPath : '');
+                }
+                if (!isset($declared[$jobCode]) || (is_array($jobConfig) && !empty($jobConfig['run']))) {
+                    $declared[$jobCode] = $jobConfig;
                 }
             }
         }
-        foreach ($declared as $jobConfig) {
-            if (is_array($jobConfig)) {
-                self::claimCronConfigPath($claimed, (string) ($jobConfig['schedule']['config_path'] ?? ''));
-            }
-        }
 
-        foreach (array_keys($paths) as $jobCode) {
+        foreach (array_keys($declaringPaths) as $jobCode) {
             $declared[$jobCode] ??= [];
         }
 
@@ -380,7 +392,8 @@ class HealthCheck extends BaseMahoCommand
                 continue;
             }
 
-            $model = is_array($jobConfig) ? trim((string) ($jobConfig['run']['model'] ?? '')) : '';
+            $model = is_array($jobConfig) ? ($jobConfig['run']['model'] ?? '') : '';
+            $model = is_scalar($model) ? trim((string) $model) : '';
             if ($model === '') {
                 $reason = 'declares no run/model and no #[Maho\Config\CronJob] registers it';
             } elseif (!preg_match(\Mage_Cron_Model_Observer::REGEX_RUN_MODEL, $model, $run)) {
@@ -412,12 +425,38 @@ class HealthCheck extends BaseMahoCommand
         }
 
         foreach ($schedules as $jobCode => $count) {
-            if (!isset($claimed[$jobCode]) && !isset($declared[$jobCode])) {
-                $findings['dead'][] = ['job_code' => $jobCode, 'schedules' => $count];
+            if (isset($claimed[$jobCode]) || isset($declared[$jobCode])) {
+                continue;
             }
+            // A disabled module's XML never merges, so its rows are not "dead": the
+            // declaration still exists and re-enabling the module revives the job.
+            $disabledModuleJobs ??= self::findDisabledModuleCronJobs();
+            if (isset($disabledModuleJobs[$jobCode])) {
+                $findings['disabled'][] = [
+                    'job_code' => $jobCode,
+                    'module' => $disabledModuleJobs[$jobCode],
+                    'paths' => $paths[$jobCode] ?? [],
+                ];
+                continue;
+            }
+            $findings['dead'][] = ['job_code' => $jobCode, 'schedules' => $count];
         }
 
         return $findings;
+    }
+
+    /**
+     * Parse an XML file without leaking libxml warnings, false on failure.
+     */
+    private static function loadXmlFile(string $file): \SimpleXMLElement|false
+    {
+        $previousLibxmlErrors = libxml_use_internal_errors(true);
+        try {
+            return simplexml_load_file($file);
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previousLibxmlErrors);
+        }
     }
 
     /**
@@ -453,9 +492,11 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
-     * Every core_config_data path under crontab/jobs, grouped by job code.
+     * Every core_config_data path under crontab/jobs, grouped by job code. Only
+     * default-scope rows merge into the tree the scheduler reads, so only those
+     * codes count as declarations; the paths of every scope remain deletable.
      *
-     * @return array<string, list<string>>
+     * @return array{paths: array<string, list<string>>, declaring: array<string, true>}
      */
     private static function findCronConfigPaths(): array
     {
@@ -463,19 +504,27 @@ class HealthCheck extends BaseMahoCommand
         $adapter = $resource->getConnection('core_read');
 
         $select = $adapter->select()
-            ->from($resource->getTableName('core/config_data'), ['path'])
+            ->from($resource->getTableName('core/config_data'), ['path', 'scope'])
             ->where('path LIKE ?', 'crontab/jobs/%')
             ->order('path');
 
         $paths = [];
-        foreach ($adapter->fetchCol($select) as $path) {
-            $jobCode = explode('/', (string) $path)[2] ?? '';
-            if ($jobCode !== '' && !in_array($path, $paths[$jobCode] ?? [], true)) {
-                $paths[$jobCode][] = (string) $path;
+        $declaring = [];
+        foreach ($adapter->fetchAll($select) as $row) {
+            $path = (string) $row['path'];
+            $jobCode = explode('/', $path)[2] ?? '';
+            if ($jobCode === '') {
+                continue;
+            }
+            if (!in_array($path, $paths[$jobCode] ?? [], true)) {
+                $paths[$jobCode][] = $path;
+            }
+            if ((string) ($row['scope'] ?? '') === 'default') {
+                $declaring[$jobCode] = true;
             }
         }
 
-        return $paths;
+        return ['paths' => $paths, 'declaring' => $declaring];
     }
 
     /**
@@ -524,10 +573,7 @@ class HealthCheck extends BaseMahoCommand
                 continue;
             }
 
-            $previousLibxmlErrors = libxml_use_internal_errors(true);
-            $xml = simplexml_load_file($file);
-            libxml_clear_errors();
-            libxml_use_internal_errors($previousLibxmlErrors);
+            $xml = self::loadXmlFile($file);
             if ($xml === false) {
                 continue;
             }
@@ -815,9 +861,7 @@ class HealthCheck extends BaseMahoCommand
             return null;
         }
 
-        libxml_use_internal_errors(true);
-        $xml = simplexml_load_file($file);
-        libxml_clear_errors();
+        $xml = self::loadXmlFile($file);
         if ($xml === false) {
             return null;
         }
@@ -859,8 +903,8 @@ class HealthCheck extends BaseMahoCommand
 
         if ($findings['orphans'] !== []) {
             $parts[] = sprintf(
-                '%d job(s) declared with no code to run them (%s). They keep generating cron_schedule rows that '
-                . 'can never execute: run "./maho health-check" to review and delete their core_config_data rows.',
+                '%d job(s) declared with no code to run them (%s). Their cron_schedule rows can never '
+                . 'execute or be cleaned up: run "./maho health-check" to review and remove the leftovers.',
                 count($findings['orphans']),
                 implode(', ', array_column($findings['orphans'], 'job_code')),
             );
@@ -1015,12 +1059,11 @@ class HealthCheck extends BaseMahoCommand
 
         try {
             $orphanedCron = self::findOrphanedCronJobs();
-            $cronFindings = count($orphanedCron['orphans']) + count($orphanedCron['stale'])
-                + count($orphanedCron['disabled']) + count($orphanedCron['dead']);
+            $cronHealthy = array_filter($orphanedCron) === [];
             $checks[] = [
                 'check' => 'Orphaned Cron Jobs',
-                'severity' => $cronFindings === 0 ? 'ok' : 'warning',
-                'details' => $cronFindings === 0 ? '' : self::formatOrphanedCronSummary($orphanedCron),
+                'severity' => $cronHealthy ? 'ok' : 'warning',
+                'details' => $cronHealthy ? '' : self::formatOrphanedCronSummary($orphanedCron),
             ];
         } catch (\Throwable) {
             $checks[] = [
@@ -1256,9 +1299,7 @@ class HealthCheck extends BaseMahoCommand
             $themeXmlPath = \Maho::findFile(self::DESIGN_PATH . "/{$package}/{$themeName}/etc/theme.xml");
 
             if ($themeXmlPath !== false) {
-                libxml_use_internal_errors(true);
-                $xml = simplexml_load_file($themeXmlPath);
-                libxml_clear_errors();
+                $xml = self::loadXmlFile($themeXmlPath);
 
                 if ($xml !== false && isset($xml->parent)) {
                     $parentMap[$theme] = (string) $xml->parent;
@@ -1837,8 +1878,8 @@ class HealthCheck extends BaseMahoCommand
                     $output->writeln('    core_config_data: ' . $path);
                 }
             }
-            $output->writeln('They are scheduled on every cron run and can never execute, and their pending');
-            $output->writeln('rows are never deleted, so they pile up until the declaration is removed.');
+            $output->writeln('Unless disabled, they are scheduled on every cron run and can never execute,');
+            $output->writeln('and their pending rows are never deleted until the declaration is removed.');
         }
 
         if ($findings['stale'] !== []) {
@@ -1870,11 +1911,30 @@ class HealthCheck extends BaseMahoCommand
             }
         }
 
+        // An orphan with no config rows is declared in a module's XML: deleting its
+        // schedule rows is futile, generate() recreates them on the next cron tick.
+        $purgeableOrphans = array_values(array_filter(
+            $findings['orphans'],
+            fn(array $orphan) => $orphan['paths'] !== [],
+        ));
+        $xmlOrphans = array_column(array_filter(
+            $findings['orphans'],
+            fn(array $orphan) => $orphan['paths'] === [],
+        ), 'job_code');
+        if ($xmlOrphans !== []) {
+            $output->writeln('');
+            $output->writeln(sprintf(
+                '<comment>%s: declared in a module\'s XML, so there are no database rows to delete;</comment>',
+                implode(', ', $xmlOrphans),
+            ));
+            $output->writeln('<comment>remove the crontab declaration from the module\'s config.xml instead.</comment>');
+        }
+
         $purgeable = array_merge(
-            array_column($findings['orphans'], 'job_code'),
+            array_column($purgeableOrphans, 'job_code'),
             array_column($findings['dead'], 'job_code'),
         );
-        $configPaths = array_merge(...array_column($findings['orphans'], 'paths'));
+        $configPaths = array_merge(...array_column($purgeableOrphans, 'paths'));
         if ($purgeable === []) {
             $output->writeln('');
             return;

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -313,6 +313,7 @@ class HealthCheck extends BaseMahoCommand
     {
         $config = Mage::getConfig();
         $findings = ['orphans' => [], 'stale' => [], 'disabled' => [], 'dead' => []];
+        $paths = self::findCronConfigPaths();
 
         // A code named by a config_path is owned too: rows saved there are overrides.
         $claimed = [];
@@ -327,6 +328,11 @@ class HealthCheck extends BaseMahoCommand
                 && $config->getNode('modules/' . $module) !== false
                 && !Mage::helper('core')->isModuleEnabled($module)
             ) {
+                $findings['disabled'][] = [
+                    'job_code' => $jobCode,
+                    'module' => $module,
+                    'paths' => $paths[$jobCode] ?? [],
+                ];
                 continue;
             }
 
@@ -343,12 +349,16 @@ class HealthCheck extends BaseMahoCommand
         }
 
         // The database rows arrive here: loadToXml() merges core_config_data paths
-        // into the config tree under `default/`.
+        // into the config tree under `default/`. XML wins over `default/`, matching
+        // the precedence dispatch() resolves a job's run config with.
         $declared = [];
-        foreach (['crontab/jobs', 'default/crontab/jobs'] as $path) {
+        foreach (['default/crontab/jobs', 'crontab/jobs'] as $path) {
             $node = $config->getNode($path);
             if ($node instanceof \Maho\Simplexml\Element) {
-                $declared = array_replace_recursive($declared, $node->asArray());
+                $jobs = $node->asArray();
+                if (is_array($jobs)) {
+                    $declared = array_replace_recursive($declared, $jobs);
+                }
             }
         }
         foreach ($declared as $jobConfig) {
@@ -357,13 +367,12 @@ class HealthCheck extends BaseMahoCommand
             }
         }
 
-        $paths = self::findCronConfigPaths();
         foreach (array_keys($paths) as $jobCode) {
             $declared[$jobCode] ??= [];
         }
 
         $schedules = self::countCronSchedules();
-        $disabledModuleJobs = self::findDisabledModuleCronJobs();
+        $disabledModuleJobs = null;
 
         foreach ($declared as $jobCode => $jobConfig) {
             $jobCode = (string) $jobCode;
@@ -374,14 +383,16 @@ class HealthCheck extends BaseMahoCommand
             $model = is_array($jobConfig) ? trim((string) ($jobConfig['run']['model'] ?? '')) : '';
             if ($model === '') {
                 $reason = 'declares no run/model and no #[Maho\Config\CronJob] registers it';
+            } elseif (!preg_match(\Mage_Cron_Model_Observer::REGEX_RUN_MODEL, $model, $run)) {
+                $reason = 'run/model is not of the "model/class::method" form the scheduler requires';
             } else {
-                [$alias, $method] = array_pad(explode('::', $model, 2), 2, '');
-                $reason = self::findMissingCronCallback($alias, $method);
+                $reason = self::findMissingCronCallback($run[1], $run[2]);
             }
             if ($reason === null) {
                 continue;
             }
 
+            $disabledModuleJobs ??= self::findDisabledModuleCronJobs();
             if (isset($disabledModuleJobs[$jobCode])) {
                 $findings['disabled'][] = [
                     'job_code' => $jobCode,
@@ -502,8 +513,8 @@ class HealthCheck extends BaseMahoCommand
         }
 
         foreach ($modules->children() as $moduleName => $moduleNode) {
-            $active = strtolower(trim((string) $moduleNode->active));
-            if ($active !== '' && $active !== 'false' && $active !== 'off') {
+            // Same predicate the config loader merges config.xml with.
+            if (!$moduleNode instanceof \Mage_Core_Model_Config_Element || $moduleNode->is('active')) {
                 continue;
             }
 
@@ -513,15 +524,15 @@ class HealthCheck extends BaseMahoCommand
                 continue;
             }
 
-            libxml_use_internal_errors(true);
+            $previousLibxmlErrors = libxml_use_internal_errors(true);
             $xml = simplexml_load_file($file);
             libxml_clear_errors();
+            libxml_use_internal_errors($previousLibxmlErrors);
             if ($xml === false) {
                 continue;
             }
 
-            foreach (['crontab', 'default'] as $root) {
-                $node = $root === 'crontab' ? ($xml->crontab->jobs ?? null) : ($xml->default->crontab->jobs ?? null);
+            foreach ([$xml->crontab->jobs ?? null, $xml->default->crontab->jobs ?? null] as $node) {
                 if ($node === null) {
                     continue;
                 }
@@ -1011,7 +1022,7 @@ class HealthCheck extends BaseMahoCommand
                 'severity' => $cronFindings === 0 ? 'ok' : 'warning',
                 'details' => $cronFindings === 0 ? '' : self::formatOrphanedCronSummary($orphanedCron),
             ];
-        } catch (\Exception) {
+        } catch (\Throwable) {
             $checks[] = [
                 'check' => 'Orphaned Cron Jobs',
                 'severity' => 'error',
@@ -1794,7 +1805,6 @@ class HealthCheck extends BaseMahoCommand
         $output->writeln('');
     }
 
-
     /**
      * Only plain leftovers can be deleted: a stale registry needs recompiling, and a
      * disabled module needs re-enabling.
@@ -1864,10 +1874,7 @@ class HealthCheck extends BaseMahoCommand
             array_column($findings['orphans'], 'job_code'),
             array_column($findings['dead'], 'job_code'),
         );
-        $configPaths = [];
-        foreach ($findings['orphans'] as $orphan) {
-            $configPaths = array_merge($configPaths, $orphan['paths']);
-        }
+        $configPaths = array_merge(...array_column($findings['orphans'], 'paths'));
         if ($purgeable === []) {
             $output->writeln('');
             return;

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -299,12 +299,8 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
-     * Cron declarations with no code left to run them, the leftovers of an uninstalled
-     * module. Legacy modules wrote their schedule into `core_config_data` under
-     * `crontab/jobs/<code>/…`, and those rows outlive the code: `generate()` schedules
-     * anything carrying a cron expression without looking for a `<run>` node, while
-     * `dispatch()` skips a job that has none. Nothing deletes a pending row, so every
-     * generate pass adds `cron_schedule` rows that can never execute and never expire.
+     * Cron jobs still declared, usually in the database, with no code left to run them.
+     * They are scheduled on every cron run, never execute, and are never cleaned up.
      *
      * @return array{
      *     orphans: list<array{job_code: string, reason: string, model: string, paths: list<string>, schedules: int}>,
@@ -318,19 +314,14 @@ class HealthCheck extends BaseMahoCommand
         $config = Mage::getConfig();
         $findings = ['orphans' => [], 'stale' => [], 'disabled' => [], 'dead' => []];
 
-        // Codes an attribute owns, plus every code some live declaration points its
-        // configurable schedule at: a config_path may name a job code other than its
-        // own, and the row the admin writes there must not read as a declaration.
+        // A code named by a config_path is owned too: rows saved there are overrides.
         $claimed = [];
         foreach (\Maho::getCompiledAttributes()['crontab'] ?? [] as $jobCode => $jobDef) {
             $jobCode = (string) $jobCode;
             $claimed[$jobCode] = true;
             self::claimCronConfigPath($claimed, (string) ($jobDef['config_path'] ?? ''));
 
-            // A module that is switched off has no models in the config tree, so its
-            // aliases cannot resolve: that says nothing about whether its code is still
-            // there. A module that is gone entirely is not declared at all, and is the
-            // case worth reporting.
+            // A disabled module's alias cannot resolve even when its code is there.
             $module = (string) ($jobDef['module'] ?? '');
             if ($module !== ''
                 && $config->getNode('modules/' . $module) !== false
@@ -351,8 +342,8 @@ class HealthCheck extends BaseMahoCommand
             }
         }
 
-        // `default/crontab/jobs` carries the database rows: loadToXml() merges every
-        // core_config_data path into the config tree under `default/`.
+        // The database rows arrive here: loadToXml() merges core_config_data paths
+        // into the config tree under `default/`.
         $declared = [];
         foreach (['crontab/jobs', 'default/crontab/jobs'] as $path) {
             $node = $config->getNode($path);
@@ -430,9 +421,8 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
-     * Why `alias::method` cannot be called, or null when it resolves. An unknown group
-     * makes getModelClassName() fabricate a class name rather than fail, so the
-     * class_exists() check is what actually catches a module that is gone.
+     * Why `alias::method` cannot be called, or null when it can. getModelClassName()
+     * invents a class name for an unknown alias, so class_exists() is the real test.
      */
     private static function findMissingCronCallback(string $alias, string $method): ?string
     {
@@ -452,9 +442,7 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
-     * Every core_config_data path under crontab/jobs, grouped by job code. The config
-     * tree alone cannot answer this: it merges scopes and drops the row identity we
-     * need to tell the user (and the purge) exactly what to delete.
+     * Every core_config_data path under crontab/jobs, grouped by job code.
      *
      * @return array<string, list<string>>
      */
@@ -500,9 +488,8 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
-     * Cron jobs declared by a module that is installed but switched off. Its config.xml
-     * is never merged, so its jobs look exactly like an uninstalled module's leftovers:
-     * the code is still there, and re-enabling the module is the fix, not deleting rows.
+     * Cron jobs of an installed but disabled module. Its config.xml is never merged,
+     * so they look like leftovers even though the code is there.
      *
      * @return array<string, string> job code => module name
      */
@@ -550,10 +537,9 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
-     * Delete the given core_config_data rows and every cron_schedule row belonging to
-     * the given job codes. Paths are passed in verbatim rather than rebuilt from the
-     * job codes: a LIKE prefix would treat an underscore in a code as a wildcard and
-     * take a neighbouring job's rows with it.
+     * Delete the given config rows and the schedule rows of the given job codes. Paths
+     * are passed in rather than built as a LIKE prefix, where an underscore in a job
+     * code would act as a wildcard.
      *
      * @param list<string> $jobCodes
      * @param list<string> $configPaths
@@ -1810,9 +1796,8 @@ class HealthCheck extends BaseMahoCommand
 
 
     /**
-     * Report cron declarations that survived the code they call, and offer to delete
-     * the rows behind them. Only the plain leftovers are purgeable: a stale attribute
-     * registry is fixed by recompiling, and a disabled module by re-enabling it.
+     * Only plain leftovers can be deleted: a stale registry needs recompiling, and a
+     * disabled module needs re-enabling.
      */
     private function checkOrphanedCronJobs(InputInterface $input, OutputInterface $output): void
     {
@@ -1842,8 +1827,8 @@ class HealthCheck extends BaseMahoCommand
                     $output->writeln('    core_config_data: ' . $path);
                 }
             }
-            $output->writeln('Schedules keep being generated for them and can never execute, and a pending row is');
-            $output->writeln('never cleaned up: they accumulate until the declaration is removed.');
+            $output->writeln('They are scheduled on every cron run and can never execute, and their pending');
+            $output->writeln('rows are never deleted, so they pile up until the declaration is removed.');
         }
 
         if ($findings['stale'] !== []) {

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -301,10 +301,10 @@ class HealthCheck extends BaseMahoCommand
      * They are scheduled on every cron run, never execute, and are never cleaned up.
      *
      * @return array{
-     *     orphans: list<array{job_code: string, reason: string, model: string, paths: list<string>, schedules: int}>,
+     *     orphans: list<array{job_code: string, reason: string, model: string, paths: list<string>, schedules: int, xml_declared: bool}>,
      *     stale: list<array{job_code: string, model: string, reason: string}>,
      *     disabled: list<array{job_code: string, module: string, paths: list<string>}>,
-     *     dead: list<array{job_code: string, schedules: int}>,
+     *     dead: list<array{job_code: string, schedules: int, paths: list<string>}>,
      * }
      */
     public static function findOrphanedCronJobs(): array
@@ -356,9 +356,11 @@ class HealthCheck extends BaseMahoCommand
 
         // The database rows arrive here: loadToXml() merges default-scope core_config_data
         // paths into the config tree under `default/`. Node precedence matches dispatch():
-        // the XML node wins only when it carries a non-empty <run>; otherwise dispatch()
-        // falls back to the whole `default/` node, so the health check must too.
+        // the `crontab/jobs` node wins when it carries a <run> node at all, even an empty
+        // one (dispatch() falls back to `default/` only when the node or its <run> is
+        // missing; an empty <run/> is used as-is and errors every schedule).
         $declared = [];
+        $xmlDeclared = [];
         foreach (['default/crontab/jobs', 'crontab/jobs'] as $path) {
             $node = $config->getNode($path);
             if (!$node instanceof \Maho\Simplexml\Element) {
@@ -369,11 +371,15 @@ class HealthCheck extends BaseMahoCommand
                 continue;
             }
             foreach ($jobs as $jobCode => $jobConfig) {
+                $jobCode = (string) $jobCode;
+                if ($path === 'crontab/jobs') {
+                    $xmlDeclared[$jobCode] = true;
+                }
                 if (is_array($jobConfig)) {
                     $configPath = $jobConfig['schedule']['config_path'] ?? '';
-                    self::claimCronConfigPath($claimed, is_scalar($configPath) ? (string) $configPath : '');
+                    self::claimCronConfigPath($claimed, is_scalar($configPath) ? (string) $configPath : '', $jobCode);
                 }
-                if (!isset($declared[$jobCode]) || (is_array($jobConfig) && !empty($jobConfig['run']))) {
+                if (!isset($declared[$jobCode]) || (is_array($jobConfig) && array_key_exists('run', $jobConfig))) {
                     $declared[$jobCode] = $jobConfig;
                 }
             }
@@ -421,6 +427,8 @@ class HealthCheck extends BaseMahoCommand
                 'model' => $model,
                 'paths' => $paths[$jobCode] ?? [],
                 'schedules' => $schedules[$jobCode] ?? 0,
+                // A `default/` node no default-scope row explains must come from module XML.
+                'xml_declared' => isset($xmlDeclared[$jobCode]) || !isset($declaringPaths[$jobCode]),
             ];
         }
 
@@ -439,7 +447,11 @@ class HealthCheck extends BaseMahoCommand
                 ];
                 continue;
             }
-            $findings['dead'][] = ['job_code' => $jobCode, 'schedules' => $count];
+            $findings['dead'][] = [
+                'job_code' => (string) $jobCode,
+                'schedules' => $count,
+                'paths' => $paths[$jobCode] ?? [],
+            ];
         }
 
         return $findings;
@@ -460,12 +472,16 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
+     * $ownJobCode keeps a job's self-referential config_path from hiding the job itself.
+     *
      * @param array<string, true> $claimed
      */
-    private static function claimCronConfigPath(array &$claimed, string $configPath): void
+    private static function claimCronConfigPath(array &$claimed, string $configPath, ?string $ownJobCode = null): void
     {
         $segments = explode('/', $configPath);
-        if (($segments[0] ?? '') === 'crontab' && ($segments[1] ?? '') === 'jobs' && ($segments[2] ?? '') !== '') {
+        if (($segments[0] ?? '') === 'crontab' && ($segments[1] ?? '') === 'jobs'
+            && ($segments[2] ?? '') !== '' && $segments[2] !== $ownJobCode
+        ) {
             $claimed[$segments[2]] = true;
         }
     }
@@ -484,7 +500,11 @@ class HealthCheck extends BaseMahoCommand
         if ($class === '' || !class_exists($class)) {
             return sprintf('model "%s" resolves to %s, which does not exist', $alias, $class === '' ? '(nothing)' : $class);
         }
-        if (!method_exists($class, $method)) {
+        $reflection = new \ReflectionClass($class);
+        if (!$reflection->isInstantiable()) {
+            return sprintf('model "%s" resolves to %s, which cannot be instantiated', $alias, $class);
+        }
+        if (!$reflection->hasMethod($method)) {
             return sprintf('%s::%s() does not exist', $class, $method);
         }
 
@@ -528,7 +548,7 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
-     * @return array<string, int> job code => number of cron_schedule rows
+     * @return array<int|string, int> job code => number of cron_schedule rows
      */
     private static function countCronSchedules(): array
     {
@@ -541,7 +561,7 @@ class HealthCheck extends BaseMahoCommand
 
         $counts = [];
         foreach ($adapter->fetchPairs($select) as $jobCode => $total) {
-            $counts[(string) $jobCode] = (int) $total;
+            $counts[$jobCode] = (int) $total;
         }
 
         return $counts;
@@ -891,10 +911,10 @@ class HealthCheck extends BaseMahoCommand
 
     /**
      * @param array{
-     *     orphans: list<array{job_code: string, reason: string, model: string, paths: list<string>, schedules: int}>,
+     *     orphans: list<array{job_code: string, reason: string, model: string, paths: list<string>, schedules: int, xml_declared: bool}>,
      *     stale: list<array{job_code: string, model: string, reason: string}>,
      *     disabled: list<array{job_code: string, module: string, paths: list<string>}>,
-     *     dead: list<array{job_code: string, schedules: int}>,
+     *     dead: list<array{job_code: string, schedules: int, paths: list<string>}>,
      * } $findings
      */
     private static function formatOrphanedCronSummary(array $findings): string
@@ -1908,23 +1928,27 @@ class HealthCheck extends BaseMahoCommand
             $output->writeln('<comment>Warning: cron_schedule rows for job codes nothing declares:</comment>');
             foreach ($findings['dead'] as $dead) {
                 $output->writeln(sprintf('- %s (%d row(s))', $dead['job_code'], $dead['schedules']));
+                foreach ($dead['paths'] as $path) {
+                    $output->writeln('    core_config_data: ' . $path);
+                }
             }
         }
 
-        // An orphan with no config rows is declared in a module's XML: deleting its
-        // schedule rows is futile, generate() recreates them on the next cron tick.
-        $purgeableOrphans = array_values(array_filter(
-            $findings['orphans'],
-            fn(array $orphan) => $orphan['paths'] !== [],
-        ));
-        $xmlOrphans = array_column(array_filter(
-            $findings['orphans'],
-            fn(array $orphan) => $orphan['paths'] === [],
-        ), 'job_code');
+        // Purging an XML-declared orphan is futile: the declaration survives in the
+        // module's config.xml and generate() recreates the schedule rows on the next tick.
+        $purgeableOrphans = [];
+        $xmlOrphans = [];
+        foreach ($findings['orphans'] as $orphan) {
+            if ($orphan['xml_declared']) {
+                $xmlOrphans[] = $orphan['job_code'];
+            } else {
+                $purgeableOrphans[] = $orphan;
+            }
+        }
         if ($xmlOrphans !== []) {
             $output->writeln('');
             $output->writeln(sprintf(
-                '<comment>%s: declared in a module\'s XML, so there are no database rows to delete;</comment>',
+                '<comment>%s: declared in a module\'s XML, so deleting database rows cannot remove them;</comment>',
                 implode(', ', $xmlOrphans),
             ));
             $output->writeln('<comment>remove the crontab declaration from the module\'s config.xml instead.</comment>');
@@ -1934,7 +1958,10 @@ class HealthCheck extends BaseMahoCommand
             array_column($purgeableOrphans, 'job_code'),
             array_column($findings['dead'], 'job_code'),
         );
-        $configPaths = array_merge(...array_column($purgeableOrphans, 'paths'));
+        $configPaths = array_merge(
+            ...array_column($purgeableOrphans, 'paths'),
+            ...array_column($findings['dead'], 'paths'),
+        );
         if ($purgeable === []) {
             $output->writeln('');
             return;

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -575,7 +575,7 @@ class HealthCheck extends BaseMahoCommand
         );
 
         if ($configRows > 0) {
-            Mage::app()->cleanCache([Mage_Core_Model_Config::CACHE_TAG]);
+            Mage::app()->cleanCache([\Mage_Core_Model_Config::CACHE_TAG]);
         }
 
         return [$configRows, $scheduleRows];

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -299,6 +299,289 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
+     * Cron declarations with no code left to run them, the leftovers of an uninstalled
+     * module. Legacy modules wrote their schedule into `core_config_data` under
+     * `crontab/jobs/<code>/…`, and those rows outlive the code: `generate()` schedules
+     * anything carrying a cron expression without looking for a `<run>` node, while
+     * `dispatch()` skips a job that has none. Nothing deletes a pending row, so every
+     * generate pass adds `cron_schedule` rows that can never execute and never expire.
+     *
+     * @return array{
+     *     orphans: list<array{job_code: string, reason: string, model: string, paths: list<string>, schedules: int}>,
+     *     stale: list<array{job_code: string, model: string, reason: string}>,
+     *     disabled: list<array{job_code: string, module: string, paths: list<string>}>,
+     *     dead: list<array{job_code: string, schedules: int}>,
+     * }
+     */
+    public static function findOrphanedCronJobs(): array
+    {
+        $config = Mage::getConfig();
+        $findings = ['orphans' => [], 'stale' => [], 'disabled' => [], 'dead' => []];
+
+        // Codes an attribute owns, plus every code some live declaration points its
+        // configurable schedule at: a config_path may name a job code other than its
+        // own, and the row the admin writes there must not read as a declaration.
+        $claimed = [];
+        foreach (\Maho::getCompiledAttributes()['crontab'] ?? [] as $jobCode => $jobDef) {
+            $jobCode = (string) $jobCode;
+            $claimed[$jobCode] = true;
+            self::claimCronConfigPath($claimed, (string) ($jobDef['config_path'] ?? ''));
+
+            // A module that is switched off has no models in the config tree, so its
+            // aliases cannot resolve: that says nothing about whether its code is still
+            // there. A module that is gone entirely is not declared at all, and is the
+            // case worth reporting.
+            $module = (string) ($jobDef['module'] ?? '');
+            if ($module !== ''
+                && $config->getNode('modules/' . $module) !== false
+                && !Mage::helper('core')->isModuleEnabled($module)
+            ) {
+                continue;
+            }
+
+            $alias = (string) ($jobDef['alias'] ?? '');
+            $method = (string) ($jobDef['method'] ?? '');
+            $reason = self::findMissingCronCallback($alias, $method);
+            if ($reason !== null) {
+                $findings['stale'][] = [
+                    'job_code' => $jobCode,
+                    'model' => $alias . '::' . $method,
+                    'reason' => $reason,
+                ];
+            }
+        }
+
+        // `default/crontab/jobs` carries the database rows: loadToXml() merges every
+        // core_config_data path into the config tree under `default/`.
+        $declared = [];
+        foreach (['crontab/jobs', 'default/crontab/jobs'] as $path) {
+            $node = $config->getNode($path);
+            if ($node instanceof \Maho\Simplexml\Element) {
+                $declared = array_replace_recursive($declared, $node->asArray());
+            }
+        }
+        foreach ($declared as $jobConfig) {
+            if (is_array($jobConfig)) {
+                self::claimCronConfigPath($claimed, (string) ($jobConfig['schedule']['config_path'] ?? ''));
+            }
+        }
+
+        $paths = self::findCronConfigPaths();
+        foreach (array_keys($paths) as $jobCode) {
+            $declared[$jobCode] ??= [];
+        }
+
+        $schedules = self::countCronSchedules();
+        $disabledModuleJobs = self::findDisabledModuleCronJobs();
+
+        foreach ($declared as $jobCode => $jobConfig) {
+            $jobCode = (string) $jobCode;
+            if (isset($claimed[$jobCode])) {
+                continue;
+            }
+
+            $model = is_array($jobConfig) ? trim((string) ($jobConfig['run']['model'] ?? '')) : '';
+            if ($model === '') {
+                $reason = 'declares no run/model and no #[Maho\Config\CronJob] registers it';
+            } else {
+                [$alias, $method] = array_pad(explode('::', $model, 2), 2, '');
+                $reason = self::findMissingCronCallback($alias, $method);
+            }
+            if ($reason === null) {
+                continue;
+            }
+
+            if (isset($disabledModuleJobs[$jobCode])) {
+                $findings['disabled'][] = [
+                    'job_code' => $jobCode,
+                    'module' => $disabledModuleJobs[$jobCode],
+                    'paths' => $paths[$jobCode] ?? [],
+                ];
+                continue;
+            }
+
+            $findings['orphans'][] = [
+                'job_code' => $jobCode,
+                'reason' => $reason,
+                'model' => $model,
+                'paths' => $paths[$jobCode] ?? [],
+                'schedules' => $schedules[$jobCode] ?? 0,
+            ];
+        }
+
+        foreach ($schedules as $jobCode => $count) {
+            if (!isset($claimed[$jobCode]) && !isset($declared[$jobCode])) {
+                $findings['dead'][] = ['job_code' => $jobCode, 'schedules' => $count];
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param array<string, true> $claimed
+     */
+    private static function claimCronConfigPath(array &$claimed, string $configPath): void
+    {
+        $segments = explode('/', $configPath);
+        if (($segments[0] ?? '') === 'crontab' && ($segments[1] ?? '') === 'jobs' && ($segments[2] ?? '') !== '') {
+            $claimed[$segments[2]] = true;
+        }
+    }
+
+    /**
+     * Why `alias::method` cannot be called, or null when it resolves. An unknown group
+     * makes getModelClassName() fabricate a class name rather than fail, so the
+     * class_exists() check is what actually catches a module that is gone.
+     */
+    private static function findMissingCronCallback(string $alias, string $method): ?string
+    {
+        if ($alias === '' || $method === '') {
+            return 'declares an incomplete callback';
+        }
+
+        $class = Mage::getConfig()->getModelClassName($alias);
+        if ($class === '' || !class_exists($class)) {
+            return sprintf('model "%s" resolves to %s, which does not exist', $alias, $class === '' ? '(nothing)' : $class);
+        }
+        if (!method_exists($class, $method)) {
+            return sprintf('%s::%s() does not exist', $class, $method);
+        }
+
+        return null;
+    }
+
+    /**
+     * Every core_config_data path under crontab/jobs, grouped by job code. The config
+     * tree alone cannot answer this: it merges scopes and drops the row identity we
+     * need to tell the user (and the purge) exactly what to delete.
+     *
+     * @return array<string, list<string>>
+     */
+    private static function findCronConfigPaths(): array
+    {
+        $resource = Mage::getSingleton('core/resource');
+        $adapter = $resource->getConnection('core_read');
+
+        $select = $adapter->select()
+            ->from($resource->getTableName('core/config_data'), ['path'])
+            ->where('path LIKE ?', 'crontab/jobs/%')
+            ->order('path');
+
+        $paths = [];
+        foreach ($adapter->fetchCol($select) as $path) {
+            $jobCode = explode('/', (string) $path)[2] ?? '';
+            if ($jobCode !== '' && !in_array($path, $paths[$jobCode] ?? [], true)) {
+                $paths[$jobCode][] = (string) $path;
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * @return array<string, int> job code => number of cron_schedule rows
+     */
+    private static function countCronSchedules(): array
+    {
+        $resource = Mage::getSingleton('core/resource');
+        $adapter = $resource->getConnection('core_read');
+
+        $select = $adapter->select()
+            ->from($resource->getTableName('cron/schedule'), ['job_code', 'total' => new \Maho\Db\Expr('COUNT(*)')])
+            ->group('job_code');
+
+        $counts = [];
+        foreach ($adapter->fetchPairs($select) as $jobCode => $total) {
+            $counts[(string) $jobCode] = (int) $total;
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Cron jobs declared by a module that is installed but switched off. Its config.xml
+     * is never merged, so its jobs look exactly like an uninstalled module's leftovers:
+     * the code is still there, and re-enabling the module is the fix, not deleting rows.
+     *
+     * @return array<string, string> job code => module name
+     */
+    private static function findDisabledModuleCronJobs(): array
+    {
+        $jobs = [];
+        $modules = Mage::getConfig()->getNode('modules');
+        if (!$modules instanceof \Maho\Simplexml\Element) {
+            return $jobs;
+        }
+
+        foreach ($modules->children() as $moduleName => $moduleNode) {
+            $active = strtolower(trim((string) $moduleNode->active));
+            if ($active !== '' && $active !== 'false' && $active !== 'off') {
+                continue;
+            }
+
+            $moduleName = (string) $moduleName;
+            $file = \Maho::findFile(Mage::getConfig()->getModuleDir('etc', $moduleName) . '/config.xml');
+            if ($file === false) {
+                continue;
+            }
+
+            libxml_use_internal_errors(true);
+            $xml = simplexml_load_file($file);
+            libxml_clear_errors();
+            if ($xml === false) {
+                continue;
+            }
+
+            foreach (['crontab', 'default'] as $root) {
+                $node = $root === 'crontab' ? ($xml->crontab->jobs ?? null) : ($xml->default->crontab->jobs ?? null);
+                if ($node === null) {
+                    continue;
+                }
+                foreach ($node->children() as $jobCode => $jobNode) {
+                    if (isset($jobNode->run)) {
+                        $jobs[(string) $jobCode] ??= $moduleName;
+                    }
+                }
+            }
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * Delete the given core_config_data rows and every cron_schedule row belonging to
+     * the given job codes. Paths are passed in verbatim rather than rebuilt from the
+     * job codes: a LIKE prefix would treat an underscore in a code as a wildcard and
+     * take a neighbouring job's rows with it.
+     *
+     * @param list<string> $jobCodes
+     * @param list<string> $configPaths
+     * @return array{0: int, 1: int} rows deleted from core_config_data and cron_schedule
+     */
+    public static function purgeOrphanedCronJobs(array $jobCodes, array $configPaths): array
+    {
+        $resource = Mage::getSingleton('core/resource');
+        $write = $resource->getConnection('core_write');
+
+        $configRows = $configPaths === [] ? 0 : $write->delete(
+            $resource->getTableName('core/config_data'),
+            ['path IN (?)' => $configPaths],
+        );
+
+        $scheduleRows = $jobCodes === [] ? 0 : $write->delete(
+            $resource->getTableName('cron/schedule'),
+            ['job_code IN (?)' => $jobCodes],
+        );
+
+        if ($configRows > 0) {
+            Mage::app()->cleanCache([Mage_Core_Model_Config::CACHE_TAG]);
+        }
+
+        return [$configRows, $scheduleRows];
+    }
+
+    /**
      * Validate the configured encryption key, returning the reason it is unusable
      * or null when it is a proper libsodium key. Magento/OpenMage stores carry an
      * mcrypt key (32 hex characters by default, but the installer took any key up
@@ -566,6 +849,55 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
+     * @param array{
+     *     orphans: list<array{job_code: string, reason: string, model: string, paths: list<string>, schedules: int}>,
+     *     stale: list<array{job_code: string, model: string, reason: string}>,
+     *     disabled: list<array{job_code: string, module: string, paths: list<string>}>,
+     *     dead: list<array{job_code: string, schedules: int}>,
+     * } $findings
+     */
+    private static function formatOrphanedCronSummary(array $findings): string
+    {
+        $parts = [];
+
+        if ($findings['orphans'] !== []) {
+            $parts[] = sprintf(
+                '%d job(s) declared with no code to run them (%s). They keep generating cron_schedule rows that '
+                . 'can never execute: run "./maho health-check" to review and delete their core_config_data rows.',
+                count($findings['orphans']),
+                implode(', ', array_column($findings['orphans'], 'job_code')),
+            );
+        }
+
+        if ($findings['stale'] !== []) {
+            $parts[] = sprintf(
+                '%d #[Maho\\Config\\CronJob] registration(s) point at code that no longer exists (%s). '
+                . 'Run "composer dump-autoload" to recompile the attribute registry.',
+                count($findings['stale']),
+                implode(', ', array_column($findings['stale'], 'job_code')),
+            );
+        }
+
+        if ($findings['disabled'] !== []) {
+            $parts[] = sprintf(
+                '%d job(s) still configured for a disabled module (%s). Re-enable the module or delete the config.',
+                count($findings['disabled']),
+                implode(', ', array_column($findings['disabled'], 'job_code')),
+            );
+        }
+
+        if ($findings['dead'] !== []) {
+            $parts[] = sprintf(
+                '%d job code(s) in cron_schedule with no declaration anywhere (%s).',
+                count($findings['dead']),
+                implode(', ', array_column($findings['dead'], 'job_code')),
+            );
+        }
+
+        return implode(' ', $parts);
+    }
+
+    /**
      * @return array<int, array{check: string, severity: string, details: string}>
      */
     public static function getCheckResults(): array
@@ -683,6 +1015,23 @@ class HealthCheck extends BaseMahoCommand
                 '#[Maho\\Config\\CronJob]',
             ),
         ];
+
+        try {
+            $orphanedCron = self::findOrphanedCronJobs();
+            $cronFindings = count($orphanedCron['orphans']) + count($orphanedCron['stale'])
+                + count($orphanedCron['disabled']) + count($orphanedCron['dead']);
+            $checks[] = [
+                'check' => 'Orphaned Cron Jobs',
+                'severity' => $cronFindings === 0 ? 'ok' : 'warning',
+                'details' => $cronFindings === 0 ? '' : self::formatOrphanedCronSummary($orphanedCron),
+            ];
+        } catch (\Exception) {
+            $checks[] = [
+                'check' => 'Orphaned Cron Jobs',
+                'severity' => 'error',
+                'details' => 'Unable to check cron job declarations.',
+            ];
+        }
 
         ['failure' => $failure, 'keyIssue' => $keyIssue, 'legacyOk' => $legacyOk] = self::encryptionVerdict();
         $checks[] = [
@@ -1254,6 +1603,7 @@ class HealthCheck extends BaseMahoCommand
 
         $this->checkOrphanedResources($input, $output, Mage::getResourceModel('admin/rules'), 'admin');
         $this->checkOrphanedResources($input, $output, Mage::getResourceModel('api/rules'), 'API');
+        $this->checkOrphanedCronJobs($input, $output);
 
         $this->checkZeroDates($output, (bool) $input->getOption('check-zero-dates'));
         $this->checkTableEngines($output);
@@ -1455,6 +1805,108 @@ class HealthCheck extends BaseMahoCommand
         $output->writeln('Bloat this size usually means rows were purged in bulk, or that a cleanup job is not');
         $output->writeln('running: check ./maho log:status and ./maho log:clean before rebuilding.');
         $output->writeln('Run: ./maho db:optimize (during a maintenance window)');
+        $output->writeln('');
+    }
+
+
+    /**
+     * Report cron declarations that survived the code they call, and offer to delete
+     * the rows behind them. Only the plain leftovers are purgeable: a stale attribute
+     * registry is fixed by recompiling, and a disabled module by re-enabling it.
+     */
+    private function checkOrphanedCronJobs(InputInterface $input, OutputInterface $output): void
+    {
+        $output->write('Checking cron job declarations... ');
+
+        $findings = self::findOrphanedCronJobs();
+        if (array_filter($findings) === []) {
+            $output->writeln('<info>OK</info>');
+            return;
+        }
+
+        $output->writeln('');
+
+        if ($findings['orphans'] !== []) {
+            $output->writeln(sprintf(
+                '<comment>Warning: Found %d cron job(s) with no code left to run them:</comment>',
+                count($findings['orphans']),
+            ));
+            foreach ($findings['orphans'] as $orphan) {
+                $output->writeln(sprintf(
+                    '- %s: %s%s',
+                    $orphan['job_code'],
+                    $orphan['reason'],
+                    $orphan['schedules'] === 0 ? '' : sprintf(' (%d cron_schedule row(s))', $orphan['schedules']),
+                ));
+                foreach ($orphan['paths'] as $path) {
+                    $output->writeln('    core_config_data: ' . $path);
+                }
+            }
+            $output->writeln('Schedules keep being generated for them and can never execute, and a pending row is');
+            $output->writeln('never cleaned up: they accumulate until the declaration is removed.');
+        }
+
+        if ($findings['stale'] !== []) {
+            $output->writeln('');
+            $output->writeln('<comment>Warning: Attribute-registered cron jobs pointing at missing code:</comment>');
+            foreach ($findings['stale'] as $stale) {
+                $output->writeln(sprintf('- %s (%s): %s', $stale['job_code'], $stale['model'], $stale['reason']));
+            }
+            $output->writeln('The compiled registry is out of date. Run: composer dump-autoload');
+        }
+
+        if ($findings['disabled'] !== []) {
+            $output->writeln('');
+            $output->writeln('<comment>Warning: Cron config left over from disabled modules:</comment>');
+            foreach ($findings['disabled'] as $disabled) {
+                $output->writeln(sprintf('- %s (module %s is disabled)', $disabled['job_code'], $disabled['module']));
+                foreach ($disabled['paths'] as $path) {
+                    $output->writeln('    core_config_data: ' . $path);
+                }
+            }
+            $output->writeln('Re-enable the module, or remove its configuration.');
+        }
+
+        if ($findings['dead'] !== []) {
+            $output->writeln('');
+            $output->writeln('<comment>Warning: cron_schedule rows for job codes nothing declares:</comment>');
+            foreach ($findings['dead'] as $dead) {
+                $output->writeln(sprintf('- %s (%d row(s))', $dead['job_code'], $dead['schedules']));
+            }
+        }
+
+        $purgeable = array_merge(
+            array_column($findings['orphans'], 'job_code'),
+            array_column($findings['dead'], 'job_code'),
+        );
+        $configPaths = [];
+        foreach ($findings['orphans'] as $orphan) {
+            $configPaths = array_merge($configPaths, $orphan['paths']);
+        }
+        if ($purgeable === []) {
+            $output->writeln('');
+            return;
+        }
+
+        $output->writeln('');
+
+        /** @var \Symfony\Component\Console\Helper\QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion(
+            sprintf(
+                '<question>Delete the configuration and schedule rows of %s? [y/N]</question> ',
+                implode(', ', $purgeable),
+            ),
+            false,
+        );
+        if ($helper->ask($input, $output, $question)) {
+            [$configRows, $scheduleRows] = self::purgeOrphanedCronJobs($purgeable, $configPaths);
+            $output->writeln(sprintf(
+                '<info>Deleted %d core_config_data row(s) and %d cron_schedule row(s).</info>',
+                $configRows,
+                $scheduleRows,
+            ));
+        }
         $output->writeln('');
     }
 

--- a/tests/Backend/Unit/MahoCLI/Commands/HealthCheckCronTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/HealthCheckCronTest.php
@@ -154,6 +154,57 @@ it('lets a valid XML run/model win over a stale database override, as dispatch()
     );
 });
 
+it('falls back to the database run/model when the XML run node is empty, as dispatch() does', function () {
+    $jobCode = 'healthcheck_emptyrun_' . uniqid();
+
+    healthCheckWithCronConfig(
+        ["crontab/jobs/{$jobCode}/run/model" => 'core/observer::cleanCache'],
+        function () use ($jobCode) {
+            // dispatch() treats a falsy XML <run/> as absent and uses the default/ node.
+            Mage::getConfig()->setNode("crontab/jobs/{$jobCode}/run", '');
+
+            expect(healthCheckCronCodes(HealthCheck::findOrphanedCronJobs()['orphans']))->not->toContain($jobCode);
+        },
+    );
+});
+
+it('ignores store-scoped config rows the scheduler never reads', function () {
+    $jobCode = 'healthcheck_storescope_' . uniqid();
+    $path = "crontab/jobs/{$jobCode}/schedule/cron_expr";
+
+    $resource = Mage::getSingleton('core/resource');
+    $write = $resource->getConnection('core_write');
+    $table = $resource->getTableName('core/config_data');
+    $write->insert($table, ['scope' => 'stores', 'scope_id' => 0, 'path' => $path, 'value' => '*/5 * * * *']);
+
+    try {
+        $findings = HealthCheck::findOrphanedCronJobs();
+
+        expect(healthCheckCronCodes($findings['orphans']))->not->toContain($jobCode)
+            ->and(healthCheckCronCodes($findings['dead']))->not->toContain($jobCode);
+    } finally {
+        $write->delete($table, ['path = ?' => $path]);
+    }
+});
+
+it('does not flag a nested run/model left by junk config rows', function () {
+    $jobCode = 'healthcheck_nested_' . uniqid();
+
+    healthCheckWithCronConfig(
+        [
+            "crontab/jobs/{$jobCode}/schedule/cron_expr" => '*/5 * * * *',
+            "crontab/jobs/{$jobCode}/run/model/junk" => 'whatever',
+        ],
+        function () use ($jobCode) {
+            $orphans = HealthCheck::findOrphanedCronJobs()['orphans'];
+            $orphan = current(array_filter($orphans, fn(array $o) => $o['job_code'] === $jobCode));
+
+            expect($orphan)->not->toBeFalse()
+                ->and($orphan['reason'])->toContain('no run/model');
+        },
+    );
+});
+
 it('leaves a database schedule override of an attribute-registered job alone', function () {
     healthCheckWithCronConfig(
         ['crontab/jobs/sitemap_generate/schedule/cron_expr' => '0 3 * * *'],

--- a/tests/Backend/Unit/MahoCLI/Commands/HealthCheckCronTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/HealthCheckCronTest.php
@@ -25,40 +25,38 @@ uses(Tests\MahoBackendTestCase::class);
  */
 function healthCheckWithCronConfig(array $rows, callable $assert): void
 {
+    $config = Mage::getConfig();
     $resource = Mage::getSingleton('core/resource');
-    $write = $resource->getConnection('core_write');
+    $read = $resource->getConnection('core_read');
     $table = $resource->getTableName('core/config_data');
 
     $previous = [];
     foreach ($rows as $path => $value) {
-        $existing = $write->fetchRow(
-            $write->select()
-                ->from($table, ['config_id', 'value'])
+        $existing = $read->fetchRow(
+            $read->select()
+                ->from($table, ['value'])
                 ->where('scope = ?', 'default')
                 ->where('scope_id = ?', 0)
                 ->where('path = ?', $path),
         );
-
         if ($existing) {
             $previous[$path] = (string) $existing['value'];
-            $write->update($table, ['value' => $value], ['config_id = ?' => (int) $existing['config_id']]);
-        } else {
-            $write->insert($table, ['scope' => 'default', 'scope_id' => 0, 'path' => $path, 'value' => $value]);
         }
+        $config->saveConfig($path, $value);
     }
-    Mage::getConfig()->reinit();
+    $config->reinit();
 
     try {
         $assert();
     } finally {
-        foreach ($rows as $path => $value) {
+        foreach (array_keys($rows) as $path) {
             if (isset($previous[$path])) {
-                $write->update($table, ['value' => $previous[$path]], ['scope = ?' => 'default', 'scope_id = ?' => 0, 'path = ?' => $path]);
+                $config->saveConfig($path, $previous[$path]);
             } else {
-                $write->delete($table, ['scope = ?' => 'default', 'scope_id = ?' => 0, 'path = ?' => $path]);
+                $config->deleteConfig($path);
             }
         }
-        Mage::getConfig()->reinit();
+        $config->reinit();
     }
 }
 
@@ -76,7 +74,7 @@ function healthCheckCronSchedule(string $jobCode): Mage_Cron_Model_Schedule
 }
 
 /**
- * @param list<array{job_code: string}> $findings
+ * @param list<array{job_code: string, ...}> $findings
  * @return list<string>
  */
 function healthCheckCronCodes(array $findings): array
@@ -123,6 +121,35 @@ it('flags a job whose run/model points at a class that no longer exists', functi
             expect($orphan)->not->toBeFalse()
                 ->and($orphan['reason'])->toContain('does not exist')
                 ->and($orphan['model'])->toBe('nosuchmodule/observer::run');
+        },
+    );
+});
+
+it('flags a run/model the scheduler rejects even when the class exists', function () {
+    $jobCode = 'healthcheck_orphan_' . uniqid();
+
+    healthCheckWithCronConfig(
+        // A bare class name resolves via class_exists but fails REGEX_RUN_MODEL at dispatch.
+        ["crontab/jobs/{$jobCode}/run/model" => 'Mage_Log_Model_Log::clean'],
+        function () use ($jobCode) {
+            $orphans = HealthCheck::findOrphanedCronJobs()['orphans'];
+            $orphan = current(array_filter($orphans, fn(array $o) => $o['job_code'] === $jobCode));
+
+            expect($orphan)->not->toBeFalse()
+                ->and($orphan['reason'])->toContain('model/class::method');
+        },
+    );
+});
+
+it('lets a valid XML run/model win over a stale database override, as dispatch() does', function () {
+    $jobCode = 'healthcheck_precedence_' . uniqid();
+
+    healthCheckWithCronConfig(
+        ["crontab/jobs/{$jobCode}/run/model" => 'nosuchmodule/observer::run'],
+        function () use ($jobCode) {
+            Mage::getConfig()->setNode("crontab/jobs/{$jobCode}/run/model", 'core/observer::cleanCache');
+
+            expect(healthCheckCronCodes(HealthCheck::findOrphanedCronJobs()['orphans']))->not->toContain($jobCode);
         },
     );
 });
@@ -175,26 +202,26 @@ it('flags schedule rows for a job code nothing declares', function () {
 it('purges the config and schedule rows of an orphaned job', function () {
     $jobCode = 'healthcheck_orphan_' . uniqid();
     $path = "crontab/jobs/{$jobCode}/schedule/cron_expr";
+    $schedule = healthCheckCronSchedule($jobCode);
 
-    $resource = Mage::getSingleton('core/resource');
-    $write = $resource->getConnection('core_write');
-    $write->insert($resource->getTableName('core/config_data'), [
-        'scope' => 'default',
-        'scope_id' => 0,
-        'path' => $path,
-        'value' => '*/5 * * * *',
-    ]);
-    healthCheckCronSchedule($jobCode);
-    Mage::getConfig()->reinit();
+    try {
+        healthCheckWithCronConfig(
+            [$path => '*/5 * * * *'],
+            function () use ($jobCode, $path) {
+                expect(healthCheckCronCodes(HealthCheck::findOrphanedCronJobs()['orphans']))->toContain($jobCode);
 
-    expect(healthCheckCronCodes(HealthCheck::findOrphanedCronJobs()['orphans']))->toContain($jobCode);
+                [$configRows, $scheduleRows] = HealthCheck::purgeOrphanedCronJobs([$jobCode], [$path]);
+                Mage::getConfig()->reinit();
 
-    [$configRows, $scheduleRows] = HealthCheck::purgeOrphanedCronJobs([$jobCode], [$path]);
-    Mage::getConfig()->reinit();
-
-    expect($configRows)->toBe(1)
-        ->and($scheduleRows)->toBe(1)
-        ->and(healthCheckCronCodes(HealthCheck::findOrphanedCronJobs()['orphans']))->not->toContain($jobCode);
+                expect($configRows)->toBe(1)
+                    ->and($scheduleRows)->toBe(1)
+                    ->and(healthCheckCronCodes(HealthCheck::findOrphanedCronJobs()['orphans']))->not->toContain($jobCode);
+            },
+        );
+    } finally {
+        // A no-op after a successful purge; cleans up when an assertion failed first.
+        $schedule->delete();
+    }
 });
 
 it('purges only the paths it is given, never a neighbouring job code', function () {
@@ -202,31 +229,24 @@ it('purges only the paths it is given, never a neighbouring job code', function 
     $target = "healthcheck_orphan_{$suffix}";
     // Differs from $target only at the underscores a LIKE purge treats as wildcards.
     $neighbour = "healthcheckXorphanX{$suffix}";
+    $paths = [
+        $target => "crontab/jobs/{$target}/schedule/cron_expr",
+        $neighbour => "crontab/jobs/{$neighbour}/schedule/cron_expr",
+    ];
 
-    $resource = Mage::getSingleton('core/resource');
-    $write = $resource->getConnection('core_write');
-    $table = $resource->getTableName('core/config_data');
+    healthCheckWithCronConfig(
+        array_fill_keys(array_values($paths), '*/5 * * * *'),
+        function () use ($target, $neighbour, $paths) {
+            HealthCheck::purgeOrphanedCronJobs([$target], [$paths[$target]]);
 
-    $paths = [];
-    foreach ([$target, $neighbour] as $jobCode) {
-        $paths[$jobCode] = "crontab/jobs/{$jobCode}/schedule/cron_expr";
-        $write->insert($table, [
-            'scope' => 'default',
-            'scope_id' => 0,
-            'path' => $paths[$jobCode],
-            'value' => '*/5 * * * *',
-        ]);
-    }
-
-    try {
-        HealthCheck::purgeOrphanedCronJobs([$target], [$paths[$target]]);
-
-        $surviving = $write->fetchCol(
-            $write->select()->from($table, ['path'])->where('path IN (?)', array_values($paths)),
-        );
-        expect($surviving)->toBe([$paths[$neighbour]]);
-    } finally {
-        $write->delete($table, ['path IN (?)' => array_values($paths)]);
-        Mage::getConfig()->reinit();
-    }
+            $resource = Mage::getSingleton('core/resource');
+            $read = $resource->getConnection('core_read');
+            $surviving = $read->fetchCol(
+                $read->select()
+                    ->from($resource->getTableName('core/config_data'), ['path'])
+                    ->where('path IN (?)', array_values($paths)),
+            );
+            expect($surviving)->toBe([$paths[$neighbour]]);
+        },
+    );
 });

--- a/tests/Backend/Unit/MahoCLI/Commands/HealthCheckCronTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/HealthCheckCronTest.php
@@ -299,7 +299,7 @@ it('lists the config rows of a dead job so the purge can delete them', function 
     $write->insert($table, ['scope' => 'stores', 'scope_id' => 0, 'path' => $path, 'value' => '*/5 * * * *']);
 
     try {
-        $dead = HealthCheck::findOrphanedCronJobs()['wdead'];
+        $dead = HealthCheck::findOrphanedCronJobs()['dead'];
         $entry = current(array_filter($dead, fn(array $d) => $d['job_code'] === $jobCode));
 
         expect($entry)->not->toBeFalse()

--- a/tests/Backend/Unit/MahoCLI/Commands/HealthCheckCronTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/HealthCheckCronTest.php
@@ -13,17 +13,13 @@ use MahoCLI\Commands\HealthCheck;
 uses(Tests\MahoBackendTestCase::class);
 
 /**
- * Coverage for the health check that finds cron declarations outliving their code.
- * Uninstalling a module leaves its crontab/jobs rows in core_config_data, and the
- * scheduler keeps generating cron_schedule rows for them: generate() only reads the
- * schedule expression, dispatch() skips a job with no run/model, and nothing ever
- * deletes a pending row.
+ * Coverage for the health check that finds cron jobs left declared after the module
+ * that ran them was uninstalled.
  */
 
 /**
- * Run $assert with $rows (path => value) present in core_config_data at default scope,
- * restoring whatever was there before. (scope, scope_id, path) is unique, so a path the
- * install already configures must be updated rather than inserted into.
+ * Run $assert with $rows (path => value) in core_config_data, then put the table back.
+ * (scope, scope_id, path) is unique, so an existing path is updated, not inserted.
  *
  * @param array<string, string> $rows
  */
@@ -204,8 +200,7 @@ it('purges the config and schedule rows of an orphaned job', function () {
 it('purges only the paths it is given, never a neighbouring job code', function () {
     $suffix = uniqid();
     $target = "healthcheck_orphan_{$suffix}";
-    // Differs from $target only where it has an underscore: a LIKE-based purge would
-    // treat that underscore as a wildcard and delete this job's rows too.
+    // Differs from $target only at the underscores a LIKE purge treats as wildcards.
     $neighbour = "healthcheckXorphanX{$suffix}";
 
     $resource = Mage::getSingleton('core/resource');

--- a/tests/Backend/Unit/MahoCLI/Commands/HealthCheckCronTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/HealthCheckCronTest.php
@@ -1,0 +1,237 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package MahoCLI
+ */
+
+declare(strict_types=1);
+
+use MahoCLI\Commands\HealthCheck;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Coverage for the health check that finds cron declarations outliving their code.
+ * Uninstalling a module leaves its crontab/jobs rows in core_config_data, and the
+ * scheduler keeps generating cron_schedule rows for them: generate() only reads the
+ * schedule expression, dispatch() skips a job with no run/model, and nothing ever
+ * deletes a pending row.
+ */
+
+/**
+ * Run $assert with $rows (path => value) present in core_config_data at default scope,
+ * restoring whatever was there before. (scope, scope_id, path) is unique, so a path the
+ * install already configures must be updated rather than inserted into.
+ *
+ * @param array<string, string> $rows
+ */
+function healthCheckWithCronConfig(array $rows, callable $assert): void
+{
+    $resource = Mage::getSingleton('core/resource');
+    $write = $resource->getConnection('core_write');
+    $table = $resource->getTableName('core/config_data');
+
+    $previous = [];
+    foreach ($rows as $path => $value) {
+        $existing = $write->fetchRow(
+            $write->select()
+                ->from($table, ['config_id', 'value'])
+                ->where('scope = ?', 'default')
+                ->where('scope_id = ?', 0)
+                ->where('path = ?', $path),
+        );
+
+        if ($existing) {
+            $previous[$path] = (string) $existing['value'];
+            $write->update($table, ['value' => $value], ['config_id = ?' => (int) $existing['config_id']]);
+        } else {
+            $write->insert($table, ['scope' => 'default', 'scope_id' => 0, 'path' => $path, 'value' => $value]);
+        }
+    }
+    Mage::getConfig()->reinit();
+
+    try {
+        $assert();
+    } finally {
+        foreach ($rows as $path => $value) {
+            if (isset($previous[$path])) {
+                $write->update($table, ['value' => $previous[$path]], ['scope = ?' => 'default', 'scope_id = ?' => 0, 'path = ?' => $path]);
+            } else {
+                $write->delete($table, ['scope = ?' => 'default', 'scope_id = ?' => 0, 'path = ?' => $path]);
+            }
+        }
+        Mage::getConfig()->reinit();
+    }
+}
+
+function healthCheckCronSchedule(string $jobCode): Mage_Cron_Model_Schedule
+{
+    /** @var Mage_Cron_Model_Schedule $schedule */
+    $schedule = Mage::getModel('cron/schedule');
+    $schedule->setJobCode($jobCode)
+        ->setStatus(Mage_Cron_Model_Schedule::STATUS_PENDING)
+        ->setCreatedAt(Mage::app()->getLocale()->formatDateForDb('now'))
+        ->setScheduledAt(Mage::app()->getLocale()->formatDateForDb('now'))
+        ->save();
+
+    return $schedule;
+}
+
+/**
+ * @param list<array{job_code: string}> $findings
+ * @return list<string>
+ */
+function healthCheckCronCodes(array $findings): array
+{
+    return array_column($findings, 'job_code');
+}
+
+it('reports no orphaned or stale cron jobs on a healthy install', function () {
+    $findings = HealthCheck::findOrphanedCronJobs();
+
+    expect($findings['orphans'])->toBe([])
+        ->and($findings['stale'])->toBe([]);
+});
+
+it('flags a database-declared job with no code behind it', function () {
+    $jobCode = 'healthcheck_orphan_' . uniqid();
+
+    healthCheckWithCronConfig(
+        ["crontab/jobs/{$jobCode}/schedule/cron_expr" => '*/5 * * * *'],
+        function () use ($jobCode) {
+            $findings = HealthCheck::findOrphanedCronJobs();
+
+            expect(healthCheckCronCodes($findings['orphans']))->toContain($jobCode);
+
+            $orphan = current(array_filter($findings['orphans'], fn(array $o) => $o['job_code'] === $jobCode));
+            expect($orphan['reason'])->toContain('no run/model')
+                ->and($orphan['paths'])->toBe(["crontab/jobs/{$jobCode}/schedule/cron_expr"]);
+        },
+    );
+});
+
+it('flags a job whose run/model points at a class that no longer exists', function () {
+    $jobCode = 'healthcheck_orphan_' . uniqid();
+
+    healthCheckWithCronConfig(
+        [
+            "crontab/jobs/{$jobCode}/schedule/cron_expr" => '*/5 * * * *',
+            "crontab/jobs/{$jobCode}/run/model" => 'nosuchmodule/observer::run',
+        ],
+        function () use ($jobCode) {
+            $orphans = HealthCheck::findOrphanedCronJobs()['orphans'];
+            $orphan = current(array_filter($orphans, fn(array $o) => $o['job_code'] === $jobCode));
+
+            expect($orphan)->not->toBeFalse()
+                ->and($orphan['reason'])->toContain('does not exist')
+                ->and($orphan['model'])->toBe('nosuchmodule/observer::run');
+        },
+    );
+});
+
+it('leaves a database schedule override of an attribute-registered job alone', function () {
+    healthCheckWithCronConfig(
+        ['crontab/jobs/sitemap_generate/schedule/cron_expr' => '0 3 * * *'],
+        function () {
+            $findings = HealthCheck::findOrphanedCronJobs();
+
+            expect(healthCheckCronCodes($findings['orphans']))->not->toContain('sitemap_generate')
+                ->and(healthCheckCronCodes($findings['disabled']))->not->toContain('sitemap_generate');
+        },
+    );
+});
+
+it('counts the schedule rows an orphaned job keeps generating', function () {
+    $jobCode = 'healthcheck_orphan_' . uniqid();
+    $schedule = healthCheckCronSchedule($jobCode);
+
+    try {
+        healthCheckWithCronConfig(
+            ["crontab/jobs/{$jobCode}/schedule/cron_expr" => '*/5 * * * *'],
+            function () use ($jobCode) {
+                $orphans = HealthCheck::findOrphanedCronJobs()['orphans'];
+                $orphan = current(array_filter($orphans, fn(array $o) => $o['job_code'] === $jobCode));
+
+                expect($orphan['schedules'])->toBe(1);
+            },
+        );
+    } finally {
+        $schedule->delete();
+    }
+});
+
+it('flags schedule rows for a job code nothing declares', function () {
+    $jobCode = 'healthcheck_dead_' . uniqid();
+    $schedule = healthCheckCronSchedule($jobCode);
+
+    try {
+        $findings = HealthCheck::findOrphanedCronJobs();
+
+        expect(healthCheckCronCodes($findings['dead']))->toContain($jobCode)
+            ->and(healthCheckCronCodes($findings['orphans']))->not->toContain($jobCode);
+    } finally {
+        $schedule->delete();
+    }
+});
+
+it('purges the config and schedule rows of an orphaned job', function () {
+    $jobCode = 'healthcheck_orphan_' . uniqid();
+    $path = "crontab/jobs/{$jobCode}/schedule/cron_expr";
+
+    $resource = Mage::getSingleton('core/resource');
+    $write = $resource->getConnection('core_write');
+    $write->insert($resource->getTableName('core/config_data'), [
+        'scope' => 'default',
+        'scope_id' => 0,
+        'path' => $path,
+        'value' => '*/5 * * * *',
+    ]);
+    healthCheckCronSchedule($jobCode);
+    Mage::getConfig()->reinit();
+
+    expect(healthCheckCronCodes(HealthCheck::findOrphanedCronJobs()['orphans']))->toContain($jobCode);
+
+    [$configRows, $scheduleRows] = HealthCheck::purgeOrphanedCronJobs([$jobCode], [$path]);
+    Mage::getConfig()->reinit();
+
+    expect($configRows)->toBe(1)
+        ->and($scheduleRows)->toBe(1)
+        ->and(healthCheckCronCodes(HealthCheck::findOrphanedCronJobs()['orphans']))->not->toContain($jobCode);
+});
+
+it('purges only the paths it is given, never a neighbouring job code', function () {
+    $suffix = uniqid();
+    $target = "healthcheck_orphan_{$suffix}";
+    // Differs from $target only where it has an underscore: a LIKE-based purge would
+    // treat that underscore as a wildcard and delete this job's rows too.
+    $neighbour = "healthcheckXorphanX{$suffix}";
+
+    $resource = Mage::getSingleton('core/resource');
+    $write = $resource->getConnection('core_write');
+    $table = $resource->getTableName('core/config_data');
+
+    $paths = [];
+    foreach ([$target, $neighbour] as $jobCode) {
+        $paths[$jobCode] = "crontab/jobs/{$jobCode}/schedule/cron_expr";
+        $write->insert($table, [
+            'scope' => 'default',
+            'scope_id' => 0,
+            'path' => $paths[$jobCode],
+            'value' => '*/5 * * * *',
+        ]);
+    }
+
+    try {
+        HealthCheck::purgeOrphanedCronJobs([$target], [$paths[$target]]);
+
+        $surviving = $write->fetchCol(
+            $write->select()->from($table, ['path'])->where('path IN (?)', array_values($paths)),
+        );
+        expect($surviving)->toBe([$paths[$neighbour]]);
+    } finally {
+        $write->delete($table, ['path IN (?)' => array_values($paths)]);
+        Mage::getConfig()->reinit();
+    }
+});

--- a/tests/Backend/Unit/MahoCLI/Commands/HealthCheckCronTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/HealthCheckCronTest.php
@@ -101,7 +101,8 @@ it('flags a database-declared job with no code behind it', function () {
 
             $orphan = current(array_filter($findings['orphans'], fn(array $o) => $o['job_code'] === $jobCode));
             expect($orphan['reason'])->toContain('no run/model')
-                ->and($orphan['paths'])->toBe(["crontab/jobs/{$jobCode}/schedule/cron_expr"]);
+                ->and($orphan['paths'])->toBe(["crontab/jobs/{$jobCode}/schedule/cron_expr"])
+                ->and($orphan['xml_declared'])->toBeFalse();
         },
     );
 });
@@ -154,16 +155,51 @@ it('lets a valid XML run/model win over a stale database override, as dispatch()
     );
 });
 
-it('falls back to the database run/model when the XML run node is empty, as dispatch() does', function () {
+it('flags a job whose XML run node is empty even when a database run/model exists', function () {
     $jobCode = 'healthcheck_emptyrun_' . uniqid();
 
     healthCheckWithCronConfig(
         ["crontab/jobs/{$jobCode}/run/model" => 'core/observer::cleanCache'],
         function () use ($jobCode) {
-            // dispatch() treats a falsy XML <run/> as absent and uses the default/ node.
+            // An existing <run/> is truthy as a SimpleXML element, so dispatch() never
+            // falls back to default/ and errors every schedule with "No callbacks found".
             Mage::getConfig()->setNode("crontab/jobs/{$jobCode}/run", '');
 
-            expect(healthCheckCronCodes(HealthCheck::findOrphanedCronJobs()['orphans']))->not->toContain($jobCode);
+            $orphans = HealthCheck::findOrphanedCronJobs()['orphans'];
+            $orphan = current(array_filter($orphans, fn(array $o) => $o['job_code'] === $jobCode));
+
+            expect($orphan)->not->toBeFalse()
+                ->and($orphan['reason'])->toContain('no run/model')
+                ->and($orphan['xml_declared'])->toBeTrue();
+        },
+    );
+});
+
+it('reports an orphan even when its own config_path points back at itself', function () {
+    $jobCode = 'healthcheck_selfclaim_' . uniqid();
+
+    healthCheckWithCronConfig(
+        [
+            "crontab/jobs/{$jobCode}/run/model" => 'nosuchmodule/observer::run',
+            "crontab/jobs/{$jobCode}/schedule/config_path" => "crontab/jobs/{$jobCode}/schedule/cron_expr",
+        ],
+        function () use ($jobCode) {
+            expect(healthCheckCronCodes(HealthCheck::findOrphanedCronJobs()['orphans']))->toContain($jobCode);
+        },
+    );
+});
+
+it('flags a run/model resolving to a class that cannot be instantiated', function () {
+    $jobCode = 'healthcheck_abstract_' . uniqid();
+
+    healthCheckWithCronConfig(
+        ["crontab/jobs/{$jobCode}/run/model" => 'core/abstract::save'],
+        function () use ($jobCode) {
+            $orphans = HealthCheck::findOrphanedCronJobs()['orphans'];
+            $orphan = current(array_filter($orphans, fn(array $o) => $o['job_code'] === $jobCode));
+
+            expect($orphan)->not->toBeFalse()
+                ->and($orphan['reason'])->toContain('cannot be instantiated');
         },
     );
 });
@@ -246,6 +282,30 @@ it('flags schedule rows for a job code nothing declares', function () {
         expect(healthCheckCronCodes($findings['dead']))->toContain($jobCode)
             ->and(healthCheckCronCodes($findings['orphans']))->not->toContain($jobCode);
     } finally {
+        $schedule->delete();
+    }
+});
+
+it('lists the config rows of a dead job so the purge can delete them', function () {
+    $jobCode = 'healthcheck_dead_' . uniqid();
+    $path = "crontab/jobs/{$jobCode}/schedule/cron_expr";
+    $schedule = healthCheckCronSchedule($jobCode);
+
+    // A store-scoped row never counts as a declaration, so the job stays dead,
+    // but the row itself must still be offered for deletion.
+    $resource = Mage::getSingleton('core/resource');
+    $write = $resource->getConnection('core_write');
+    $table = $resource->getTableName('core/config_data');
+    $write->insert($table, ['scope' => 'stores', 'scope_id' => 0, 'path' => $path, 'value' => '*/5 * * * *']);
+
+    try {
+        $dead = HealthCheck::findOrphanedCronJobs()['wdead'];
+        $entry = current(array_filter($dead, fn(array $d) => $d['job_code'] === $jobCode));
+
+        expect($entry)->not->toBeFalse()
+            ->and($entry['paths'])->toBe([$path]);
+    } finally {
+        $write->delete($table, ['path = ?' => $path]);
         $schedule->delete();
     }
 });


### PR DESCRIPTION
Closes #1315.

Uninstalling a module removes its code but not its cron configuration. A legacy module wrote its schedule into `core_config_data` under `crontab/jobs/<code>/`, and `loadToXml()` merges those rows into the config tree as `default/crontab/jobs`, so the scheduler keeps seeing the job: `generate()` schedules anything carrying a cron expression without looking for a `run/model`, while `dispatch()` skips a job whose node has no `<run>`.

The issue understates the effect: those rows never expire. `missed` is only assigned inside `_executeScheduledJob()`, which an orphan never reaches, and `cleanup()` only deletes success/missed/error rows, so the pending rows accumulate permanently and inflate the pending count.

`health-check` now cross-references every declaration (attribute registry, XML, database) against the code that would run it and reports four cases:

- jobs whose `run/model` is missing, fails the scheduler's `REGEX_RUN_MODEL`, or points at code that no longer exists, with no `#[Maho\Config\CronJob]` claiming the code
- attribute registrations pointing at code that no longer exists (stale compiled registry)
- leftovers belonging to a module that is only *disabled*, whether declared in XML, database rows, or attributes, where re-enabling it is the fix rather than deleting rows
- `cron_schedule` rows for job codes nothing declares

It offers to delete the config and schedule rows of the first and last. The results also surface on the admin health check page, which picks up `getCheckResults()` automatically.

Two things the detection is careful about: XML and database declarations are merged with the same precedence `dispatch()` resolves them with (XML wins over `default/`), and a database row that merely overrides the schedule of a real job is not a declaration (job codes named by any live `config_path` are claimed, not just a job's own id). Deletion works off the exact `core_config_data` paths rather than a `LIKE` prefix, so an underscore in a job code cannot take a neighbouring job's rows with it.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->
