### PR TITLE
Joined an array street into the column before an address is saved

### DIFF
--- a/app/code/core/Mage/Customer/Model/Address/Abstract.php
+++ b/app/code/core/Mage/Customer/Model/Address/Abstract.php
@@ -401,6 +401,9 @@ class Mage_Customer_Model_Address_Abstract extends Mage_Core_Model_Abstract
     {
         parent::_beforeSave();
         $this->getRegion();
+        if (is_array($this->getData('street'))) {
+            $this->implodeStreetAddress();
+        }
         return $this;
     }
 

--- a/tests/Backend/Integration/Checkout/Api/CartAddressStreetTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartAddressStreetTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Mage\Checkout\Api\CartService;
+use Mage\Sales\Api\OrderService;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Every REST and GraphQL cart address write lands in CartService, which applies
+ * the payload with addData(). addData() bypasses the setStreet() magic setter,
+ * so the street array reached the flat column as the literal string 'Array'
+ * (issue #1327). The response looked correct, because it reads the in-memory
+ * model before the column round-trip.
+ */
+function cartApiAddressInput(): array
+{
+    return [
+        'firstName' => 'Street',
+        'lastName' => 'Tester',
+        'street' => ['1 Test Street', 'Apt 7'],
+        'city' => 'Los Angeles',
+        'region' => 'California',
+        'postcode' => '90210',
+        'countryId' => 'US',
+        'telephone' => '5125550100',
+    ];
+}
+
+function cartApiQuoteStreet(int $quoteId, string $addressType): mixed
+{
+    $core = Mage::getSingleton('core/resource');
+    $adapter = $core->getConnection('core_read');
+
+    return $adapter->fetchOne(
+        $adapter->select()
+            ->from($core->getTableName('sales/quote_address'), ['street'])
+            ->where('quote_id = ?', $quoteId)
+            ->where('address_type = ?', $addressType),
+    );
+}
+
+function cartApiOrderStreet(int $addressId): mixed
+{
+    $core = Mage::getSingleton('core/resource');
+    $adapter = $core->getConnection('core_read');
+
+    return $adapter->fetchOne(
+        $adapter->select()
+            ->from($core->getTableName('sales/order_address'), ['street'])
+            ->where('entity_id = ?', $addressId),
+    );
+}
+
+describe('cart API street lines', function (): void {
+
+    it('stores every line of a shipping address', function (): void {
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+        $quote->save();
+
+        try {
+            $service = new CartService();
+            $service->setShippingAddress($quote, $service->mapAddressInput(cartApiAddressInput()));
+
+            expect(cartApiQuoteStreet((int) $quote->getId(), 'shipping'))->toBe("1 Test Street\nApt 7");
+
+            $reloaded = Mage::getModel('sales/quote')->load($quote->getId());
+            expect($reloaded->getShippingAddress()->getStreet())->toBe(['1 Test Street', 'Apt 7']);
+        } finally {
+            $quote->delete();
+        }
+    });
+
+    it('stores every line of a billing address', function (): void {
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+        $quote->save();
+
+        try {
+            $service = new CartService();
+            $service->setBillingAddress($quote, $service->mapAddressInput(cartApiAddressInput()));
+
+            expect(cartApiQuoteStreet((int) $quote->getId(), 'billing'))->toBe("1 Test Street\nApt 7");
+
+            $reloaded = Mage::getModel('sales/quote')->load($quote->getId());
+            expect($reloaded->getBillingAddress()->getStreet())->toBe(['1 Test Street', 'Apt 7']);
+        } finally {
+            $quote->delete();
+        }
+    });
+
+    it('copies every line when the billing address is the same as shipping', function (): void {
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+        $quote->save();
+
+        try {
+            $service = new CartService();
+            $service->setShippingAddress($quote, $service->mapAddressInput(cartApiAddressInput()));
+            $service->setBillingAddress($quote, [], true);
+
+            expect(cartApiQuoteStreet((int) $quote->getId(), 'billing'))->toBe("1 Test Street\nApt 7");
+        } finally {
+            $quote->delete();
+        }
+    });
+
+    it('carries every line onto the order addresses', function (): void {
+        $product = loadSimplePricedProduct();
+        $stock = Mage::getModel('cataloginventory/stock_item')->loadByProduct($product);
+        $stockQty = (float) $stock->getQty();
+        $stockIsIn = (int) $stock->getIsInStock();
+
+        try {
+            $quote = createPlaceableQuote($product, 1);
+
+            $service = new CartService();
+            $service->setShippingAddress($quote, $service->mapAddressInput(cartApiAddressInput()));
+            $service->setBillingAddress($quote, [], true);
+
+            // Place-order is its own request, so it reads the address back from
+            // the column instead of reusing the model the write left in memory.
+            $placed = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+            if (!$placed->getShippingAddress()->getShippingMethod()) {
+                test()->markTestSkipped('Flat rate shipping not available in this environment');
+            }
+
+            $order = (new OrderService())->placeAdminOrder($placed)['order'];
+
+            foreach ([$order->getShippingAddress(), $order->getBillingAddress()] as $address) {
+                expect(cartApiOrderStreet((int) $address->getId()))->toBe("1 Test Street\nApt 7");
+                expect($address->getStreet())->toBe(['1 Test Street', 'Apt 7']);
+            }
+        } finally {
+            $stock->setQty($stockQty)->setIsInStock($stockIsIn)->save();
+        }
+    });
+
+});

--- a/tests/Backend/Integration/Sales/Model/QuoteAddressStreetTest.php
+++ b/tests/Backend/Integration/Sales/Model/QuoteAddressStreetTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * A street column holds one newline-joined string. setStreet() enforces that, but
+ * setData()/addData() bypass the magic setter, so an array survived to the flat
+ * table and prepareColumnValue() cast it to the literal string 'Array'.
+ */
+function quoteAddressStreetColumn(int $addressId): mixed
+{
+    $core = Mage::getSingleton('core/resource');
+    $adapter = $core->getConnection('core_read');
+
+    return $adapter->fetchOne(
+        $adapter->select()
+            ->from($core->getTableName('sales/quote_address'), ['street'])
+            ->where('address_id = ?', $addressId),
+    );
+}
+
+describe('quote address street column', function (): void {
+
+    it('joins an array street applied with addData', function (): void {
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+        $quote->save();
+
+        try {
+            $address = $quote->getShippingAddress();
+            $address->addData([
+                'firstname' => 'Street',
+                'lastname' => 'Tester',
+                'street' => ['1 Test Street', 'Apt 7'],
+                'city' => 'Los Angeles',
+                'postcode' => '90210',
+                'country_id' => 'US',
+            ]);
+            $address->save();
+
+            expect(quoteAddressStreetColumn((int) $address->getId()))->toBe("1 Test Street\nApt 7");
+
+            $reloaded = Mage::getModel('sales/quote_address')->load($address->getId());
+            expect($reloaded->getStreet())->toBe(['1 Test Street', 'Apt 7']);
+        } finally {
+            $quote->delete();
+        }
+    });
+
+    it('leaves a string street untouched', function (): void {
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+        $quote->save();
+
+        try {
+            $address = $quote->getShippingAddress();
+            $address->addData([
+                'street' => "1 Test Street\nApt 7",
+                'country_id' => 'US',
+            ]);
+            $address->save();
+
+            expect(quoteAddressStreetColumn((int) $address->getId()))->toBe("1 Test Street\nApt 7");
+        } finally {
+            $quote->delete();
+        }
+    });
+
+});


### PR DESCRIPTION
Fixes #1327.

The API address writes apply the payload with `addData()`, which bypasses the `setStreet()` magic setter. The street array reached the flat quote and order address columns, and `prepareColumnValue()` cast it to the literal string `Array`. Every street line was lost. The response looked correct, because it reads the in-memory model before the column round-trip.

`Mage_Customer_Model_Address_Abstract` owns `setStreet()` and `implodeStreetAddress()`, so it now enforces the invariant in `_beforeSave()`. One place covers the quote address, the order address and the customer address, and every writer, not only the API. The `is_array()` guard keeps a model that never held a street from writing a null over the column.

The issue lists five affected endpoints. There is a sixth: `CartProcessor::getShippingMethodsForCart()` applies an address through the same service.

Tests: two new files assert the raw column, not the response body. The order test reloads the quote first, the way a separate place-order request does; without the reload the quote-to-order copy goes through the magic setter and hides the bug. All five bug tests fail against the unfixed code.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->