### PR TITLE
Added health checks for the database state a removed module leaves behind

### DIFF
--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -2393,7 +2393,10 @@ class HealthCheck extends BaseMahoCommand
         /** @var \Symfony\Component\Console\Helper\QuestionHelper $helper */
         $helper = $this->getHelper('question');
         $question = new ConfirmationQuestion(
-            sprintf('<question>Delete the %d configuration row(s) behind them? [y/N]</question> ', count($paths)),
+            sprintf(
+                '<question>Delete the %d configuration path(s) behind them, in every scope? [y/N]</question> ',
+                count($paths),
+            ),
             false,
         );
         if ($helper->ask($input, $output, $question)) {
@@ -2482,11 +2485,15 @@ class HealthCheck extends BaseMahoCommand
                 '<comment>Warning: %d configuration section(s) that no installed module declares:</comment>',
                 count($findings['unclaimed']),
             ));
+            $table = Mage::getSingleton('core/resource')->getTableName('core/config_data');
             foreach ($findings['unclaimed'] as $section) {
                 $output->writeln(sprintf('- %s (%d row(s))', $section['section'], $section['rows']));
+                // "_" and "%" are LIKE wildcards, and a section name may hold either.
+                $pattern = str_replace(['!', '_', '%'], ['!!', '!_', '!%'], $section['section']);
                 $output->writeln(sprintf(
-                    "    DELETE FROM core_config_data WHERE path LIKE '%s/%%';",
-                    $section['section'],
+                    "    DELETE FROM %s WHERE path LIKE '%s/%%' ESCAPE '!';",
+                    $table,
+                    $pattern,
                 ));
             }
             $output->writeln('This check reports only. An operator can also hand-write a section that no');

--- a/lib/MahoCLI/Commands/HealthCheck.php
+++ b/lib/MahoCLI/Commands/HealthCheck.php
@@ -192,6 +192,46 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
+     * @return list<array{section: string, label: string, code: string, active: bool, model: string, reason: string, paths: list<string>}>
+     */
+    public static function findPhantomMethods(): array
+    {
+        return \MahoCLI\Helper\PhantomMethodScanner::scan();
+    }
+
+    /**
+     * @return array{unclaimed: list<array{section: string, rows: int}>, disabled: list<array{section: string, module: string, rows: int}>}
+     */
+    public static function findUnclaimedConfigSections(): array
+    {
+        return \MahoCLI\Helper\UnclaimedConfigScanner::scan();
+    }
+
+    /**
+     * @return array{stale: list<array{code: string, version: string}>, disabled: list<array{code: string, module: string}>}
+     */
+    public static function findStaleResourceVersions(): array
+    {
+        return \MahoCLI\Helper\StaleModuleVersionScanner::scan();
+    }
+
+    /**
+     * @return array{unclaimed: list<string>, disabled: list<array{table: string, module: string}>}
+     */
+    public static function findUnclaimedTables(): array
+    {
+        return \MahoCLI\Helper\UnclaimedTableScanner::scan();
+    }
+
+    /**
+     * @return list<array{kind: string, name: string, target: string, reason: string}>
+     */
+    public static function findStaleRegistrations(): array
+    {
+        return \MahoCLI\Helper\StaleRegistrationScanner::scan();
+    }
+
+    /**
      * Scans user code (app/code/local and app/code/community) for legacy XML config
      * declarations that have PHP-attribute equivalents introduced in v26.5.
      *
@@ -487,28 +527,11 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
-     * Why `alias::method` cannot be called, or null when it can. getModelClassName()
-     * invents a class name for an unknown alias, so class_exists() is the real test.
+     * Why `alias::method` cannot be called, or null when it can.
      */
     private static function findMissingCronCallback(string $alias, string $method): ?string
     {
-        if ($alias === '' || $method === '') {
-            return 'declares an incomplete callback';
-        }
-
-        $class = Mage::getConfig()->getModelClassName($alias);
-        if ($class === '' || !class_exists($class)) {
-            return sprintf('model "%s" resolves to %s, which does not exist', $alias, $class === '' ? '(nothing)' : $class);
-        }
-        $reflection = new \ReflectionClass($class);
-        if (!$reflection->isInstantiable()) {
-            return sprintf('model "%s" resolves to %s, which cannot be instantiated', $alias, $class);
-        }
-        if (!$reflection->hasMethod($method)) {
-            return sprintf('%s::%s() does not exist', $class, $method);
-        }
-
-        return null;
+        return \MahoCLI\Helper\CallbackResolver::findMissingCallback($alias, $method);
     }
 
     /**
@@ -959,6 +982,139 @@ class HealthCheck extends BaseMahoCommand
     }
 
     /**
+     * @param list<array{section: string, label: string, code: string, active: bool, model: string, reason: string, paths: list<string>}> $findings
+     */
+    private static function formatPhantomMethodSummary(array $findings): string
+    {
+        $labels = [];
+        foreach ($findings as $finding) {
+            $labels[] = $finding['section'] . '/' . $finding['code'] . ($finding['active'] ? ' (active)' : '');
+        }
+
+        $summary = sprintf(
+            '%d payment method(s) or shipping carrier(s) are configured but have no model class: %s.',
+            count($findings),
+            implode(', ', $labels),
+        );
+
+        if (array_filter(array_column($findings, 'active')) !== []) {
+            $summary .= ' An active one is offered at checkout and breaks the admin order view.';
+        }
+
+        return $summary . ' Run "./maho health-check" to delete their configuration rows.';
+    }
+
+    /**
+     * @param array{unclaimed: list<array{section: string, rows: int}>, disabled: list<array{section: string, module: string, rows: int}>} $findings
+     */
+    private static function formatUnclaimedConfigSummary(array $findings): string
+    {
+        $parts = [];
+
+        if ($findings['unclaimed'] !== []) {
+            $sections = [];
+            foreach ($findings['unclaimed'] as $section) {
+                $sections[] = sprintf('%s (%d row(s))', $section['section'], $section['rows']);
+            }
+            $parts[] = sprintf(
+                '%d core_config_data section(s) that no installed module declares: %s. '
+                . 'Report only: a section can also be hand-written. Delete the rows only when the module that '
+                . 'wrote them is gone for good.',
+                count($findings['unclaimed']),
+                implode(', ', $sections),
+            );
+        }
+
+        if ($findings['disabled'] !== []) {
+            $parts[] = sprintf(
+                '%d section(s) belong to a disabled module (%s). Re-enable the module or delete the rows.',
+                count($findings['disabled']),
+                implode(', ', array_column($findings['disabled'], 'section')),
+            );
+        }
+
+        return implode(' ', $parts);
+    }
+
+    /**
+     * @param array{stale: list<array{code: string, version: string}>, disabled: list<array{code: string, module: string}>} $findings
+     */
+    private static function formatStaleResourceSummary(array $findings): string
+    {
+        $parts = [];
+
+        if ($findings['stale'] !== []) {
+            $codes = [];
+            foreach ($findings['stale'] as $row) {
+                $codes[] = sprintf('%s (%s)', $row['code'], $row['version'] === '' ? 'no version' : $row['version']);
+            }
+            $parts[] = sprintf(
+                '%d core_resource row(s) record the install history of a setup resource no installed module '
+                . 'ships: %s. Run "./maho health-check" to delete them.',
+                count($findings['stale']),
+                implode(', ', $codes),
+            );
+        }
+
+        if ($findings['disabled'] !== []) {
+            $parts[] = sprintf(
+                '%d row(s) belong to a disabled module (%s), so they are kept.',
+                count($findings['disabled']),
+                implode(', ', array_column($findings['disabled'], 'code')),
+            );
+        }
+
+        return implode(' ', $parts);
+    }
+
+    /**
+     * @param array{unclaimed: list<string>, disabled: list<array{table: string, module: string}>} $findings
+     */
+    private static function formatUnclaimedTableSummary(array $findings): string
+    {
+        $parts = [];
+
+        if ($findings['unclaimed'] !== []) {
+            $parts[] = sprintf(
+                '%d table(s) that no installed module declares, in sql/schema.php or as a resource entity: %s. '
+                . 'Report only, and never dropped automatically: a module can create a table in an install '
+                . 'script and name it nowhere else. Back up the database before you drop one.',
+                count($findings['unclaimed']),
+                implode(', ', $findings['unclaimed']),
+            );
+        }
+
+        if ($findings['disabled'] !== []) {
+            $parts[] = sprintf(
+                '%d table(s) belong to a disabled module (%s), so they are kept.',
+                count($findings['disabled']),
+                implode(', ', array_column($findings['disabled'], 'table')),
+            );
+        }
+
+        return implode(' ', $parts);
+    }
+
+    /**
+     * @param list<array{kind: string, name: string, target: string, reason: string}> $findings
+     */
+    private static function formatStaleRegistrationSummary(array $findings): string
+    {
+        $counts = array_count_values(array_column($findings, 'kind'));
+        $parts = [];
+        foreach ($counts as $kind => $count) {
+            $parts[] = sprintf('%d %s(s)', $count, $kind);
+        }
+
+        return sprintf(
+            'The compiled attribute registry holds %d registration(s) that point at code that no longer '
+            . 'exists (%s). Run "composer dump-autoload" to recompile it.',
+            count($findings),
+            implode(', ', $parts),
+        );
+    }
+
+    /**
      * @return array<int, array{check: string, severity: string, details: string}>
      */
     public static function getCheckResults(): array
@@ -1090,6 +1246,88 @@ class HealthCheck extends BaseMahoCommand
                 'check' => 'Orphaned Cron Jobs',
                 'severity' => 'error',
                 'details' => 'Unable to check cron job declarations.',
