### PR TITLE
Fixed two broken cron aggregation queries

### DIFF
--- a/app/code/core/Mage/Reports/Model/Resource/Helper/Mysql.php
+++ b/app/code/core/Mage/Reports/Model/Resource/Helper/Mysql.php
@@ -36,10 +36,7 @@ class Mage_Reports_Model_Resource_Helper_Mysql extends Mage_Core_Model_Resource_
     #[\Override]
     public function updateReportRatingPos($type, $column, $mainTable, $aggregationTable)
     {
-        $adapter         = $this->_getWriteAdapter();
-        $periodSubSelect = $adapter->select();
-        $ratingSubSelect = $adapter->select();
-        $ratingSelect    = $adapter->select();
+        $adapter = $this->_getWriteAdapter();
 
         $periodCol = match ($type) {
             'year' => $adapter->getDateFormatSql('t.period', '%Y-01-01'),
@@ -73,45 +70,30 @@ class Mage_Reports_Model_Resource_Helper_Mysql extends Mage_Core_Model_Resource_
         }
         $cols['total_qty'] = new Maho\Db\Expr('SUM(t.' . $column . ')');
 
+        $periodSubSelect = $adapter->select();
         $periodSubSelect->from(['t' => $mainTable], $cols)
             ->group(['t.store_id', $periodCol, 't.product_id']);
 
+        $orderExpr = 'total_qty DESC';
         if ($column == 'qty_ordered') {
-            $productTypesInExpr = $adapter->quoteInto(
-                'MAX(t.product_type_id) IN (?)',
-                Mage_Catalog_Model_Product_Type::getCompositeTypes(),
-            );
-            $periodSubSelect->order(
-                [
-                    't.store_id',
-                    $periodCol,
-                    $adapter->getCheckSql($productTypesInExpr, '1', '0'),
-                    'total_qty DESC',
-                ],
-            );
-        } else {
-            $periodSubSelect->order(['t.store_id', $periodCol, 'total_qty DESC']);
+            $compositeTypes = $adapter->quote(Mage_Catalog_Model_Product_Type::getCompositeTypes());
+            $orderExpr = "CASE WHEN t.product_type_id IN ($compositeTypes) THEN 1 ELSE 0 END, total_qty DESC";
         }
 
-        $cols = $columns;
-        $cols[$column] = 't.total_qty';
-        $cols['rating_pos']  = new Maho\Db\Expr(
-            "(@pos := IF(t.`store_id` <> @prevStoreId OR {$periodCol} <> @prevPeriod, 1, @pos+1))",
+        // ROW_NUMBER() instead of MySQL user variables: the old sentinel compared a DATE
+        // against '0000-00-00', which strict mode rejects inside an INSERT ... SELECT, and
+        // the ranking relied on an ORDER BY in a derived table, which is not guaranteed.
+        $finalCols               = $columns;
+        $finalCols['period']     = new Maho\Db\Expr($periodCol);
+        $finalCols[$column]      = 't.total_qty';
+        $finalCols['rating_pos'] = new Maho\Db\Expr(
+            "ROW_NUMBER() OVER (PARTITION BY t.store_id, {$periodCol} ORDER BY {$orderExpr})",
         );
-        $cols['prevStoreId'] = new Maho\Db\Expr('(@prevStoreId := t.`store_id`)');
-        $cols['prevPeriod']  = new Maho\Db\Expr("(@prevPeriod := {$periodCol})");
-        $ratingSubSelect->from(['t' => $periodSubSelect], $cols);
 
-        $cols               = $columns;
-        $cols['period']     = $periodCol;
-        $cols[$column]      = 't.' . $column;
-        $cols['rating_pos'] = 't.rating_pos';
-        $ratingSelect->from(['t' => $ratingSubSelect], $cols);
+        $ratingSelect = $adapter->select();
+        $ratingSelect->from(['t' => $periodSubSelect], $finalCols);
 
-        $sql = $ratingSelect->insertFromSelect($aggregationTable, array_keys($cols));
-        $adapter->query("SET @pos = 0, @prevStoreId = -1, @prevPeriod = '0000-00-00'");
-
-        $adapter->query($sql);
+        $adapter->query($ratingSelect->insertFromSelect($aggregationTable, array_keys($finalCols)));
 
         return $this;
     }

--- a/app/code/core/Maho/Ai/Model/TaskRunner.php
+++ b/app/code/core/Maho/Ai/Model/TaskRunner.php
@@ -80,7 +80,8 @@ class Maho_Ai_Model_TaskRunner
             ])
             ->where('status = ?', Maho_Ai_Model_Task::STATUS_COMPLETE)
             ->where('platform IS NOT NULL')
