### PR TITLE
Kept every selected value of a report filter multiselect

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Report/Filter/Form.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Filter/Form.php
@@ -166,13 +166,7 @@ class Mage_Adminhtml_Block_Report_Filter_Form extends Mage_Adminhtml_Block_Widge
     #[\Override]
     protected function _initFormValues()
     {
-        $data = $this->getFilterData()->getData();
-        foreach ($data as $key => $value) {
-            if (is_array($value) && isset($value[0])) {
-                $data[$key] = explode(',', $value[0]);
-            }
-        }
-        $this->getForm()->addValues($data);
+        $this->getForm()->addValues($this->getFilterData()->getData());
         return parent::_initFormValues();
     }
 

--- a/app/code/core/Mage/Adminhtml/Block/Report/Grid/Abstract.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Grid/Abstract.php
@@ -168,13 +168,6 @@ class Mage_Adminhtml_Block_Report_Grid_Abstract extends Mage_Adminhtml_Block_Wid
 
         $storeIds = $this->_getStoreIds();
 
-        $orderStatuses = $filterData->getData('order_statuses');
-        if (is_array($orderStatuses)) {
-            if (count($orderStatuses) == 1 && str_contains($orderStatuses[0], ',')) {
-                $filterData->setData('order_statuses', explode(',', $orderStatuses[0]));
-            }
-        }
-
         /** @var Mage_Sales_Model_Resource_Report_Collection_Abstract $resourceCollection */
         $resourceCollection = Mage::getResourceModel($this->getResourceCollectionName());
         $resourceCollection