+            ];
+        }
+
+        try {
+            $phantomMethods = self::findPhantomMethods();
+            $checks[] = [
+                'check' => 'Phantom Payment Methods and Carriers',
+                'severity' => match (true) {
+                    $phantomMethods === [] => 'ok',
+                    array_filter(array_column($phantomMethods, 'active')) !== [] => 'error',
+                    default => 'warning',
+                },
+                'details' => $phantomMethods === [] ? '' : self::formatPhantomMethodSummary($phantomMethods),
+            ];
+        } catch (\Throwable) {
+            $checks[] = [
+                'check' => 'Phantom Payment Methods and Carriers',
+                'severity' => 'error',
+                'details' => 'Unable to check payment methods and shipping carriers.',
+            ];
+        }
+
+        try {
+            $unclaimedSections = self::findUnclaimedConfigSections();
+            $sectionsHealthy = array_filter($unclaimedSections) === [];
+            $checks[] = [
+                'check' => 'Unclaimed Config Sections',
+                'severity' => $sectionsHealthy ? 'ok' : 'warning',
+                'details' => $sectionsHealthy ? '' : self::formatUnclaimedConfigSummary($unclaimedSections),
+            ];
+        } catch (\Throwable) {
+            $checks[] = [
+                'check' => 'Unclaimed Config Sections',
+                'severity' => 'error',
+                'details' => 'Unable to check store configuration sections.',
+            ];
+        }
+
+        try {
+            $staleResources = self::findStaleResourceVersions();
+            $resourcesHealthy = array_filter($staleResources) === [];
+            $checks[] = [
+                'check' => 'Stale Module Versions',
+                'severity' => $resourcesHealthy ? 'ok' : 'warning',
+                'details' => $resourcesHealthy ? '' : self::formatStaleResourceSummary($staleResources),
+            ];
+        } catch (\Throwable) {
+            $checks[] = [
+                'check' => 'Stale Module Versions',
+                'severity' => 'error',
+                'details' => 'Unable to check module version records.',
+            ];
+        }
+
+        try {
+            $unclaimedTables = self::findUnclaimedTables();
+            $tablesHealthy = array_filter($unclaimedTables) === [];
+            $checks[] = [
+                'check' => 'Unclaimed Tables',
+                'severity' => $tablesHealthy ? 'ok' : 'warning',
+                'details' => $tablesHealthy ? '' : self::formatUnclaimedTableSummary($unclaimedTables),
+            ];
+        } catch (\Throwable) {
+            $checks[] = [
+                'check' => 'Unclaimed Tables',
+                'severity' => 'error',
+                'details' => 'Unable to check table ownership.',
+            ];
+        }
+
+        try {
+            $staleRegistrations = self::findStaleRegistrations();
+            $checks[] = [
+                'check' => 'Compiled Attribute Registry',
+                'severity' => $staleRegistrations === [] ? 'ok' : 'warning',
+                'details' => $staleRegistrations === [] ? '' : self::formatStaleRegistrationSummary($staleRegistrations),
+            ];
+        } catch (\Throwable) {
+            $checks[] = [
+                'check' => 'Compiled Attribute Registry',
+                'severity' => 'error',
+                'details' => 'Unable to check the compiled attribute registry.',
             ];
         }
 
@@ -1742,6 +1980,11 @@ class HealthCheck extends BaseMahoCommand
         $this->checkOrphanedResources($input, $output, Mage::getResourceModel('admin/rules'), 'admin');
         $this->checkOrphanedResources($input, $output, Mage::getResourceModel('api/rules'), 'API');
         $this->checkOrphanedCronJobs($input, $output);
+        $this->checkPhantomMethods($input, $output);
+        $this->checkStaleResourceVersions($input, $output);
+        $this->checkUnclaimedConfigSections($output);
+        $this->checkUnclaimedTables($output);
+        $this->checkStaleRegistrations($output);
 
         $this->checkZeroDates($output, (bool) $input->getOption('check-zero-dates'));
         $this->checkTableEngines($output);
@@ -2105,6 +2348,224 @@ class HealthCheck extends BaseMahoCommand
             $deleted = $rulesResource->deleteOrphanedResources($orphanedIds);
             $output->writeln("<info>Deleted {$deleted} orphaned {$label} role resource rule(s).</info>");
         }
+        $output->writeln('');
+    }
+
+    private function checkPhantomMethods(InputInterface $input, OutputInterface $output): void
+    {
+        $output->write('Checking payment methods and shipping carriers... ');
+
+        $findings = self::findPhantomMethods();
+        if ($findings === []) {
+            $output->writeln('<info>OK</info>');
+            return;
+        }
+
+        $output->writeln('');
+        $output->writeln(sprintf(
+            '<comment>Warning: Found %d %s with no model class:</comment>',
+            count($findings),
+            count($findings) === 1 ? 'method or carrier' : 'methods or carriers',
+        ));
+        foreach ($findings as $finding) {
+            $output->writeln(sprintf(
+                '- %s "%s"%s: %s',
+                $finding['label'],
+                $finding['code'],
+                $finding['active'] ? ' <error>is active</error>' : '',
+                $finding['reason'],
+            ));
+            foreach ($finding['paths'] as $path) {
+                $output->writeln('    core_config_data: ' . $path);
+            }
+        }
+        $output->writeln('An active one is offered at checkout, and it breaks the admin view of every');
+        $output->writeln('order that used it.');
+
+        $paths = array_merge(...array_column($findings, 'paths'));
+        if ($paths === []) {
+            $output->writeln('');
+            return;
+        }
+
+        $output->writeln('');
+
+        /** @var \Symfony\Component\Console\Helper\QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion(
+            sprintf('<question>Delete the %d configuration row(s) behind them? [y/N]</question> ', count($paths)),
+            false,
+        );
+        if ($helper->ask($input, $output, $question)) {
+            $deleted = \MahoCLI\Helper\PhantomMethodScanner::purge($paths);
+            $output->writeln(sprintf('<info>Deleted %d core_config_data row(s).</info>', $deleted));
+        }
+        $output->writeln('');
+    }
+
+    private function checkStaleResourceVersions(InputInterface $input, OutputInterface $output): void
+    {
+        $output->write('Checking module version records... ');
+
+        $findings = self::findStaleResourceVersions();
+        if (array_filter($findings) === []) {
+            $output->writeln('<info>OK</info>');
+            return;
+        }
+
+        $output->writeln('');
+
+        if ($findings['stale'] !== []) {
+            $output->writeln(sprintf(
+                '<comment>Warning: %d core_resource row(s) name a setup resource no installed module ships:</comment>',
+                count($findings['stale']),
+            ));
+            foreach ($findings['stale'] as $row) {
+                $output->writeln(sprintf(
+                    '- %s (version %s)',
+                    $row['code'],
+                    $row['version'] === '' ? 'unknown' : $row['version'],
+                ));
+            }
+        }
+
+        if ($findings['disabled'] !== []) {
+            $output->writeln('');
+            $output->writeln('<comment>Warning: version records of disabled modules:</comment>');
+            foreach ($findings['disabled'] as $row) {
+                $output->writeln(sprintf('- %s (module %s is disabled)', $row['code'], $row['module']));
+            }
+            $output->writeln('They are kept. Re-enable the module, or remove it for good first.');
+        }
+
+        if ($findings['stale'] === []) {
+            $output->writeln('');
+            return;
+        }
+
+        $output->writeln('');
+        $output->writeln('<comment>A version record is install history. If the module ever comes back, its</comment>');
+        $output->writeln('<comment>install script runs again from the start.</comment>');
+
+        /** @var \Symfony\Component\Console\Helper\QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion(
+            sprintf(
+                '<question>Delete the version record of %s? [y/N]</question> ',
+                implode(', ', array_column($findings['stale'], 'code')),
+            ),
+            false,
+        );
+        if ($helper->ask($input, $output, $question)) {
+            $deleted = \MahoCLI\Helper\StaleModuleVersionScanner::purge(
+                array_column($findings['stale'], 'code'),
+            );
+            $output->writeln(sprintf('<info>Deleted %d core_resource row(s).</info>', $deleted));
+        }
+        $output->writeln('');
+    }
+
+    private function checkUnclaimedConfigSections(OutputInterface $output): void
+    {
+        $output->write('Checking store configuration sections... ');
+
+        $findings = self::findUnclaimedConfigSections();
+        if (array_filter($findings) === []) {
+            $output->writeln('<info>OK</info>');
+            return;
+        }
+
+        $output->writeln('');
+
+        if ($findings['unclaimed'] !== []) {
+            $output->writeln(sprintf(
+                '<comment>Warning: %d configuration section(s) that no installed module declares:</comment>',
+                count($findings['unclaimed']),
+            ));
+            foreach ($findings['unclaimed'] as $section) {
+                $output->writeln(sprintf('- %s (%d row(s))', $section['section'], $section['rows']));
+                $output->writeln(sprintf(
+                    "    DELETE FROM core_config_data WHERE path LIKE '%s/%%';",
+                    $section['section'],
+                ));
+            }
+            $output->writeln('This check reports only. An operator can also hand-write a section that no');
+            $output->writeln('system.xml declares, so read the rows before you delete them.');
+        }
+
+        if ($findings['disabled'] !== []) {
+            $output->writeln('');
+            $output->writeln('<comment>Warning: configuration of disabled modules:</comment>');
+            foreach ($findings['disabled'] as $section) {
+                $output->writeln(sprintf(
+                    '- %s (%d row(s), module %s is disabled)',
+                    $section['section'],
+                    $section['rows'],
+                    $section['module'],
+                ));
+            }
+            $output->writeln('Re-enable the module, or remove its configuration.');
+        }
+
+        $output->writeln('');
+    }
+
+    private function checkUnclaimedTables(OutputInterface $output): void
+    {
+        $output->write('Checking table ownership... ');
+
+        $findings = self::findUnclaimedTables();
+        if (array_filter($findings) === []) {
+            $output->writeln('<info>OK</info>');
+            return;
+        }
+
+        $output->writeln('');
+
+        if ($findings['unclaimed'] !== []) {
+            $output->writeln(sprintf(
+                '<comment>Warning: %d table(s) that no installed module declares:</comment>',
+                count($findings['unclaimed']),
+            ));
+            foreach ($findings['unclaimed'] as $table) {
+                $output->writeln(sprintf('- %s', $table));
+                $output->writeln(sprintf('    DROP TABLE %s;', $table));
+            }
+            $output->writeln('This check reports only, and it never drops a table. A module can create a');
+            $output->writeln('table in an install script and declare it nowhere else. Back up the database');
+            $output->writeln('before you drop one.');
+        }
+
+        if ($findings['disabled'] !== []) {
+            $output->writeln('');
+            $output->writeln('<comment>Warning: tables of disabled modules:</comment>');
+            foreach ($findings['disabled'] as $table) {
+                $output->writeln(sprintf('- %s (module %s is disabled)', $table['table'], $table['module']));
+            }
+        }
+
+        $output->writeln('');
+    }
+
+    private function checkStaleRegistrations(OutputInterface $output): void
+    {
+        $output->write('Checking the compiled attribute registry... ');
+
+        $findings = self::findStaleRegistrations();
+        if ($findings === []) {
+            $output->writeln('<info>OK</info>');
+            return;
+        }
+
+        $output->writeln('');
+        $output->writeln(sprintf(
+            '<comment>Warning: %d registration(s) point at code that no longer exists:</comment>',
+            count($findings),
+        ));
+        foreach ($findings as $finding) {
+            $output->writeln(sprintf('- %s %s: %s', $finding['kind'], $finding['name'], $finding['reason']));
+        }
+        $output->writeln('The compiled registry is out of date. Run: composer dump-autoload');
         $output->writeln('');
     }
 }

--- a/lib/MahoCLI/Helper/CallbackResolver.php
+++ b/lib/MahoCLI/Helper/CallbackResolver.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Explains why a configured callback cannot be called, for the checks that verify one.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package MahoCLI
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Helper;
+
+use Mage;
+
+class CallbackResolver
+{
+    /**
+     * Why `alias::method` cannot be called, or null when it can.
+     */
+    public static function findMissingCallback(string $alias, string $method): ?string
+    {
+        if ($alias === '' || $method === '') {
+            return 'declares an incomplete callback';
+        }
+
+        $reason = self::findMissingModel($alias);
+        if ($reason !== null) {
+            return $reason;
+        }
+
+        return self::findMissingClassCallback(Mage::getConfig()->getModelClassName($alias), $method);
+    }
+
+    /**
+     * Why the model alias cannot be built, or null when it can. getModelClassName()
+     * invents a class name for an unknown alias, so class_exists() is the real test.
+     */
+    public static function findMissingModel(string $alias): ?string
+    {
+        if ($alias === '') {
+            return 'declares no model, so no installed module owns it';
+        }
+
+        $class = Mage::getConfig()->getModelClassName($alias);
+        if ($class === '' || !class_exists($class)) {
+            return sprintf('model "%s" resolves to %s, which does not exist', $alias, $class === '' ? '(nothing)' : $class);
+        }
+
+        return null;
+    }
+
+    /**
+     * Why `class::method` cannot be called, or null when it can.
+     */
+    public static function findMissingClassCallback(string $class, string $method): ?string
+    {
+        if ($class === '' || $method === '') {
+            return 'declares an incomplete callback';
+        }
+        if (!class_exists($class)) {
+            return sprintf('class %s does not exist', $class);
+        }
+
+        $reflection = new \ReflectionClass($class);
+        if (!$reflection->isInstantiable()) {
+            return sprintf('class %s cannot be instantiated', $class);
+        }
+        if (!$reflection->hasMethod($method)) {
+            return sprintf('%s::%s() does not exist', $class, $method);
+        }
+
+        return null;
+    }
+}

