### PR TITLE
Added table and column rename support to the declarative schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,22 @@ and add a new `upgrade-X.Y.Z-A.B.C.php` (or `maho-X.Y.Z.php`) script. Fresh inst
 install plus every upgrade in sequence, so the new script repairs both fresh and existing
 installs. This applies even to "obvious cleanups" (e.g. adding a missing explicit `default`).
 
+**Renames** are invisible to a structural diff, so declare them in `sql/schema.php` on the
+table the rename produced. Rename the object as usual, then record what it used to be called:
+
+```php
+$t = $schema->createTable('sales_flat_order');
+Renamer::renamed($t, from: 'sales_order', columns: ['customer_email' => 'customer_mail']);
+```
+
+`./maho migrate` renames the live objects before it compares anything. Both `from:` and each
+`columns:` value take a single name or a newest-first list, so a column renamed `a` to `b` to
+`c` declares `['b', 'a']`. An entry applies only when the old name exists and the new one does
+not, so it is self-idempotent and needs no ordering: a fresh install ignores it. A previous name that another table or column also declares is
+rejected at collect time, and a database holding *both* names is refused with guidance, since
+only a human can decide which one holds the real rows. Drop entries once upgrades from that
+release are no longer supported.
+
 ### Configuration via PHP attributes
 
 Observers, cron jobs, routes, and API resources are declared with PHP attributes in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,10 +102,10 @@ Renamer::renamed($t, from: 'sales_order', columns: ['customer_email' => 'custome
 `./maho migrate` renames the live objects before it compares anything. Both `from:` and each
 `columns:` value take a single name or a newest-first list, so a column renamed `a` to `b` to
 `c` declares `['b', 'a']`. An entry applies only when the old name exists and the new one does
-not, so it is self-idempotent and needs no ordering: a fresh install ignores it. A previous name that another table or column also declares is
-rejected at collect time, and a database holding *both* names is refused with guidance, since
-only a human can decide which one holds the real rows. Drop entries once upgrades from that
-release are no longer supported.
+not, so it is self-idempotent and needs no ordering: a fresh install ignores it. A previous
+name that another table or column also declares is rejected at collect time, and a database
+holding *both* names is refused with guidance, since only a human can decide which one holds
+the real rows. Drop entries once upgrades from that release are no longer supported.
 
 ### Configuration via PHP attributes
 

--- a/lib/Maho/Db/Schema/Applier.php
+++ b/lib/Maho/Db/Schema/Applier.php
@@ -69,13 +69,29 @@ final class Applier
             $existing[$existingName->getUnqualifiedName()->getValue()] = true;
         }
 
+        // Emitted here but executed ahead of the diff, so each live table is
+        // also renamed in memory below and the Comparator sees the end state.
+        $tableRenames = Renamer::planTableRenames($platform, $target, $existing);
+        $columnRenames = [];
+
         $existingTables = [];
         $tablesToCreate = [];
         $tablesToAlter = [];
         foreach ($target->getTables() as $targetTable) {
             $name = $targetTable->getObjectName()->getUnqualifiedName()->getValue();
-            if (isset($existing[$name])) {
-                $liveTable = $schemaManager->introspectTableByUnquotedName($name);
+            // A table awaiting a rename is still stored under its former name.
+            $liveName = $tableRenames['sources'][$name] ?? $name;
+            if (isset($existing[$liveName])) {
+                $liveTable = $schemaManager->introspectTableByUnquotedName($liveName);
+                if ($liveName !== $name) {
+                    $liveTable = $liveTable->edit()
+                        ->setName($targetTable->getObjectName())
+                        ->create();
+                }
+
+                $columnRename = Renamer::renameLiveColumns($platform, $liveTable, $targetTable);
+                $columnRenames = array_merge($columnRenames, $columnRename['sql']);
+                $liveTable = $columnRename['live'];
                 // Reduce the live table and its declarative target to
                 // parity-equivalent form, so the Comparator below emits only the
                 // genuine structural delta instead of ~1200 statements of
@@ -84,7 +100,7 @@ final class Applier
                 // physical index list distinguishes a real index from one DBAL
                 // synthesizes for a foreign key. See Canonicalizer.
                 $physicalIndexNames = [];
-                foreach ($schemaManager->introspectTableIndexesByUnquotedName($name) as $index) {
+                foreach ($schemaManager->introspectTableIndexesByUnquotedName($liveName) as $index) {
                     $physicalIndexNames[] = $index->getObjectName()->toString();
                 }
                 Canonicalizer::reconcile($liveTable, $targetTable, $physicalIndexNames);
@@ -158,7 +174,9 @@ final class Applier
             ? self::engineConversions($connection, $platform, $tablePrefix)
             : [];
 
-        return array_merge($conversions, $creates, $alters);
+        // Conversions keep the lead: legacyEngineTables() scans before any
+        // rename runs, so its statements name the tables as they still stand.
+        return array_merge($conversions, $tableRenames['sql'], $columnRenames, $creates, $alters);
     }
 
     /**

--- a/lib/Maho/Db/Schema/Applier.php
+++ b/lib/Maho/Db/Schema/Applier.php
@@ -88,6 +88,7 @@ final class Applier
                         ->setName($targetTable->getObjectName())
                         ->create();
                 }
+                $liveTable = Renamer::repointForeignKeys($liveTable, $tableRenames['sources']);
 
                 $columnRename = Renamer::renameLiveColumns($platform, $liveTable, $targetTable);
                 $columnRenames = array_merge($columnRenames, $columnRename['sql']);
@@ -154,7 +155,7 @@ final class Applier
         }
 
         if ($platform instanceof PostgreSQLPlatform) {
-            $alters = self::rewritePostgresUniqueConstraintDrops($connection, $platform, $alters);
+            $alters = self::rewritePostgresUniqueConstraintDrops($connection, $platform, $alters, $tableRenames['sources']);
             $alters = self::quotePostgresRenameIndexNames($platform, $alters);
             $alters = self::fixPostgresColumnTypeChanges($platform, $existingTables, $tablesToAlter, $alters);
         }
@@ -431,10 +432,14 @@ final class Applier
      * catalog does. Look up the owning constraints once and rewrite the drops.
      *
      * @param list<string> $statements
+     * @param array<string, string> $renameSources target name => live source
+     *        name; the catalog still names a to-be-renamed table by its old
+     *        name, but the rewritten drop runs after the rename
      * @return list<string>
      */
-    private static function rewritePostgresUniqueConstraintDrops(Connection $connection, AbstractPlatform $platform, array $statements): array
+    private static function rewritePostgresUniqueConstraintDrops(Connection $connection, AbstractPlatform $platform, array $statements, array $renameSources = []): array
     {
+        $renamedTo = array_flip($renameSources);
         $constraintTable = [];
         $rows = $connection->fetchAllAssociative(
             "SELECT c.conname, t.relname
@@ -451,7 +456,7 @@ final class Applier
             return $statements;
         }
 
-        return array_map(static function (string $stmt) use ($constraintTable, $platform): string {
+        return array_map(static function (string $stmt) use ($constraintTable, $platform, $renamedTo): string {
             if (preg_match('/^\s*DROP\s+INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+EXISTS\s+)?"?([^"\s;]+)"?\s*;?\s*$/i', $stmt, $m) !== 1) {
                 return $stmt;
             }
@@ -459,10 +464,11 @@ final class Applier
             if (!isset($constraintTable[$name])) {
                 return $stmt;
             }
+            $tableName = $renamedTo[$constraintTable[$name]] ?? $constraintTable[$name];
 
             return sprintf(
                 'ALTER TABLE %s DROP CONSTRAINT %s',
-                $platform->quoteSingleIdentifier($constraintTable[$name]),
+                $platform->quoteSingleIdentifier($tableName),
                 $platform->quoteSingleIdentifier($name),
             );
         }, $statements);

--- a/lib/Maho/Db/Schema/Collector.php
+++ b/lib/Maho/Db/Schema/Collector.php
@@ -93,6 +93,8 @@ final class Collector
         // declarative schema makes the indexes explicit on every engine,
         // which is the more portable shape.
 
+        Renamer::validate($schema);
+
         return [$schema, $contributors];
     }
 
@@ -177,10 +179,14 @@ final class Collector
                     ->create();
             }
 
-            $newTables[] = $old->edit()
+            $new = $old->edit()
                 ->setName(OptionallyQualifiedName::unquoted($prefix . $old->getObjectName()->getUnqualifiedName()->getValue()))
                 ->setForeignKeyConstraints(...$newFks)
                 ->create();
+
+            Renamer::applyPrefix($new, $prefix);
+
+            $newTables[] = $new;
         }
 
         return new Schema($newTables);

--- a/lib/Maho/Db/Schema/Renamer.php
+++ b/lib/Maho/Db/Schema/Renamer.php
@@ -1,0 +1,371 @@
+<?php
+
+/**
+ * Former names of a declarative table and of its columns, and the renames a
+ * live database still needs to catch up with them.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+namespace Maho\Db\Schema;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+
+/**
+ * A schema comparison is structural, so it cannot tell a rename from a drop
+ * plus an add. The author supplies the missing identity link on the table the
+ * rename produced, newest name first:
+ *
+ *     $t = $schema->createTable('sales_flat_order');
+ *     Renamer::renamed($t, from: 'sales_order', columns: ['customer_email' => 'customer_mail']);
+ *
+ * That lands in one table option, which this class depends on for three DBAL
+ * properties: Table::edit() copies options, so the prefix rebuild preserves
+ * them; every platform builds DDL options from a closed allowlist, so an
+ * unknown key never reaches a CREATE TABLE; and the Comparator never diffs
+ * options, so the key causes no churn. DBAL's own Table::renameColumn() map is
+ * unusable here, since TableEditor does not carry it and
+ * Canonicalizer::preserveUndeclaredColumns() moves the old column into the
+ * target before the Comparator could read it.
+ *
+ * Renames run before the plan compares anything, so every path downstream (the
+ * comparator diff, the Postgres fixups, the SQLite rebuild) only ever sees a
+ * database whose objects already carry their declared names.
+ *
+ * Each rename carries its own precondition instead of a position in an ordered
+ * list. Sources and destinations are disjoint, since validate() rejects an
+ * alias that names a declared object, so the renames commute and are
+ * self-idempotent: no ordering, no version counter, no state table.
+ *
+ *   source present, destination absent   rename
+ *   source absent,  destination present  skip, the rename already ran
+ *   both absent                          skip
+ *   both present                         refuse, a human must merge the two
+ */
+final class Renamer
+{
+    public const OPTION = 'maho_previous_names';
+
+    /**
+     * Record what $target and its columns used to be called. Repeated calls
+     * append, so a module can extend a history another module declared.
+     *
+     * @param string|list<string> $from former table name(s), newest-first
+     * @param array<string, string|list<string>> $columns current column name => former name(s), newest-first
+     */
+    public static function renamed(Table $target, string|array $from = [], array $columns = []): void
+    {
+        $history = self::read($target);
+
+        foreach ((array) $from as $name) {
+            if (!in_array($name, $history['table'], true)) {
+                $history['table'][] = $name;
+            }
+        }
+
+        foreach ($columns as $current => $previous) {
+            $history['columns'][$current] ??= [];
+            foreach ((array) $previous as $name) {
+                if (!in_array($name, $history['columns'][$current], true)) {
+                    $history['columns'][$current][] = $name;
+                }
+            }
+        }
+
+        $target->addOption(self::OPTION, $history);
+    }
+
+    /**
+     * @return list<string> newest-first
+     */
+    public static function previousTableNames(Table $table): array
+    {
+        return self::read($table)['table'];
+    }
+
+    /**
+     * @return array<string, list<string>> current name => former names, newest-first
+     */
+    public static function previousColumnNames(Table $table): array
+    {
+        return self::read($table)['columns'];
+    }
+
+    /**
+     * Authors declare unprefixed names throughout, so the recorded table names
+     * move with the ones Collector::rebuildWithPrefix() rewrites.
+     */
+    public static function applyPrefix(Table $table, string $prefix): void
+    {
+        if ($prefix === '' || !$table->hasOption(self::OPTION)) {
+            return;
+        }
+
+        $history = self::read($table);
+        $history['table'] = array_map(static fn(string $name): string => $prefix . $name, $history['table']);
+        $table->addOption(self::OPTION, $history);
+    }
+
+    /**
+     * Reject a history that cannot be applied unambiguously, whatever the live
+     * database holds. Called from Collector::collect(), so the request path
+     * gets the check too, via Status::isConverged().
+     *
+     * The first rule does double duty: an alias naming a declared table would
+     * let one rename destroy another table, and forbidding it also makes a
+     * rename cycle impossible, since a cycle needs both names declared.
+     *
+     * @throws UnsupportedMigrationException
+     */
+    public static function validate(Schema $target): void
+    {
+        $declaredTables = [];
+        foreach ($target->getTables() as $table) {
+            $declaredTables[strtolower(self::tableName($table))] = self::tableName($table);
+        }
+
+        $claimedBy = [];
+        foreach ($target->getTables() as $table) {
+            $name = self::tableName($table);
+            foreach (self::previousTableNames($table) as $previous) {
+                $key = strtolower($previous);
+
+                if (isset($declaredTables[$key])) {
+                    throw new UnsupportedMigrationException(sprintf(
+                        'Table "%s" declares the previous name "%s", but "%s" is itself a declared table. '
+                        . 'Renaming onto a live table would destroy it.',
+                        $name,
+                        $previous,
+                        $declaredTables[$key],
+                    ));
+                }
+
+                if (isset($claimedBy[$key])) {
+                    throw new UnsupportedMigrationException(sprintf(
+                        'Tables "%s" and "%s" both declare the previous name "%s". Only one table can inherit it.',
+                        $claimedBy[$key],
+                        $name,
+                        $previous,
+                    ));
+                }
+
+                $claimedBy[$key] = $name;
+            }
+
+            self::validateColumns($table, $name);
+        }
+    }
+
+    /**
+     * @throws UnsupportedMigrationException
+     */
+    private static function validateColumns(Table $table, string $tableName): void
+    {
+        $claimedBy = [];
+        foreach (self::previousColumnNames($table) as $current => $previousNames) {
+            if (!$table->hasColumn($current)) {
+                throw new UnsupportedMigrationException(sprintf(
+                    'Table "%s" declares a previous name for column "%s", but the table declares no such column.',
+                    $tableName,
+                    $current,
+                ));
+            }
+
+            foreach ($previousNames as $previous) {
+                $key = strtolower($previous);
+
+                if ($table->hasColumn($previous)) {
+                    throw new UnsupportedMigrationException(sprintf(
+                        'Column "%s.%s" declares the previous name "%s", but "%s" is itself a declared column.',
+                        $tableName,
+                        $current,
+                        $previous,
+                        $previous,
+                    ));
+                }
+
+                if (isset($claimedBy[$key])) {
+                    throw new UnsupportedMigrationException(sprintf(
+                        'Columns "%s" and "%s" of table "%s" both declare the previous name "%s".',
+                        $claimedBy[$key],
+                        $current,
+                        $tableName,
+                        $previous,
+                    ));
+                }
+
+                $claimedBy[$key] = $current;
+            }
+        }
+    }
+
+    /**
+     * $existing is the live table-name set plan() already built. The returned
+     * sources map lets plan() introspect a renamed table under the name it
+     * still physically carries.
+     *
+     * @param array<string, true> $existing
+     * @return array{sql: list<string>, sources: array<string, string>} target name => live source name
+     * @throws UnsupportedMigrationException
+     */
+    public static function planTableRenames(AbstractPlatform $platform, Schema $target, array $existing): array
+    {
+        $sql = [];
+        $sources = [];
+
+        foreach ($target->getTables() as $table) {
+            $name = self::tableName($table);
+            $present = self::presentNames(self::previousTableNames($table), $existing);
+
+            if (isset($existing[$name])) {
+                if ($present !== []) {
+                    throw new UnsupportedMigrationException(sprintf(
+                        'Cannot rename "%s" to "%s": both tables exist. Merge them by hand, then drop the old one.',
+                        $present[0],
+                        $name,
+                    ));
+                }
+                continue;
+            }
+
+            if ($present === []) {
+                continue;
+            }
+
+            if (count($present) > 1) {
+                throw new UnsupportedMigrationException(sprintf(
+                    'Cannot rename to "%s": the previous names %s all exist. Merge them by hand, then keep one.',
+                    $name,
+                    '"' . implode('", "', $present) . '"',
+                ));
+            }
+
+            $sql[] = $platform->getRenameTableSQL(
+                $platform->quoteSingleIdentifier($present[0]),
+                $platform->quoteSingleIdentifier($name),
+            );
+            $sources[$name] = $present[0];
+        }
+
+        return ['sql' => $sql, 'sources' => $sources];
+    }
+
+    /**
+     * Column renames the live table still needs, plus that table rewritten as
+     * the renames leave it.
+     *
+     * @return array{sql: list<string>, live: Table}
+     * @throws UnsupportedMigrationException
+     */
+    public static function renameLiveColumns(AbstractPlatform $platform, Table $live, Table $target): array
+    {
+        $tableName = self::tableName($target);
+        $sql = [];
+        $pending = [];
+
+        foreach (self::previousColumnNames($target) as $current => $previousNames) {
+            $present = array_values(array_filter($previousNames, $live->hasColumn(...)));
+
+            if ($live->hasColumn($current)) {
+                if ($present !== []) {
+                    throw new UnsupportedMigrationException(sprintf(
+                        'Cannot rename "%s.%s" to "%s": both columns exist. Copy the data across by hand, '
+                        . 'then drop the old column.',
+                        $tableName,
+                        $present[0],
+                        $current,
+                    ));
+                }
+                continue;
+            }
+
+            if ($present === []) {
+                continue;
+            }
+
+            if (count($present) > 1) {
+                throw new UnsupportedMigrationException(sprintf(
+                    'Cannot rename to "%s.%s": the previous names %s all exist. Keep one by hand.',
+                    $tableName,
+                    $current,
+                    '"' . implode('", "', $present) . '"',
+                ));
+            }
+
+            // Emitted directly: getRenameColumnSQL() is protected, and routing a
+            // rename through getAlterTableSQL() makes SQLite rebuild the table
+            // from a partial diff, which Applier::sqliteAlters() exists to avoid.
+            $sql[] = sprintf(
+                'ALTER TABLE %s RENAME COLUMN %s TO %s',
+                $platform->quoteSingleIdentifier($tableName),
+                $platform->quoteSingleIdentifier($present[0]),
+                $platform->quoteSingleIdentifier($current),
+            );
+            $pending[] = [$present[0], $current];
+        }
+
+        if ($pending === []) {
+            return ['sql' => [], 'live' => $live];
+        }
+
+        // Via the editor, not Table::renameColumn(): the latter leaves the
+        // primary key constraint on the old column name, which would make the
+        // Comparator rebuild the primary key.
+        $editor = $live->edit();
+        foreach ($pending as [$from, $to]) {
+            $editor->renameColumnByUnquotedName($from, $to);
+        }
+
+        return ['sql' => $sql, 'live' => $editor->create()];
+    }
+
+    /**
+     * @param list<string> $names
+     * @param array<string, true> $existing
+     * @return list<string>
+     */
+    private static function presentNames(array $names, array $existing): array
+    {
+        return array_values(array_filter($names, static fn(string $name): bool => isset($existing[$name])));
+    }
+
+    private static function tableName(Table $table): string
+    {
+        return $table->getObjectName()->getUnqualifiedName()->getValue();
+    }
+
+    /**
+     * @return array{table: list<string>, columns: array<string, list<string>>}
+     */
+    private static function read(Table $table): array
+    {
+        return self::normalize($table->hasOption(self::OPTION) ? $table->getOption(self::OPTION) : null);
+    }
+
+    /**
+     * @return array{table: list<string>, columns: array<string, list<string>>}
+     */
+    private static function normalize(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return ['table' => [], 'columns' => []];
+        }
+
+        $tables = [];
+        foreach (is_array($value['table'] ?? null) ? $value['table'] : [] as $name) {
+            $tables[] = (string) $name;
+        }
+
+        $columns = [];
+        foreach (is_array($value['columns'] ?? null) ? $value['columns'] : [] as $current => $names) {
+            $columns[(string) $current] = array_map(strval(...), is_array($names) ? array_values($names) : []);
+        }
+
+        return ['table' => $tables, 'columns' => $columns];
+    }
+}

--- a/lib/Maho/Db/Schema/Renamer.php
+++ b/lib/Maho/Db/Schema/Renamer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Maho\Db\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 
@@ -215,12 +216,20 @@ final class Renamer
      */
     public static function planTableRenames(AbstractPlatform $platform, Schema $target, array $existing): array
     {
+        // Previous names match the live set case-insensitively, the way
+        // validate() already treats them; the live spelling is what the
+        // rename statement must name.
+        $live = [];
+        foreach (array_keys($existing) as $liveName) {
+            $live[strtolower((string) $liveName)] = (string) $liveName;
+        }
+
         $sql = [];
         $sources = [];
 
         foreach ($target->getTables() as $table) {
             $name = self::tableName($table);
-            $present = self::presentNames(self::previousTableNames($table), $existing);
+            $present = self::presentNames(self::previousTableNames($table), $live);
 
             if (isset($existing[$name])) {
                 if ($present !== []) {
@@ -253,6 +262,44 @@ final class Renamer
         }
 
         return ['sql' => $sql, 'sources' => $sources];
+    }
+
+    /**
+     * Repoint live foreign keys that still reference a renamed table by its
+     * former name. The physical constraint follows the rename on every engine
+     * (MySQL and Postgres track the table itself, SQLite rewrites the
+     * reference), so the introspected copy is repointed the same way; without
+     * this the Comparator would drop and re-add every inbound foreign key,
+     * and rebuild whole referencing tables on SQLite.
+     *
+     * @param array<string, string> $sources target name => live source name,
+     *        as planTableRenames() returns them
+     */
+    public static function repointForeignKeys(Table $live, array $sources): Table
+    {
+        if ($sources === []) {
+            return $live;
+        }
+        $renamedTo = array_flip($sources);
+
+        $changed = false;
+        $foreignKeys = [];
+        foreach ($live->getForeignKeys() as $foreignKey) {
+            $referenced = $foreignKey->getReferencedTableName()->getUnqualifiedName()->getValue();
+            if (isset($renamedTo[$referenced])) {
+                $foreignKey = $foreignKey->edit()
+                    ->setReferencedTableName(OptionallyQualifiedName::unquoted($renamedTo[$referenced]))
+                    ->create();
+                $changed = true;
+            }
+            $foreignKeys[] = $foreignKey;
+        }
+
+        if (!$changed) {
+            return $live;
+        }
+
+        return $live->edit()->setForeignKeyConstraints(...$foreignKeys)->create();
     }
 
     /**
@@ -326,12 +373,20 @@ final class Renamer
 
     /**
      * @param list<string> $names
-     * @param array<string, true> $existing
-     * @return list<string>
+     * @param array<string, string> $live lowercased live name => live spelling
+     * @return list<string> live spellings
      */
-    private static function presentNames(array $names, array $existing): array
+    private static function presentNames(array $names, array $live): array
     {
-        return array_values(array_filter($names, static fn(string $name): bool => isset($existing[$name])));
+        $present = [];
+        foreach ($names as $name) {
+            $key = strtolower($name);
+            if (isset($live[$key]) && !in_array($live[$key], $present, true)) {
+                $present[] = $live[$key];
+            }
+        }
+
+        return $present;
     }
 
     private static function tableName(Table $table): string
@@ -348,24 +403,57 @@ final class Renamer
     }
 
     /**
+     * A malformed history must refuse loudly: coercing it to an empty one
+     * would silently skip the rename and leave plan() creating a fresh table
+     * next to the stranded old one.
+     *
      * @return array{table: list<string>, columns: array<string, list<string>>}
+     * @throws UnsupportedMigrationException
      */
     private static function normalize(mixed $value): array
     {
-        if (!is_array($value)) {
+        if ($value === null) {
             return ['table' => [], 'columns' => []];
         }
 
-        $tables = [];
-        foreach (is_array($value['table'] ?? null) ? $value['table'] : [] as $name) {
-            $tables[] = (string) $name;
+        if (!is_array($value) || array_diff_key($value, ['table' => true, 'columns' => true]) !== []) {
+            self::malformed();
         }
 
-        $columns = [];
-        foreach (is_array($value['columns'] ?? null) ? $value['columns'] : [] as $current => $names) {
-            $columns[(string) $current] = array_map(strval(...), is_array($names) ? array_values($names) : []);
+        $tables = $value['table'] ?? [];
+        $columns = $value['columns'] ?? [];
+        if (!is_array($tables) || !is_array($columns)) {
+            self::malformed();
         }
 
-        return ['table' => $tables, 'columns' => $columns];
+        foreach ($tables as $name) {
+            if (!is_string($name)) {
+                self::malformed();
+            }
+        }
+
+        $normalizedColumns = [];
+        foreach ($columns as $current => $names) {
+            if (!is_string($current) || !is_array($names)) {
+                self::malformed();
+            }
+            foreach ($names as $name) {
+                if (!is_string($name)) {
+                    self::malformed();
+                }
+            }
+            $normalizedColumns[$current] = array_values($names);
+        }
+
+        return ['table' => array_values($tables), 'columns' => $normalizedColumns];
+    }
+
+    private static function malformed(): never
+    {
+        throw new UnsupportedMigrationException(sprintf(
+            'A "%s" table option does not carry the shape Renamer::renamed() writes. '
+            . 'Declare previous names through Renamer::renamed() instead of addOption().',
+            self::OPTION,
+        ));
     }
 }

--- a/lib/Maho/Db/Schema/Renamer.php
+++ b/lib/Maho/Db/Schema/Renamer.php
@@ -231,7 +231,7 @@ final class Renamer
             $name = self::tableName($table);
             $present = self::presentNames(self::previousTableNames($table), $live);
 
-            if (isset($existing[$name])) {
+            if (isset($live[strtolower($name)])) {
                 if ($present !== []) {
                     throw new UnsupportedMigrationException(sprintf(
                         'Cannot rename "%s" to "%s": both tables exist. Merge them by hand, then drop the old one.',
@@ -267,10 +267,11 @@ final class Renamer
     /**
      * Repoint live foreign keys that still reference a renamed table by its
      * former name. The physical constraint follows the rename on every engine
-     * (MySQL and Postgres track the table itself, SQLite rewrites the
-     * reference), so the introspected copy is repointed the same way; without
-     * this the Comparator would drop and re-add every inbound foreign key,
-     * and rebuild whole referencing tables on SQLite.
+     * (MySQL and Postgres track the table itself, SQLite rewrites the clause
+     * text under its default legacy_alter_table = OFF, whatever the
+     * foreign_keys pragma says), so the introspected copy is repointed the same
+     * way; without this the Comparator would drop and re-add every inbound
+     * foreign key, and rebuild whole referencing tables on SQLite.
      *
      * @param array<string, string> $sources target name => live source name,
      *        as planTableRenames() returns them

--- a/lib/Maho/Db/Schema/Status.php
+++ b/lib/Maho/Db/Schema/Status.php
@@ -29,7 +29,7 @@ final class Status
      * table default, a different canonicalization rule), so they count
      * towards the fingerprint like the declarations themselves.
      */
-    private const PIPELINE_FILES = ['Collector.php', 'Canonicalizer.php', 'Applier.php'];
+    private const PIPELINE_FILES = ['Collector.php', 'Canonicalizer.php', 'Applier.php', 'Renamer.php'];
 
     /**
      * Fingerprint of the declared schema: the contents of every active

--- a/lib/MahoCLI/Commands/Migrate.php
+++ b/lib/MahoCLI/Commands/Migrate.php
@@ -331,7 +331,7 @@ class Migrate extends BaseMahoCommand
         if (preg_match('/^ALTER\s+TABLE\s+[`"]?([^`"\s]+?)[`"]?\s+RENAME\s+COLUMN\s+[`"]?([^`"\s]+?)[`"]?\s+TO\s+[`"]?([^`"\s;]+)/i', $stmt, $m)) {
             return ['text' => "rename column {$m[1]}.{$m[2]} to {$m[3]}", 'destructive' => false];
         }
-        if (preg_match('/^(?:ALTER|RENAME)\s+TABLE\s+[`"]?([^`"\s]+?)[`"]?\s+RENAME\s+(?:TO\s+)?[`"]?([^`"\s;]+)/i', $stmt, $m)) {
+        if (preg_match('/^ALTER\s+TABLE\s+[`"]?([^`"\s]+?)[`"]?\s+RENAME\s+TO\s+[`"]?([^`"\s;]+)/i', $stmt, $m)) {
             return ['text' => "rename table {$m[1]} to {$m[2]}", 'destructive' => false];
         }
         if (preg_match('/^CREATE\s+TABLE\s+[`"]?([^`"\s(]+)/i', $stmt, $m)) {

--- a/lib/MahoCLI/Commands/Migrate.php
+++ b/lib/MahoCLI/Commands/Migrate.php
@@ -137,8 +137,15 @@ class Migrate extends BaseMahoCommand
         $adapter = Mage::getSingleton('core/resource')->getConnection('core_setup');
 
         $output->writeln('<comment>Declarative schema</comment>');
-        [$target, $contributors] = Collector::collect();
         $drops = 0;
+        try {
+            // collect() validates the declared name history, so it refuses for
+            // the same reasons plan() does.
+            [$target, $contributors] = Collector::collect();
+        } catch (\Maho\Db\Schema\UnsupportedMigrationException $e) {
+            $output->writeln('  <error>' . $e->getMessage() . '</error>');
+            return Command::FAILURE;
+        }
         if ($contributors === []) {
             $output->writeln('  No modules declare sql/schema.php');
         } else {
@@ -319,6 +326,14 @@ class Migrate extends BaseMahoCommand
         $stmt = trim($stmt);
         $destructive = preg_match('/\bDROP\s+(INDEX|FOREIGN\s+KEY|CONSTRAINT|COLUMN|PRIMARY\s+KEY)\b/i', $stmt) === 1;
 
+        // Before the create/alter branches: a rename must never fall through to
+        // the generic ALTER form, which would read as destructive.
+        if (preg_match('/^ALTER\s+TABLE\s+[`"]?([^`"\s]+?)[`"]?\s+RENAME\s+COLUMN\s+[`"]?([^`"\s]+?)[`"]?\s+TO\s+[`"]?([^`"\s;]+)/i', $stmt, $m)) {
+            return ['text' => "rename column {$m[1]}.{$m[2]} to {$m[3]}", 'destructive' => false];
+        }
+        if (preg_match('/^(?:ALTER|RENAME)\s+TABLE\s+[`"]?([^`"\s]+?)[`"]?\s+RENAME\s+(?:TO\s+)?[`"]?([^`"\s;]+)/i', $stmt, $m)) {
+            return ['text' => "rename table {$m[1]} to {$m[2]}", 'destructive' => false];
+        }
         if (preg_match('/^CREATE\s+TABLE\s+[`"]?([^`"\s(]+)/i', $stmt, $m)) {
             return ['text' => "create table {$m[1]}", 'destructive' => false];
         }

--- a/tests/Backend/Integration/Db/Schema/RenameTest.php
+++ b/tests/Backend/Integration/Db/Schema/RenameTest.php
@@ -25,14 +25,19 @@ uses(Tests\MahoBackendTestCase::class);
 
 const RENAME_OLD_TABLE = 'maho_rename_probe_old';
 const RENAME_NEW_TABLE = 'maho_rename_probe_new';
+const RENAME_CHILD_TABLE = 'maho_rename_probe_child';
 
-function renameProbeSchema(string $table, string $emailColumn, bool $withHistory): Schema
-{
+function renameProbeSchema(
+    string $table,
+    string $emailColumn,
+    bool $withHistory,
+    string $index = 'IDX_MAHO_PROBE_EMAIL',
+): Schema {
     $schema = new Schema();
     $probe = $schema->createTable($table);
     $probe->addColumn('entity_id', Types::INTEGER, ['unsigned' => true, 'autoincrement' => true]);
     $probe->addColumn($emailColumn, Types::STRING, ['length' => 255, 'notnull' => false]);
-    $probe->addIndex([$emailColumn], 'IDX_MAHO_PROBE_EMAIL');
+    $probe->addIndex([$emailColumn], $index);
     $probe->addPrimaryKeyConstraint(
         PrimaryKeyConstraint::editor()->setUnquotedColumnNames('entity_id')->create(),
     );
@@ -43,6 +48,24 @@ function renameProbeSchema(string $table, string $emailColumn, bool $withHistory
     if ($withHistory) {
         Renamer::renamed($probe, from: RENAME_OLD_TABLE, columns: ['customer_email' => 'legacy_email']);
     }
+
+    return $schema;
+}
+
+function renameProbeSchemaWithChild(string $table, string $emailColumn, bool $withHistory): Schema
+{
+    $schema = renameProbeSchema($table, $emailColumn, $withHistory);
+
+    $child = $schema->createTable(RENAME_CHILD_TABLE);
+    $child->addColumn('entity_id', Types::INTEGER, ['unsigned' => true, 'autoincrement' => true]);
+    $child->addColumn('parent_id', Types::INTEGER, ['unsigned' => true]);
+    $child->addPrimaryKeyConstraint(
+        PrimaryKeyConstraint::editor()->setUnquotedColumnNames('entity_id')->create(),
+    );
+    $child->addForeignKeyConstraint($table, ['parent_id'], ['entity_id'], [], 'FK_MAHO_PROBE_CHILD');
+    $child->addOption('engine', 'InnoDB');
+    $child->addOption('charset', 'utf8');
+    $child->addOption('collation', 'utf8_general_ci');
 
     return $schema;
 }
@@ -59,7 +82,8 @@ beforeEach(function () {
         return $sql;
     };
 
-    foreach ([RENAME_OLD_TABLE, RENAME_NEW_TABLE] as $table) {
+    // Child first: it holds the foreign key onto the probe tables.
+    foreach ([RENAME_CHILD_TABLE, RENAME_OLD_TABLE, RENAME_NEW_TABLE] as $table) {
         $this->adapter->dropTable($table);
     }
 
@@ -68,7 +92,7 @@ beforeEach(function () {
 });
 
 afterEach(function () {
-    foreach ([RENAME_OLD_TABLE, RENAME_NEW_TABLE] as $table) {
+    foreach ([RENAME_CHILD_TABLE, RENAME_OLD_TABLE, RENAME_NEW_TABLE] as $table) {
         $this->adapter->dropTable($table);
     }
 });
@@ -107,8 +131,24 @@ it('leaves a database that never carried the old names alone', function () {
     expect($this->adapter->isTableExists(RENAME_NEW_TABLE))->toBeTrue();
 });
 
+it('keeps a foreign key onto a renamed table usable', function () {
+    ($this->converge)(renameProbeSchemaWithChild(RENAME_OLD_TABLE, 'legacy_email', false));
+
+    ($this->converge)(renameProbeSchemaWithChild(RENAME_NEW_TABLE, 'customer_email', true));
+
+    $parentId = (int) $this->adapter->fetchOne(
+        $this->adapter->select()->from(RENAME_NEW_TABLE, ['entity_id']),
+    );
+    $this->adapter->insert(RENAME_CHILD_TABLE, ['parent_id' => $parentId]);
+
+    $row = $this->adapter->fetchRow($this->adapter->select()->from(RENAME_CHILD_TABLE));
+    expect((int) $row['parent_id'])->toBe($parentId);
+});
+
 it('refuses to rename when both tables exist', function () {
-    ($this->converge)(renameProbeSchema(RENAME_NEW_TABLE, 'customer_email', false));
+    // Its own index name: SQLite and Postgres scope index names to the database,
+    // not to the table, and this is the one test where both probes coexist.
+    ($this->converge)(renameProbeSchema(RENAME_NEW_TABLE, 'customer_email', false, 'IDX_MAHO_PROBE_EMAIL_2'));
 
     expect(fn() => Applier::plan(
         $this->connection,

--- a/tests/Backend/Integration/Db/Schema/RenameTest.php
+++ b/tests/Backend/Integration/Db/Schema/RenameTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Maho\Db\Schema\Applier;
+use Maho\Db\Schema\Renamer;
+use Maho\Db\Schema\UnsupportedMigrationException;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * End-to-end coverage against the live database: the unit tests fix the SQL
+ * shape, this fixes what it does to real rows. Both the before and the after
+ * state are built through Applier, so "second plan is empty" measures
+ * convergence rather than canonicalization noise.
+ */
+
+const RENAME_OLD_TABLE = 'maho_rename_probe_old';
+const RENAME_NEW_TABLE = 'maho_rename_probe_new';
+
+function renameProbeSchema(string $table, string $emailColumn, bool $withHistory): Schema
+{
+    $schema = new Schema();
+    $probe = $schema->createTable($table);
+    $probe->addColumn('entity_id', Types::INTEGER, ['unsigned' => true, 'autoincrement' => true]);
+    $probe->addColumn($emailColumn, Types::STRING, ['length' => 255, 'notnull' => false]);
+    $probe->addIndex([$emailColumn], 'IDX_MAHO_PROBE_EMAIL');
+    $probe->addPrimaryKeyConstraint(
+        PrimaryKeyConstraint::editor()->setUnquotedColumnNames('entity_id')->create(),
+    );
+    $probe->addOption('engine', 'InnoDB');
+    $probe->addOption('charset', 'utf8');
+    $probe->addOption('collation', 'utf8_general_ci');
+
+    if ($withHistory) {
+        Renamer::renamed($probe, from: RENAME_OLD_TABLE, columns: ['customer_email' => 'legacy_email']);
+    }
+
+    return $schema;
+}
+
+beforeEach(function () {
+    $this->adapter = Mage::getSingleton('core/resource')->getConnection('core_setup');
+    $this->connection = $this->adapter->getConnection();
+
+    $this->converge = function (Schema $target): array {
+        $sql = Applier::plan($this->connection, $target, '', false);
+        if ($sql !== []) {
+            Applier::execute($this->adapter, $sql);
+        }
+        return $sql;
+    };
+
+    foreach ([RENAME_OLD_TABLE, RENAME_NEW_TABLE] as $table) {
+        $this->adapter->dropTable($table);
+    }
+
+    ($this->converge)(renameProbeSchema(RENAME_OLD_TABLE, 'legacy_email', false));
+    $this->adapter->insert(RENAME_OLD_TABLE, ['legacy_email' => 'shopper@example.com']);
+});
+
+afterEach(function () {
+    foreach ([RENAME_OLD_TABLE, RENAME_NEW_TABLE] as $table) {
+        $this->adapter->dropTable($table);
+    }
+});
+
+it('renames the table and the column, and keeps the row', function () {
+    $target = renameProbeSchema(RENAME_NEW_TABLE, 'customer_email', true);
+
+    $sql = ($this->converge)($target);
+
+    expect($sql)->not->toBe([]);
+    expect($this->adapter->isTableExists(RENAME_OLD_TABLE))->toBeFalse();
+    expect($this->adapter->isTableExists(RENAME_NEW_TABLE))->toBeTrue();
+
+    $row = $this->adapter->fetchRow($this->adapter->select()->from(RENAME_NEW_TABLE));
+    expect($row['customer_email'])->toBe('shopper@example.com');
+    expect((int) $row['entity_id'])->toBe(1);
+});
+
+it('converges, so a second run has nothing left to do', function () {
+    $target = renameProbeSchema(RENAME_NEW_TABLE, 'customer_email', true);
+    ($this->converge)($target);
+
+    // Rebuilt from scratch: the pre-pass must read the live database, not a
+    // Schema a previous plan mutated.
+    $second = Applier::plan($this->connection, renameProbeSchema(RENAME_NEW_TABLE, 'customer_email', true), '', false);
+
+    expect($second)->toBe([]);
+});
+
+it('leaves a database that never carried the old names alone', function () {
+    $this->adapter->dropTable(RENAME_OLD_TABLE);
+
+    $sql = ($this->converge)(renameProbeSchema(RENAME_NEW_TABLE, 'customer_email', true));
+
+    expect(preg_grep('/RENAME\s+(TO|COLUMN)/i', $sql))->toBe([]);
+    expect($this->adapter->isTableExists(RENAME_NEW_TABLE))->toBeTrue();
+});
+
+it('refuses to rename when both tables exist', function () {
+    ($this->converge)(renameProbeSchema(RENAME_NEW_TABLE, 'customer_email', false));
+
+    expect(fn() => Applier::plan(
+        $this->connection,
+        renameProbeSchema(RENAME_NEW_TABLE, 'customer_email', true),
+        '',
+        false,
+    ))->toThrow(UnsupportedMigrationException::class, 'both tables exist');
+});

--- a/tests/Backend/Unit/Maho/Db/Schema/RenamerTest.php
+++ b/tests/Backend/Unit/Maho/Db/Schema/RenamerTest.php
@@ -104,6 +104,14 @@ it('survives the rebuild Collector uses to apply the table prefix', function () 
     expect(Renamer::previousColumnNames($rebuilt))->toBe(['customer_email' => ['customer_mail']]);
 });
 
+it('refuses a hand-written history that is not the shape renamed() writes', function () {
+    $table = renamerTable(new Schema(), 't');
+    $table->addOption(Renamer::OPTION, ['table' => 'old']);
+
+    expect(fn() => Renamer::previousTableNames($table))
+        ->toThrow(UnsupportedMigrationException::class, 'Renamer::renamed()');
+});
+
 it('never reaches the DDL of any supported platform', function () {
     $table = renamerTable(new Schema(), 'sales_flat_order');
     Renamer::renamed($table, from: 'sales_order', columns: ['customer_email' => 'customer_mail']);
@@ -235,6 +243,16 @@ it('refuses a table rename when two former names exist', function () {
         ->toThrow(UnsupportedMigrationException::class, 'all exist');
 });
 
+it('matches a former table name case-insensitively but renames the live spelling', function () {
+    $schema = new Schema();
+    Renamer::renamed(renamerTable($schema, 'sales_flat_order'), from: 'sales_order');
+
+    $result = Renamer::planTableRenames(new MySQLPlatform(), $schema, renamerLive(['Sales_Order']));
+
+    expect($result['sql'])->toBe(['ALTER TABLE `Sales_Order` RENAME TO `sales_flat_order`']);
+    expect($result['sources'])->toBe(['sales_flat_order' => 'Sales_Order']);
+});
+
 it('follows a rename chain to whichever former name survived', function () {
     $schema = new Schema();
     Renamer::renamed(renamerTable($schema, 'c'), from: ['b', 'a']);
@@ -242,6 +260,29 @@ it('follows a rename chain to whichever former name survived', function () {
     $result = Renamer::planTableRenames(new MySQLPlatform(), $schema, renamerLive(['a']));
 
     expect($result['sources'])->toBe(['c' => 'a']);
+});
+
+// --- repointForeignKeys() ------------------------------------------------
+
+it('repoints a live foreign key that references a renamed table', function () {
+    $live = (new Schema())->createTable('sales_order_item');
+    $live->addColumn('order_id', Types::INTEGER, ['unsigned' => true]);
+    $live->addForeignKeyConstraint('sales_order', ['order_id'], ['entity_id'], [], 'FK_ORDER');
+
+    $repointed = Renamer::repointForeignKeys($live, ['sales_flat_order' => 'sales_order']);
+
+    $foreignKey = $repointed->getForeignKey('FK_ORDER');
+    expect($foreignKey->getReferencedTableName()->getUnqualifiedName()->getValue())->toBe('sales_flat_order');
+});
+
+it('leaves a table without foreign keys onto renamed tables untouched', function () {
+    $live = (new Schema())->createTable('t');
+    $live->addColumn('store_id', Types::SMALLINT, ['unsigned' => true]);
+    $live->addForeignKeyConstraint('core_store', ['store_id'], ['store_id'], [], 'FK_STORE');
+
+    $repointed = Renamer::repointForeignKeys($live, ['sales_flat_order' => 'sales_order']);
+
+    expect($repointed)->toBe($live);
 });
 
 // --- renameLiveColumns() -------------------------------------------------
@@ -276,7 +317,10 @@ it('renames a live column and moves the primary key and index with it', function
     $primaryKey = $result['live']->getPrimaryKeyConstraint();
     expect($primaryKey)->not->toBeNull();
     expect(array_map(fn($n): string => $n->toString(), $primaryKey->getColumnNames()))->toBe(['customer_email']);
-    expect($result['live']->getIndex('IDX_MAIL')->getUnquotedColumns())->toBe(['customer_email']);
+    expect(array_map(
+        fn($c): string => $c->getColumnName()->toString(),
+        $result['live']->getIndex('IDX_MAIL')->getIndexedColumns(),
+    ))->toBe(['customer_email']);
 });
 
 it('moves a foreign key with the renamed column', function () {

--- a/tests/Backend/Unit/Maho/Db/Schema/RenamerTest.php
+++ b/tests/Backend/Unit/Maho/Db/Schema/RenamerTest.php
@@ -253,6 +253,17 @@ it('matches a former table name case-insensitively but renames the live spelling
     expect($result['sources'])->toBe(['sales_flat_order' => 'Sales_Order']);
 });
 
+it('refuses a table rename when the live destination differs only in case', function () {
+    $schema = new Schema();
+    Renamer::renamed(renamerTable($schema, 'sales_flat_order'), from: 'sales_order');
+
+    expect(fn() => Renamer::planTableRenames(
+        new MySQLPlatform(),
+        $schema,
+        renamerLive(['sales_order', 'Sales_Flat_Order']),
+    ))->toThrow(UnsupportedMigrationException::class, 'both tables exist');
+});
+
 it('follows a rename chain to whichever former name survived', function () {
     $schema = new Schema();
     Renamer::renamed(renamerTable($schema, 'c'), from: ['b', 'a']);

--- a/tests/Backend/Unit/Maho/Db/Schema/RenamerTest.php
+++ b/tests/Backend/Unit/Maho/Db/Schema/RenamerTest.php
@@ -1,0 +1,344 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
+use Maho\Db\Schema\Renamer;
+use Maho\Db\Schema\UnsupportedMigrationException;
+
+/**
+ * Unit coverage for the rename pre-pass: the declaration API, the rules that
+ * refuse an ambiguous history, the four apply rules, and the SQL each platform
+ * gets. No bootstrap.
+ */
+
+function renamerTable(Schema $schema, string $name): Table
+{
+    $table = $schema->createTable($name);
+    $table->addColumn('entity_id', Types::INTEGER, ['unsigned' => true]);
+    $table->addColumn('customer_email', Types::STRING, ['length' => 255, 'notnull' => false]);
+
+    return $table;
+}
+
+/** @param list<string> $names */
+function renamerLive(array $names): array
+{
+    return array_fill_keys($names, true);
+}
+
+// --- the declaration ------------------------------------------------------
+
+it('records nothing until asked', function () {
+    $table = renamerTable(new Schema(), 't');
+
+    expect(Renamer::previousTableNames($table))->toBe([]);
+    expect(Renamer::previousColumnNames($table))->toBe([]);
+});
+
+it('records a former table name and a former column name in one option', function () {
+    $table = renamerTable(new Schema(), 'sales_flat_order');
+    Renamer::renamed($table, from: 'sales_order', columns: ['customer_email' => 'customer_mail']);
+
+    expect($table->getOption(Renamer::OPTION))->toBe([
+        'table' => ['sales_order'],
+        'columns' => ['customer_email' => ['customer_mail']],
+    ]);
+});
+
+it('keeps a rename chain newest-first and ignores a repeated name', function () {
+    $table = renamerTable(new Schema(), 'c');
+    Renamer::renamed($table, from: 'b');
+    Renamer::renamed($table, from: 'a');
+    Renamer::renamed($table, from: 'b');
+
+    expect(Renamer::previousTableNames($table))->toBe(['b', 'a']);
+
+    Renamer::renamed($table, columns: ['customer_email' => ['second', 'first']]);
+    Renamer::renamed($table, columns: ['customer_email' => 'second']);
+
+    expect(Renamer::previousColumnNames($table))->toBe(['customer_email' => ['second', 'first']]);
+});
+
+it('prefixes recorded table names but never column names', function () {
+    $table = renamerTable(new Schema(), 'sales_flat_order');
+    Renamer::renamed($table, from: 'sales_order', columns: ['customer_email' => 'customer_mail']);
+
+    Renamer::applyPrefix($table, 'pfx_');
+
+    expect(Renamer::previousTableNames($table))->toBe(['pfx_sales_order']);
+    expect(Renamer::previousColumnNames($table))->toBe(['customer_email' => ['customer_mail']]);
+});
+
+it('leaves the history alone when no prefix is configured', function () {
+    $table = renamerTable(new Schema(), 't');
+    Renamer::renamed($table, from: 'old');
+
+    Renamer::applyPrefix($table, '');
+
+    expect(Renamer::previousTableNames($table))->toBe(['old']);
+});
+
+it('survives the rebuild Collector uses to apply the table prefix', function () {
+    $table = renamerTable(new Schema(), 'sales_flat_order');
+    Renamer::renamed($table, from: 'sales_order', columns: ['customer_email' => 'customer_mail']);
+
+    // Mirrors Collector::rebuildWithPrefix().
+    $rebuilt = $table->edit()
+        ->setName(OptionallyQualifiedName::unquoted('pfx_sales_flat_order'))
+        ->create();
+
+    expect(Renamer::previousTableNames($rebuilt))->toBe(['sales_order']);
+    expect(Renamer::previousColumnNames($rebuilt))->toBe(['customer_email' => ['customer_mail']]);
+});
+
+it('never reaches the DDL of any supported platform', function () {
+    $table = renamerTable(new Schema(), 'sales_flat_order');
+    Renamer::renamed($table, from: 'sales_order', columns: ['customer_email' => 'customer_mail']);
+
+    foreach ([new MySQLPlatform(), new PostgreSQLPlatform(), new SQLitePlatform()] as $platform) {
+        foreach ($platform->getCreateTableSQL($table) as $statement) {
+            expect($statement)->not->toContain(Renamer::OPTION);
+            expect($statement)->not->toContain('sales_order');
+            expect($statement)->not->toContain('customer_mail');
+        }
+    }
+});
+
+// --- validate() ----------------------------------------------------------
+
+it('accepts a history that names nothing declared', function () {
+    $schema = new Schema();
+    $table = renamerTable($schema, 'sales_flat_order');
+    Renamer::renamed($table, from: 'sales_order', columns: ['customer_email' => 'customer_mail']);
+
+    Renamer::validate($schema);
+
+    expect(Renamer::previousTableNames($schema->getTable('sales_flat_order')))->toBe(['sales_order']);
+});
+
+it('refuses a table alias that names another declared table', function () {
+    $schema = new Schema();
+    renamerTable($schema, 'sales_order');
+    Renamer::renamed(renamerTable($schema, 'sales_flat_order'), from: 'sales_order');
+
+    expect(fn() => Renamer::validate($schema))
+        ->toThrow(UnsupportedMigrationException::class, 'is itself a declared table');
+});
+
+it('refuses two tables that claim the same alias', function () {
+    $schema = new Schema();
+    Renamer::renamed(renamerTable($schema, 'a'), from: 'shared_old');
+    Renamer::renamed(renamerTable($schema, 'b'), from: 'shared_old');
+
+    expect(fn() => Renamer::validate($schema))
+        ->toThrow(UnsupportedMigrationException::class, 'Only one table can inherit it');
+});
+
+it('refuses a column history that names an undeclared column', function () {
+    $schema = new Schema();
+    Renamer::renamed(renamerTable($schema, 't'), columns: ['no_such_column' => 'old']);
+
+    expect(fn() => Renamer::validate($schema))
+        ->toThrow(UnsupportedMigrationException::class, 'the table declares no such column');
+});
+
+it('refuses a column alias that names another declared column', function () {
+    $schema = new Schema();
+    Renamer::renamed(renamerTable($schema, 't'), columns: ['customer_email' => 'entity_id']);
+
+    expect(fn() => Renamer::validate($schema))
+        ->toThrow(UnsupportedMigrationException::class, 'is itself a declared column');
+});
+
+it('refuses two columns of one table that claim the same alias', function () {
+    $schema = new Schema();
+    $table = renamerTable($schema, 't');
+    $table->addColumn('other', Types::STRING, ['length' => 8, 'notnull' => false]);
+    Renamer::renamed($table, columns: ['customer_email' => 'shared_old']);
+    Renamer::renamed($table, columns: ['other' => 'shared_old']);
+
+    expect(fn() => Renamer::validate($schema))
+        ->toThrow(UnsupportedMigrationException::class, 'both declare the previous name');
+});
+
+// --- planTableRenames() --------------------------------------------------
+
+it('renames a table when only the former name exists', function () {
+    $schema = new Schema();
+    Renamer::renamed(renamerTable($schema, 'sales_flat_order'), from: 'sales_order');
+
+    $result = Renamer::planTableRenames(new MySQLPlatform(), $schema, renamerLive(['sales_order']));
+
+    expect($result['sql'])->toBe(['ALTER TABLE `sales_order` RENAME TO `sales_flat_order`']);
+    expect($result['sources'])->toBe(['sales_flat_order' => 'sales_order']);
+});
+
+it('emits the same rename form on every supported platform', function () {
+    $schema = new Schema();
+    Renamer::renamed(renamerTable($schema, 'new_name'), from: 'old_name');
+
+    foreach ([new MySQLPlatform(), new PostgreSQLPlatform(), new SQLitePlatform()] as $platform) {
+        $result = Renamer::planTableRenames($platform, $schema, renamerLive(['old_name']));
+        expect($result['sql'])->toHaveCount(1);
+        expect($result['sql'][0])->toContain('old_name');
+        expect($result['sql'][0])->toContain('RENAME TO');
+        expect($result['sql'][0])->toContain('new_name');
+    }
+});
+
+it('skips a table rename that already ran', function () {
+    $schema = new Schema();
+    Renamer::renamed(renamerTable($schema, 'sales_flat_order'), from: 'sales_order');
+
+    $result = Renamer::planTableRenames(new MySQLPlatform(), $schema, renamerLive(['sales_flat_order']));
+
+    expect($result['sql'])->toBe([]);
+    expect($result['sources'])->toBe([]);
+});
+
+it('skips a table rename when neither name exists', function () {
+    $schema = new Schema();
+    Renamer::renamed(renamerTable($schema, 'sales_flat_order'), from: 'sales_order');
+
+    expect(Renamer::planTableRenames(new MySQLPlatform(), $schema, renamerLive([]))['sql'])->toBe([]);
+});
+
+it('refuses a table rename when both names exist', function () {
+    $schema = new Schema();
+    Renamer::renamed(renamerTable($schema, 'sales_flat_order'), from: 'sales_order');
+
+    expect(fn() => Renamer::planTableRenames(
+        new MySQLPlatform(),
+        $schema,
+        renamerLive(['sales_order', 'sales_flat_order']),
+    ))->toThrow(UnsupportedMigrationException::class, 'both tables exist');
+});
+
+it('refuses a table rename when two former names exist', function () {
+    $schema = new Schema();
+    Renamer::renamed(renamerTable($schema, 'c'), from: ['b', 'a']);
+
+    expect(fn() => Renamer::planTableRenames(new MySQLPlatform(), $schema, renamerLive(['a', 'b'])))
+        ->toThrow(UnsupportedMigrationException::class, 'all exist');
+});
+
+it('follows a rename chain to whichever former name survived', function () {
+    $schema = new Schema();
+    Renamer::renamed(renamerTable($schema, 'c'), from: ['b', 'a']);
+
+    $result = Renamer::planTableRenames(new MySQLPlatform(), $schema, renamerLive(['a']));
+
+    expect($result['sources'])->toBe(['c' => 'a']);
+});
+
+// --- renameLiveColumns() -------------------------------------------------
+
+function renamerLiveTable(string $oldColumnName): Table
+{
+    $table = (new Schema())->createTable('sales_flat_order');
+    $table->addColumn('entity_id', Types::INTEGER, ['unsigned' => true]);
+    $table->addColumn($oldColumnName, Types::STRING, ['length' => 255, 'notnull' => false]);
+    $table->addIndex([$oldColumnName], 'IDX_MAIL');
+    $table->addPrimaryKeyConstraint(
+        PrimaryKeyConstraint::editor()->setUnquotedColumnNames($oldColumnName)->create(),
+    );
+
+    return $table;
+}
+
+it('renames a live column and moves the primary key and index with it', function () {
+    $schema = new Schema();
+    $target = renamerTable($schema, 'sales_flat_order');
+    Renamer::renamed($target, columns: ['customer_email' => 'customer_mail']);
+
+    $result = Renamer::renameLiveColumns(new MySQLPlatform(), renamerLiveTable('customer_mail'), $target);
+
+    expect($result['sql'])->toBe(
+        ['ALTER TABLE `sales_flat_order` RENAME COLUMN `customer_mail` TO `customer_email`'],
+    );
+    expect($result['live']->hasColumn('customer_email'))->toBeTrue();
+    expect($result['live']->hasColumn('customer_mail'))->toBeFalse();
+
+    // Table::renameColumn() would leave the primary key on the old name.
+    $primaryKey = $result['live']->getPrimaryKeyConstraint();
+    expect($primaryKey)->not->toBeNull();
+    expect(array_map(fn($n): string => $n->toString(), $primaryKey->getColumnNames()))->toBe(['customer_email']);
+    expect($result['live']->getIndex('IDX_MAIL')->getUnquotedColumns())->toBe(['customer_email']);
+});
+
+it('moves a foreign key with the renamed column', function () {
+    $live = (new Schema())->createTable('t');
+    $live->addColumn('old_store_id', Types::SMALLINT, ['unsigned' => true]);
+    $live->addForeignKeyConstraint('core_store', ['old_store_id'], ['store_id'], [], 'FK_STORE');
+
+    $schema = new Schema();
+    $target = $schema->createTable('t');
+    $target->addColumn('store_id', Types::SMALLINT, ['unsigned' => true]);
+    Renamer::renamed($target, columns: ['store_id' => 'old_store_id']);
+
+    $result = Renamer::renameLiveColumns(new MySQLPlatform(), $live, $target);
+
+    $foreignKey = $result['live']->getForeignKey('FK_STORE');
+    expect(array_map(fn($n): string => $n->toString(), $foreignKey->getReferencingColumnNames()))->toBe(['store_id']);
+});
+
+it('emits the same column rename form on every supported platform', function () {
+    $schema = new Schema();
+    $target = renamerTable($schema, 'sales_flat_order');
+    Renamer::renamed($target, columns: ['customer_email' => 'customer_mail']);
+
+    foreach ([new MySQLPlatform(), new PostgreSQLPlatform(), new SQLitePlatform()] as $platform) {
+        $result = Renamer::renameLiveColumns($platform, renamerLiveTable('customer_mail'), $target);
+        expect($result['sql'])->toHaveCount(1);
+        expect($result['sql'][0])->toContain('RENAME COLUMN');
+        expect($result['sql'][0])->toContain('customer_mail');
+        expect($result['sql'][0])->toContain('customer_email');
+    }
+});
+
+it('skips a column rename that already ran', function () {
+    $schema = new Schema();
+    $target = renamerTable($schema, 'sales_flat_order');
+    Renamer::renamed($target, columns: ['customer_email' => 'customer_mail']);
+
+    $result = Renamer::renameLiveColumns(new MySQLPlatform(), renamerLiveTable('customer_email'), $target);
+
+    expect($result['sql'])->toBe([]);
+    expect($result['live']->hasColumn('customer_email'))->toBeTrue();
+});
+
+it('skips a column rename when neither name exists', function () {
+    $schema = new Schema();
+    $target = renamerTable($schema, 'sales_flat_order');
+    Renamer::renamed($target, columns: ['customer_email' => 'customer_mail']);
+
+    $live = (new Schema())->createTable('sales_flat_order');
+    $live->addColumn('entity_id', Types::INTEGER, ['unsigned' => true]);
+
+    expect(Renamer::renameLiveColumns(new MySQLPlatform(), $live, $target)['sql'])->toBe([]);
+});
+
+it('refuses a column rename when both columns exist', function () {
+    $schema = new Schema();
+    $target = renamerTable($schema, 'sales_flat_order');
+    Renamer::renamed($target, columns: ['customer_email' => 'customer_mail']);
+
+    $live = renamerLiveTable('customer_mail');
+    $live->addColumn('customer_email', Types::STRING, ['length' => 255, 'notnull' => false]);
+
+    expect(fn() => Renamer::renameLiveColumns(new MySQLPlatform(), $live, $target))
+        ->toThrow(UnsupportedMigrationException::class, 'both columns exist');
+});


### PR DESCRIPTION
A schema comparison is structural, so it cannot tell a rename from a drop plus an add. Until now a rename left the old object holding every row and created the new one empty, on every engine and with no warning.

Modules now declare the identity history on the table the rename produced:

```php
$t = $schema->createTable('sales_flat_order');
Renamer::renamed($t, from: 'sales_order', columns: ['customer_email' => 'customer_mail']);
```

Both `from:` and each `columns:` value take a single name or a newest-first list, so a column renamed `a` to `b` to `c` declares `['b', 'a']`.

`Applier::plan()` renames the live objects before it compares anything, so the comparator diff, the Postgres fixups and the SQLite rebuild all see the end state and are unchanged. Statement order becomes conversions, renames, creates, alters.

Each entry applies only when the old name exists and the new one does not. That makes it self-idempotent and free of ordering, so there is no state table and no version counter, and a fresh install ignores it. A database holding both names is refused with guidance rather than merged. `Collector::collect()` rejects an ambiguous history up front, which also rules out a rename cycle. `./maho migrate --dry-run` lists renames as non-destructive.

DBAL cannot carry this itself. `SchemaDiff` models no table rename, and its column rename map is dropped by `TableEditor` during the table-prefix rebuild and never read anyway, because `Canonicalizer::preserveUndeclaredColumns()` moves the old column into the target first. The history therefore rides in a table option, which DBAL carries through `Table::edit()`, never emits as DDL, and never diffs.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->