### PR TITLE
Raised the minimum supported PostgreSQL version to 15

### DIFF
--- a/.github/workflows/eol-check.yml
+++ b/.github/workflows/eol-check.yml
@@ -61,7 +61,7 @@ jobs:
 
           check_version "mysql"   "8.4"   "MySQL"
           check_version "mariadb" "10.11" "MariaDB"
-          check_version "postgresql" "14" "PostgreSQL"
+          check_version "postgresql" "15" "PostgreSQL"
           check_version "php"     "8.3"   "PHP"
 
           echo ""

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -62,9 +62,9 @@ jobs:
             db_pass: root
             health_cmd: healthcheck.sh --connect --innodb_initialized
             db_command: --skip-name-resolve
-          - name: pgsql-14
+          - name: pgsql-15
             db_engine: pgsql
-            db_image: postgres:14
+            db_image: postgres:15
             db_user: postgres
             db_pass: postgres
             health_cmd: pg_isready


### PR DESCRIPTION
PostgreSQL 14 is close to end of life (November 2026), so 15 becomes the oldest supported release.

- `pest.yml`: the `pgsql-14` matrix job now runs `postgres:15`
- `eol-check.yml`: the weekly lifecycle check tracks PostgreSQL 15

Those two files were the only places declaring the floor; there is no runtime version check to update, and nothing in the codebase relies on a PG 14-specific behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wm82pFRf13cVy73wgo2Muf)_

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->