--- a/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons/Grid.php
+++ b/app/code/core/Mage/Adminhtml/Block/Report/Sales/Coupons/Grid.php
@@ -147,9 +147,8 @@ class Mage_Adminhtml_Block_Report_Sales_Coupons_Grid extends Mage_Adminhtml_Bloc
     {
         if ($filterData->getPriceRuleType()) {
             $rulesList = $filterData->getData('rules_list');
-            if (isset($rulesList[0])) {
-                $rulesIds = explode(',', $rulesList[0]);
-                $collection->addRuleFilter($rulesIds);
+            if (is_array($rulesList) && $rulesList !== []) {
+                $collection->addRuleFilter($rulesList);
             }
         }
 

--- a/app/design/adminhtml/default/default/template/report/grid/container.phtml
+++ b/app/design/adminhtml/default/default/template/report/grid/container.phtml
@@ -25,25 +25,16 @@
 <script>
     function filterFormSubmit() {
         const filterForm = document.getElementById('filter_form');
-        if (!filterForm) return;
+        if (!filterForm || !filterForm.checkValidity()) return;
 
-        const filters = filterForm.querySelectorAll('input, select');
-        const elements = [];
-
-        filters.forEach(filter => {
-            if (filter.value && filter.value.length && !filter.disabled) {
-                elements.push(filter);
+        // FormData keeps every selected option of a multiselect, one entry per option
+        const params = new URLSearchParams();
+        for (const [ name, value ] of new FormData(filterForm)) {
+            if (value !== '') {
+                params.append(name, value);
             }
-        });
-
-        if (filterForm.checkValidity()) {
-            const formData = new FormData();
-            elements.forEach(element => {
-                formData.append(element.name, element.value);
-            });
-
-            const params = new URLSearchParams(formData).toString();
-            setLocation(setRouteParams('<?= $this->getFilterUrl() ?>', { filter: btoa(params) }));
         }
+
+        setLocation(setRouteParams('<?= $this->getFilterUrl() ?>', { filter: btoa(params.toString()) }));
     }
 </script>

--- a/app/design/adminhtml/default/default/template/report/grid/container.phtml
+++ b/app/design/adminhtml/default/default/template/report/grid/container.phtml
@@ -25,7 +25,7 @@
 <script>
     function filterFormSubmit() {
         const filterForm = document.getElementById('filter_form');
-        if (!filterForm || !filterForm.checkValidity()) return;
+        if (!filterForm || !filterForm.reportValidity()) return;
 
         // FormData keeps every selected option of a multiselect, one entry per option
         const params = new URLSearchParams();

--- a/tests/Backend/Unit/Adminhtml/Block/Report/CouponsGridFilterTest.php
+++ b/tests/Backend/Unit/Adminhtml/Block/Report/CouponsGridFilterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * The coupons report filter form is a multiselect, so the grid must pass on every rule the
+ * user picked. It used to read the first entry only and split it on commas.
+ */
+
+/** A stand-in for the report collection that records the rule ids the grid gives it. */
+function couponsRuleFilterSpy(): object
+{
+    return new class {
+        public ?array $rulesList = null;
+
+        public function addRuleFilter(array $rulesList): static
+        {
+            $this->rulesList = $rulesList;
+            return $this;
+        }
+    };
+}
+
+/** Run the grid's custom filter over $filterData and return what the collection received. */
+function couponsRuleFilter(array $filterData): ?array
+{
+    $grid = Mage::app()->getLayout()->createBlock('adminhtml/report_sales_coupons_grid');
+    $collection = couponsRuleFilterSpy();
+
+    Closure::bind(
+        function ($collection, $filterData) {
+            $this->_addCustomFilter($collection, $filterData);
+        },
+        $grid,
+        $grid::class,
+    )($collection, new Maho\DataObject($filterData));
+
+    return $collection->rulesList;
+}
+
+describe('Mage_Adminhtml_Block_Report_Sales_Coupons_Grid::_addCustomFilter', function () {
+    it('filters on every selected price rule', function () {
+        expect(couponsRuleFilter(['price_rule_type' => '1', 'rules_list' => ['3', '7']]))
+            ->toBe(['3', '7']);
+    });
+
+    it('filters on a single selected price rule', function () {
+        expect(couponsRuleFilter(['price_rule_type' => '1', 'rules_list' => ['3']]))
+            ->toBe(['3']);
+    });
+
+    it('does not filter when no price rule is selected', function () {
+        expect(couponsRuleFilter(['price_rule_type' => '1']))->toBeNull();
+    });
+
+    it('does not filter when the report runs for any price rule', function () {
+        expect(couponsRuleFilter(['rules_list' => ['3', '7']]))->toBeNull();
+    });
+});

--- a/tests/Browser/AdminReportOrderStatusFilterTest.php
+++ b/tests/Browser/AdminReportOrderStatusFilterTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Tests\MahoBrowserTestCase;
+
+uses(MahoBrowserTestCase::class)->group('browser');
+
+/**
+ * Regression for a sales report that keeps only the first of the selected order statuses.
+ *
+ * The filter form encodes itself into the "filter" segment of the url. A multiselect holds
+ * more than one selected option, so the encoder must read all of them, and the form must show
+ * all of them again on the page the report comes back on.
+ */
+
+const REPORT_STATUS_ADMIN_USER = 'report-status-admin';
+const REPORT_STATUS_ADMIN_PASSWORD = 'Password123!';
+
+beforeEach(function () {
+    createReportStatusAdmin();
+});
+
+afterEach(function () {
+    deleteReportStatusAdmin();
+});
+
+function deleteReportStatusAdmin(): void
+{
+    $user = Mage::getModel('admin/user')->loadByUsername(REPORT_STATUS_ADMIN_USER);
+    if ($user->getId()) {
+        $user->delete();
+    }
+}
+
+/** A fresh admin with the full-access role, so the password is known and ACL never gets in the way. */
+function createReportStatusAdmin(): void
+{
+    deleteReportStatusAdmin();
+
+    $user = Mage::getModel('admin/user')
+        ->setUsername(REPORT_STATUS_ADMIN_USER)
+        ->setFirstname('Report')
+        ->setLastname('Status')
+        ->setEmail('report-status@example.test')
+        ->setPassword(REPORT_STATUS_ADMIN_PASSWORD)
+        ->setIsActive(1)
+        ->save();
+
+    $roleId = Mage::getModel('admin/role')->getCollection()
+        ->addFieldToFilter('role_type', Mage_Admin_Model_Acl::ROLE_TYPE_GROUP)
+        ->setPageSize(1)
+        ->getFirstItem()
+        ->getId();
+
+    Mage::getModel('admin/user')->load($user->getId())->setRoleIds([$roleId])->saveRelations();
+}
+
+/** Decode the filter the report was run with out of the url the report landed on. */
+function decodeReportFilter(string $url): array
+{
+    preg_match('#/filter/([^/]+)#', (string) parse_url($url, PHP_URL_PATH), $matches);
+    parse_str((string) base64_decode(rawurldecode($matches[1] ?? '')), $filter);
+
+    return $filter;
+}
+
+/** The values of the options that are selected in a select element, in document order. */
+function selectedOptionValues(object $page, string $selector): array
+{
+    $values = $page->script(
+        "Array.from(document.querySelectorAll('{$selector} option:checked')).map(option => option.value).join(',')",
+    );
+
+    return $values === '' ? [] : explode(',', (string) $values);
+}
+
+it('runs a sales report with every selected order status', function () {
+    $page = adminLoginAndVisit(
+        REPORT_STATUS_ADMIN_USER,
+        REPORT_STATUS_ADMIN_PASSWORD,
+        '/admin/report_sales/sales',
+        '#filter_form',
+    );
+
+    $page->fill('#sales_report_from', '2026-07-01')
+        ->fill('#sales_report_to', '2026-07-31')
+        ->select('#sales_report_show_order_statuses', '1')
+        ->select('#sales_report_order_statuses', ['processing', 'complete'])
+        ->click('Show Report')
+        ->wait(2);
+
+    waitForPageLoad($page, '#filter_form');
+
+    $ranWith = decodeReportFilter($page->url())['order_statuses'] ?? [];
+    $stillSelected = selectedOptionValues($page, '#sales_report_order_statuses');
+    sort($ranWith);
+    sort($stillSelected);
+
+    expect($ranWith)->toBe(['complete', 'processing'])
+        ->and($stillSelected)->toBe(['complete', 'processing']);
+});


### PR DESCRIPTION
Fixes #1334

The report filter form encodes itself into the `filter` segment of the url with `element.value`, which holds only the first selected option of a `<select multiple>`. Reports > Sales > Orders ran on one order status, and the coupons report on one price rule. The encoder now reads the form through `FormData`, which gives one entry per selected option, so this covers every report that uses the filter form.

Two consumers assumed the broken shape and split the first value on commas: the filter form redisplay (which dropped every status after the first, so the page that came back showed one selected) and the coupons grid. Both now take the array as it arrives. The matching workaround in `Mage_Adminhtml_Block_Report_Grid_Abstract` is gone.

Tests were written first and fail against the unfixed code: a browser test that runs the orders report with two statuses and checks both the url and the form, and a unit test for the rule ids the coupons grid passes to the collection.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->