### PR TITLE
Fixed the website price row scan throwing when Mage_Downloadable is disabled

### DIFF
--- a/app/code/core/Mage/Catalog/Helper/Data.php
+++ b/app/code/core/Mage/Catalog/Helper/Data.php
@@ -269,14 +269,16 @@ class Mage_Catalog_Helper_Data extends Mage_Core_Helper_Abstract
             ];
         }
 
-        $linkPriceTable = $resource->getTableName('downloadable/link_price');
-        if ($adapter->isTableExists($linkPriceTable)) {
-            $selects['link'] = [
-                'select' => $adapter->select()
-                    ->from(['s' => $linkPriceTable], [])
-                    ->where('s.website_id != ?', 0),
-                'table' => $linkPriceTable,
-            ];
+        if (Mage::helper('core')->isModuleEnabled('Mage_Downloadable')) {
+            $linkPriceTable = $resource->getTableName('downloadable/link_price');
+            if ($adapter->isTableExists($linkPriceTable)) {
+                $selects['link'] = [
+                    'select' => $adapter->select()
+                        ->from(['s' => $linkPriceTable], [])
+                        ->where('s.website_id != ?', 0),
+                    'table' => $linkPriceTable,
+                ];
+            }
         }
 
         return $selects;

--- a/tests/Backend/Integration/Catalog/WebsitePriceRowNoticeTest.php
+++ b/tests/Backend/Integration/Catalog/WebsitePriceRowNoticeTest.php
@@ -235,3 +235,38 @@ it('says nothing when there are none', function () {
     expect(priceNoticeLatestTitles())
         ->not->toContain('Website prices are no longer converted from the currency rate');
 });
+
+function priceNoticeWithoutDownloadable(callable $callback): mixed
+{
+    $config = Mage::getConfig();
+    $resourceModel = (string) $config->getNode('global/models/downloadable/resourceModel');
+    unset($config->getNode('global/models/downloadable')->resourceModel);
+    $config->setNode('modules/Mage_Downloadable/active', 'false');
+    Mage::unregister('_helper/core');
+
+    try {
+        return $callback();
+    } finally {
+        $config->setNode('global/models/downloadable/resourceModel', $resourceModel);
+        $config->setNode('modules/Mage_Downloadable/active', 'true');
+        Mage::unregister('_helper/core');
+    }
+}
+
+it('leaves out the downloadable link prices when the module is disabled', function () {
+    $selects = priceNoticeWithoutDownloadable(
+        fn(): array => Mage_Catalog_Helper_Data::websiteScopePriceRowSelects(),
+    );
+
+    expect($selects)->not->toHaveKey('link')
+        ->and($selects)->toHaveKeys(['attribute', 'option', 'option_value']);
+});
+
+it('raises the notice from the upgrade with the module disabled', function () {
+    priceNoticeWriteRow((int) $this->product->getId(), $this->storeId, 12.0);
+
+    priceNoticeWithoutDownloadable(fn() => priceNoticeRunUpgrade());
+
+    expect(priceNoticeLatestTitles())
+        ->toContain('Website prices are no longer converted from the currency rate');
+});


### PR DESCRIPTION
`Mage_Catalog_Helper_Data::websiteScopePriceRowSelects()`, added in #1319, resolves the
downloadable link price table before checking whether the module is enabled. A disabled module
contributes no config, so the model alias has nothing to resolve through and `getTableName()`
throws ahead of the `isTableExists()` guard that was meant to cover this case.

With `Mage_Downloadable` disabled, `./maho migrate` fails in the data-upgrade phase:

```
✓ Applied declarative schema (60 module(s), 3 statement(s) executed)
✓ Applied legacy schema/data updates (0 script(s))
Error in file: ".../Mage/Catalog/data/catalog_setup/data-upgrade-2.0.0-2.0.1.php"
  - Can't retrieve entity config: downloadable/link_price
```

Reproduce: 
1. set `<active>false</active>` for `Mage_Downloadable`,
2. run `./maho migrate` with `catalog_setup` below `2.0.1`