-            ->where('completed_at BETWEEN ? AND ?', [$yesterdayStart, $yesterdayEnd])
+            ->where('completed_at >= ?', $yesterdayStart)
+            ->where('completed_at <= ?', $yesterdayEnd)
             ->group(['consumer', 'platform', 'model', 'store_id']);
 
         foreach ($connection->fetchAll($select) as $row) {

--- a/tests/Backend/Unit/Reports/AggregationSqlTest.php
+++ b/tests/Backend/Unit/Reports/AggregationSqlTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Mage_Reports
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Guards two cron aggregations that built invalid SQL: the AI usage roll-up expanded a
+ * two-placeholder BETWEEN with one array bind, and the bestsellers rating position seeded
+ * a '0000-00-00' sentinel that a strict server rejects inside an INSERT ... SELECT.
+ */
+
+const BESTSELLERS_TEST_PERIOD = '2035-01-01';
+
+afterEach(function () {
+    $resource = Mage::getSingleton('core/resource');
+    $resource->getConnection('core_write')->delete(
+        $resource->getTableName('sales/bestsellers_aggregated_daily'),
+        ['period = ?' => BESTSELLERS_TEST_PERIOD],
+    );
+});
+
+it('aggregates AI usage with a valid date range condition', function () {
+    (new Maho_Ai_Model_TaskRunner())->aggregateUsage();
+    expect(true)->toBeTrue();
+});
+
+it('ranks bestsellers without a zero-date sentinel', function () {
+    $resource = Mage::getSingleton('core/resource');
+    $adapter  = $resource->getConnection('core_write');
+
+    if (!$adapter instanceof \Maho\Db\Adapter\Pdo\Mysql) {
+        $this->markTestSkipped('The user-variable sentinel exists only in the MySQL helper.');
+    }
+
+    $productIds = $adapter->fetchCol(
+        $adapter->select()->from($resource->getTableName('catalog/product'), ['entity_id'])->limit(2),
+    );
+    if (count($productIds) < 2) {
+        $this->markTestSkipped('The catalog holds fewer than two products.');
+    }
+
+    $table = $resource->getTableName('sales/bestsellers_aggregated_daily');
+    foreach ([[$productIds[0], 3], [$productIds[1], 9]] as [$productId, $qty]) {
+        $adapter->insertOnDuplicate($table, [
+            'period'          => BESTSELLERS_TEST_PERIOD,
+            'store_id'        => 1,
+            'product_id'      => $productId,
+            'product_name'    => 'Aggregation test product',
+            'product_price'   => 10.0,
+            'product_type_id' => 'simple',
+            'qty_ordered'     => $qty,
+            'rating_pos'      => 1,
+        ]);
+    }
+
+    $method = new ReflectionMethod(Mage_Sales_Model_Resource_Report_Bestsellers::class, '_updateRatingPos');
+    $method->invoke(Mage::getResourceModel('sales/report_bestsellers'), 'daily');
+
+    $warnings = $adapter->fetchAll('SHOW WARNINGS');
+    $messages = array_column($warnings, 'Message');
+    expect(implode("\n", $messages))->not->toContain('0000-00-00');
+
+    $ranked = $adapter->fetchPairs(
+        $adapter->select()
+            ->from($table, ['product_id', 'rating_pos'])
+            ->where('period = ?', BESTSELLERS_TEST_PERIOD)
+            ->where('store_id = ?', 1),
+    );
+    expect((int) $ranked[$productIds[1]])->toBe(1);
+    expect((int) $ranked[$productIds[0]])->toBe(2);
+});


### PR DESCRIPTION
Two cron jobs failed with SQL errors.

**`ai_aggregate_usage`** used `where('completed_at BETWEEN ? AND ?', [$start, $end])`. An array bind is quoted as one comma-separated list, and that list replaces every placeholder, so the statement never parsed on any engine. It has been broken since #915. Split into two conditions.

**`aggregate_sales_report_bestsellers_data`** built the rating position with the MySQL user-variable trick. It seeded `@prevPeriod` with `'0000-00-00'` and compared a DATE column against that sentinel inside an `INSERT ... SELECT`, which a strict server can reject. The ranking also relied on an `ORDER BY` in a derived table, which MySQL does not guarantee. Replaced both with `ROW_NUMBER() OVER (PARTITION BY store_id, period ORDER BY ...)`, matching the PostgreSQL helper.

The new test reproduces the AI failure exactly against the unfixed code. The bestsellers half asserts the ranking and the absence of a zero-date warning, and it skips on PostgreSQL and SQLite, whose helper never had the sentinel.

One open point: the zero-date report came from a live site, and I did not reproduce it. On MySQL 9.7 the old code emits no zero-date warning, because the `OR` short-circuits on the first row and the sentinel is never compared. Removing the sentinel is correct either way, but it may not be the whole cause on that site.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->