--- a/lib/MahoCLI/Helper/ModuleInspector.php
+++ b/lib/MahoCLI/Helper/ModuleInspector.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Reads what the installed modules declare, for the checks that compare code to database state.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package MahoCLI
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Helper;
+
+use Mage;
+use Maho;
+
+class ModuleInspector
+{
+    /**
+     * Every module declared in app/etc/modules, as name => whether it is active.
+     * A module missing from this list is gone; a disabled one is not residue.
+     *
+     * @return array<string, bool>
+     */
+    public static function declaredModules(): array
+    {
+        $modules = [];
+        $node = Mage::getConfig()->getNode('modules');
+        if (!$node instanceof \Maho\Simplexml\Element) {
+            return $modules;
+        }
+
+        foreach ($node->children() as $name => $moduleNode) {
+            if (!$moduleNode instanceof \Mage_Core_Model_Config_Element) {
+                continue;
+            }
+            $modules[(string) $name] = (bool) $moduleNode->is('active');
+        }
+
+        return $modules;
+    }
+
+    /**
+     * Parse one etc/*.xml of a module without leaking libxml warnings, null on failure.
+     * The merged config tree cannot answer for a disabled module, and it already holds
+     * the database rows the residue checks test, so the file is read directly.
+     */
+    public static function loadModuleXml(string $module, string $fileName): ?\SimpleXMLElement
+    {
+        $file = Maho::findFile(Mage::getConfig()->getModuleDir('etc', $module) . '/' . $fileName);
+        if ($file === false) {
+            return null;
+        }
+
+        $previousLibxmlErrors = libxml_use_internal_errors(true);
+        try {
+            $xml = simplexml_load_file($file);
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previousLibxmlErrors);
+        }
+
+        return $xml === false ? null : $xml;
+    }
+
+    /**
+     * Table names a module's config.xml declares as resource entities, keyed by name.
+     * An entity with no <table> node takes the entity name.
+     *
+     * @return array<string, true>
+     */
+    public static function entityTablesFromXml(\SimpleXMLElement $xml, string $prefix): array
+    {
+        $tables = [];
+        if (!isset($xml->global->models)) {
+            return $tables;
+        }
+
+        foreach ($xml->global->models->children() as $node) {
+            if (!isset($node->entities)) {
+                continue;
+            }
+            foreach ($node->entities->children() as $entity => $entityNode) {
+                $table = trim((string) $entityNode->table);
+                $tables[$prefix . ($table === '' ? (string) $entity : $table)] = true;
+            }
+        }
+
+        return $tables;
+    }
+}

--- a/lib/MahoCLI/Helper/ModuleInspector.php
+++ b/lib/MahoCLI/Helper/ModuleInspector.php
@@ -65,19 +65,19 @@ class ModuleInspector
     }
 
     /**
-     * Table names a module's config.xml declares as resource entities, keyed by name.
+     * Table names a <global><models> node declares as resource entities, keyed by name.
      * An entity with no <table> node takes the entity name.
      *
      * @return array<string, true>
      */
