### PR TITLE
Returned 404 for a numeric quote id on a guest-cart add-to-cart

### DIFF
--- a/app/code/core/Mage/Api/Api/AuthTokenProcessor.php
+++ b/app/code/core/Mage/Api/Api/AuthTokenProcessor.php
@@ -101,7 +101,7 @@ class AuthTokenProcessor extends \Maho\ApiPlatform\Processor
             $cartId = null;
             $customerCart = null;
 
-            if ($guestCartMaskedId && is_string($guestCartMaskedId) && preg_match('/^[a-f0-9]{32}$/i', $guestCartMaskedId)) {
+            if (CartService::isValidMaskedId($guestCartMaskedId)) {
                 try {
                     // Delegate to CartService::mergeCarts, which enforces the full
                     // guest-cart ownership guard (rejecting a masked ID resolving

--- a/app/code/core/Mage/Checkout/Api/CartProcessor.php
+++ b/app/code/core/Mage/Checkout/Api/CartProcessor.php
@@ -295,7 +295,11 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             return $quote;
         }
 
-        if ($this->isGuestCartRequest($context)) {
+        // Only a well-formed masked id earns the recreation: it is the shape a
+        // pruned or expired cart leaves behind. A malformed id, such as the
+        // numeric quote id the create response also returns, is a caller
+        // mistake, so it must 404 instead of building a second, unrelated cart.
+        if ($this->guestCartMaskedIdFromRequest($context) !== null) {
             $recreated = true;
             return $this->cartService->createEmptyCart()['quote'];
         }
@@ -303,12 +307,20 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         throw new NotFoundHttpException('Cart not found');
     }
 
-    /** True when the request targets the public /guest-carts/… path. */
-    private function isGuestCartRequest(array $context): bool
+    /**
+     * The masked id in a public /guest-carts/{id}/… path. Returns null when the
+     * request is not on that path, or when the id is not a valid masked id.
+     */
+    private function guestCartMaskedIdFromRequest(array $context): ?string
     {
         $request = $context['request'] ?? null;
-        return $request instanceof \Symfony\Component\HttpFoundation\Request
-            && str_contains($request->getPathInfo(), '/guest-carts/');
+        if (!$request instanceof \Symfony\Component\HttpFoundation\Request) {
+            return null;
+        }
+        if (!preg_match('#/guest-carts/([^/?]+)#', $request->getPathInfo(), $m)) {
+            return null;
+        }
+        return preg_match('/^[a-f0-9]{32}$/i', $m[1]) ? $m[1] : null;
     }
 
     /**

--- a/app/code/core/Mage/Checkout/Api/CartProcessor.php
+++ b/app/code/core/Mage/Checkout/Api/CartProcessor.php
@@ -277,12 +277,12 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
      * Resolve the target cart for an add-to-cart. On the public guest path a
      * stale/expired/non-existent masked cart is transparently replaced with a
      * fresh guest cart (flagged via $recreated) so a returning shopper whose
-     * quote was pruned can keep shopping instead of hitting a 404. Authenticated
-     * and numeric /carts/{id} adds still 404 on a missing cart.
+     * quote was pruned can keep shopping instead of hitting a 404. An id that is
+     * not a well-formed masked id still 404s, and so does every /carts/{id} add.
      */
     private function resolveCartForItemAdd(array $context, array $uriVariables, bool &$recreated): \Mage_Sales_Model_Quote
     {
-        ['quote' => $quote, 'accessedByMaskedId' => $byMasked] =
+        ['quote' => $quote, 'accessedByMaskedId' => $byMasked, 'maskedId' => $maskedId] =
             $this->cartService->resolveCartFromRequest($uriVariables, $context);
 
         if ($quote) {
@@ -296,8 +296,9 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         }
 
         // A malformed id, such as the numeric quote id the create response also
-        // returns, is a caller mistake, not a pruned cart.
-        if ($this->guestCartMaskedIdFromRequest($context) !== null) {
+        // returns, is a caller mistake, not a pruned cart. The gate reads the id
+        // the lookup used, never a second, possibly different, id of its own.
+        if ($maskedId !== null && $this->isGuestCartRequest($context)) {
             $recreated = true;
             return $this->cartService->createEmptyCart()['quote'];
         }
@@ -305,17 +306,12 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         throw new NotFoundHttpException('Cart not found');
     }
 
-    /** The masked id in a public /guest-carts/{id}/… path, or null when there is none. */
-    private function guestCartMaskedIdFromRequest(array $context): ?string
+    /** True when the request targets the public /guest-carts/… path. */
+    private function isGuestCartRequest(array $context): bool
     {
         $request = $context['request'] ?? null;
-        if (!$request instanceof \Symfony\Component\HttpFoundation\Request) {
-            return null;
-        }
-        if (!preg_match('#/guest-carts/([^/?]+)#', $request->getPathInfo(), $m)) {
-            return null;
-        }
-        return preg_match('/^[a-f0-9]{32}$/i', $m[1]) ? $m[1] : null;
+        return $request instanceof \Symfony\Component\HttpFoundation\Request
+            && str_contains($request->getPathInfo(), '/guest-carts/');
     }
 
     /**

--- a/app/code/core/Mage/Checkout/Api/CartProcessor.php
+++ b/app/code/core/Mage/Checkout/Api/CartProcessor.php
@@ -295,10 +295,8 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             return $quote;
         }
 
-        // Only a well-formed masked id earns the recreation: it is the shape a
-        // pruned or expired cart leaves behind. A malformed id, such as the
-        // numeric quote id the create response also returns, is a caller
-        // mistake, so it must 404 instead of building a second, unrelated cart.
+        // A malformed id, such as the numeric quote id the create response also
+        // returns, is a caller mistake, not a pruned cart.
         if ($this->guestCartMaskedIdFromRequest($context) !== null) {
             $recreated = true;
             return $this->cartService->createEmptyCart()['quote'];
@@ -307,10 +305,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         throw new NotFoundHttpException('Cart not found');
     }
 
-    /**
-     * The masked id in a public /guest-carts/{id}/… path. Returns null when the
-     * request is not on that path, or when the id is not a valid masked id.
-     */
+    /** The masked id in a public /guest-carts/{id}/… path, or null when there is none. */
     private function guestCartMaskedIdFromRequest(array $context): ?string
     {
         $request = $context['request'] ?? null;

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -22,6 +22,27 @@ class CartService
 {
     private const MAX_ITEM_QTY = 10000;
 
+    /** The shape of a masked cart id, bare of delimiters so a route requirement can reuse it. */
+    public const MASKED_ID_PATTERN = '[a-f0-9]{32}';
+
+    public static function isValidMaskedId(mixed $maskedId): bool
+    {
+        return is_string($maskedId) && preg_match('/^' . self::MASKED_ID_PATTERN . '$/i', $maskedId) === 1;
+    }
+
+    /**
+     * The masked cart id a /guest-carts/{id}/… path names, or null when the path
+     * has no such segment. The whole segment must match: on a partial match one
+     * malformed id would resolve to a cart the caller never wrote.
+     */
+    public static function maskedIdFromPath(string $path): ?string
+    {
+        if (!preg_match('#/guest-carts/([^/?]+)#', $path, $m)) {
+            return null;
+        }
+        return self::isValidMaskedId($m[1]) ? $m[1] : null;
+    }
+
     /**
      * Create empty cart
      *
@@ -140,7 +161,7 @@ class CartService
      * Resolve a cart from API request context.
      * Handles both /carts/{id} (numeric) and /guest-carts/{maskedId} (hex) patterns.
      *
-     * @return array{quote: \Mage_Sales_Model_Quote|null, accessedByMaskedId: bool}
+     * @return array{quote: \Mage_Sales_Model_Quote|null, accessedByMaskedId: bool, maskedId: string|null}
      */
     public function resolveCartFromRequest(
         array $uriVariables,
@@ -161,34 +182,42 @@ class CartService
             }
         }
 
-        // Priority 1: maskedId from GraphQL args or REST body
-        $maskedId = $args['maskedId'] ?? null;
-
-        // Priority 2: maskedId from REST guest-cart URI (regex to bypass int cast)
+        // On a guest-carts route the path segment is the identifier, so it wins
+        // over a body maskedId: the caller and the lookup must never disagree
+        // about which cart a request names. A body maskedId applies only where
+        // there is no such segment (GraphQL, /carts). The path is read from the
+        // raw string because API Platform casts URI placeholders to Cart.id (int),
+        // which truncates a hex masked id.
+        $maskedId = null;
         $isGuestCartRoute = false;
         if ($request instanceof \Symfony\Component\HttpFoundation\Request) {
             $isGuestCartRoute = str_contains($request->getPathInfo(), '/guest-carts/');
-            if (!$maskedId && preg_match('#/guest-carts/([a-f0-9]{32})#i', $request->getPathInfo(), $m)) {
-                $maskedId = $m[1];
+            $maskedId = self::maskedIdFromPath($request->getPathInfo());
+        }
+        if (!$maskedId && !$isGuestCartRoute && is_string($args['maskedId'] ?? null)) {
+            $maskedId = $args['maskedId'];
+        }
+
+        // Last: cartId from GraphQL args or uriVariables. On the guest-carts
+        // route the {id} is a masked id, never a numeric quote id. If it wasn't a
+        // valid masked id above, the cart simply doesn't exist. Falling back to
+        // numeric loading there, from the body or from the URI, would resolve an
+        // unrelated quote and leak its existence (404 vs 401) to an enumerating
+        // caller.
+        $cartId = null;
+        if (!$isGuestCartRoute) {
+            $cartId = isset($args['cartId']) ? (int) $args['cartId'] : null;
+            if (!$cartId && !$maskedId && isset($uriVariables['id'])) {
+                $cartId = (int) $uriVariables['id'];
             }
         }
 
-        // Priority 3: cartId from GraphQL args or uriVariables. On the guest-carts
-        // route the {id} is a masked id, never a numeric quote id — if it wasn't a
-        // valid masked id above, the cart simply doesn't exist. Falling back to
-        // numeric loading there would resolve an unrelated quote and leak its
-        // existence (404 vs 401) to an enumerating caller.
-        $cartId = isset($args['cartId']) ? (int) $args['cartId'] : null;
-        if (!$cartId && !$maskedId && !$isGuestCartRoute && isset($uriVariables['id'])) {
-            $cartId = (int) $uriVariables['id'];
-        }
-
         if (!$maskedId && !$cartId) {
-            return ['quote' => null, 'accessedByMaskedId' => false];
+            return ['quote' => null, 'accessedByMaskedId' => false, 'maskedId' => null];
         }
 
         $quote = $this->getCart($cartId, $maskedId);
-        return ['quote' => $quote, 'accessedByMaskedId' => $maskedId !== null];
+        return ['quote' => $quote, 'accessedByMaskedId' => $maskedId !== null, 'maskedId' => $maskedId];
     }
 
     /**
@@ -1165,7 +1194,7 @@ class CartService
     private function getCartIdFromMaskedId(string $maskedId): ?int
     {
         // Only accept secure 32-char hex format
-        if (!preg_match('/^[a-f0-9]{32}$/i', $maskedId)) {
+        if (!self::isValidMaskedId($maskedId)) {
             return null;
         }
 

--- a/app/code/core/Mage/Sales/Api/Order.php
+++ b/app/code/core/Mage/Sales/Api/Order.php
@@ -17,6 +17,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Post;
 use Mage\Checkout\Api\Cart;
+use Mage\Checkout\Api\CartService;
 use ApiPlatform\Metadata\GraphQl\Query;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\GraphQl\Mutation;
@@ -75,7 +76,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
             uriVariables: [
                 'maskedQuoteId' => new Link(fromClass: Cart::class, identifiers: []),
             ],
-            requirements: ['maskedQuoteId' => '[a-f0-9]{32}'],
+            requirements: ['maskedQuoteId' => CartService::MASKED_ID_PATTERN],
             security: 'true',
             description: 'Place order from guest cart. Body carries the full checkout state in one shot: shippingAddress, billingAddress, guestEmail, paymentMethod, paymentData, shippingMethod (carrier_method), orderNote',
         ),

--- a/app/code/core/Mage/Sales/Api/OrderProcessor.php
+++ b/app/code/core/Mage/Sales/Api/OrderProcessor.php
@@ -113,21 +113,19 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
                 $cartId = $cm[1];
             }
         }
-        // Accept the masked-id from either the request body or from the URI.
-        // We pull from the Request path rather than $uriVariables because API
-        // Platform casts URI placeholders to the resource identifier's PHP
-        // type, Order.id is int, so a 32-char hex masked id gets silently
-        // truncated to its leading digit run via PHP (int) coercion. Parsing
-        // the path ourselves preserves the string verbatim.
-        $maskedId = $args['maskedId'] ?? null;
-        if (!$maskedId) {
-            $request = $context['request'] ?? null;
-            if ($request instanceof \Symfony\Component\HttpFoundation\Request) {
-                $path = $request->getPathInfo();
-                if (preg_match('#/guest-carts/([a-f0-9]{32})/place-order#i', $path, $m)) {
-                    $maskedId = $m[1];
-                }
-            }
+        // Accept the masked id from the URI, else from the request body. We pull
+        // from the Request path rather than $uriVariables because API Platform
+        // casts URI placeholders to the resource identifier's PHP type, Order.id
+        // is int, so a 32-char hex masked id gets silently truncated to its
+        // leading digit run via PHP (int) coercion. Parsing the path ourselves
+        // preserves the string verbatim. The path wins over the body so that a
+        // body id can never place the order of a cart the URI does not name.
+        $request = $context['request'] ?? null;
+        $maskedId = $request instanceof \Symfony\Component\HttpFoundation\Request
+            ? CartService::maskedIdFromPath($request->getPathInfo())
+            : null;
+        if (!$maskedId && is_string($args['maskedId'] ?? null)) {
+            $maskedId = $args['maskedId'];
         }
         $guestEmail = $args['guestEmail'] ?? $args['email'] ?? null;
         $orderNote = $args['orderNote'] ?? null;

--- a/app/code/core/Maho/SocialLogin/Api/SocialAuthProcessor.php
+++ b/app/code/core/Maho/SocialLogin/Api/SocialAuthProcessor.php
@@ -101,7 +101,7 @@ class SocialAuthProcessor extends \Maho\ApiPlatform\Processor
         $guestCartMaskedId = $data->cartId;
         $cartId = null;
         $customerCart = null;
-        if (is_string($guestCartMaskedId) && preg_match('/^[a-f0-9]{32}$/i', $guestCartMaskedId)) {
+        if (CartService::isValidMaskedId($guestCartMaskedId)) {
             try {
                 // CartService::mergeCarts enforces the guest-cart ownership guard,
                 // re-collects totals, and deactivates the guest cart atomically.

--- a/tests/Api/V2/Write/GuestCartTest.php
+++ b/tests/Api/V2/Write/GuestCartTest.php
@@ -208,6 +208,41 @@ describe('POST /api/rest/v2/guest-carts/{id}/items (Add Item)', function (): voi
         expect($cart['json']['itemsCount'])->toBe(0);
     });
 
+    it('adds to the cart in the path, not to a maskedId in the body', function (): void {
+        $createResponse = createGuestCart();
+        expect($createResponse['status'])->toBe(201);
+        $maskedId = $createResponse['json']['maskedId'];
+
+        $response = apiPost("/api/rest/v2/guest-carts/{$maskedId}/items", [
+            'maskedId' => str_repeat('b2c3d4e5', 4),
+            'sku' => fixtures('write_test_sku'),
+            'qty' => 1,
+        ]);
+
+        expect($response['status'])->toBe(200);
+        expect($response['json']['cartRecreated'])->toBeFalse();
+        expect((int) $response['json']['id'])->toBe((int) $createResponse['json']['id']);
+
+        $cart = apiGet("/api/rest/v2/guest-carts/{$maskedId}");
+        expect($cart['json']['itemsCount'])->toBe(1);
+    });
+
+    it('returns 404 for a masked ID with trailing characters', function (): void {
+        $createResponse = createGuestCart();
+        expect($createResponse['status'])->toBe(201);
+        $maskedId = $createResponse['json']['maskedId'];
+
+        $response = apiPost("/api/rest/v2/guest-carts/{$maskedId}extra/items", [
+            'sku' => fixtures('write_test_sku'),
+            'qty' => 1,
+        ]);
+
+        expect($response['status'])->toBeNotFound();
+
+        $cart = apiGet("/api/rest/v2/guest-carts/{$maskedId}");
+        expect($cart['json']['itemsCount'])->toBe(0);
+    });
+
 });
 
 describe('PUT /api/rest/v2/guest-carts/{id}/items/{itemId} (Update Item)', function (): void {

--- a/tests/Api/V2/Write/GuestCartTest.php
+++ b/tests/Api/V2/Write/GuestCartTest.php
@@ -168,15 +168,46 @@ describe('POST /api/rest/v2/guest-carts/{id}/items (Add Item)', function (): voi
     });
 
     it('auto-recreates expired or non-existent cart', function (): void {
-        $response = apiPost('/api/rest/v2/guest-carts/999999999/items', [
+        $maskedId = str_repeat('a1b2c3d4', 4);
+
+        $response = apiPost("/api/rest/v2/guest-carts/{$maskedId}/items", [
             'sku' => fixtures('write_test_sku'),
             'qty' => 1,
         ]);
 
-        // Non-existent masked IDs trigger cart auto-recreation
+        // A well-formed masked ID that resolves to nothing triggers cart auto-recreation
         expect($response['status'])->toBe(200);
         expect($response['json']['cartRecreated'])->toBeTrue();
         expect($response['json']['itemsCount'])->toBeGreaterThan(0);
+        trackCreated('quote', (int) $response['json']['id']);
+    });
+
+    it('returns 404 for a malformed cart ID', function (): void {
+        $response = apiPost('/api/rest/v2/guest-carts/not-a-masked-id/items', [
+            'sku' => fixtures('write_test_sku'),
+            'qty' => 1,
+        ]);
+
+        expect($response['status'])->toBeNotFound();
+    });
+
+    it('returns 404 for a numeric quote ID and leaves that quote untouched', function (): void {
+        $createResponse = createGuestCart();
+        expect($createResponse['status'])->toBe(201);
+        $quoteId = (int) $createResponse['json']['id'];
+        $maskedId = $createResponse['json']['maskedId'];
+
+        $response = apiPost("/api/rest/v2/guest-carts/{$quoteId}/items", [
+            'sku' => fixtures('write_test_sku'),
+            'qty' => 1,
+        ]);
+
+        expect($response['status'])->toBeNotFound();
+
+        // The real cart must stay empty, and no second cart must appear
+        $cart = apiGet("/api/rest/v2/guest-carts/{$maskedId}");
+        expect($cart['status'])->toBe(200);
+        expect($cart['json']['itemsCount'])->toBe(0);
     });
 
 });

--- a/tests/Api/V2/Write/GuestCartTest.php
+++ b/tests/Api/V2/Write/GuestCartTest.php
@@ -175,7 +175,6 @@ describe('POST /api/rest/v2/guest-carts/{id}/items (Add Item)', function (): voi
             'qty' => 1,
         ]);
 
-        // A well-formed masked ID that resolves to nothing triggers cart auto-recreation
         expect($response['status'])->toBe(200);
         expect($response['json']['cartRecreated'])->toBeTrue();
         expect($response['json']['itemsCount'])->toBeGreaterThan(0);
@@ -204,7 +203,6 @@ describe('POST /api/rest/v2/guest-carts/{id}/items (Add Item)', function (): voi
 
         expect($response['status'])->toBeNotFound();
 
-        // The real cart must stay empty, and no second cart must appear
         $cart = apiGet("/api/rest/v2/guest-carts/{$maskedId}");
         expect($cart['status'])->toBe(200);
         expect($cart['json']['itemsCount'])->toBe(0);


### PR DESCRIPTION
Fixes #1336.

`POST /guest-carts/{id}/items` recreates a guest cart when the masked id no longer resolves, so a shopper whose quote was pruned can keep shopping. That path matched every unresolvable id on `/guest-carts/`, including the numeric quote id that the create response also returns. The call built a second, unrelated cart and returned 200, while the intended quote stayed empty until place-order failed.

The recreation now runs only when the `{id}` segment is a valid masked id (32 hex characters). A malformed id returns 404, which matches every other guest-cart operation and the read path.

Tests: the old case used the numeric id `999999999` and asserted the buggy 200, so it now uses a well-formed masked id that resolves to nothing. Two tests cover the malformed id and the numeric quote id, and confirm that the real cart stays empty.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->