-    public static function entityTablesFromXml(\SimpleXMLElement $xml, string $prefix): array
+    public static function entityTables(?\SimpleXMLElement $models, string $prefix): array
     {
         $tables = [];
-        if (!isset($xml->global->models)) {
+        if ($models === null) {
             return $tables;
         }
 
-        foreach ($xml->global->models->children() as $node) {
+        foreach ($models->children() as $node) {
             if (!isset($node->entities)) {
                 continue;
             }

--- a/lib/MahoCLI/Helper/PhantomMethodScanner.php
+++ b/lib/MahoCLI/Helper/PhantomMethodScanner.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Finds payment methods and shipping carriers that are configured but have no model class.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package MahoCLI
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Helper;
+
+use Mage;
+
+class PhantomMethodScanner
+{
+    /** Both sections share the "group with a model node" shape. */
+    public const SECTIONS = [
+        'payment' => 'payment method',
+        'carriers' => 'shipping carrier',
+    ];
+
+    /**
+     * Methods and carriers the store still offers with no model behind them. An
+     * active one is a live fault: the checkout and the admin order view both ask
+     * for a model the configuration promises and no module can build.
+     *
+     * @return list<array{section: string, label: string, code: string, active: bool, model: string, reason: string, paths: list<string>}>
+     */
+    public static function scan(): array
+    {
+        $config = Mage::getConfig();
+        $findings = [];
+
+        foreach (self::SECTIONS as $section => $label) {
+            $rows = self::configRows($section);
+
+            $codes = array_keys($rows);
+            $node = $config->getNode('default/' . $section);
+            if ($node instanceof \Maho\Simplexml\Element) {
+                foreach ($node->children() as $groupNode) {
+                    $codes[] = $groupNode->getName();
+                }
+            }
+
+            foreach (array_unique($codes) as $code) {
+                $code = (string) $code;
+                $alias = trim((string) $config->getNode("default/{$section}/{$code}/model"));
+                $reason = CallbackResolver::findMissingModel($alias);
+                if ($reason === null) {
+                    continue;
+                }
+
+                $findings[] = [
+                    'section' => $section,
+                    'label' => $label,
+                    'code' => $code,
+                    'active' => ((string) $config->getNode("default/{$section}/{$code}/active") === '1')
+                        || ($rows[$code]['active'] ?? false),
+                    'model' => $alias,
+                    'reason' => $reason,
+                    'paths' => $rows[$code]['paths'] ?? [],
+                ];
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Delete the given core_config_data paths. Paths are passed in rather than built
+     * as a LIKE prefix, where an underscore in a method code would act as a wildcard.
+     *
+     * @param list<string> $paths
+     */
+    public static function purge(array $paths): int
+    {
+        if ($paths === []) {
+            return 0;
+        }
+
+        $resource = Mage::getSingleton('core/resource');
+        $deleted = $resource->getConnection('core_write')->delete(
+            $resource->getTableName('core/config_data'),
+            ['path IN (?)' => $paths],
+        );
+
+        if ($deleted > 0) {
+            Mage::app()->cleanCache([\Mage_Core_Model_Config::CACHE_TAG]);
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * Every core_config_data path of one section, grouped by the code that follows it.
+     * Every scope counts: a row only a website activates is still deletable, and still
+     * offers the method to that website.
+     *
+     * @return array<string, array{paths: list<string>, active: bool}>
+     */
+    private static function configRows(string $section): array
+    {
+        $resource = Mage::getSingleton('core/resource');
+        $adapter = $resource->getConnection('core_read');
+
+        $select = $adapter->select()
+            ->from($resource->getTableName('core/config_data'), ['path', 'value'])
+            ->where('path LIKE ?', $section . '/%')
+            ->order('path');
+
+        $rows = [];
+        foreach ($adapter->fetchAll($select) as $row) {
+            $path = (string) $row['path'];
+            $segments = explode('/', $path);
+            $code = $segments[1] ?? '';
+            if ($code === '') {
+                continue;
+            }
+
+            $rows[$code] ??= ['paths' => [], 'active' => false];
+            if (!in_array($path, $rows[$code]['paths'], true)) {
+                $rows[$code]['paths'][] = $path;
+            }
+            if (($segments[2] ?? '') === 'active' && (string) ($row['value'] ?? '') === '1') {
+                $rows[$code]['active'] = true;
+            }
+        }
+
+        return $rows;
+    }
+}

--- a/lib/MahoCLI/Helper/PhantomMethodScanner.php
+++ b/lib/MahoCLI/Helper/PhantomMethodScanner.php
@@ -32,6 +32,7 @@ class PhantomMethodScanner
     public static function scan(): array
     {
         $config = Mage::getConfig();
+        $declared = self::declaredGroups();
         $findings = [];
 
         foreach (self::SECTIONS as $section => $label) {
@@ -48,6 +49,12 @@ class PhantomMethodScanner
             foreach (array_unique($codes) as $code) {
                 $code = (string) $code;
                 $alias = trim((string) $config->getNode("default/{$section}/{$code}/model"));
+                // A group with no model at all is residue only when no declared module
+                // names it. A disabled module still declares its method, and an active
+                // one can group shared settings under a code that carries no model.
+                if ($alias === '' && isset($declared[$section][$code])) {
+                    continue;
+                }
                 $reason = CallbackResolver::findMissingModel($alias);
                 if ($reason === null) {
                     continue;
@@ -92,6 +99,35 @@ class PhantomMethodScanner
         }
 
         return $deleted;
+    }
+
+    /**
+     * The method and carrier codes every declared module names under <default>, read from
+     * its own config.xml: the merged tree drops a disabled module, and it already holds the
+     * database rows under test.
+     *
+     * @return array<string, array<string, true>> section => code => true
+     */
+    private static function declaredGroups(): array
+    {
+        $declared = array_fill_keys(array_keys(self::SECTIONS), []);
+
+        foreach (array_keys(ModuleInspector::declaredModules()) as $module) {
+            $xml = ModuleInspector::loadModuleXml($module, 'config.xml');
+            if ($xml === null || !isset($xml->default)) {
+                continue;
+            }
+            foreach (array_keys(self::SECTIONS) as $section) {
+                if (!isset($xml->default->{$section})) {
+                    continue;
+                }
+                foreach ($xml->default->{$section}->children() as $groupNode) {
+                    $declared[$section][$groupNode->getName()] = true;
+                }
+            }
+        }
+
+        return $declared;
     }
 
     /**

--- a/lib/MahoCLI/Helper/PhantomMethodScanner.php
+++ b/lib/MahoCLI/Helper/PhantomMethodScanner.php
@@ -102,9 +102,11 @@ class PhantomMethodScanner
     }
 
     /**
-     * The method and carrier codes every declared module names under <default>, read from
-     * its own config.xml: the merged tree drops a disabled module, and it already holds the
-     * database rows under test.
+     * The method and carrier codes every declared module names, read from its own XML: the
+     * merged tree drops a disabled module, and it already holds the database rows under
+     * test. A group in system.xml counts as a declaration too. A module can give a vendor
+     * its own settings group there and put the model on the methods that use it, so the
+     * group owns rows without ever naming a model.
      *
      * @return array<string, array<string, true>> section => code => true
      */
@@ -113,21 +115,41 @@ class PhantomMethodScanner
         $declared = array_fill_keys(array_keys(self::SECTIONS), []);
 
         foreach (array_keys(ModuleInspector::declaredModules()) as $module) {
-            $xml = ModuleInspector::loadModuleXml($module, 'config.xml');
-            if ($xml === null || !isset($xml->default)) {
-                continue;
-            }
-            foreach (array_keys(self::SECTIONS) as $section) {
-                if (!isset($xml->default->{$section})) {
+            foreach (['config.xml', 'system.xml'] as $fileName) {
+                $xml = ModuleInspector::loadModuleXml($module, $fileName);
+                if ($xml === null) {
                     continue;
                 }
-                foreach ($xml->default->{$section}->children() as $groupNode) {
-                    $declared[$section][$groupNode->getName()] = true;
+                foreach (array_keys(self::SECTIONS) as $section) {
+                    foreach (self::groupsOf($xml, $fileName, $section) as $code) {
+                        $declared[$section][$code] = true;
+                    }
                 }
             }
         }
 
         return $declared;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function groupsOf(\SimpleXMLElement $xml, string $fileName, string $section): array
+    {
+        $node = $fileName === 'system.xml'
+            ? ($xml->sections->{$section}->groups ?? null)
+            : ($xml->default->{$section} ?? null);
+
+        if ($node === null || $node->count() === 0) {
+            return [];
+        }
+
+        $codes = [];
+        foreach ($node->children() as $groupNode) {
+            $codes[] = $groupNode->getName();
+        }
+
+        return $codes;
     }
 
     /**

--- a/lib/MahoCLI/Helper/PhantomMethodScanner.php
+++ b/lib/MahoCLI/Helper/PhantomMethodScanner.php
@@ -22,6 +22,9 @@ class PhantomMethodScanner
         'carriers' => 'shipping carrier',
     ];
 
+    /** Scope nodes keyed by store or website code, so a section sits one level deeper. */
+    private const CODE_KEYED_SCOPE_NODES = ['stores', 'websites'];
+
     /**
      * Methods and carriers the store still offers with no model behind them. An
      * active one is a live fault: the checkout and the admin order view both ask
@@ -37,25 +40,37 @@ class PhantomMethodScanner
 
         foreach (self::SECTIONS as $section => $label) {
             $rows = self::configRows($section);
+            $scopePaths = self::scopePaths($section);
 
             $codes = array_keys($rows);
-            $node = $config->getNode('default/' . $section);
-            if ($node instanceof \Maho\Simplexml\Element) {
-                foreach ($node->children() as $groupNode) {
-                    $codes[] = $groupNode->getName();
+            foreach ($scopePaths as $scopePath) {
+                $node = $config->getNode($scopePath);
+                if ($node instanceof \Maho\Simplexml\Element) {
+                    foreach ($node->children() as $groupNode) {
+                        $codes[] = $groupNode->getName();
+                    }
                 }
             }
 
             foreach (array_unique($codes) as $code) {
                 $code = (string) $code;
-                $alias = trim((string) $config->getNode("default/{$section}/{$code}/model"));
-                // A group with no model at all is residue only when no declared module
-                // names it. A disabled module still declares its method, and an active
-                // one can group shared settings under a code that carries no model.
-                if ($alias === '' && isset($declared[$section][$code])) {
+                $aliases = self::scopeValues($scopePaths, $code, 'model');
+                // A group with no model in any scope is residue only when no declared
+                // module names it. A disabled module still declares its method, and an
+                // active one can group shared settings under a code that carries no model.
+                if ($aliases === [] && isset($declared[$section][$code])) {
                     continue;
                 }
-                $reason = CallbackResolver::findMissingModel($alias);
+
+                $model = '';
+                $reason = null;
+                foreach ($aliases === [] ? [''] : $aliases as $alias) {
+                    $reason = CallbackResolver::findMissingModel($alias);
+                    if ($reason !== null) {
+                        $model = $alias;
+                        break;
+                    }
+                }
                 if ($reason === null) {
                     continue;
                 }
@@ -64,9 +79,9 @@ class PhantomMethodScanner
                     'section' => $section,
                     'label' => $label,
                     'code' => $code,
-                    'active' => ((string) $config->getNode("default/{$section}/{$code}/active") === '1')
+                    'active' => in_array('1', self::scopeValues($scopePaths, $code, 'active'), true)
                         || ($rows[$code]['active'] ?? false),
-                    'model' => $alias,
+                    'model' => $model,
                     'reason' => $reason,
                     'paths' => $rows[$code]['paths'] ?? [],
                 ];
@@ -74,6 +89,53 @@ class PhantomMethodScanner
         }
 
         return $findings;
+    }
+
+    /**
+     * Config-tree path of one section, one per scope. loadToXml() extends the default
+     * scope into every website node and each website into its stores, so a store node
+     * carries the whole tree. A group declared for one store alone lives nowhere else.
+     *
+     * @return list<string>
+     */
+    private static function scopePaths(string $section): array
+    {
+        $config = Mage::getConfig();
+        $paths = ['default/' . $section];
+
+        foreach (self::CODE_KEYED_SCOPE_NODES as $scope) {
+            $node = $config->getNode($scope);
+            if (!$node instanceof \Maho\Simplexml\Element) {
+                continue;
+            }
+            foreach ($node->children() as $code => $codeNode) {
+                $paths[] = sprintf('%s/%s/%s', $scope, $code, $section);
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * The distinct values one field of a group carries across the scopes, in scope order
+     * and without the empty ones.
+     *
+     * @param list<string> $scopePaths
+     * @return list<string>
+     */
+    private static function scopeValues(array $scopePaths, string $code, string $field): array
+    {
+        $config = Mage::getConfig();
+        $values = [];
+
+        foreach ($scopePaths as $scopePath) {
+            $value = trim((string) $config->getNode("{$scopePath}/{$code}/{$field}"));
+            if ($value !== '' && !in_array($value, $values, true)) {
+                $values[] = $value;
+            }
+        }
+
+        return $values;
     }
 
     /**
@@ -136,17 +198,29 @@ class PhantomMethodScanner
      */
     private static function groupsOf(\SimpleXMLElement $xml, string $fileName, string $section): array
     {
-        $node = $fileName === 'system.xml'
-            ? ($xml->sections->{$section}->groups ?? null)
-            : ($xml->default->{$section} ?? null);
-
-        if ($node === null || $node->count() === 0) {
-            return [];
+        $nodes = [];
+        if ($fileName === 'system.xml') {
+            $nodes[] = $xml->sections->{$section}->groups ?? null;
+        } else {
+            $nodes[] = $xml->default->{$section} ?? null;
+            foreach (self::CODE_KEYED_SCOPE_NODES as $scope) {
+                if (!isset($xml->{$scope})) {
+                    continue;
+                }
+                foreach ($xml->{$scope}->children() as $codeNode) {
+                    $nodes[] = $codeNode->{$section} ?? null;
+                }
+            }
         }
 
         $codes = [];
-        foreach ($node->children() as $groupNode) {
-            $codes[] = $groupNode->getName();
+        foreach ($nodes as $node) {
+            if ($node === null || $node->count() === 0) {
+                continue;
+            }
+            foreach ($node->children() as $groupNode) {
+                $codes[] = $groupNode->getName();
+            }
         }
 
         return $codes;

--- a/lib/MahoCLI/Helper/StaleModuleVersionScanner.php
+++ b/lib/MahoCLI/Helper/StaleModuleVersionScanner.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Finds core_resource rows that record the install history of a module that is gone.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package MahoCLI
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Helper;
+
+use Mage;
+use Maho;
+use Maho\Db\Schema\Status;
+
+class StaleModuleVersionScanner
+{
+    /** The migration layer owns this row, so no module declares it. */
+    private const PLATFORM_RESOURCES = [Status::RESOURCE_CODE];
+
+    /**
+     * core_resource rows naming a setup resource that no installed module ships.
+     *
+     * @return array{stale: list<array{code: string, version: string}>, disabled: list<array{code: string, module: string}>}
+     */
+    public static function scan(): array
+    {
+        $known = \Mage_Core_Model_Resource_Setup::getAllSetupResources();
+        $disabledResources = self::disabledModuleResources();
+        $findings = ['stale' => [], 'disabled' => []];
+
+        $resource = Mage::getSingleton('core/resource');
+        $adapter = $resource->getConnection('core_read');
+        $select = $adapter->select()
+            ->from($resource->getTableName('core/resource'), ['code', 'version'])
+            ->order('code');
+
+        foreach ($adapter->fetchAll($select) as $row) {
+            $code = (string) $row['code'];
+            if (isset($known[$code]) || in_array($code, self::PLATFORM_RESOURCES, true)) {
+                continue;
+            }
+            if (isset($disabledResources[$code])) {
+                $findings['disabled'][] = ['code' => $code, 'module' => $disabledResources[$code]];
+                continue;
+            }
+            $findings['stale'][] = ['code' => $code, 'version' => (string) ($row['version'] ?? '')];
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    public static function purge(array $codes): int
+    {
+        if ($codes === []) {
+            return 0;
+        }
+
+        $resource = Mage::getSingleton('core/resource');
+        return $resource->getConnection('core_write')->delete(
+            $resource->getTableName('core/resource'),
+            ['code IN (?)' => $codes],
+        );
+    }
+
+    /**
+     * Setup resource names of declared but disabled modules. getAllSetupResources()
+     * skips them, so without this every disabled module reads as removed.
+     *
+     * @return array<string, string> resource name => module
+     */
+    private static function disabledModuleResources(): array
+    {
+        $resources = [];
+
+        foreach (ModuleInspector::declaredModules() as $module => $active) {
+            if ($active) {
+                continue;
+            }
+
+            foreach (['sql', 'data'] as $type) {
+                $dir = Mage::getConfig()->getModuleDir($type, $module);
+                foreach (Maho::listDirectories($dir) as $subDir) {
+                    if (str_ends_with($subDir, '_setup')) {
+                        $resources[$subDir] ??= $module;
+                    }
+                }
+            }
+
+            $xml = ModuleInspector::loadModuleXml($module, 'config.xml');
+            if ($xml === null || !isset($xml->global->resources)) {
+                continue;
+            }
+            foreach ($xml->global->resources->children() as $name => $node) {
+                if (isset($node->setup)) {
+                    $resources[(string) $name] ??= $module;
+                }
+            }
+        }
+
+        return $resources;
+    }
+}

--- a/lib/MahoCLI/Helper/StaleRegistrationScanner.php
+++ b/lib/MahoCLI/Helper/StaleRegistrationScanner.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * Finds compiled attribute registrations that point at code that no longer exists.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package MahoCLI
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Helper;
+
+use Maho;
+
+class StaleRegistrationScanner
+{
+    /**
+     * Observers, message handlers, and routes in vendor/composer/maho_attributes.php
+     * whose class or method is gone. The registry is a build artifact, so every finding
+     * means the same thing: it was not recompiled. Cron jobs are checked separately,
+     * because a job code also carries database configuration.
+     *
+     * @return list<array{kind: string, name: string, target: string, reason: string}>
+     */
+    public static function scan(): array
+    {
+        $attributes = Maho::getCompiledAttributes();
+
+        return [
+            ...self::scanObservers($attributes['observers'] ?? []),
+            ...self::scanMessageHandlers($attributes['messageHandlers'] ?? []),
+            ...self::scanRoutes($attributes['routes'] ?? []),
+        ];
+    }
+
+    /**
+     * @param array<string, array<string, list<array<string, mixed>>>> $observers
+     * @return list<array{kind: string, name: string, target: string, reason: string}>
+     */
+    private static function scanObservers(array $observers): array
+    {
+        $findings = [];
+        foreach ($observers as $area => $events) {
+            foreach ($events as $event => $registrations) {
+                foreach ($registrations as $observer) {
+                    $class = (string) ($observer['class'] ?? '');
+                    $method = (string) ($observer['method'] ?? '');
+                    $reason = CallbackResolver::findMissingClassCallback($class, $method);
+                    if ($reason !== null) {
+                        $findings[] = [
+                            'kind' => 'observer',
+                            'name' => sprintf('%s/%s/%s', $area, $event, $observer['name'] ?? '?'),
+                            'target' => $class . '::' . $method,
+                            'reason' => $reason,
+                        ];
+                    }
+                }
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param array<string, list<array<string, mixed>>> $handlers
+     * @return list<array{kind: string, name: string, target: string, reason: string}>
+     */
+    private static function scanMessageHandlers(array $handlers): array
+    {
+        $findings = [];
+        foreach ($handlers as $message => $registrations) {
+            $message = (string) $message;
+            if (!class_exists($message)) {
+                $findings[] = [
+                    'kind' => 'message handler',
+                    'name' => $message,
+                    'target' => $message,
+                    'reason' => sprintf('message class %s does not exist', $message),
+                ];
+                continue;
+            }
+            foreach ($registrations as $handler) {
+                $class = (string) ($handler['class'] ?? '');
+                $method = (string) ($handler['method'] ?? '');
+                $reason = CallbackResolver::findMissingClassCallback($class, $method);
+                if ($reason !== null) {
+                    $findings[] = [
+                        'kind' => 'message handler',
+                        'name' => $message,
+                        'target' => $class . '::' . $method,
+                        'reason' => $reason,
+                    ];
+                }
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $routes
+     * @return list<array{kind: string, name: string, target: string, reason: string}>
+     */
+    private static function scanRoutes(array $routes): array
+    {
+        $findings = [];
+        foreach ($routes as $name => $route) {
+            $class = (string) ($route['class'] ?? '');
+            $action = (string) ($route['action'] ?? '');
+            $reason = CallbackResolver::findMissingClassCallback($class, $action);
+            if ($reason !== null) {
+                $findings[] = [
+                    'kind' => 'route',
+                    'name' => (string) $name,
+                    'target' => $class . '::' . $action,
+                    'reason' => $reason,
+                ];
+            }
+        }
+
+        return $findings;
+    }
+}

--- a/lib/MahoCLI/Helper/UnclaimedConfigScanner.php
+++ b/lib/MahoCLI/Helper/UnclaimedConfigScanner.php
@@ -16,8 +16,14 @@ use Mage;
 
 class UnclaimedConfigScanner
 {
-    /** Scope nodes of a config.xml whose children name a store-config section. */
-    private const SCOPE_NODES = ['default', 'frontend', 'adminhtml', 'stores', 'websites'];
+    /**
+     * Config scopes of a config.xml. Under <default> the children are sections; under
+     * <stores> and <websites> they are store and website codes, so the sections sit one
+     * level deeper. <frontend> and <adminhtml> are areas, not scopes, and their children
+     * (layout, translate, events, routers) are not sections.
+     */
+    private const SCOPE_NODES = ['default'];
+    private const CODE_KEYED_SCOPE_NODES = ['stores', 'websites'];
 
     /**
      * core_config_data sections with no owner in code. Advisory only: an operator can
@@ -60,8 +66,8 @@ class UnclaimedConfigScanner
             ->from($resource->getTableName('core/config_data'), ['path']);
 
         $counts = [];
-        foreach ($adapter->fetchAll($select) as $row) {
-            $section = explode('/', (string) $row['path'])[0];
+        foreach ($adapter->fetchCol($select) as $path) {
+            $section = explode('/', (string) $path)[0];
             if ($section === '') {
                 continue;
             }
@@ -124,6 +130,17 @@ class UnclaimedConfigScanner
             }
             foreach ($xml->{$scope}->children() as $sectionNode) {
                 $sections[] = $sectionNode->getName();
+            }
+        }
+
+        foreach (self::CODE_KEYED_SCOPE_NODES as $scope) {
+            if (!isset($xml->{$scope})) {
+                continue;
+            }
+            foreach ($xml->{$scope}->children() as $codeNode) {
+                foreach ($codeNode->children() as $sectionNode) {
+                    $sections[] = $sectionNode->getName();
+                }
             }
         }
 

--- a/lib/MahoCLI/Helper/UnclaimedConfigScanner.php
+++ b/lib/MahoCLI/Helper/UnclaimedConfigScanner.php
@@ -26,6 +26,16 @@ class UnclaimedConfigScanner
     private const CODE_KEYED_SCOPE_NODES = ['stores', 'websites'];
 
     /**
+     * Sections a config.xml also declares at the top level, outside any scope node. The
+     * runtime reads both crontab/jobs and default/crontab/jobs, so a legacy
+     * <crontab><jobs> declaration claims the section that a cron backend model writes to.
+     */
+    private const GLOBAL_SCOPE_SECTIONS = ['crontab'];
+
+    /** The section a #[CronJob] attribute claims, the modern form of the node above. */
+    private const CRON_ATTRIBUTE_SECTION = 'crontab';
+
+    /**
      * core_config_data sections with no owner in code. Advisory only: an operator can
      * hand-write a section that no system.xml declares, so a finding is a question,
      * not a verdict.
@@ -96,16 +106,49 @@ class UnclaimedConfigScanner
                 }
 
                 foreach (self::sectionsOf($xml, $fileName) as $section) {
-                    // An active owner wins: a section that both an active and a disabled
-                    // module declares is still owned.
-                    if (!isset($owners[$section]) || (!$owners[$section]['active'] && $active)) {
-                        $owners[$section] = ['module' => $module, 'active' => $active];
-                    }
+                    self::claim($owners, $section, $module, $active);
                 }
             }
         }
 
+        foreach (self::cronAttributeModules() as $module => $active) {
+            self::claim($owners, self::CRON_ATTRIBUTE_SECTION, $module, $active);
+        }
+
         return $owners;
+    }
+
+    /**
+     * Modules that declare a cron job with an attribute rather than an XML node.
+     *
+     * @return array<string, bool>
+     */
+    private static function cronAttributeModules(): array
+    {
+        $declared = ModuleInspector::declaredModules();
+        $modules = [];
+
+        foreach (\Maho::getCompiledAttributes()['crontab'] ?? [] as $jobDef) {
+            $module = (string) ($jobDef['module'] ?? '');
+            if ($module !== '' && isset($declared[$module])) {
+                $modules[$module] = $declared[$module];
+            }
+        }
+
+        return $modules;
+    }
+
+    /**
+     * An active owner wins: a section that both an active and a disabled module declares
+     * is still owned.
+     *
+     * @param array<string, array{module: string, active: bool}> $owners
+     */
+    private static function claim(array &$owners, string $section, string $module, bool $active): void
+    {
+        if (!isset($owners[$section]) || (!$owners[$section]['active'] && $active)) {
+            $owners[$section] = ['module' => $module, 'active' => $active];
+        }
     }
 
     /**
@@ -141,6 +184,12 @@ class UnclaimedConfigScanner
                 foreach ($codeNode->children() as $sectionNode) {
                     $sections[] = $sectionNode->getName();
                 }
+            }
+        }
+
+        foreach (self::GLOBAL_SCOPE_SECTIONS as $section) {
+            if (isset($xml->{$section})) {
+                $sections[] = $section;
             }
         }
 

--- a/lib/MahoCLI/Helper/UnclaimedConfigScanner.php
+++ b/lib/MahoCLI/Helper/UnclaimedConfigScanner.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Finds store configuration sections that no installed module declares.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package MahoCLI
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Helper;
+
+use Mage;
+
+class UnclaimedConfigScanner
+{
+    /** Scope nodes of a config.xml whose children name a store-config section. */
+    private const SCOPE_NODES = ['default', 'frontend', 'adminhtml', 'stores', 'websites'];
+
+    /**
+     * core_config_data sections with no owner in code. Advisory only: an operator can
+     * hand-write a section that no system.xml declares, so a finding is a question,
+     * not a verdict.
+     *
+     * @return array{unclaimed: list<array{section: string, rows: int}>, disabled: list<array{section: string, module: string, rows: int}>}
+     */
+    public static function scan(): array
+    {
+        $owners = self::sectionOwners();
+        $findings = ['unclaimed' => [], 'disabled' => []];
+
+        foreach (self::sectionCounts() as $section => $count) {
+            $owner = $owners[$section] ?? null;
+            if ($owner !== null && $owner['active']) {
+                continue;
+            }
+            if ($owner !== null) {
+                $findings['disabled'][] = ['section' => $section, 'module' => $owner['module'], 'rows' => $count];
+                continue;
+            }
+            $findings['unclaimed'][] = ['section' => $section, 'rows' => $count];
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Row count of every core_config_data section, keyed by the first path segment.
+     *
+     * @return array<string, int>
+     */
+    private static function sectionCounts(): array
+    {
+        $resource = Mage::getSingleton('core/resource');
+        $adapter = $resource->getConnection('core_read');
+
+        $select = $adapter->select()
+            ->from($resource->getTableName('core/config_data'), ['path']);
+
+        $counts = [];
+        foreach ($adapter->fetchAll($select) as $row) {
+            $section = explode('/', (string) $row['path'])[0];
+            if ($section === '') {
+                continue;
+            }
+            $counts[$section] = ($counts[$section] ?? 0) + 1;
+        }
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * The module that declares each section, read from the module XML rather than the
+     * merged tree: the merged tree already holds the rows under test.
+     *
+     * @return array<string, array{module: string, active: bool}>
+     */
+    private static function sectionOwners(): array
+    {
+        $owners = [];
+
+        foreach (ModuleInspector::declaredModules() as $module => $active) {
+            foreach (['config.xml', 'system.xml'] as $fileName) {
+                $xml = ModuleInspector::loadModuleXml($module, $fileName);
+                if ($xml === null) {
+                    continue;
+                }
+
+                foreach (self::sectionsOf($xml, $fileName) as $section) {
+                    // An active owner wins: a section that both an active and a disabled
+                    // module declares is still owned.
+                    if (!isset($owners[$section]) || (!$owners[$section]['active'] && $active)) {
+                        $owners[$section] = ['module' => $module, 'active' => $active];
+                    }
+                }
+            }
+        }
+
+        return $owners;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function sectionsOf(\SimpleXMLElement $xml, string $fileName): array
+    {
+        $sections = [];
+
+        if ($fileName === 'system.xml') {
+            if (isset($xml->sections)) {
+                foreach ($xml->sections->children() as $sectionNode) {
+                    $sections[] = $sectionNode->getName();
+                }
+            }
+            return $sections;
+        }
+
+        foreach (self::SCOPE_NODES as $scope) {
+            if (!isset($xml->{$scope})) {
+                continue;
+            }
+            foreach ($xml->{$scope}->children() as $sectionNode) {
+                $sections[] = $sectionNode->getName();
+            }
+        }
+
+        return $sections;
+    }
+}

--- a/lib/MahoCLI/Helper/UnclaimedTableScanner.php
+++ b/lib/MahoCLI/Helper/UnclaimedTableScanner.php
@@ -35,6 +35,8 @@ class UnclaimedTableScanner
 
         $owned = self::declaredEntityTables($prefix);
         foreach (self::PLATFORM_TABLES as $table) {
+            // The SQLite adapter hard-codes the unprefixed name, so exempt both spellings.
+            $owned[$table] = true;
             $owned[$prefix . $table] = true;
         }
         [$schema] = Collector::collect();
@@ -62,28 +64,19 @@ class UnclaimedTableScanner
      */
     private static function declaredEntityTables(string $prefix): array
     {
-        $tables = [];
-
         $models = Mage::getConfig()->getNode('global/models');
-        if ($models instanceof \Maho\Simplexml\Element) {
-            foreach ($models->children() as $node) {
-                if (!isset($node->entities)) {
-                    continue;
-                }
-                foreach ($node->entities->children() as $entity => $entityNode) {
-                    $table = trim((string) $entityNode->table);
-                    $tables[$prefix . ($table === '' ? (string) $entity : $table)] = true;
-                }
-            }
-        }
+        $tables = ModuleInspector::entityTables(
+            $models instanceof \Maho\Simplexml\Element ? $models : null,
+            $prefix,
+        );
 
         foreach (ModuleInspector::declaredModules() as $module => $active) {
             if ($active) {
                 continue;
             }
             $xml = ModuleInspector::loadModuleXml($module, 'config.xml');
-            if ($xml !== null) {
-                $tables += ModuleInspector::entityTablesFromXml($xml, $prefix);
+            if ($xml !== null && isset($xml->global->models)) {
+                $tables += ModuleInspector::entityTables($xml->global->models, $prefix);
             }
         }
 

--- a/lib/MahoCLI/Helper/UnclaimedTableScanner.php
+++ b/lib/MahoCLI/Helper/UnclaimedTableScanner.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * Finds live tables that no installed module declares.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package MahoCLI
+ */
+
+declare(strict_types=1);
+
+namespace MahoCLI\Helper;
+
+use Mage;
+use Maho;
+use Maho\Db\Schema\Collector;
+
+class UnclaimedTableScanner
+{
+    /** The SQLite adapter creates this table at runtime, so no schema declares it. */
+    private const PLATFORM_TABLES = ['core_advisory_lock'];
+
+    /**
+     * Tables that neither a sql/schema.php nor a resource entity claims. Advisory only,
+     * and nothing is ever dropped: a module can create a table in an install script and
+     * name it nowhere else. "./maho migrate" is forward-only, so nothing else reports these.
+     *
+     * @return array{unclaimed: list<string>, disabled: list<array{table: string, module: string}>}
+     */
+    public static function scan(): array
+    {
+        $adapter = Mage::getSingleton('core/resource')->getConnection('core_read');
+        $prefix = Collector::tablePrefix();
+
+        $owned = self::declaredEntityTables($prefix);
+        foreach (self::PLATFORM_TABLES as $table) {
+            $owned[$prefix . $table] = true;
+        }
+        [$schema] = Collector::collect();
+        foreach ($schema->getTables() as $table) {
+            $owned[$table->getObjectName()->getUnqualifiedName()->getValue()] = true;
+        }
+
+        $unclaimed = [];
+        foreach ($adapter->listTables() as $table) {
+            $table = (string) $table;
+            if (!isset($owned[$table])) {
+                $unclaimed[] = $table;
+            }
+        }
+        sort($unclaimed);
+
+        return self::splitTablesOfDisabledModules($unclaimed, $prefix);
+    }
+
+    /**
+     * Tables named by a resource entity of any declared module. The merged tree covers
+     * every active module at once; disabled modules are read from their own XML.
+     *
+     * @return array<string, true>
+     */
+    private static function declaredEntityTables(string $prefix): array
+    {
+        $tables = [];
+
+        $models = Mage::getConfig()->getNode('global/models');
+        if ($models instanceof \Maho\Simplexml\Element) {
+            foreach ($models->children() as $node) {
+                if (!isset($node->entities)) {
+                    continue;
+                }
+                foreach ($node->entities->children() as $entity => $entityNode) {
+                    $table = trim((string) $entityNode->table);
+                    $tables[$prefix . ($table === '' ? (string) $entity : $table)] = true;
+                }
+            }
+        }
+
+        foreach (ModuleInspector::declaredModules() as $module => $active) {
+            if ($active) {
+                continue;
+            }
+            $xml = ModuleInspector::loadModuleXml($module, 'config.xml');
+            if ($xml !== null) {
+                $tables += ModuleInspector::entityTablesFromXml($xml, $prefix);
+            }
+        }
+
+        return $tables;
+    }
+
+    /**
+     * Move to the disabled bucket every table a disabled module's sql/schema.php creates.
+     * Collector only runs the schema of active modules, so the source text is read
+     * instead of executed.
+     *
+     * @param list<string> $unclaimed
+     * @return array{unclaimed: list<string>, disabled: list<array{table: string, module: string}>}
+     */
+    private static function splitTablesOfDisabledModules(array $unclaimed, string $prefix): array
+    {
+        if ($unclaimed === []) {
+            return ['unclaimed' => [], 'disabled' => []];
+        }
+
+        $disabled = [];
+        foreach (ModuleInspector::declaredModules() as $module => $active) {
+            if ($active || $unclaimed === []) {
+                continue;
+            }
+
+            $file = Maho::findFile(Mage::getConfig()->getModuleDir('sql', $module) . '/schema.php');
+            if ($file === false) {
+                continue;
+            }
+            $source = (string) file_get_contents($file);
+
+            foreach ($unclaimed as $index => $table) {
+                $bare = str_starts_with($table, $prefix) ? substr($table, strlen($prefix)) : $table;
+                if (preg_match('/createTable\(\s*[\'"]' . preg_quote($bare, '/') . '[\'"]/', $source) === 1) {
+                    $disabled[] = ['table' => $table, 'module' => $module];
+                    unset($unclaimed[$index]);
+                }
+            }
+        }
+
+        return ['unclaimed' => array_values($unclaimed), 'disabled' => $disabled];
+    }
+}

--- a/tests/Backend/Unit/Adminhtml/Model/System/Config/Backend/LogCronTest.php
+++ b/tests/Backend/Unit/Adminhtml/Model/System/Config/Backend/LogCronTest.php
@@ -48,9 +48,19 @@ function logCronExpr(): string
     return (string) $adapter->fetchOne($select);
 }
 
-beforeEach(function () {
+function deleteLogCleanCronConfig(): void
+{
     $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
     $adapter->delete('core_config_data', "path LIKE 'crontab/jobs/log_clean/%'");
+}
+
+beforeEach(function () {
+    deleteLogCleanCronConfig();
+});
+
+// Leave no row behind: another test asserts that the install carries no config residue.
+afterEach(function () {
+    deleteLogCleanCronConfig();
 });
 
 it('builds the cron expression from the configured start time and frequency', function () {

--- a/tests/Backend/Unit/MahoCLI/Commands/HealthCheckResidueTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/HealthCheckResidueTest.php
@@ -1,0 +1,310 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package MahoCLI
+ */
+
+declare(strict_types=1);
+
+use MahoCLI\Commands\HealthCheck;
+use MahoCLI\Helper\CallbackResolver;
+use MahoCLI\Helper\PhantomMethodScanner;
+use MahoCLI\Helper\StaleModuleVersionScanner;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Coverage for the health checks that find database state left behind by a module
+ * whose code is gone: phantom payment methods and carriers, unclaimed config
+ * sections, stale version records, unclaimed tables, and stale attribute
+ * registrations. A disabled module is not residue, so each rule keeps its own
+ * bucket for one, and the purge never touches it.
+ */
+
+/**
+ * Run $assert with $rows (path => value) in core_config_data, then put the table back.
+ *
+ * @param array<string, string> $rows
+ */
+function residueWithConfig(array $rows, callable $assert): void
+{
+    $config = Mage::getConfig();
+    foreach ($rows as $path => $value) {
+        $config->saveConfig($path, $value);
+    }
+    $config->reinit();
+
+    try {
+        $assert();
+    } finally {
+        foreach (array_keys($rows) as $path) {
+            $config->deleteConfig($path);
+        }
+        $config->reinit();
+    }
+}
+
+/**
+ * Declare a disabled module that ships $files (path relative to the module root),
+ * run $assert, then delete every file and directory it created.
+ *
+ * @param array<string, string> $files
+ */
+function residueWithDisabledModule(string $module, array $files, callable $assert): void
+{
+    $declaration = Mage::getBaseDir('etc') . "/modules/{$module}.xml";
+    $base = Mage::getBaseDir('code') . '/local/' . str_replace('_', '/', $module);
+
+    $created = [];
+    foreach ($files as $relative => $contents) {
+        $file = "{$base}/{$relative}";
+        if (!is_dir(dirname($file))) {
+            mkdir(dirname($file), 0o777, true);
+        }
+        file_put_contents($file, $contents);
+        $created[] = $file;
+    }
+    file_put_contents($declaration, sprintf(
+        '<?xml version="1.0"?><config><modules><%s><active>false</active><codePool>local</codePool></%s></modules></config>',
+        $module,
+        $module,
+    ));
+
+    Mage::getConfig()->reinit();
+
+    try {
+        $assert();
+    } finally {
+        unlink($declaration);
+        foreach ($created as $file) {
+            unlink($file);
+        }
+        // Deepest first, and only the directories this fixture created.
+        $directories = array_unique(array_map(dirname(...), $created));
+        usort($directories, fn(string $a, string $b) => strlen($b) <=> strlen($a));
+        foreach ([...$directories, $base, dirname($base)] as $directory) {
+            @rmdir($directory);
+        }
+        Mage::getConfig()->reinit();
+    }
+}
+
+/**
+ * Create $table with a single id column, run $assert, then drop it.
+ */
+function residueWithTable(string $table, callable $assert): void
+{
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    $adapter->createTable(
+        $adapter->newTable($table)->addColumn('id', \Maho\Db\Ddl\Table::TYPE_INTEGER, null, [], 'Id'),
+    );
+
+    try {
+        $assert();
+    } finally {
+        $adapter->dropTable($table);
+    }
+}
+
+/**
+ * Insert a core_resource row, run $assert, then delete the row.
+ */
+function residueWithResourceVersion(string $code, callable $assert): void
+{
+    $resource = Mage::getSingleton('core/resource');
+    $adapter = $resource->getConnection('core_write');
+    $table = $resource->getTableName('core/resource');
+    $adapter->insert($table, ['code' => $code, 'version' => '1.0.0', 'data_version' => '1.0.0']);
+
+    try {
+        $assert();
+    } finally {
+        $adapter->delete($table, ['code = ?' => $code]);
+    }
+}
+
+it('reports no residue on a healthy install', function () {
+    expect(HealthCheck::findPhantomMethods())->toBe([])
+        ->and(HealthCheck::findUnclaimedConfigSections())->toBe(['unclaimed' => [], 'disabled' => []])
+        ->and(HealthCheck::findStaleResourceVersions())->toBe(['stale' => [], 'disabled' => []])
+        ->and(HealthCheck::findUnclaimedTables())->toBe(['unclaimed' => [], 'disabled' => []])
+        ->and(HealthCheck::findStaleRegistrations())->toBe([]);
+});
+
+it('flags an active payment method whose model class is gone', function () {
+    $code = 'residue_' . uniqid();
+
+    residueWithConfig(["payment/{$code}/active" => '1'], function () use ($code) {
+        $findings = HealthCheck::findPhantomMethods();
+        $finding = current(array_filter($findings, fn(array $f) => $f['code'] === $code));
+
+        expect($finding)->not->toBeFalse()
+            ->and($finding['section'])->toBe('payment')
+            ->and($finding['active'])->toBeTrue()
+            ->and($finding['reason'])->toContain('no model')
+            ->and($finding['paths'])->toBe(["payment/{$code}/active"]);
+    });
+});
+
+it('flags a shipping carrier whose model class is gone', function () {
+    $code = 'residue_' . uniqid();
+
+    residueWithConfig(["carriers/{$code}/active" => '1'], function () use ($code) {
+        $codes = array_column(HealthCheck::findPhantomMethods(), 'code');
+
+        expect($codes)->toContain($code);
+    });
+});
+
+it('leaves an installed payment method alone', function () {
+    $codes = array_column(HealthCheck::findPhantomMethods(), 'code');
+
+    expect($codes)->not->toContain('checkmo')
+        ->and($codes)->not->toContain('flatrate');
+});
+
+it('purges the configuration rows of a phantom method', function () {
+    $code = 'residue_' . uniqid();
+    $path = "payment/{$code}/active";
+
+    residueWithConfig([$path => '1'], function () use ($code, $path) {
+        expect(array_column(HealthCheck::findPhantomMethods(), 'code'))->toContain($code);
+
+        $deleted = PhantomMethodScanner::purge([$path]);
+        Mage::getConfig()->reinit();
+
+        expect($deleted)->toBe(1)
+            ->and(array_column(HealthCheck::findPhantomMethods(), 'code'))->not->toContain($code);
+    });
+});
+
+it('flags a config section that no installed module declares', function () {
+    $section = 'residue' . uniqid();
+
+    residueWithConfig(["{$section}/group/field" => '1'], function () use ($section) {
+        $findings = HealthCheck::findUnclaimedConfigSections();
+        $finding = current(array_filter($findings['unclaimed'], fn(array $f) => $f['section'] === $section));
+
+        expect($finding)->not->toBeFalse()
+            ->and($finding['rows'])->toBe(1);
+    });
+});
+
+it('leaves a config section of an installed module alone', function () {
+    $sections = array_column(HealthCheck::findUnclaimedConfigSections()['unclaimed'], 'section');
+
+    expect($sections)->not->toContain('web')
+        ->and($sections)->not->toContain('catalog');
+});
+
+it('flags a version record of a setup resource no module ships', function () {
+    $code = 'residue' . uniqid() . '_setup';
+
+    residueWithResourceVersion($code, function () use ($code) {
+        $findings = HealthCheck::findStaleResourceVersions();
+
+        expect(array_column($findings['stale'], 'code'))->toContain($code);
+    });
+});
+
+it('never flags the version record of the declarative schema', function () {
+    $findings = HealthCheck::findStaleResourceVersions();
+
+    expect(array_column($findings['stale'], 'code'))->not->toContain(\Maho\Db\Schema\Status::RESOURCE_CODE);
+});
+
+it('purges a stale version record', function () {
+    $code = 'residue' . uniqid() . '_setup';
+
+    residueWithResourceVersion($code, function () use ($code) {
+        expect(array_column(HealthCheck::findStaleResourceVersions()['stale'], 'code'))->toContain($code);
+
+        $deleted = StaleModuleVersionScanner::purge([$code]);
+
+        expect($deleted)->toBe(1)
+            ->and(array_column(HealthCheck::findStaleResourceVersions()['stale'], 'code'))->not->toContain($code);
+    });
+});
+
+it('flags a table that no installed module declares', function () {
+    $table = 'residue' . uniqid();
+
+    residueWithTable($table, function () use ($table) {
+        expect(HealthCheck::findUnclaimedTables()['unclaimed'])->toContain($table);
+    });
+});
+
+it('leaves a declared table alone', function () {
+    $unclaimed = HealthCheck::findUnclaimedTables()['unclaimed'];
+
+    expect($unclaimed)->not->toContain(Mage::getSingleton('core/resource')->getTableName('core/config_data'))
+        ->and($unclaimed)->not->toContain(Mage::getSingleton('core/resource')->getTableName('catalog/product'));
+});
+
+it('keeps the residue of a disabled module out of the purge lists', function () {
+    $module = 'Residue_Probe';
+    $section = 'residueprobe';
+    $files = [
+        'etc/config.xml' => sprintf(
+            '<?xml version="1.0"?><config><global><models><%1$s><entities><thing><table>%1$s_thing</table>'
+            . '</thing></entities></%1$s></models></global><default><%1$s><group><field>1</field></group>'
+            . '</%1$s></default></config>',
+            $section,
+        ),
+        'sql/schema.php' => "<?php return function (\$schema) { \$schema->createTable('{$section}_schema'); };\n",
+        "sql/{$section}_setup/.gitkeep" => '',
+    ];
+
+    $assert = function () use ($module, $section) {
+        $sections = HealthCheck::findUnclaimedConfigSections();
+        $resources = HealthCheck::findStaleResourceVersions();
+        $tables = HealthCheck::findUnclaimedTables();
+
+        expect(array_column($sections['unclaimed'], 'section'))->not->toContain($section)
+            ->and(array_column($sections['disabled'], 'section'))->toContain($section)
+            ->and(array_column($sections['disabled'], 'module'))->toContain($module)
+            ->and(array_column($resources['stale'], 'code'))->not->toContain("{$section}_setup")
+            ->and(array_column($resources['disabled'], 'code'))->toContain("{$section}_setup")
+            ->and($tables['unclaimed'])->not->toContain("{$section}_schema")
+            ->and(array_column($tables['disabled'], 'table'))->toContain("{$section}_schema");
+    };
+
+    residueWithDisabledModule($module, $files, fn() => residueWithConfig(
+        ["{$section}/group/field" => '1'],
+        fn() => residueWithResourceVersion(
+            "{$section}_setup",
+            fn() => residueWithTable("{$section}_schema", $assert),
+        ),
+    ));
+});
+
+it('leaves a table a disabled module declares as an entity alone', function () {
+    $module = 'Residue_Probe';
+    $section = 'residueprobe';
+    $files = [
+        'etc/config.xml' => sprintf(
+            '<?xml version="1.0"?><config><global><models><%1$s><entities><thing><table>%1$s_thing</table>'
+            . '</thing></entities></%1$s></models></global></config>',
+            $section,
+        ),
+    ];
+
+    residueWithDisabledModule($module, $files, function () use ($section) {
+        residueWithTable("{$section}_thing", function () use ($section) {
+            $tables = HealthCheck::findUnclaimedTables();
+
+            expect($tables['unclaimed'])->not->toContain("{$section}_thing")
+                ->and(array_column($tables['disabled'], 'table'))->not->toContain("{$section}_thing");
+        });
+    });
+});
+
+it('reports why a callback cannot be resolved', function () {
+    expect(CallbackResolver::findMissingCallback('core/nosuchmodel', 'run'))->toContain('does not exist')
+        ->and(CallbackResolver::findMissingModel('core/nosuchmodel'))->toContain('does not exist')
+        ->and(CallbackResolver::findMissingModel(''))->toContain('no model')
+        ->and(CallbackResolver::findMissingCallback('core/config', 'noSuchMethod'))->toContain('does not exist')
+        ->and(CallbackResolver::findMissingCallback('core/config', 'reinit'))->toBeNull();
+});

--- a/tests/Backend/Unit/MahoCLI/Commands/HealthCheckResidueTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/HealthCheckResidueTest.php
@@ -222,6 +222,16 @@ it('leaves a config section of an installed module alone', function () {
         ->and($sections)->not->toContain('catalog');
 });
 
+it('leaves a cron schedule row alone, because a legacy crontab node claims it', function () {
+    // A cron backend model writes this path. The declaration is a top-level
+    // <crontab><jobs> node, which the scanner used to read as no declaration at all.
+    residueWithConfig(['crontab/jobs/residue_job/schedule/cron_expr' => '0 3 * * *'], function () {
+        $sections = array_column(HealthCheck::findUnclaimedConfigSections()['unclaimed'], 'section');
+
+        expect($sections)->not->toContain('crontab');
+    });
+});
+
 it('flags a version record of a setup resource no module ships', function () {
     $code = 'residue' . uniqid() . '_setup';
 

--- a/tests/Backend/Unit/MahoCLI/Commands/HealthCheckResidueTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/HealthCheckResidueTest.php
@@ -205,6 +205,46 @@ it('leaves the payment method of a disabled module alone', function () {
     ));
 });
 
+it('leaves a carrier a module declares for one store view alone', function () {
+    // loadToXml() extends the default scope into every store node, so a group declared
+    // under <stores><code> lives nowhere else. Reading the default scope alone missed it.
+    $module = 'Residue_Scoped';
+    $code = 'residuescopedcarrier';
+    $files = [
+        'etc/config.xml' => sprintf(
+            '<?xml version="1.0"?><config><stores><default><carriers><%1$s>'
+            . '<model>usa/shipping_carrier_ups</model><active>1</active>'
+            . '</%1$s></carriers></default></stores></config>',
+            $code,
+        ),
+    ];
+
+    residueWithModule($module, $files, function () use ($code) {
+        expect(array_column(HealthCheck::findPhantomMethods(), 'code'))->not->toContain($code);
+    }, active: true);
+});
+
+it('flags a carrier of one store view whose model class is gone', function () {
+    $module = 'Residue_ScopedGone';
+    $code = 'residuescopedgone';
+    $files = [
+        'etc/config.xml' => sprintf(
+            '<?xml version="1.0"?><config><stores><default><carriers><%1$s>'
+            . '<model>residuescopedgone/carrier</model><active>1</active>'
+            . '</%1$s></carriers></default></stores></config>',
+            $code,
+        ),
+    ];
+
+    residueWithModule($module, $files, function () use ($code) {
+        $findings = HealthCheck::findPhantomMethods();
+        $finding = current(array_filter($findings, fn(array $f) => $f['code'] === $code));
+
+        expect($finding)->not->toBeFalse()
+            ->and($finding['active'])->toBeTrue();
+    }, active: true);
+});
+
 it('leaves a settings-only payment group that system.xml declares alone', function () {
     // A vendor can give its shared settings their own group and put the model on the
     // methods that use it. The group owns rows and names no model, but it is not residue.

--- a/tests/Backend/Unit/MahoCLI/Commands/HealthCheckResidueTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/HealthCheckResidueTest.php
@@ -180,6 +180,29 @@ it('purges the configuration rows of a phantom method', function () {
     });
 });
 
+it('leaves the payment method of a disabled module alone', function () {
+    $module = 'Residue_Probe';
+    $code = 'residueprobepay';
+    $files = [
+        'etc/config.xml' => sprintf(
+            '<?xml version="1.0"?><config><default><payment><%1$s><model>residueprobe/method</model>'
+            . '<active>1</active></%1$s><%1$s_shared><some_key>x</some_key></%1$s_shared>'
+            . '</payment></default></config>',
+            $code,
+        ),
+    ];
+
+    residueWithDisabledModule($module, $files, fn() => residueWithConfig(
+        ["payment/{$code}/active" => '1', "payment/{$code}/api_key" => 'secret'],
+        function () use ($code) {
+            $codes = array_column(HealthCheck::findPhantomMethods(), 'code');
+
+            expect($codes)->not->toContain($code)
+                ->and($codes)->not->toContain("{$code}_shared");
+        },
+    ));
+});
+
 it('flags a config section that no installed module declares', function () {
     $section = 'residue' . uniqid();
 

--- a/tests/Backend/Unit/MahoCLI/Commands/HealthCheckResidueTest.php
+++ b/tests/Backend/Unit/MahoCLI/Commands/HealthCheckResidueTest.php
@@ -47,12 +47,13 @@ function residueWithConfig(array $rows, callable $assert): void
 }
 
 /**
- * Declare a disabled module that ships $files (path relative to the module root),
- * run $assert, then delete every file and directory it created.
+ * Declare a module that ships $files (path relative to the module root), run $assert,
+ * then delete every file and directory it created. The module is disabled unless
+ * $active says otherwise.
  *
  * @param array<string, string> $files
  */
-function residueWithDisabledModule(string $module, array $files, callable $assert): void
+function residueWithModule(string $module, array $files, callable $assert, bool $active = false): void
 {
     $declaration = Mage::getBaseDir('etc') . "/modules/{$module}.xml";
     $base = Mage::getBaseDir('code') . '/local/' . str_replace('_', '/', $module);
@@ -67,8 +68,9 @@ function residueWithDisabledModule(string $module, array $files, callable $asser
         $created[] = $file;
     }
     file_put_contents($declaration, sprintf(
-        '<?xml version="1.0"?><config><modules><%s><active>false</active><codePool>local</codePool></%s></modules></config>',
+        '<?xml version="1.0"?><config><modules><%s><active>%s</active><codePool>local</codePool></%s></modules></config>',
         $module,
+        $active ? 'true' : 'false',
         $module,
     ));
 
@@ -192,7 +194,7 @@ it('leaves the payment method of a disabled module alone', function () {
         ),
     ];
 
-    residueWithDisabledModule($module, $files, fn() => residueWithConfig(
+    residueWithModule($module, $files, fn() => residueWithConfig(
         ["payment/{$code}/active" => '1', "payment/{$code}/api_key" => 'secret'],
         function () use ($code) {
             $codes = array_column(HealthCheck::findPhantomMethods(), 'code');
@@ -201,6 +203,28 @@ it('leaves the payment method of a disabled module alone', function () {
                 ->and($codes)->not->toContain("{$code}_shared");
         },
     ));
+});
+
+it('leaves a settings-only payment group that system.xml declares alone', function () {
+    // A vendor can give its shared settings their own group and put the model on the
+    // methods that use it. The group owns rows and names no model, but it is not residue.
+    $module = 'Residue_Shared';
+    $code = 'residuesharedpay';
+    $files = [
+        'etc/system.xml' => sprintf(
+            '<?xml version="1.0"?><config><sections><payment><groups><%s><fields><token/></fields>'
+            . '</%s></groups></payment></sections></config>',
+            $code,
+            $code,
+        ),
+    ];
+
+    residueWithModule($module, $files, fn() => residueWithConfig(
+        ["payment/{$code}/token" => 'secret'],
+        function () use ($code) {
+            expect(array_column(HealthCheck::findPhantomMethods(), 'code'))->not->toContain($code);
+        },
+    ), active: true);
 });
 
 it('flags a config section that no installed module declares', function () {
@@ -304,7 +328,7 @@ it('keeps the residue of a disabled module out of the purge lists', function () 
             ->and(array_column($tables['disabled'], 'table'))->toContain("{$section}_schema");
     };
 
-    residueWithDisabledModule($module, $files, fn() => residueWithConfig(
+    residueWithModule($module, $files, fn() => residueWithConfig(
         ["{$section}/group/field" => '1'],
         fn() => residueWithResourceVersion(
             "{$section}_setup",
@@ -324,7 +348,7 @@ it('leaves a table a disabled module declares as an entity alone', function () {
         ),
     ];
 
-    residueWithDisabledModule($module, $files, function () use ($section) {
+    residueWithModule($module, $files, function () use ($section) {
         residueWithTable("{$section}_thing", function () use ($section) {
             $tables = HealthCheck::findUnclaimedTables();
 


### PR DESCRIPTION
Stage 1 of #1318, minus rule 1, which already landed as the orphaned cron check. Health check now also finds:

- **Phantom payment methods and carriers** — `payment/<code>/active` or `carriers/<code>/active` with no model class. An active one is offered at checkout and breaks the admin order view (#743), so it reports as an error.
- **Unclaimed config sections** — `core_config_data` sections no installed module declares.
- **Stale module versions** — `core_resource` rows for a setup resource no installed module ships.
- **Unclaimed tables** — tables neither a `sql/schema.php` nor a resource entity claims. `./maho migrate` is forward-only, so nothing else reports these.
- **Compiled attribute registry** — observer, message-handler and route registrations pointing at code that is gone.

Two things differ from the RFC. Ownership comes from code rather than from name prefixes: tables are matched against `Collector::collect()` plus every module's `<entities>`, and config sections against the module XML read from disk, not the merged tree, which already holds the rows under test. And a disabled module is not residue, so every rule keeps a separate bucket for one and never offers to purge it.

Phantom methods and stale version records offer a confirm-then-delete purge, as the cron rule does. The other three print the statement and change nothing. None of the five change the exit code, matching the cron, engine and bloat checks. All five also appear on System > Tools > Health Check, with no change to the block or the template.

Detection lives in one helper per rule under `lib/MahoCLI/Helper/`, with `ModuleInspector` and `CallbackResolver` shared. The cron rule now uses that shared resolver instead of its own copy.

Stage 2 of the RFC (the artifact ledger and `module:remove`) is not here; it is sequenced after #1032.