### PR TITLE
Scoped cart API store switches, collected totals once per request, and fixed stale-totals gates

### DIFF
--- a/app/code/core/Mage/Catalog/Api/GraphQL/ProductQueryHandler.php
+++ b/app/code/core/Mage/Catalog/Api/GraphQL/ProductQueryHandler.php
@@ -84,8 +84,7 @@ class ProductQueryHandler
         AdminAcl::checkResource(Product::class);
         // Honor the requested store like handleGetCategories does: pricing,
         // visibility, and name overrides are store-scoped, and the search layer
-        // below reads the current store. withStore() also mirrors the switch
-        // into StoreContext and restores the caller's scope afterwards.
+        // below reads the current store.
         return StoreContext::withStore((int) ($context['store_id'] ?? 1), fn(): array => $this->searchProductsInCurrentScope($variables));
     }
 
@@ -192,7 +191,7 @@ class ProductQueryHandler
     public function handleGetCategories(array $variables, array $context): array
     {
         AdminAcl::checkResource(Category::class);
-        // Store-scoped names, activity and image URLs; scope restored afterwards
+        // Store-scoped names, activity and image URLs
         $storeId = (int) ($context['store_id'] ?? 1);
         return StoreContext::withStore($storeId, fn(): array => $this->getCategoriesInCurrentScope($variables, $storeId));
     }

--- a/app/code/core/Mage/Catalog/Api/GraphQL/ProductQueryHandler.php
+++ b/app/code/core/Mage/Catalog/Api/GraphQL/ProductQueryHandler.php
@@ -15,6 +15,7 @@ use Mage\Catalog\Api\Product;
 use Mage\Catalog\Api\ProductProvider;
 use Maho\ApiPlatform\Exception\ValidationException;
 use Maho\ApiPlatform\Security\AdminAcl;
+use Maho\ApiPlatform\Service\StoreContext;
 
 /**
  * Product Query Handler.
@@ -83,8 +84,13 @@ class ProductQueryHandler
         AdminAcl::checkResource(Product::class);
         // Honor the requested store like handleGetCategories does: pricing,
         // visibility, and name overrides are store-scoped, and the search layer
-        // below reads the current store.
-        \Mage::app()->setCurrentStore($context['store_id'] ?? 1);
+        // below reads the current store. withStore() also mirrors the switch
+        // into StoreContext and restores the caller's scope afterwards.
+        return StoreContext::withStore((int) ($context['store_id'] ?? 1), fn(): array => $this->searchProductsInCurrentScope($variables));
+    }
+
+    private function searchProductsInCurrentScope(array $variables): array
+    {
         $search = $variables['search'] ?? $variables['query'] ?? '';
         $page = $variables['page'] ?? 1;
         $pageSize = $variables['pageSize'] ?? $variables['limit'] ?? 20;
@@ -186,9 +192,13 @@ class ProductQueryHandler
     public function handleGetCategories(array $variables, array $context): array
     {
         AdminAcl::checkResource(Category::class);
-        $storeId = $context['store_id'] ?? 1;
-        \Mage::app()->setCurrentStore($storeId);
+        // Store-scoped names, activity and image URLs; scope restored afterwards
+        $storeId = (int) ($context['store_id'] ?? 1);
+        return StoreContext::withStore($storeId, fn(): array => $this->getCategoriesInCurrentScope($variables, $storeId));
+    }
 
+    private function getCategoriesInCurrentScope(array $variables, int $storeId): array
+    {
         $parentId = $variables['parentId'] ?? null;
         $maxDepth = $variables['maxDepth'] ?? 3;
         $includeInactive = $variables['includeInactive'] ?? false;

--- a/app/code/core/Mage/Checkout/Api/Cart.php
+++ b/app/code/core/Mage/Checkout/Api/Cart.php
@@ -27,6 +27,9 @@ use Mage\Customer\Api\Address;
     mahoSection: 'Customers',
     mahoOperations: ['read' => 'View', 'write' => 'Create & Modify'],
     mahoCustomerScoped: true,
+    // CartProcessor resolves and verifies the cart itself, so writes skip the
+    // provider read pass (see SelfResolvingWriteResourceMetadataCollectionFactory)
+    mahoSelfResolvingWrites: true,
     shortName: 'Cart',
     description: 'View cart, add/remove items, apply coupons, set shipping & payment',
     provider: CartProvider::class,
@@ -43,12 +46,9 @@ use Mage\Customer\Api\Address;
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Create a new cart for the authenticated customer',
         ),
-        // Write operations declare read: false: CartProcessor resolves and
-        // verifies the cart itself, so the provider's read pass is discarded work.
         new Post(
             uriTemplate: '/carts/{id}/items',
             name: 'add_cart_item',
-            read: false,
             // Returns the updated cart representation (200 OK), not a newly
             // created addressable resource with a Location (which would be 201).
             status: 200,
@@ -58,7 +58,6 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/carts/{id}/items/{itemId}',
             name: 'update_cart_item',
-            read: false,
             // Returns the updated cart representation (200 OK with body) so the
             // client sees the new item/total state in one round-trip.
             status: 200,
@@ -68,7 +67,6 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/carts/{id}/items/{itemId}',
             name: 'remove_cart_item',
-            read: false,
             status: 200,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Remove item from cart',
@@ -81,21 +79,18 @@ use Mage\Customer\Api\Address;
         new Post(
             uriTemplate: '/carts/{id}/coupon',
             name: 'apply_my_coupon',
-            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Apply coupon to cart',
         ),
         new Delete(
             uriTemplate: '/carts/{id}/coupon',
             name: 'remove_my_coupon',
-            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Remove coupon from cart',
         ),
         new Post(
             uriTemplate: '/carts/{id}/giftcards',
             name: 'apply_my_giftcard',
-            read: false,
             status: 200,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Apply gift card to cart',
@@ -103,7 +98,6 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/carts/{id}/giftcards/{code}',
             name: 'remove_my_giftcard',
-            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Remove gift card from cart',
         ),
@@ -116,7 +110,6 @@ use Mage\Customer\Api\Address;
         new Post(
             uriTemplate: '/carts/{id}/shipping-methods',
             name: 'get_my_shipping',
-            read: false,
             // A query-by-POST (address in the body); returns the method list as
             // a representation (200), not a newly created resource (201).
             status: 200,
@@ -134,28 +127,24 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/carts/{id}/shipping-address',
             name: 'set_my_shipping_address',
-            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Set the shipping address on the cart. Body: firstName, lastName, street[], city, region/regionId, postcode, countryId, telephone, company',
         ),
         new Put(
             uriTemplate: '/carts/{id}/billing-address',
             name: 'set_my_billing_address',
-            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Set the billing address on the cart. Same body as shipping-address, or {"sameAsShipping": true} to copy the shipping address',
         ),
         new Put(
             uriTemplate: '/carts/{id}/shipping-method',
             name: 'set_my_shipping_method',
-            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Select a shipping method on the cart. Body: carrierCode, methodCode (must be available for the current shipping address)',
         ),
         new Put(
             uriTemplate: '/carts/{id}/payment-method',
             name: 'set_my_payment_method',
-            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Select a payment method on the cart. Body: methodCode, optional additionalData',
         ),
@@ -165,35 +154,30 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/carts/{id}/gift-message',
             name: 'set_my_cart_gift_message',
-            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Set the gift message on the cart',
         ),
         new Delete(
             uriTemplate: '/carts/{id}/gift-message',
             name: 'remove_my_cart_gift_message',
-            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Remove the gift message from the cart',
         ),
         new Put(
             uriTemplate: '/carts/{id}/items/{itemId}/gift-message',
             name: 'set_my_item_gift_message',
-            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Set the gift message on a cart item',
         ),
         new Delete(
             uriTemplate: '/carts/{id}/items/{itemId}/gift-message',
             name: 'remove_my_item_gift_message',
-            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Remove the gift message from a cart item',
         ),
         new Put(
             uriTemplate: '/guest-carts/{id}/gift-message',
             name: 'set_guest_cart_gift_message',
-            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Set the gift message on a guest cart',
@@ -201,7 +185,6 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/guest-carts/{id}/gift-message',
             name: 'remove_guest_cart_gift_message',
-            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Remove the gift message from a guest cart',
@@ -209,7 +192,6 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/items/{itemId}/gift-message',
             name: 'set_guest_item_gift_message',
-            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Set the gift message on a guest cart item',
@@ -217,7 +199,6 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/guest-carts/{id}/items/{itemId}/gift-message',
             name: 'remove_guest_item_gift_message',
-            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Remove the gift message from a guest cart item',
@@ -238,7 +219,6 @@ use Mage\Customer\Api\Address;
         new Post(
             uriTemplate: '/guest-carts/{id}/items',
             name: 'add_guest_item',
-            read: false,
             status: 200,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
@@ -247,7 +227,6 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/items/{itemId}',
             name: 'update_guest_item',
-            read: false,
             status: 200,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
@@ -256,7 +235,6 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/guest-carts/{id}/items/{itemId}',
             name: 'remove_guest_item',
-            read: false,
             status: 200,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
@@ -265,7 +243,6 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/coupon',
             name: 'apply_guest_coupon',
-            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Apply coupon to guest cart',
@@ -273,7 +250,6 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/guest-carts/{id}/coupon',
             name: 'remove_guest_coupon',
-            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Remove coupon from guest cart',
@@ -281,7 +257,6 @@ use Mage\Customer\Api\Address;
         new Post(
             uriTemplate: '/guest-carts/{id}/giftcards',
             name: 'apply_guest_giftcard',
-            read: false,
             status: 200,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
@@ -290,7 +265,6 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/guest-carts/{id}/giftcards/{code}',
             name: 'remove_guest_giftcard',
-            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Remove gift card from guest cart',
@@ -305,7 +279,6 @@ use Mage\Customer\Api\Address;
         new Post(
             uriTemplate: '/guest-carts/{id}/shipping-methods',
             name: 'get_guest_shipping',
-            read: false,
             status: 200,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
@@ -322,7 +295,6 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/shipping-address',
             name: 'set_guest_shipping_address',
-            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Set the shipping address on a guest cart. Body: firstName, lastName, street[], city, region/regionId, postcode, countryId, telephone, company',
@@ -330,7 +302,6 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/billing-address',
             name: 'set_guest_billing_address',
-            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Set the billing address on a guest cart. Same body as shipping-address, or {"sameAsShipping": true} to copy the shipping address',
@@ -338,7 +309,6 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/shipping-method',
             name: 'set_guest_shipping_method',
-            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Select a shipping method on a guest cart. Body: carrierCode, methodCode (must be available for the current shipping address)',
@@ -346,7 +316,6 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/payment-method',
             name: 'set_guest_payment_method',
-            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Select a payment method on a guest cart. Body: methodCode, optional additionalData',
@@ -383,13 +352,9 @@ use Mage\Customer\Api\Address;
             args: ['storeId' => ['type' => 'Int', 'description' => 'Optional store ID, defaults to current store']],
             description: 'Create an empty cart',
         ),
-        // Cart-mutating GraphQL operations declare read: false like the REST
-        // writes above: CartProcessor resolves and verifies the cart itself,
-        // so the provider's read pass is discarded work.
         new Mutation(
             security: 'true',
             name: 'addTo',
-            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],
@@ -414,35 +379,30 @@ use Mage\Customer\Api\Address;
         new Mutation(
             security: 'true',
             name: 'updateItemQtyIn',
-            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String'], 'itemId' => ['type' => 'ID!'], 'qty' => ['type' => 'Float!']],
             description: 'Update cart item quantity',
         ),
         new Mutation(
             security: 'true',
             name: 'removeItemFrom',
-            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String'], 'itemId' => ['type' => 'ID!']],
             description: 'Remove item from cart',
         ),
         new Mutation(
             security: 'true',
             name: 'applyCouponTo',
-            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String'], 'couponCode' => ['type' => 'String!']],
             description: 'Apply coupon code to cart',
         ),
         new Mutation(
             security: 'true',
             name: 'removeCouponFrom',
-            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String']],
             description: 'Remove coupon code from cart',
         ),
         new Mutation(
             security: 'true',
             name: 'setShippingAddressOn',
-            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],
@@ -462,7 +422,6 @@ use Mage\Customer\Api\Address;
         new Mutation(
             security: 'true',
             name: 'setBillingAddressOn',
-            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],
@@ -483,7 +442,6 @@ use Mage\Customer\Api\Address;
         new Mutation(
             security: 'true',
             name: 'setShippingMethodOn',
-            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],
@@ -495,7 +453,6 @@ use Mage\Customer\Api\Address;
         new Mutation(
             security: 'true',
             name: 'setPaymentMethodOn',
-            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],
@@ -505,7 +462,6 @@ use Mage\Customer\Api\Address;
         ),
         new Mutation(
             name: 'assignCustomerTo',
-            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String'], 'customerId' => ['type' => 'ID!']],
             description: 'Assign customer to cart',
             security: "is_granted('ROLE_CUSTOMER') or is_granted('carts/write')",
@@ -513,14 +469,12 @@ use Mage\Customer\Api\Address;
         new Mutation(
             security: 'true',
             name: 'applyGiftcardTo',
-            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String'], 'giftcardCode' => ['type' => 'String!']],
             description: 'Apply gift card to cart',
         ),
         new Mutation(
             security: 'true',
             name: 'removeGiftcardFrom',
-            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String'], 'giftcardCode' => ['type' => 'String!']],
             description: 'Remove gift card from cart',
         ),
@@ -530,7 +484,6 @@ use Mage\Customer\Api\Address;
             // resource suffix reads as `setGiftMessageCart`, not a stuttering
             // `setCartGiftMessageCart`.
             name: 'setGiftMessageOn',
-            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],
@@ -544,7 +497,6 @@ use Mage\Customer\Api\Address;
         new Mutation(
             security: 'true',
             name: 'removeGiftMessageFrom',
-            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],

--- a/app/code/core/Mage/Checkout/Api/Cart.php
+++ b/app/code/core/Mage/Checkout/Api/Cart.php
@@ -43,9 +43,14 @@ use Mage\Customer\Api\Address;
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Create a new cart for the authenticated customer',
         ),
+        // Write operations declare read: false. CartProcessor resolves and
+        // verifies the cart itself, so the provider's read pass would load the
+        // quote, check access and build a DTO only for all of it to be
+        // discarded and redone by the processor.
         new Post(
             uriTemplate: '/carts/{id}/items',
             name: 'add_cart_item',
+            read: false,
             // Returns the updated cart representation (200 OK), not a newly
             // created addressable resource with a Location (which would be 201).
             status: 200,
@@ -55,6 +60,7 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/carts/{id}/items/{itemId}',
             name: 'update_cart_item',
+            read: false,
             // Returns the updated cart representation (200 OK with body) so the
             // client sees the new item/total state in one round-trip.
             status: 200,
@@ -64,6 +70,7 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/carts/{id}/items/{itemId}',
             name: 'remove_cart_item',
+            read: false,
             status: 200,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Remove item from cart',
@@ -76,18 +83,21 @@ use Mage\Customer\Api\Address;
         new Post(
             uriTemplate: '/carts/{id}/coupon',
             name: 'apply_my_coupon',
+            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Apply coupon to cart',
         ),
         new Delete(
             uriTemplate: '/carts/{id}/coupon',
             name: 'remove_my_coupon',
+            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Remove coupon from cart',
         ),
         new Post(
             uriTemplate: '/carts/{id}/giftcards',
             name: 'apply_my_giftcard',
+            read: false,
             status: 200,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Apply gift card to cart',
@@ -95,6 +105,7 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/carts/{id}/giftcards/{code}',
             name: 'remove_my_giftcard',
+            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Remove gift card from cart',
         ),
@@ -107,6 +118,7 @@ use Mage\Customer\Api\Address;
         new Post(
             uriTemplate: '/carts/{id}/shipping-methods',
             name: 'get_my_shipping',
+            read: false,
             // A query-by-POST (address in the body); returns the method list as
             // a representation (200), not a newly created resource (201).
             status: 200,
@@ -124,24 +136,28 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/carts/{id}/shipping-address',
             name: 'set_my_shipping_address',
+            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Set the shipping address on the cart. Body: firstName, lastName, street[], city, region/regionId, postcode, countryId, telephone, company',
         ),
         new Put(
             uriTemplate: '/carts/{id}/billing-address',
             name: 'set_my_billing_address',
+            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Set the billing address on the cart. Same body as shipping-address, or {"sameAsShipping": true} to copy the shipping address',
         ),
         new Put(
             uriTemplate: '/carts/{id}/shipping-method',
             name: 'set_my_shipping_method',
+            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Select a shipping method on the cart. Body: carrierCode, methodCode (must be available for the current shipping address)',
         ),
         new Put(
             uriTemplate: '/carts/{id}/payment-method',
             name: 'set_my_payment_method',
+            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Select a payment method on the cart. Body: methodCode, optional additionalData',
         ),
@@ -151,30 +167,35 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/carts/{id}/gift-message',
             name: 'set_my_cart_gift_message',
+            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Set the gift message on the cart',
         ),
         new Delete(
             uriTemplate: '/carts/{id}/gift-message',
             name: 'remove_my_cart_gift_message',
+            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Remove the gift message from the cart',
         ),
         new Put(
             uriTemplate: '/carts/{id}/items/{itemId}/gift-message',
             name: 'set_my_item_gift_message',
+            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Set the gift message on a cart item',
         ),
         new Delete(
             uriTemplate: '/carts/{id}/items/{itemId}/gift-message',
             name: 'remove_my_item_gift_message',
+            read: false,
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Remove the gift message from a cart item',
         ),
         new Put(
             uriTemplate: '/guest-carts/{id}/gift-message',
             name: 'set_guest_cart_gift_message',
+            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Set the gift message on a guest cart',
@@ -182,6 +203,7 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/guest-carts/{id}/gift-message',
             name: 'remove_guest_cart_gift_message',
+            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Remove the gift message from a guest cart',
@@ -189,6 +211,7 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/items/{itemId}/gift-message',
             name: 'set_guest_item_gift_message',
+            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Set the gift message on a guest cart item',
@@ -196,6 +219,7 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/guest-carts/{id}/items/{itemId}/gift-message',
             name: 'remove_guest_item_gift_message',
+            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Remove the gift message from a guest cart item',
@@ -216,6 +240,7 @@ use Mage\Customer\Api\Address;
         new Post(
             uriTemplate: '/guest-carts/{id}/items',
             name: 'add_guest_item',
+            read: false,
             status: 200,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
@@ -224,6 +249,7 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/items/{itemId}',
             name: 'update_guest_item',
+            read: false,
             status: 200,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
@@ -232,6 +258,7 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/guest-carts/{id}/items/{itemId}',
             name: 'remove_guest_item',
+            read: false,
             status: 200,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
@@ -240,6 +267,7 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/coupon',
             name: 'apply_guest_coupon',
+            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Apply coupon to guest cart',
@@ -247,6 +275,7 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/guest-carts/{id}/coupon',
             name: 'remove_guest_coupon',
+            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Remove coupon from guest cart',
@@ -254,6 +283,7 @@ use Mage\Customer\Api\Address;
         new Post(
             uriTemplate: '/guest-carts/{id}/giftcards',
             name: 'apply_guest_giftcard',
+            read: false,
             status: 200,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
@@ -262,6 +292,7 @@ use Mage\Customer\Api\Address;
         new Delete(
             uriTemplate: '/guest-carts/{id}/giftcards/{code}',
             name: 'remove_guest_giftcard',
+            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Remove gift card from guest cart',
@@ -276,6 +307,7 @@ use Mage\Customer\Api\Address;
         new Post(
             uriTemplate: '/guest-carts/{id}/shipping-methods',
             name: 'get_guest_shipping',
+            read: false,
             status: 200,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
@@ -292,6 +324,7 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/shipping-address',
             name: 'set_guest_shipping_address',
+            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Set the shipping address on a guest cart. Body: firstName, lastName, street[], city, region/regionId, postcode, countryId, telephone, company',
@@ -299,6 +332,7 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/billing-address',
             name: 'set_guest_billing_address',
+            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Set the billing address on a guest cart. Same body as shipping-address, or {"sameAsShipping": true} to copy the shipping address',
@@ -306,6 +340,7 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/shipping-method',
             name: 'set_guest_shipping_method',
+            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Select a shipping method on a guest cart. Body: carrierCode, methodCode (must be available for the current shipping address)',
@@ -313,6 +348,7 @@ use Mage\Customer\Api\Address;
         new Put(
             uriTemplate: '/guest-carts/{id}/payment-method',
             name: 'set_guest_payment_method',
+            read: false,
             uriVariables: ['id' => new Link(fromClass: Cart::class, identifiers: [])],
             security: 'true',
             description: 'Select a payment method on a guest cart. Body: methodCode, optional additionalData',

--- a/app/code/core/Mage/Checkout/Api/Cart.php
+++ b/app/code/core/Mage/Checkout/Api/Cart.php
@@ -43,10 +43,8 @@ use Mage\Customer\Api\Address;
             security: "is_granted('ROLE_CUSTOMER') or is_granted('ROLE_ADMIN') or is_granted('carts/write')",
             description: 'Create a new cart for the authenticated customer',
         ),
-        // Write operations declare read: false. CartProcessor resolves and
-        // verifies the cart itself, so the provider's read pass would load the
-        // quote, check access and build a DTO only for all of it to be
-        // discarded and redone by the processor.
+        // Write operations declare read: false: CartProcessor resolves and
+        // verifies the cart itself, so the provider's read pass is discarded work.
         new Post(
             uriTemplate: '/carts/{id}/items',
             name: 'add_cart_item',

--- a/app/code/core/Mage/Checkout/Api/Cart.php
+++ b/app/code/core/Mage/Checkout/Api/Cart.php
@@ -383,9 +383,13 @@ use Mage\Customer\Api\Address;
             args: ['storeId' => ['type' => 'Int', 'description' => 'Optional store ID, defaults to current store']],
             description: 'Create an empty cart',
         ),
+        // Cart-mutating GraphQL operations declare read: false like the REST
+        // writes above: CartProcessor resolves and verifies the cart itself,
+        // so the provider's read pass is discarded work.
         new Mutation(
             security: 'true',
             name: 'addTo',
+            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],
@@ -410,30 +414,35 @@ use Mage\Customer\Api\Address;
         new Mutation(
             security: 'true',
             name: 'updateItemQtyIn',
+            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String'], 'itemId' => ['type' => 'ID!'], 'qty' => ['type' => 'Float!']],
             description: 'Update cart item quantity',
         ),
         new Mutation(
             security: 'true',
             name: 'removeItemFrom',
+            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String'], 'itemId' => ['type' => 'ID!']],
             description: 'Remove item from cart',
         ),
         new Mutation(
             security: 'true',
             name: 'applyCouponTo',
+            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String'], 'couponCode' => ['type' => 'String!']],
             description: 'Apply coupon code to cart',
         ),
         new Mutation(
             security: 'true',
             name: 'removeCouponFrom',
+            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String']],
             description: 'Remove coupon code from cart',
         ),
         new Mutation(
             security: 'true',
             name: 'setShippingAddressOn',
+            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],
@@ -453,6 +462,7 @@ use Mage\Customer\Api\Address;
         new Mutation(
             security: 'true',
             name: 'setBillingAddressOn',
+            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],
@@ -473,6 +483,7 @@ use Mage\Customer\Api\Address;
         new Mutation(
             security: 'true',
             name: 'setShippingMethodOn',
+            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],
@@ -484,6 +495,7 @@ use Mage\Customer\Api\Address;
         new Mutation(
             security: 'true',
             name: 'setPaymentMethodOn',
+            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],
@@ -493,6 +505,7 @@ use Mage\Customer\Api\Address;
         ),
         new Mutation(
             name: 'assignCustomerTo',
+            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String'], 'customerId' => ['type' => 'ID!']],
             description: 'Assign customer to cart',
             security: "is_granted('ROLE_CUSTOMER') or is_granted('carts/write')",
@@ -500,12 +513,14 @@ use Mage\Customer\Api\Address;
         new Mutation(
             security: 'true',
             name: 'applyGiftcardTo',
+            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String'], 'giftcardCode' => ['type' => 'String!']],
             description: 'Apply gift card to cart',
         ),
         new Mutation(
             security: 'true',
             name: 'removeGiftcardFrom',
+            read: false,
             args: ['cartId' => ['type' => 'ID'], 'maskedId' => ['type' => 'String'], 'giftcardCode' => ['type' => 'String!']],
             description: 'Remove gift card from cart',
         ),
@@ -515,6 +530,7 @@ use Mage\Customer\Api\Address;
             // resource suffix reads as `setGiftMessageCart`, not a stuttering
             // `setCartGiftMessageCart`.
             name: 'setGiftMessageOn',
+            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],
@@ -528,6 +544,7 @@ use Mage\Customer\Api\Address;
         new Mutation(
             security: 'true',
             name: 'removeGiftMessageFrom',
+            read: false,
             args: [
                 'cartId' => ['type' => 'ID'],
                 'maskedId' => ['type' => 'String'],
@@ -596,7 +613,7 @@ class Cart extends \Maho\ApiPlatform\Resource
     #[ApiProperty(description: 'Shipping address', writable: false)]
     public ?Address $shippingAddress = null;
 
-    /** @var array<array{code: string, title: string, carrierCode: string, methodCode: string, carrierTitle: string, methodTitle: string, price: float}> */
+    /** @var array<array{code: string, title: string, carrierCode: string, methodCode: string, carrierTitle: string, methodTitle: string, price: float, available: bool, errorMessage: string|null}> */
     #[ApiProperty(description: 'Available shipping methods for current address', writable: false)]
     public array $availableShippingMethods = [];
 

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -23,6 +23,12 @@ class CartMapper
      * Built in the quote's store scope: media URLs, store-scoped attribute
      * values and shipping rates must present the cart in its own store's
      * terms, whatever scope the API caller requested.
+     *
+     * The mapper owns read-boundary totals: a quote whose totals were not yet
+     * collected in this request is collected here, so callers never thread a
+     * collect-on-load flag. Pass $collectTotals: false only when fresh totals
+     * cannot matter: a just-created empty cart, or a DTO built to be discarded
+     * (CartProvider on write operations).
      */
     public function mapQuoteToCart(\Mage_Sales_Model_Quote $quote, bool $collectTotals = true): Cart
     {
@@ -31,8 +37,8 @@ class CartMapper
 
     private function buildCartDto(\Mage_Sales_Model_Quote $quote, bool $collectTotals): Cart
     {
-        if ($collectTotals) {
-            $quote->collectTotals();
+        if ($collectTotals && !$quote->getTotalsCollectedFlag()) {
+            CartService::collectAndVerifyTotals($quote);
         }
 
         $cart = new Cart();

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -392,9 +392,13 @@ class CartMapper
 
         foreach ($address->getAllShippingRates() as $rate) {
             $carrierCode = (string) $rate->getCarrier();
-            if (!isset($carrierSortOrder[$carrierCode])) {
+            if (!array_key_exists($carrierCode, $carrierSortOrder)) {
                 $carrier = $rate->getCarrierInstance();
-                $carrierSortOrder[$carrierCode] = $carrier ? (int) $carrier->getSortOrder() : PHP_INT_MAX;
+                $carrierSortOrder[$carrierCode] = $carrier ? (int) $carrier->getSortOrder() : null;
+            }
+            // A persisted rate can outlive its carrier; skip it like getGroupedAllShippingRates()
+            if ($carrierSortOrder[$carrierCode] === null) {
+                continue;
             }
             $methodCode = (string) $rate->getMethod();
             $carrierTitle = (string) $rate->getCarrierTitle();

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -80,8 +80,14 @@ class CartMapper
         if ($shippingAddress && $shippingAddress->getId()) {
             $cart->shippingAddress = Address::fromQuoteAddress($shippingAddress);
 
-            // Get available shipping methods
-            $cart->availableShippingMethods = $this->getAvailableShippingMethods($shippingAddress);
+            // A cart read must survive a broken carrier; the dedicated
+            // shipping-method endpoints let the failure propagate instead
+            try {
+                $cart->availableShippingMethods = $this->getAvailableShippingMethods($shippingAddress);
+            } catch (\Exception $e) {
+                \Mage::log('Error getting shipping methods: ' . $e->getMessage(), \Mage::LOG_ERROR);
+                $cart->availableShippingMethods = [];
+            }
 
             // Get selected shipping method
             if ($shippingAddress->getShippingMethod()) {
@@ -367,44 +373,53 @@ class CartMapper
     /**
      * Get available shipping methods for address
      *
+     * A rate-collection failure propagates instead of masquerading as "no
+     * methods"; mapQuoteToCart() is the one caller that swallows it.
+     *
      * @return array<array{code: string, title: string, carrierCode: string, methodCode: string, carrierTitle: string, methodTitle: string, price: float, available: bool, errorMessage: string|null}>
      */
     public function getAvailableShippingMethods(\Mage_Sales_Model_Quote_Address $address): array
     {
         $methods = [];
+        $carrierSortOrder = [];
 
-        try {
-            $address->collectShippingRates();
+        $address->collectShippingRates();
 
-            // Rate prices are website base currency; the shipping total collector
-            // converts the selected one into shipping_amount, so convert here too
-            // or the same method would change price once selected.
-            $store = $address->getQuote()->getStore();
+        // Rate prices are website base currency; the shipping total collector
+        // converts the selected one into shipping_amount, so convert here too
+        // or the same method would change price once selected.
+        $store = $address->getQuote()->getStore();
 
-            foreach ($address->getAllShippingRates() as $rate) {
-                $carrierCode = (string) $rate->getCarrier();
-                $methodCode = (string) $rate->getMethod();
-                $carrierTitle = (string) $rate->getCarrierTitle();
-                $methodTitle = (string) $rate->getMethodTitle();
-                $errorMessage = $rate->getErrorMessage() ?: null;
-                $methods[] = [
-                    // `code`/`title` are the flat, client-facing pair (carrier_method
-                    // and a human label); carrier/method parts are kept for callers
-                    // that need them separately (e.g. setShippingMethodOnCart).
-                    'code' => $carrierCode . '_' . $methodCode,
-                    'title' => trim($carrierTitle . ' - ' . $methodTitle, ' -'),
-                    'carrierCode' => $carrierCode,
-                    'methodCode' => $methodCode,
-                    'carrierTitle' => $carrierTitle,
-                    'methodTitle' => $methodTitle,
-                    'price' => (float) $store->convertPrice((float) $rate->getPrice(), false),
-                    'available' => $errorMessage === null,
-                    'errorMessage' => $errorMessage,
-                ];
+        foreach ($address->getAllShippingRates() as $rate) {
+            $carrierCode = (string) $rate->getCarrier();
+            if (!isset($carrierSortOrder[$carrierCode])) {
+                $carrier = $rate->getCarrierInstance();
+                $carrierSortOrder[$carrierCode] = $carrier ? (int) $carrier->getSortOrder() : PHP_INT_MAX;
             }
-        } catch (\Exception $e) {
-            \Mage::log('Error getting shipping methods: ' . $e->getMessage(), \Mage::LOG_ERROR);
+            $methodCode = (string) $rate->getMethod();
+            $carrierTitle = (string) $rate->getCarrierTitle();
+            $methodTitle = (string) $rate->getMethodTitle();
+            $errorMessage = $rate->getErrorMessage() ?: null;
+            $methods[] = [
+                // `code`/`title` are the flat, client-facing pair (carrier_method
+                // and a human label); carrier/method parts are kept for callers
+                // that need them separately (e.g. setShippingMethodOnCart).
+                'code' => $carrierCode . '_' . $methodCode,
+                'title' => trim($carrierTitle . ' - ' . $methodTitle, ' -'),
+                'carrierCode' => $carrierCode,
+                'methodCode' => $methodCode,
+                'carrierTitle' => $carrierTitle,
+                'methodTitle' => $methodTitle,
+                'price' => (float) $store->convertPrice((float) $rate->getPrice(), false),
+                'available' => $errorMessage === null,
+                'errorMessage' => $errorMessage,
+            ];
         }
+
+        // Present carriers in their configured order, like the storefront's
+        // getGroupedAllShippingRates(); usort is stable, so methods within a
+        // carrier keep their collection order
+        usort($methods, fn(array $a, array $b) => $carrierSortOrder[$a['carrierCode']] <=> $carrierSortOrder[$b['carrierCode']]);
 
         return $methods;
     }

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -18,17 +18,11 @@ use Mage\Customer\Api\Address;
 class CartMapper
 {
     /**
-     * Map Maho quote model to Cart DTO.
-     *
-     * Built in the quote's store scope: media URLs, store-scoped attribute
-     * values and shipping rates must present the cart in its own store's
-     * terms, whatever scope the API caller requested.
-     *
-     * The mapper owns read-boundary totals: a quote whose totals were not yet
-     * collected in this request is collected here, so callers never thread a
-     * collect-on-load flag. Pass $collectTotals: false only when fresh totals
-     * cannot matter: a just-created empty cart, or a DTO built to be discarded
-     * (CartProvider on write operations).
+     * Map Maho quote model to Cart DTO, in the quote's store scope so media
+     * URLs, attribute values and shipping rates reflect the cart's own store.
+     * Totals not yet collected in this request are collected here, at the read
+     * boundary; pass $collectTotals: false only when fresh totals cannot matter
+     * (a just-created empty cart, or a provider DTO the processor discards).
      */
     public function mapQuoteToCart(\Mage_Sales_Model_Quote $quote, bool $collectTotals = true): Cart
     {

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -18,9 +18,18 @@ use Mage\Customer\Api\Address;
 class CartMapper
 {
     /**
-     * Map Maho quote model to Cart DTO
+     * Map Maho quote model to Cart DTO.
+     *
+     * Built in the quote's store scope: media URLs, store-scoped attribute
+     * values and shipping rates must present the cart in its own store's
+     * terms, whatever scope the API caller requested.
      */
     public function mapQuoteToCart(\Mage_Sales_Model_Quote $quote, bool $collectTotals = true): Cart
+    {
+        return CartService::inQuoteStoreScope($quote, fn(): Cart => $this->buildCartDto($quote, $collectTotals));
+    }
+
+    private function buildCartDto(\Mage_Sales_Model_Quote $quote, bool $collectTotals): Cart
     {
         if ($collectTotals) {
             $quote->collectTotals();

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -22,7 +22,7 @@ class CartMapper
      * URLs, attribute values and shipping rates reflect the cart's own store.
      * Totals not yet collected in this request are collected here, at the read
      * boundary; pass $collectTotals: false only when fresh totals cannot matter
-     * (a just-created empty cart, or a provider DTO the processor discards).
+     * (a just-created empty cart).
      */
     public function mapQuoteToCart(\Mage_Sales_Model_Quote $quote, bool $collectTotals = true): Cart
     {
@@ -367,7 +367,7 @@ class CartMapper
     /**
      * Get available shipping methods for address
      *
-     * @return array<array{code: string, title: string, carrierCode: string, methodCode: string, carrierTitle: string, methodTitle: string, price: float}>
+     * @return array<array{code: string, title: string, carrierCode: string, methodCode: string, carrierTitle: string, methodTitle: string, price: float, available: bool, errorMessage: string|null}>
      */
     public function getAvailableShippingMethods(\Mage_Sales_Model_Quote_Address $address): array
     {
@@ -386,6 +386,7 @@ class CartMapper
                 $methodCode = (string) $rate->getMethod();
                 $carrierTitle = (string) $rate->getCarrierTitle();
                 $methodTitle = (string) $rate->getMethodTitle();
+                $errorMessage = $rate->getErrorMessage() ?: null;
                 $methods[] = [
                     // `code`/`title` are the flat, client-facing pair (carrier_method
                     // and a human label); carrier/method parts are kept for callers
@@ -397,6 +398,8 @@ class CartMapper
                     'carrierTitle' => $carrierTitle,
                     'methodTitle' => $methodTitle,
                     'price' => (float) $store->convertPrice((float) $rate->getPrice(), false),
+                    'available' => $errorMessage === null,
+                    'errorMessage' => $errorMessage,
                 ];
             }
         } catch (\Exception $e) {

--- a/app/code/core/Mage/Checkout/Api/CartProcessor.php
+++ b/app/code/core/Mage/Checkout/Api/CartProcessor.php
@@ -102,14 +102,12 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
     }
 
     /**
-     * Resolve cart and verify access, shared by all operation methods. Pass
-     * $collectTotals: false from operations that mutate the quote and recollect
-     * afterwards, so the load-time totals collection is skipped.
+     * Resolve cart and verify access, shared by all operation methods
      */
-    private function resolveAndVerify(array $context, array $uriVariables, bool $collectTotals = true): \Mage_Sales_Model_Quote
+    private function resolveAndVerify(array $context, array $uriVariables): \Mage_Sales_Model_Quote
     {
         ['quote' => $quote, 'accessedByMaskedId' => $byMasked] =
-            $this->cartService->resolveCartFromRequest($uriVariables, $context, $collectTotals);
+            $this->cartService->resolveCartFromRequest($uriVariables, $context);
 
         if (!$quote) {
             throw new NotFoundHttpException('Cart not found');
@@ -252,7 +250,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $quote = $this->resolveCartForItemAdd($context, $uriVariables, $recreated);
         $quote = $this->cartService->addItem($quote, $sku, $qty, $buyOptions, $customPrice);
 
-        $cart = $this->cartMapper->mapQuoteToCart($quote, false);
+        $cart = $this->cartMapper->mapQuoteToCart($quote);
         $cart->cartRecreated = $recreated;
         return $cart;
     }
@@ -285,7 +283,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
     private function resolveCartForItemAdd(array $context, array $uriVariables, bool &$recreated): \Mage_Sales_Model_Quote
     {
         ['quote' => $quote, 'accessedByMaskedId' => $byMasked, 'maskedId' => $maskedId] =
-            $this->cartService->resolveCartFromRequest($uriVariables, $context, collectTotals: false);
+            $this->cartService->resolveCartFromRequest($uriVariables, $context);
 
         if ($quote) {
             $this->cartService->verifyCartAccess(
@@ -330,10 +328,10 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             throw new BadRequestHttpException('Item ID is required');
         }
 
-        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
+        $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->updateItem($quote, (int) $itemId, $qty, $customPrice);
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
     /**
@@ -348,10 +346,10 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             throw new BadRequestHttpException('Item ID is required');
         }
 
-        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
+        $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->removeItem($quote, (int) $itemId);
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
 
@@ -377,10 +375,10 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             $this->checkRateLimitByIp('cart_coupon', 'coupon_validate', 60);
         }
 
-        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
+        $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->applyCoupon($quote, $couponCode);
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
     /**
@@ -388,10 +386,10 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
      */
     private function removeCouponFromCart(array $context, array $uriVariables): Cart
     {
-        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
+        $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->removeCoupon($quote);
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
     /**
@@ -402,10 +400,10 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $args = $context['args']['input'] ?? [];
         $this->cartService->assertCompleteAddressInput($args);
 
-        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
+        $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->setShippingAddress($quote, $this->cartService->mapAddressInput($args));
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
     /**
@@ -421,11 +419,11 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             $this->cartService->assertCompleteAddressInput($args);
         }
 
-        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
+        $quote = $this->resolveAndVerify($context, $uriVariables);
         $addressData = $sameAsShipping ? [] : $this->cartService->mapAddressInput($args);
         $quote = $this->cartService->setBillingAddress($quote, $addressData, $sameAsShipping);
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
     /**
@@ -438,11 +436,16 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
     {
         $args = $context['args']['input'] ?? [];
         $address = $args['address'] ?? null;
+        $applyAddress = is_array($address) && !empty($address);
 
         $quote = $this->resolveAndVerify($context, $uriVariables);
 
-        if (is_array($address) && !empty($address)) {
+        if ($applyAddress) {
             $quote = $this->cartService->setShippingAddress($quote, $this->cartService->mapAddressInput($address));
+        } else {
+            // The rate calculator reads collected address data (weight, subtotal),
+            // and no mutation collects on this path
+            CartService::collectAndVerifyTotals($quote);
         }
 
         // Guest frontend contract: return the plain list of available shipping
@@ -450,13 +453,14 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         // returns the full Cart (availableShippingMethods included).
         if ($focused) {
             $shippingAddress = $quote->getShippingAddress();
+            // Rates must resolve in the quote's store scope, like setShippingMethod()
             $methods = $shippingAddress && $shippingAddress->getId()
-                ? $this->cartMapper->getAvailableShippingMethods($shippingAddress)
+                ? CartService::inQuoteStoreScope($quote, fn(): array => $this->cartMapper->getAvailableShippingMethods($shippingAddress))
                 : [];
             return $this->respondRaw($methods);
         }
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
     /**
@@ -474,10 +478,10 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $carrierCode = (string) $carrierCode;
         $methodCode = (string) $methodCode;
 
-        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
+        $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->setShippingMethod($quote, $carrierCode, $methodCode);
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
     /**
@@ -497,10 +501,10 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         }
         $methodCode = (string) $methodCode;
 
-        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
+        $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->setPaymentMethod($quote, $methodCode, $additionalData);
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
     /**
@@ -521,7 +525,6 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             $quote = $this->cartService->getCart(
                 $cartId ? (int) $cartId : null,
                 $maskedId,
-                collectTotals: false,
             );
             if (!$quote) {
                 throw new NotFoundHttpException('Cart not found');
@@ -535,7 +538,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
 
             $quote = $this->cartService->assignCustomer($quote, $customer);
 
-            return $this->cartMapper->mapQuoteToCart($quote, false);
+            return $this->cartMapper->mapQuoteToCart($quote);
         }
 
         // Customer self-assignment (merge guest cart)
@@ -550,7 +553,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
 
         $quote = $this->cartService->mergeCarts($maskedId, $customerId);
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
     /**
@@ -569,10 +572,10 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             $this->checkRateLimitByIp('cart_giftcard', 'giftcard_balance', 60);
         }
 
-        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
+        $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->applyGiftcard($quote, $giftcardCode);
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
     /**
@@ -583,10 +586,10 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $args = $context['args']['input'] ?? [];
         $giftcardCode = trim($args['giftcardCode'] ?? '');
 
-        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
+        $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->removeGiftcard($quote, $giftcardCode);
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
     /**
@@ -604,7 +607,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->setGiftMessage($quote, $itemId, $sender, $recipient, $message);
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
     /**
@@ -618,7 +621,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $quote = $this->resolveAndVerify($context, $uriVariables);
         $quote = $this->cartService->removeGiftMessage($quote, $itemId);
 
-        return $this->cartMapper->mapQuoteToCart($quote, false);
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 
     /**

--- a/app/code/core/Mage/Checkout/Api/CartProcessor.php
+++ b/app/code/core/Mage/Checkout/Api/CartProcessor.php
@@ -436,18 +436,20 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
     {
         $args = $context['args']['input'] ?? [];
         $address = $args['address'] ?? null;
-        $applyAddress = is_array($address) && !empty($address);
 
         $quote = $this->resolveAndVerify($context, $uriVariables);
 
-        if ($applyAddress) {
+        if (is_array($address) && $address !== []) {
             $quote = $this->cartService->setShippingAddress($quote, $this->cartService->mapAddressInput($address));
         } else {
             // No address in the body: request fresh rates for the current cart
             // state. Without the flag collectShippingRates() is a no-op and the
             // response would repeat rates persisted before earlier cart changes.
+            // Persist the refresh: a later set-shipping-method validates and
+            // prices against the saved rates, so advertising unsaved ones would
+            // offer methods that call then rejects.
             $quote->getShippingAddress()->setCollectShippingRates(1);
-            CartService::collectAndVerifyTotals($quote);
+            $this->cartService->collectAndSave($quote);
         }
 
         // Guest frontend contract: return the plain list of available shipping

--- a/app/code/core/Mage/Checkout/Api/CartProcessor.php
+++ b/app/code/core/Mage/Checkout/Api/CartProcessor.php
@@ -443,8 +443,10 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         if ($applyAddress) {
             $quote = $this->cartService->setShippingAddress($quote, $this->cartService->mapAddressInput($address));
         } else {
-            // The rate calculator reads collected address data (weight, subtotal),
-            // and no mutation collects on this path
+            // No address in the body: request fresh rates for the current cart
+            // state. Without the flag collectShippingRates() is a no-op and the
+            // response would repeat rates persisted before earlier cart changes.
+            $quote->getShippingAddress()->setCollectShippingRates(1);
             CartService::collectAndVerifyTotals($quote);
         }
 

--- a/app/code/core/Mage/Checkout/Api/CartProcessor.php
+++ b/app/code/core/Mage/Checkout/Api/CartProcessor.php
@@ -453,7 +453,6 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         // returns the full Cart (availableShippingMethods included).
         if ($focused) {
             $shippingAddress = $quote->getShippingAddress();
-            // Rates must resolve in the quote's store scope, like setShippingMethod()
             $methods = $shippingAddress && $shippingAddress->getId()
                 ? CartService::inQuoteStoreScope($quote, fn(): array => $this->cartMapper->getAvailableShippingMethods($shippingAddress))
                 : [];

--- a/app/code/core/Mage/Checkout/Api/CartProcessor.php
+++ b/app/code/core/Mage/Checkout/Api/CartProcessor.php
@@ -102,12 +102,14 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
     }
 
     /**
-     * Resolve cart and verify access, shared by all operation methods
+     * Resolve cart and verify access, shared by all operation methods. Pass
+     * $collectTotals: false from operations that mutate the quote and recollect
+     * afterwards, so the load-time totals collection is skipped.
      */
-    private function resolveAndVerify(array $context, array $uriVariables): \Mage_Sales_Model_Quote
+    private function resolveAndVerify(array $context, array $uriVariables, bool $collectTotals = true): \Mage_Sales_Model_Quote
     {
         ['quote' => $quote, 'accessedByMaskedId' => $byMasked] =
-            $this->cartService->resolveCartFromRequest($uriVariables, $context);
+            $this->cartService->resolveCartFromRequest($uriVariables, $context, $collectTotals);
 
         if (!$quote) {
             throw new NotFoundHttpException('Cart not found');
@@ -283,7 +285,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
     private function resolveCartForItemAdd(array $context, array $uriVariables, bool &$recreated): \Mage_Sales_Model_Quote
     {
         ['quote' => $quote, 'accessedByMaskedId' => $byMasked, 'maskedId' => $maskedId] =
-            $this->cartService->resolveCartFromRequest($uriVariables, $context);
+            $this->cartService->resolveCartFromRequest($uriVariables, $context, collectTotals: false);
 
         if ($quote) {
             $this->cartService->verifyCartAccess(
@@ -328,7 +330,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             throw new BadRequestHttpException('Item ID is required');
         }
 
-        $quote = $this->resolveAndVerify($context, $uriVariables);
+        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
         $quote = $this->cartService->updateItem($quote, (int) $itemId, $qty, $customPrice);
 
         return $this->cartMapper->mapQuoteToCart($quote, false);
@@ -346,7 +348,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             throw new BadRequestHttpException('Item ID is required');
         }
 
-        $quote = $this->resolveAndVerify($context, $uriVariables);
+        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
         $quote = $this->cartService->removeItem($quote, (int) $itemId);
 
         return $this->cartMapper->mapQuoteToCart($quote, false);
@@ -375,7 +377,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             $this->checkRateLimitByIp('cart_coupon', 'coupon_validate', 60);
         }
 
-        $quote = $this->resolveAndVerify($context, $uriVariables);
+        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
         $quote = $this->cartService->applyCoupon($quote, $couponCode);
 
         return $this->cartMapper->mapQuoteToCart($quote, false);
@@ -386,7 +388,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
      */
     private function removeCouponFromCart(array $context, array $uriVariables): Cart
     {
-        $quote = $this->resolveAndVerify($context, $uriVariables);
+        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
         $quote = $this->cartService->removeCoupon($quote);
 
         return $this->cartMapper->mapQuoteToCart($quote, false);
@@ -400,7 +402,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $args = $context['args']['input'] ?? [];
         $this->cartService->assertCompleteAddressInput($args);
 
-        $quote = $this->resolveAndVerify($context, $uriVariables);
+        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
         $quote = $this->cartService->setShippingAddress($quote, $this->cartService->mapAddressInput($args));
 
         return $this->cartMapper->mapQuoteToCart($quote, false);
@@ -419,7 +421,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             $this->cartService->assertCompleteAddressInput($args);
         }
 
-        $quote = $this->resolveAndVerify($context, $uriVariables);
+        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
         $addressData = $sameAsShipping ? [] : $this->cartService->mapAddressInput($args);
         $quote = $this->cartService->setBillingAddress($quote, $addressData, $sameAsShipping);
 
@@ -472,7 +474,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $carrierCode = (string) $carrierCode;
         $methodCode = (string) $methodCode;
 
-        $quote = $this->resolveAndVerify($context, $uriVariables);
+        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
         $quote = $this->cartService->setShippingMethod($quote, $carrierCode, $methodCode);
 
         return $this->cartMapper->mapQuoteToCart($quote, false);
@@ -495,7 +497,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         }
         $methodCode = (string) $methodCode;
 
-        $quote = $this->resolveAndVerify($context, $uriVariables);
+        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
         $quote = $this->cartService->setPaymentMethod($quote, $methodCode, $additionalData);
 
         return $this->cartMapper->mapQuoteToCart($quote, false);
@@ -519,6 +521,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             $quote = $this->cartService->getCart(
                 $cartId ? (int) $cartId : null,
                 $maskedId,
+                collectTotals: false,
             );
             if (!$quote) {
                 throw new NotFoundHttpException('Cart not found');
@@ -530,8 +533,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
                 throw new NotFoundHttpException('Customer not found');
             }
 
-            $quote->assignCustomer($customer);
-            $quote->collectTotals()->save();
+            $quote = $this->cartService->assignCustomer($quote, $customer);
 
             return $this->cartMapper->mapQuoteToCart($quote, false);
         }
@@ -567,7 +569,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
             $this->checkRateLimitByIp('cart_giftcard', 'giftcard_balance', 60);
         }
 
-        $quote = $this->resolveAndVerify($context, $uriVariables);
+        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
         $quote = $this->cartService->applyGiftcard($quote, $giftcardCode);
 
         return $this->cartMapper->mapQuoteToCart($quote, false);
@@ -581,7 +583,7 @@ final class CartProcessor extends \Maho\ApiPlatform\Processor
         $args = $context['args']['input'] ?? [];
         $giftcardCode = trim($args['giftcardCode'] ?? '');
 
-        $quote = $this->resolveAndVerify($context, $uriVariables);
+        $quote = $this->resolveAndVerify($context, $uriVariables, collectTotals: false);
         $quote = $this->cartService->removeGiftcard($quote, $giftcardCode);
 
         return $this->cartMapper->mapQuoteToCart($quote, false);

--- a/app/code/core/Mage/Checkout/Api/CartProvider.php
+++ b/app/code/core/Mage/Checkout/Api/CartProvider.php
@@ -88,12 +88,9 @@ final class CartProvider extends \Maho\ApiPlatform\Provider
             return $this->respondRaw($this->cartMapper->getAvailablePaymentMethods($quote));
         }
 
-        // For write operations the processor loads its own quote instance and
-        // this DTO is replaced by its result, so skip the totals collection the
-        // mapper would run for the read boundary.
-        $isWriteOperation = ($operation instanceof \ApiPlatform\Metadata\HttpOperation
-                && !in_array($operation->getMethod(), ['GET', 'HEAD'], true))
-            || $operation instanceof \ApiPlatform\Metadata\GraphQl\Mutation;
-        return $this->cartMapper->mapQuoteToCart($quote, !$isWriteOperation);
+        // REST write operations declare read: false and never reach this
+        // provider. GraphQL mutations still do, and the processor replaces
+        // their DTO, so skip the read-boundary totals collection for them.
+        return $this->cartMapper->mapQuoteToCart($quote, !($operation instanceof \ApiPlatform\Metadata\GraphQl\Mutation));
     }
 }

--- a/app/code/core/Mage/Checkout/Api/CartProvider.php
+++ b/app/code/core/Mage/Checkout/Api/CartProvider.php
@@ -79,13 +79,21 @@ final class CartProvider extends \Maho\ApiPlatform\Provider
         // authenticated /carts/{id}/* variants deliberately return the full Cart.
         // They bypass the mapper's read-boundary collection, so collect here.
         if ($operationName === 'get_guest_totals') {
-            CartService::collectAndVerifyTotals($quote);
+            if (!$quote->getTotalsCollectedFlag()) {
+                CartService::collectAndVerifyTotals($quote);
+            }
             return $this->respondRaw($this->cartMapper->mapPricesToArray($quote));
         }
 
         if ($operationName === 'get_guest_payments') {
-            CartService::collectAndVerifyTotals($quote);
-            return $this->respondRaw($this->cartMapper->getAvailablePaymentMethods($quote));
+            if (!$quote->getTotalsCollectedFlag()) {
+                CartService::collectAndVerifyTotals($quote);
+            }
+            // payment_method_is_active observers must see the cart's own store, not the caller's
+            return $this->respondRaw(CartService::inQuoteStoreScope(
+                $quote,
+                fn(): array => $this->cartMapper->getAvailablePaymentMethods($quote),
+            ));
         }
 
         return $this->cartMapper->mapQuoteToCart($quote);

--- a/app/code/core/Mage/Checkout/Api/CartProvider.php
+++ b/app/code/core/Mage/Checkout/Api/CartProvider.php
@@ -55,9 +55,14 @@ final class CartProvider extends \Maho\ApiPlatform\Provider
             return $this->cartMapper->mapQuoteToCart($quote);
         }
 
-        // All other operations: resolve cart via unified method
+        // All other operations: resolve cart via unified method. For write
+        // operations the processor loads its own quote instance afterwards, so
+        // totals collected here would be thrown away; skip them.
+        $isWriteOperation = ($operation instanceof \ApiPlatform\Metadata\HttpOperation
+                && !in_array($operation->getMethod(), ['GET', 'HEAD'], true))
+            || $operation instanceof \ApiPlatform\Metadata\GraphQl\Mutation;
         ['quote' => $quote, 'accessedByMaskedId' => $byMasked] =
-            $this->cartService->resolveCartFromRequest($uriVariables, $context);
+            $this->cartService->resolveCartFromRequest($uriVariables, $context, !$isWriteOperation);
 
         if (!$quote) {
             return null;

--- a/app/code/core/Mage/Checkout/Api/CartProvider.php
+++ b/app/code/core/Mage/Checkout/Api/CartProvider.php
@@ -88,8 +88,6 @@ final class CartProvider extends \Maho\ApiPlatform\Provider
             return $this->respondRaw($this->cartMapper->getAvailablePaymentMethods($quote));
         }
 
-        // GraphQL mutations still reach this provider (REST writes declare
-        // read: false) and the processor replaces their DTO, so skip totals for them.
-        return $this->cartMapper->mapQuoteToCart($quote, !($operation instanceof \ApiPlatform\Metadata\GraphQl\Mutation));
+        return $this->cartMapper->mapQuoteToCart($quote);
     }
 }

--- a/app/code/core/Mage/Checkout/Api/CartProvider.php
+++ b/app/code/core/Mage/Checkout/Api/CartProvider.php
@@ -88,9 +88,8 @@ final class CartProvider extends \Maho\ApiPlatform\Provider
             return $this->respondRaw($this->cartMapper->getAvailablePaymentMethods($quote));
         }
 
-        // REST write operations declare read: false and never reach this
-        // provider. GraphQL mutations still do, and the processor replaces
-        // their DTO, so skip the read-boundary totals collection for them.
+        // GraphQL mutations still reach this provider (REST writes declare
+        // read: false) and the processor replaces their DTO, so skip totals for them.
         return $this->cartMapper->mapQuoteToCart($quote, !($operation instanceof \ApiPlatform\Metadata\GraphQl\Mutation));
     }
 }

--- a/app/code/core/Mage/Checkout/Api/CartProvider.php
+++ b/app/code/core/Mage/Checkout/Api/CartProvider.php
@@ -55,14 +55,9 @@ final class CartProvider extends \Maho\ApiPlatform\Provider
             return $this->cartMapper->mapQuoteToCart($quote);
         }
 
-        // All other operations: resolve cart via unified method. For write
-        // operations the processor loads its own quote instance afterwards, so
-        // totals collected here would be thrown away; skip them.
-        $isWriteOperation = ($operation instanceof \ApiPlatform\Metadata\HttpOperation
-                && !in_array($operation->getMethod(), ['GET', 'HEAD'], true))
-            || $operation instanceof \ApiPlatform\Metadata\GraphQl\Mutation;
+        // All other operations: resolve cart via unified method
         ['quote' => $quote, 'accessedByMaskedId' => $byMasked] =
-            $this->cartService->resolveCartFromRequest($uriVariables, $context, !$isWriteOperation);
+            $this->cartService->resolveCartFromRequest($uriVariables, $context);
 
         if (!$quote) {
             return null;
@@ -82,14 +77,23 @@ final class CartProvider extends \Maho\ApiPlatform\Provider
         // full Cart), matching the documented frontend contract: /totals is the
         // flat totals object and /payment-methods a plain list of methods. The
         // authenticated /carts/{id}/* variants deliberately return the full Cart.
+        // They bypass the mapper's read-boundary collection, so collect here.
         if ($operationName === 'get_guest_totals') {
+            CartService::collectAndVerifyTotals($quote);
             return $this->respondRaw($this->cartMapper->mapPricesToArray($quote));
         }
 
         if ($operationName === 'get_guest_payments') {
+            CartService::collectAndVerifyTotals($quote);
             return $this->respondRaw($this->cartMapper->getAvailablePaymentMethods($quote));
         }
 
-        return $this->cartMapper->mapQuoteToCart($quote);
+        // For write operations the processor loads its own quote instance and
+        // this DTO is replaced by its result, so skip the totals collection the
+        // mapper would run for the read boundary.
+        $isWriteOperation = ($operation instanceof \ApiPlatform\Metadata\HttpOperation
+                && !in_array($operation->getMethod(), ['GET', 'HEAD'], true))
+            || $operation instanceof \ApiPlatform\Metadata\GraphQl\Mutation;
+        return $this->cartMapper->mapQuoteToCart($quote, !$isWriteOperation);
     }
 }

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -455,36 +455,34 @@ class CartService
                 $buyRequest->setData('options_files', $optionsFiles);
             }
         }
-        // Set store context before addProduct so item prices are calculated correctly
-        if ($quote->getStoreId()) {
-            \Mage::app()->setCurrentStore($quote->getStoreId());
-        }
+        // addProduct must run in the quote's store scope so item prices are calculated correctly
+        return $this->inQuoteStoreScope($quote, function () use ($quote, $product, $buyRequest, $customPrice): \Mage_Sales_Model_Quote {
+            $result = $quote->addProduct($product, $buyRequest);
 
-        $result = $quote->addProduct($product, $buyRequest);
-
-        // addProduct returns a string error message on failure
-        if (is_string($result)) {
-            $this->logDebug("Failed to add product: {$result}");
-            throw new BadRequestHttpException("Failed to add product: {$result}");
-        }
-
-        if ($customPrice !== null) {
-            // A persisted id means addProduct() merged into an existing line, and the
-            // override would apply to units already in the cart at another price
-            // (compared at the column's DECIMAL(12,4) scale, so a re-add of the same value passes)
-            $existingOverride = $result->getOriginalCustomPrice();
-            if ($result->getId() && ($existingOverride === null || round((float) $existingOverride, 4) !== round($customPrice, 4))) {
-                throw new BadRequestHttpException('customPrice would reprice units already in the cart; update the existing item instead');
+            // addProduct returns a string error message on failure
+            if (is_string($result)) {
+                $this->logDebug("Failed to add product: {$result}");
+                throw new BadRequestHttpException("Failed to add product: {$result}");
             }
-            $result->setCustomPrice($customPrice);
-            $result->setOriginalCustomPrice($customPrice);
-        }
 
-        $this->collectAndVerifyTotals($quote);
+            if ($customPrice !== null) {
+                // A persisted id means addProduct() merged into an existing line, and the
+                // override would apply to units already in the cart at another price
+                // (compared at the column's DECIMAL(12,4) scale, so a re-add of the same value passes)
+                $existingOverride = $result->getOriginalCustomPrice();
+                if ($result->getId() && ($existingOverride === null || round((float) $existingOverride, 4) !== round($customPrice, 4))) {
+                    throw new BadRequestHttpException('customPrice would reprice units already in the cart; update the existing item instead');
+                }
+                $result->setCustomPrice($customPrice);
+                $result->setOriginalCustomPrice($customPrice);
+            }
 
-        $quote->save();
+            $this->collectAndVerifyTotals($quote);
 
-        return $quote;
+            $quote->save();
+
+            return $quote;
+        });
     }
 
     /**
@@ -1264,28 +1262,49 @@ class CartService
      */
     private function collectAndVerifyTotals(\Mage_Sales_Model_Quote $quote): void
     {
-        // Set store context so price calculation uses the correct store (not admin store 0)
-        if ($quote->getStoreId()) {
-            \Mage::app()->setCurrentStore($quote->getStoreId());
-            $quote->setStore(\Mage::app()->getStore($quote->getStoreId()));
+        // Price calculation must use the quote's store, not the admin store (0)
+        $this->inQuoteStoreScope($quote, function () use ($quote): void {
+            if ($quote->getStoreId()) {
+                $quote->setStore(\Mage::app()->getStore($quote->getStoreId()));
+            }
+
+            // Ensure quote has addresses, collectTotals() calculates per-address,
+            // so without addresses all totals (including discounts) return 0
+            $quote->getBillingAddress();
+            $quote->getShippingAddress();
+
+            // Clear address item cache, getAllItems() caches its result, so if collectTotals
+            // was called before the item was added (e.g. during cart creation), the cache is stale.
+            foreach ($quote->getAllAddresses() as $address) {
+                $address->unsetData('cached_items_all');
+                $address->unsetData('cached_items_nominal');
+                $address->unsetData('cached_items_nonnominal');
+            }
+
+            $quote->setTotalsCollectedFlag(false);
+            $quote->collectTotals();
+        });
+    }
+
+    /**
+     * Run $callback with the app switched to the quote's store, then restore the
+     * caller's scope. Leaking the switch broke admin-scoped requests
+     * (X-Store-Code: admin): payment methods read isAdmin() for MOTO handling,
+     * so a phone order placed over REST was sent as a storefront 3DS sale (issue #1337).
+     */
+    public function inQuoteStoreScope(\Mage_Sales_Model_Quote $quote, \Closure $callback): mixed
+    {
+        if (!$quote->getStoreId()) {
+            return $callback();
         }
 
-        // Ensure quote has addresses, collectTotals() calculates per-address,
-        // so without addresses all totals (including discounts) return 0
-        $quote->getBillingAddress();
-        $quote->getShippingAddress();
-
-        // Clear address item cache, getAllItems() caches its result, so if collectTotals
-        // was called before the item was added (e.g. during cart creation), the cache is stale.
-        foreach ($quote->getAllAddresses() as $address) {
-            $address->unsetData('cached_items_all');
-            $address->unsetData('cached_items_nominal');
-            $address->unsetData('cached_items_nonnominal');
+        $previousStoreId = (int) \Mage::app()->getStore()->getId();
+        \Mage::app()->setCurrentStore((int) $quote->getStoreId());
+        try {
+            return $callback();
+        } finally {
+            \Mage::app()->setCurrentStore($previousStoreId);
         }
-
-        $quote->setTotalsCollectedFlag(false);
-        $quote->collectTotals();
-
     }
 
     /**

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -929,6 +929,29 @@ class CartService
     }
 
     /**
+     * Apply a shipping address in-memory without recollecting or saving, for
+     * callers that batch several checkout fields and collect once afterwards
+     * (order placement).
+     */
+    public function applyShippingAddress(\Mage_Sales_Model_Quote $quote, array $addressData): void
+    {
+        $address = $quote->getShippingAddress();
+        $address->addData(StoreDefaults::filterAddressKeys($this->sanitizeAddressData($addressData)));
+
+        // Flag to trigger shipping rate collection
+        $address->setCollectShippingRates(1);
+    }
+
+    /**
+     * Apply a billing address in-memory without recollecting or saving
+     */
+    public function applyBillingAddress(\Mage_Sales_Model_Quote $quote, array $addressData): void
+    {
+        $address = $quote->getBillingAddress();
+        $address->addData(StoreDefaults::filterAddressKeys($this->sanitizeAddressData($addressData)));
+    }
+
+    /**
      * Set shipping address
      *
      * @param \Mage_Sales_Model_Quote $quote Quote
@@ -936,12 +959,7 @@ class CartService
      */
     public function setShippingAddress(\Mage_Sales_Model_Quote $quote, array $addressData): \Mage_Sales_Model_Quote
     {
-        $address = $quote->getShippingAddress();
-        $address->addData(StoreDefaults::filterAddressKeys($this->sanitizeAddressData($addressData)));
-
-        // Flag to trigger shipping rate collection
-        $address->setCollectShippingRates(1);
-
+        $this->applyShippingAddress($quote, $addressData);
         $this->collectAndSave($quote);
 
         return $quote;
@@ -962,12 +980,9 @@ class CartService
                 throw new BadRequestHttpException('Cart has no shipping address to copy');
             }
             $addressData = StoreDefaults::extractAddressFields($shippingAddress);
-        } else {
-            $addressData = $this->sanitizeAddressData($addressData);
         }
 
-        $address = $quote->getBillingAddress();
-        $address->addData(StoreDefaults::filterAddressKeys($addressData));
+        $this->applyBillingAddress($quote, $addressData);
         $this->collectAndSave($quote);
 
         return $quote;

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -94,9 +94,8 @@ class CartService
     }
 
     /**
-     * Get cart by ID or masked ID. The loader never collects totals: mutations
-     * recollect through their service methods, and reads collect at the
-     * mapping boundary (CartMapper) or call collectAndVerifyTotals() themselves.
+     * Get cart by ID or masked ID. Never collects totals: mutations recollect
+     * in their service methods, reads collect at the mapping boundary (CartMapper).
      *
      * @param int|null $cartId Cart ID
      * @param string|null $maskedId Masked ID
@@ -454,7 +453,6 @@ class CartService
                 $buyRequest->setData('options_files', $optionsFiles);
             }
         }
-        // addProduct must run in the quote's store scope so item prices are calculated correctly
         return self::inQuoteStoreScope($quote, function () use ($quote, $product, $buyRequest, $customPrice): \Mage_Sales_Model_Quote {
             $result = $quote->addProduct($product, $buyRequest);
 
@@ -514,8 +512,6 @@ class CartService
             throw new BadRequestHttpException('Quantity cannot exceed 10,000');
         }
 
-        // Same scoping as addItem(): qty stock checks and the save observers
-        // must see the quote's store, not the API caller's
         return self::inQuoteStoreScope($quote, function () use ($quote, $item, $qty, $customPrice): \Mage_Sales_Model_Quote {
             $item->setQty($qty);
             if ($customPrice !== null) {
@@ -929,9 +925,8 @@ class CartService
     }
 
     /**
-     * Apply a shipping address in-memory without recollecting or saving, for
-     * callers that batch several checkout fields and collect once afterwards
-     * (order placement).
+     * Apply a shipping address in-memory, for callers that batch several
+     * checkout fields and collect once afterwards (order placement).
      */
     public function applyShippingAddress(\Mage_Sales_Model_Quote $quote, array $addressData): void
     {
@@ -951,12 +946,6 @@ class CartService
         $address->addData(StoreDefaults::filterAddressKeys($this->sanitizeAddressData($addressData)));
     }
 
-    /**
-     * Set shipping address
-     *
-     * @param \Mage_Sales_Model_Quote $quote Quote
-     * @param array $addressData Address data
-     */
     public function setShippingAddress(\Mage_Sales_Model_Quote $quote, array $addressData): \Mage_Sales_Model_Quote
     {
         $this->applyShippingAddress($quote, $addressData);
@@ -999,8 +988,6 @@ class CartService
     {
         $shippingMethod = $carrierCode . '_' . $methodCode;
 
-        // Rate availability and totals must resolve in the quote's store scope,
-        // like the GraphQL shipping-methods query
         return self::inQuoteStoreScope($quote, function () use ($quote, $shippingMethod, $skipValidation): \Mage_Sales_Model_Quote {
             $address = $quote->getShippingAddress();
 
@@ -1035,10 +1022,8 @@ class CartService
      */
     public function setPaymentMethod(\Mage_Sales_Model_Quote $quote, string $methodCode, ?array $additionalData = null): \Mage_Sales_Model_Quote
     {
-        // The quote is loaded without totals collection, and the availability
-        // gate below reads quote totals (Free's zero-total check, payment
-        // restriction rules), so collect them first or persisted stale totals
-        // decide which methods are available
+        // The availability gate below reads quote totals (Free's zero-total
+        // check, payment restriction rules), so collect first or stale persisted totals decide
         self::collectAndVerifyTotals($quote);
 
         // Validate the requested method is among the store's active methods for
@@ -1119,10 +1104,7 @@ class CartService
     }
 
     /**
-     * Assign a customer to the cart and recollect totals. The recollection must
-     * reset the totals-collected flag: the assignment changes the quote's
-     * customer group, and a flag-guarded collectTotals() would keep the totals
-     * the previous group was priced with.
+     * Assignment changes the quote's customer group, so totals must be recollected.
      */
     public function assignCustomer(\Mage_Sales_Model_Quote $quote, \Mage_Customer_Model_Customer $customer): \Mage_Sales_Model_Quote
     {
@@ -1163,14 +1145,10 @@ class CartService
             throw new NotFoundHttpException('Guest cart not found');
         }
 
-        // Resolve and merge in the guest quote's store scope: getCustomerCart()
-        // scopes its lookup to the ambient store, so without the switch the
-        // merge would land in the API caller's store cart, repricing the items
-        // and hiding the result from the guest cart's own storefront
+        // getCustomerCart() scopes its lookup to the ambient store: without the
+        // switch the merge lands in the API caller's store cart, repricing the items
         $customerCart = self::inQuoteStoreScope($guestCart, function () use ($guestCart, $customerId): \Mage_Sales_Model_Quote {
             $customerCart = $this->getCustomerCart($customerId);
-
-            // Merge items from guest cart to customer cart
             $customerCart->merge($guestCart);
 
             // Import customer default addresses onto the cart so shipping quotes work
@@ -1295,7 +1273,6 @@ class CartService
      */
     public static function collectAndVerifyTotals(\Mage_Sales_Model_Quote $quote): void
     {
-        // Price calculation must use the quote's store, not the admin store (0)
         self::inQuoteStoreScope($quote, fn() => self::collectTotalsInCurrentScope($quote));
     }
 
@@ -1322,9 +1299,7 @@ class CartService
     }
 
     /**
-     * Recollect totals and persist the quote, both in its own store scope, so
-     * store-scoped config reads during collection resolve against the quote's
-     * store rather than the API caller's.
+     * Recollect totals and persist the quote, both in its own store scope.
      */
     private function collectAndSave(\Mage_Sales_Model_Quote $quote): void
     {
@@ -1335,10 +1310,8 @@ class CartService
     }
 
     /**
-     * Run $callback with the app switched to the quote's store, then restore the
-     * caller's scope. Leaking the switch broke admin-scoped requests
-     * (X-Store-Code: admin): payment methods read isAdmin() for MOTO handling,
-     * so a phone order placed over REST was sent as a storefront 3DS sale (issue #1337).
+     * Run $callback in the quote's store scope, then restore the caller's:
+     * a leaked switch sent admin MOTO orders as storefront 3DS sales (issue #1337).
      */
     public static function inQuoteStoreScope(\Mage_Sales_Model_Quote $quote, \Closure $callback): mixed
     {

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -121,12 +121,7 @@ class CartService
         // Ensure quote is loaded with its store context (important when called from admin)
         if ($quote->getStoreId()) {
             $quote->setStore(\Mage::app()->getStore($quote->getStoreId()));
-            // A trigger_recollect load already collected (and armed the totals
-            // flag) before the requested currency landed on the store; drop the
-            // flag so the read boundary reprices in the requested currency
-            if (StoreContext::applyRequestedCurrencyTo($quote->getStore())) {
-                $quote->setTotalsCollectedFlag(false);
-            }
+            StoreContext::applyRequestedCurrencyToQuote($quote);
         }
 
         return $quote;
@@ -997,16 +992,11 @@ class CartService
         return self::inQuoteStoreScope($quote, function () use ($quote, $shippingMethod, $skipValidation): \Mage_Sales_Model_Quote {
             $address = $quote->getShippingAddress();
 
-            // Validate the shipping method is available for this address
+            // Same gate as OrderProcessor: a carrier error entry would price the shipment at 0
             if (!$skipValidation) {
-                $mapper = new CartMapper();
-                $available = $mapper->getAvailableShippingMethods($address);
-                $availableCodes = array_map(
-                    fn($m) => $m['carrierCode'] . '_' . $m['methodCode'],
-                    $available,
-                );
-
-                if (!in_array($shippingMethod, $availableCodes, true)) {
+                $address->collectShippingRates();
+                $rate = $address->getShippingRateByCode($shippingMethod);
+                if (!$rate || $rate->getErrorMessage()) {
                     throw new BadRequestHttpException('Shipping method is not available for this address');
                 }
             }
@@ -1108,7 +1098,7 @@ class CartService
                     // street (sameAsShipping) silently truncates it
                     $addressData[$key] = implode("\n", array_map(
                         fn($line) => mb_substr(strip_tags($line), 0, 255),
-                        explode("\n", $value),
+                        preg_split('/\r\n|\r|\n/', $value) ?: [$value],
                     ));
                 }
                 continue;

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -572,23 +572,26 @@ class CartService
         }
 
         $quote->setCouponCode($couponCode);
-        $this->collectAndSave($quote);
 
-        // setCouponCode() persists the string even when the rule does not fire
-        // (inactive/expired/exhausted/wrong website). Confirm the coupon's rule
-        // actually applied by checking the rule id landed on a quote address.
-        if ($quote->getCouponCode() !== $couponCode || !$this->isCouponRuleApplied($quote, (int) $coupon->getRuleId())) {
-            $quote->setCouponCode('');
-            $this->collectAndSave($quote);
-            throw new BadRequestHttpException(
-                "Coupon code '{$couponCode}' could not be applied",
-                null,
-                0,
-                ['X-Api-Error-Code' => 'invalid_coupon'],
-            );
-        }
+        return self::inQuoteStoreScope($quote, function () use ($quote, $couponCode, $coupon): \Mage_Sales_Model_Quote {
+            self::collectTotalsInCurrentScope($quote);
 
-        return $quote;
+            // setCouponCode() keeps the string even when the rule does not fire
+            // (inactive/expired/exhausted/wrong website), so confirm the rule id
+            // landed on a quote address before persisting anything
+            if ($quote->getCouponCode() !== $couponCode || !$this->isCouponRuleApplied($quote, (int) $coupon->getRuleId())) {
+                throw new BadRequestHttpException(
+                    "Coupon code '{$couponCode}' could not be applied",
+                    null,
+                    0,
+                    ['X-Api-Error-Code' => 'invalid_coupon'],
+                );
+            }
+
+            $quote->save();
+
+            return $quote;
+        });
     }
 
     /**
@@ -1022,38 +1025,40 @@ class CartService
      */
     public function setPaymentMethod(\Mage_Sales_Model_Quote $quote, string $methodCode, ?array $additionalData = null): \Mage_Sales_Model_Quote
     {
-        // The availability gate below reads quote totals (Free's zero-total
-        // check, payment restriction rules), so collect first or stale persisted totals decide
-        self::collectAndVerifyTotals($quote);
-
-        // Validate the requested method is among the store's active methods for
-        // this quote before applying it, mirroring setShippingMethod(). Without
-        // this, importData() would accept any configured method code regardless
-        // of availability (min/max totals, country, currency, enabled flag).
-        $store = $quote->getStoreId();
-        $availableCodes = array_map(
-            fn($method) => $method->getCode(),
-            \Mage::helper('payment')->getStoreMethods($store, $quote),
-        );
-
-        if (!in_array($methodCode, $availableCodes, true)) {
-            throw new BadRequestHttpException('Payment method is not available for this cart');
-        }
-
         $paymentData = ['method' => $methodCode];
         if ($additionalData) {
             $paymentData['additional_data'] = $additionalData;
         }
 
-        try {
-            $quote->getPayment()->importData($paymentData);
-        } catch (\Exception $e) {
-            throw new BadRequestHttpException('Payment method is not available: ' . $e->getMessage());
-        }
+        return self::inQuoteStoreScope($quote, function () use ($quote, $methodCode, $paymentData): \Mage_Sales_Model_Quote {
+            // The gate reads quote totals, so collect first (pre-fee, so
+            // availability is judged before the method's own fee applies)
+            self::collectTotalsInCurrentScope($quote);
 
-        $this->collectAndSave($quote);
+            // importData() checks isAvailable() but no applicability (min/max
+            // totals, country, currency), so gate via getStoreMethods()
+            $availableCodes = array_map(
+                fn($method) => $method->getCode(),
+                \Mage::helper('payment')->getStoreMethods($quote->getStoreId(), $quote),
+            );
 
-        return $quote;
+            if (!in_array($methodCode, $availableCodes, true)) {
+                throw new BadRequestHttpException('Payment method is not available for this cart');
+            }
+
+            try {
+                $quote->getPayment()->importData($paymentData);
+            } catch (\Exception $e) {
+                throw new BadRequestHttpException('Payment method is not available: ' . $e->getMessage());
+            }
+
+            // Recollect with the method set so payment-dependent totals
+            // (e.g. payment fees) land on the save
+            self::collectTotalsInCurrentScope($quote);
+            $quote->save();
+
+            return $quote;
+        });
     }
 
     /**
@@ -1088,7 +1093,13 @@ class CartService
                 if (is_array($value)) {
                     $addressData[$key] = array_map(fn($line) => mb_substr(strip_tags((string) $line), 0, 255), $value);
                 } elseif (is_string($value)) {
-                    $addressData[$key] = mb_substr(strip_tags($value), 0, 255);
+                    // Quote addresses store street as one newline-joined string;
+                    // cap per line like the array branch, or copying a multi-line
+                    // street (sameAsShipping) silently truncates it
+                    $addressData[$key] = implode("\n", array_map(
+                        fn($line) => mb_substr(strip_tags($line), 0, 255),
+                        explode("\n", $value),
+                    ));
                 }
                 continue;
             }
@@ -1145,9 +1156,12 @@ class CartService
             throw new NotFoundHttpException('Guest cart not found');
         }
 
-        // getCustomerCart() scopes its lookup to the ambient store: without the
-        // switch the merge lands in the API caller's store cart, repricing the items
-        $customerCart = self::inQuoteStoreScope($guestCart, function () use ($guestCart, $customerId): \Mage_Sales_Model_Quote {
+        // getCustomerCart() scopes its lookup to the ambient store. An admin-scoped
+        // caller must not land the merge in an admin-store cart (repricing the
+        // items), so it merges in the guest cart's store. A storefront caller keeps
+        // its own scope: its later customer-cart lookups are ambient-scoped, and a
+        // merge pinned to another store view would leave the merged cart invisible.
+        $merge = function () use ($guestCart, $customerId): \Mage_Sales_Model_Quote {
             $customerCart = $this->getCustomerCart($customerId);
             $customerCart->merge($guestCart);
 
@@ -1174,7 +1188,10 @@ class CartService
             $this->collectAndSave($customerCart);
 
             return $customerCart;
-        });
+        };
+        $customerCart = \Mage::app()->getStore()->isAdmin()
+            ? self::inQuoteStoreScope($guestCart, $merge)
+            : $merge();
 
         // Deactivate guest cart
         $guestCart->setIsActive(0);
@@ -1281,6 +1298,17 @@ class CartService
      */
     private static function collectTotalsInCurrentScope(\Mage_Sales_Model_Quote $quote): void
     {
+        self::primeQuoteForCollect($quote);
+        $quote->collectTotals();
+    }
+
+    /**
+     * Prepare the quote so the next collectTotals() call runs and is correct:
+     * prime the addresses, drop stale address item caches, clear the
+     * totals-collected flag.
+     */
+    private static function primeQuoteForCollect(\Mage_Sales_Model_Quote $quote): void
+    {
         // Ensure quote has addresses, collectTotals() calculates per-address,
         // so without addresses all totals (including discounts) return 0
         $quote->getBillingAddress();
@@ -1295,7 +1323,6 @@ class CartService
         }
 
         $quote->setTotalsCollectedFlag(false);
-        $quote->collectTotals();
     }
 
     /**

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -98,8 +98,10 @@ class CartService
      *
      * @param int|null $cartId Cart ID
      * @param string|null $maskedId Masked ID
+     * @param bool $collectTotals Pass false when the caller mutates the quote
+     *        and recollects afterwards, so the load-time collection is skipped
      */
-    public function getCart(?int $cartId = null, ?string $maskedId = null): ?\Mage_Sales_Model_Quote
+    public function getCart(?int $cartId = null, ?string $maskedId = null, bool $collectTotals = true): ?\Mage_Sales_Model_Quote
     {
         if ($maskedId) {
             $cartId = $this->getCartIdFromMaskedId($maskedId);
@@ -123,8 +125,9 @@ class CartService
             StoreContext::applyRequestedCurrencyTo($quote->getStore());
         }
 
-        // Collect totals with manual fallback for admin context
-        $this->collectAndVerifyTotals($quote);
+        if ($collectTotals) {
+            $this->collectAndVerifyTotals($quote);
+        }
 
         return $quote;
     }
@@ -166,6 +169,7 @@ class CartService
     public function resolveCartFromRequest(
         array $uriVariables,
         array $context,
+        bool $collectTotals = true,
     ): array {
         $request = $context['request'] ?? null;
         $args = $context['args']['input'] ?? $context['args'] ?? [];
@@ -216,7 +220,7 @@ class CartService
             return ['quote' => null, 'accessedByMaskedId' => false, 'maskedId' => null];
         }
 
-        $quote = $this->getCart($cartId, $maskedId);
+        $quote = $this->getCart($cartId, $maskedId, $collectTotals);
         return ['quote' => $quote, 'accessedByMaskedId' => $maskedId !== null, 'maskedId' => $maskedId];
     }
 
@@ -456,7 +460,7 @@ class CartService
             }
         }
         // addProduct must run in the quote's store scope so item prices are calculated correctly
-        return $this->inQuoteStoreScope($quote, function () use ($quote, $product, $buyRequest, $customPrice): \Mage_Sales_Model_Quote {
+        return self::inQuoteStoreScope($quote, function () use ($quote, $product, $buyRequest, $customPrice): \Mage_Sales_Model_Quote {
             $result = $quote->addProduct($product, $buyRequest);
 
             // addProduct returns a string error message on failure
@@ -515,17 +519,21 @@ class CartService
             throw new BadRequestHttpException('Quantity cannot exceed 10,000');
         }
 
-        $item->setQty($qty);
-        if ($customPrice !== null) {
-            $item->setCustomPrice($customPrice);
-            $item->setOriginalCustomPrice($customPrice);
-        }
+        // Same scoping as addItem(): qty stock checks and the save observers
+        // must see the quote's store, not the API caller's
+        return self::inQuoteStoreScope($quote, function () use ($quote, $item, $qty, $customPrice): \Mage_Sales_Model_Quote {
+            $item->setQty($qty);
+            if ($customPrice !== null) {
+                $item->setCustomPrice($customPrice);
+                $item->setOriginalCustomPrice($customPrice);
+            }
 
-        $this->collectAndVerifyTotals($quote);
+            $this->collectAndVerifyTotals($quote);
 
-        $quote->save();
+            $quote->save();
 
-        return $quote;
+            return $quote;
+        });
     }
 
     /**
@@ -542,12 +550,14 @@ class CartService
             throw new \Symfony\Component\HttpKernel\Exception\NotFoundHttpException("Cart item with ID '{$itemId}' not found");
         }
 
-        $quote->removeItem($itemId);
-        $this->collectAndVerifyTotals($quote);
+        return self::inQuoteStoreScope($quote, function () use ($quote, $itemId): \Mage_Sales_Model_Quote {
+            $quote->removeItem($itemId);
+            $this->collectAndVerifyTotals($quote);
 
-        $quote->save();
+            $quote->save();
 
-        return $quote;
+            return $quote;
+        });
     }
 
     /**
@@ -571,17 +581,14 @@ class CartService
         }
 
         $quote->setCouponCode($couponCode);
-        $quote->setTotalsCollectedFlag(false);
-        $quote->collectTotals();
-        $quote->save();
+        $this->collectAndSave($quote);
 
         // setCouponCode() persists the string even when the rule does not fire
         // (inactive/expired/exhausted/wrong website). Confirm the coupon's rule
         // actually applied by checking the rule id landed on a quote address.
         if ($quote->getCouponCode() !== $couponCode || !$this->isCouponRuleApplied($quote, (int) $coupon->getRuleId())) {
             $quote->setCouponCode('');
-            $quote->setTotalsCollectedFlag(false);
-            $quote->collectTotals()->save();
+            $this->collectAndSave($quote);
             throw new BadRequestHttpException(
                 "Coupon code '{$couponCode}' could not be applied",
                 null,
@@ -621,9 +628,7 @@ class CartService
     public function removeCoupon(\Mage_Sales_Model_Quote $quote): \Mage_Sales_Model_Quote
     {
         $quote->setCouponCode('');
-        $quote->setTotalsCollectedFlag(false);
-        $quote->collectTotals();
-        $quote->save();
+        $this->collectAndSave($quote);
 
         return $quote;
     }
@@ -692,8 +697,7 @@ class CartService
         $appliedCodes[$giftcardCode] = $amount === null ? $balance : min($amount, $balance);
 
         $quote->setGiftcardCodes(\Mage::helper('core')->jsonEncode($appliedCodes));
-        $quote->setTotalsCollectedFlag(false);
-        $quote->collectTotals()->save();
+        $this->collectAndSave($quote);
 
         return $quote;
     }
@@ -741,8 +745,7 @@ class CartService
 
         if ($changed) {
             $quote->setGiftcardCodes(\Mage::helper('core')->jsonEncode($applied));
-            $quote->setTotalsCollectedFlag(false);
-            $quote->collectTotals()->save();
+            $this->collectAndSave($quote);
         }
 
         return $quote;
@@ -781,8 +784,7 @@ class CartService
 
         // Force a fresh totals pass, otherwise an already-collected quote in the
         // same request leaves a stale giftcard_amount on the saved quote.
-        $quote->setTotalsCollectedFlag(false);
-        $quote->collectTotals()->save();
+        $this->collectAndSave($quote);
 
         return $quote;
     }
@@ -945,9 +947,7 @@ class CartService
         // Flag to trigger shipping rate collection
         $address->setCollectShippingRates(1);
 
-        $quote->setTotalsCollectedFlag(false);
-        $quote->collectTotals();
-        $quote->save();
+        $this->collectAndSave($quote);
 
         return $quote;
     }
@@ -973,9 +973,7 @@ class CartService
 
         $address = $quote->getBillingAddress();
         $address->addData(StoreDefaults::filterAddressKeys($addressData));
-        $quote->setTotalsCollectedFlag(false);
-        $quote->collectTotals();
-        $quote->save();
+        $this->collectAndSave($quote);
 
         return $quote;
     }
@@ -991,28 +989,32 @@ class CartService
     {
         $shippingMethod = $carrierCode . '_' . $methodCode;
 
-        $address = $quote->getShippingAddress();
+        // Rate availability and totals must resolve in the quote's store scope,
+        // like the GraphQL shipping-methods query
+        return self::inQuoteStoreScope($quote, function () use ($quote, $shippingMethod, $skipValidation): \Mage_Sales_Model_Quote {
+            $address = $quote->getShippingAddress();
 
-        // Validate the shipping method is available for this address
-        if (!$skipValidation) {
-            $mapper = new CartMapper();
-            $available = $mapper->getAvailableShippingMethods($address);
-            $availableCodes = array_map(
-                fn($m) => $m['carrierCode'] . '_' . $m['methodCode'],
-                $available,
-            );
+            // Validate the shipping method is available for this address
+            if (!$skipValidation) {
+                $mapper = new CartMapper();
+                $available = $mapper->getAvailableShippingMethods($address);
+                $availableCodes = array_map(
+                    fn($m) => $m['carrierCode'] . '_' . $m['methodCode'],
+                    $available,
+                );
 
-            if (!in_array($shippingMethod, $availableCodes, true)) {
-                throw new BadRequestHttpException('Shipping method is not available for this address');
+                if (!in_array($shippingMethod, $availableCodes, true)) {
+                    throw new BadRequestHttpException('Shipping method is not available for this address');
+                }
             }
-        }
 
-        $address->setShippingMethod($shippingMethod);
-        $quote->setTotalsCollectedFlag(false);
-        $quote->collectTotals();
-        $quote->save();
+            $address->setShippingMethod($shippingMethod);
+            $quote->setTotalsCollectedFlag(false);
+            $quote->collectTotals();
+            $quote->save();
 
-        return $quote;
+            return $quote;
+        });
     }
 
     /**
@@ -1049,9 +1051,7 @@ class CartService
             throw new BadRequestHttpException('Payment method is not available: ' . $e->getMessage());
         }
 
-        $quote->setTotalsCollectedFlag(false);
-        $quote->collectTotals();
-        $quote->save();
+        $this->collectAndSave($quote);
 
         return $quote;
     }
@@ -1101,6 +1101,20 @@ class CartService
         }
 
         return $addressData;
+    }
+
+    /**
+     * Assign a customer to the cart and recollect totals. The recollection must
+     * reset the totals-collected flag: the assignment changes the quote's
+     * customer group, and a flag-guarded collectTotals() would keep the totals
+     * the previous group was priced with.
+     */
+    public function assignCustomer(\Mage_Sales_Model_Quote $quote, \Mage_Customer_Model_Customer $customer): \Mage_Sales_Model_Quote
+    {
+        $quote->assignCustomer($customer);
+        $this->collectAndSave($quote);
+
+        return $quote;
     }
 
     /**
@@ -1159,9 +1173,7 @@ class CartService
                 }
             }
         }
-        $customerCart->setTotalsCollectedFlag(false);
-        $customerCart->collectTotals();
-        $customerCart->save();
+        $this->collectAndSave($customerCart);
 
         // Deactivate guest cart
         $guestCart->setIsActive(0);
@@ -1255,19 +1267,13 @@ class CartService
     }
 
     /**
-     * Collect quote totals with manual fallback for admin context
-     *
-     * WORKAROUND: collectTotals() doesn't work properly in admin context.
-     * If subtotal is still 0 after collectTotals(), manually calculate from item row totals.
+     * Recollect totals in the quote's store scope, after priming the quote
+     * addresses and clearing their cached item lists.
      */
     private function collectAndVerifyTotals(\Mage_Sales_Model_Quote $quote): void
     {
         // Price calculation must use the quote's store, not the admin store (0)
-        $this->inQuoteStoreScope($quote, function () use ($quote): void {
-            if ($quote->getStoreId()) {
-                $quote->setStore(\Mage::app()->getStore($quote->getStoreId()));
-            }
-
+        self::inQuoteStoreScope($quote, function () use ($quote): void {
             // Ensure quote has addresses, collectTotals() calculates per-address,
             // so without addresses all totals (including discounts) return 0
             $quote->getBillingAddress();
@@ -1287,24 +1293,31 @@ class CartService
     }
 
     /**
+     * Recollect totals and persist the quote, both in its own store scope, so
+     * store-scoped config reads during collection resolve against the quote's
+     * store rather than the API caller's.
+     */
+    private function collectAndSave(\Mage_Sales_Model_Quote $quote): void
+    {
+        $this->collectAndVerifyTotals($quote);
+        self::inQuoteStoreScope($quote, function () use ($quote): void {
+            $quote->save();
+        });
+    }
+
+    /**
      * Run $callback with the app switched to the quote's store, then restore the
      * caller's scope. Leaking the switch broke admin-scoped requests
      * (X-Store-Code: admin): payment methods read isAdmin() for MOTO handling,
      * so a phone order placed over REST was sent as a storefront 3DS sale (issue #1337).
      */
-    public function inQuoteStoreScope(\Mage_Sales_Model_Quote $quote, \Closure $callback): mixed
+    public static function inQuoteStoreScope(\Mage_Sales_Model_Quote $quote, \Closure $callback): mixed
     {
         if (!$quote->getStoreId()) {
             return $callback();
         }
 
-        $previousStoreId = (int) \Mage::app()->getStore()->getId();
-        \Mage::app()->setCurrentStore((int) $quote->getStoreId());
-        try {
-            return $callback();
-        } finally {
-            \Mage::app()->setCurrentStore($previousStoreId);
-        }
+        return StoreContext::withStore((int) $quote->getStoreId(), $callback);
     }
 
     /**

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -121,7 +121,12 @@ class CartService
         // Ensure quote is loaded with its store context (important when called from admin)
         if ($quote->getStoreId()) {
             $quote->setStore(\Mage::app()->getStore($quote->getStoreId()));
-            StoreContext::applyRequestedCurrencyTo($quote->getStore());
+            // A trigger_recollect load already collected (and armed the totals
+            // flag) before the requested currency landed on the store; drop the
+            // flag so the read boundary reprices in the requested currency
+            if (StoreContext::applyRequestedCurrencyTo($quote->getStore())) {
+                $quote->setTotalsCollectedFlag(false);
+            }
         }
 
         return $quote;
@@ -474,9 +479,7 @@ class CartService
                 $result->setOriginalCustomPrice($customPrice);
             }
 
-            self::collectTotalsInCurrentScope($quote);
-
-            $quote->save();
+            $this->collectAndSave($quote);
 
             return $quote;
         });
@@ -519,9 +522,7 @@ class CartService
                 $item->setOriginalCustomPrice($customPrice);
             }
 
-            self::collectTotalsInCurrentScope($quote);
-
-            $quote->save();
+            $this->collectAndSave($quote);
 
             return $quote;
         });
@@ -543,9 +544,7 @@ class CartService
 
         return self::inQuoteStoreScope($quote, function () use ($quote, $itemId): \Mage_Sales_Model_Quote {
             $quote->removeItem($itemId);
-            self::collectTotalsInCurrentScope($quote);
-
-            $quote->save();
+            $this->collectAndSave($quote);
 
             return $quote;
         });
@@ -938,6 +937,9 @@ class CartService
 
         // Flag to trigger shipping rate collection
         $address->setCollectShippingRates(1);
+        // Address changes reprice tax and shipping; a stale flag would let the
+        // read boundary (CartMapper) skip recollecting them
+        $quote->setTotalsCollectedFlag(false);
     }
 
     /**
@@ -947,6 +949,7 @@ class CartService
     {
         $address = $quote->getBillingAddress();
         $address->addData(StoreDefaults::filterAddressKeys($this->sanitizeAddressData($addressData)));
+        $quote->setTotalsCollectedFlag(false);
     }
 
     public function setShippingAddress(\Mage_Sales_Model_Quote $quote, array $addressData): \Mage_Sales_Model_Quote
@@ -1009,8 +1012,7 @@ class CartService
             }
 
             $address->setShippingMethod($shippingMethod);
-            self::collectTotalsInCurrentScope($quote);
-            $quote->save();
+            $this->collectAndSave($quote);
 
             return $quote;
         });
@@ -1031,34 +1033,42 @@ class CartService
         }
 
         return self::inQuoteStoreScope($quote, function () use ($quote, $methodCode, $paymentData): \Mage_Sales_Model_Quote {
-            // The gate reads quote totals, so collect first (pre-fee, so
-            // availability is judged before the method's own fee applies)
-            self::collectTotalsInCurrentScope($quote);
+            // The gate judges on the persisted totals (current by invariant:
+            // every cart mutation recollects and saves), pre-fee by design
+            $this->assertPaymentMethodAvailable($quote, $methodCode);
 
-            // importData() checks isAvailable() but no applicability (min/max
-            // totals, country, currency), so gate via getStoreMethods()
-            $availableCodes = array_map(
-                fn($method) => $method->getCode(),
-                \Mage::helper('payment')->getStoreMethods($quote->getStoreId(), $quote),
-            );
-
-            if (!in_array($methodCode, $availableCodes, true)) {
-                throw new BadRequestHttpException('Payment method is not available for this cart');
-            }
-
+            // Suppress importData()'s internal recollect; the one real pass
+            // runs in collectAndSave() below with the method set
+            $quote->setTotalsCollectedFlag(true);
             try {
                 $quote->getPayment()->importData($paymentData);
             } catch (\Exception $e) {
                 throw new BadRequestHttpException('Payment method is not available: ' . $e->getMessage());
             }
 
-            // Recollect with the method set so payment-dependent totals
-            // (e.g. payment fees) land on the save
-            self::collectTotalsInCurrentScope($quote);
-            $quote->save();
+            $this->collectAndSave($quote);
 
             return $quote;
         });
+    }
+
+    /**
+     * Gate a payment method on the store's active methods for this quote.
+     * importData()/setMethod() alone accept any configured code, and neither
+     * this gate nor importData() checks min/max totals, country, or currency:
+     * getStoreMethods() only runs each method's isAvailable() (active flag plus
+     * the payment_method_is_active event).
+     */
+    public function assertPaymentMethodAvailable(\Mage_Sales_Model_Quote $quote, string $methodCode): void
+    {
+        $availableCodes = array_map(
+            fn($method) => $method->getCode(),
+            \Mage::helper('payment')->getStoreMethods($quote->getStoreId(), $quote),
+        );
+
+        if (!in_array($methodCode, $availableCodes, true)) {
+            throw new BadRequestHttpException('Payment method is not available for this cart');
+        }
     }
 
     /**
@@ -1328,7 +1338,7 @@ class CartService
     /**
      * Recollect totals and persist the quote, both in its own store scope.
      */
-    private function collectAndSave(\Mage_Sales_Model_Quote $quote): void
+    public function collectAndSave(\Mage_Sales_Model_Quote $quote): void
     {
         self::inQuoteStoreScope($quote, function () use ($quote): void {
             self::collectTotalsInCurrentScope($quote);

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -94,14 +94,14 @@ class CartService
     }
 
     /**
-     * Get cart by ID or masked ID
+     * Get cart by ID or masked ID. The loader never collects totals: mutations
+     * recollect through their service methods, and reads collect at the
+     * mapping boundary (CartMapper) or call collectAndVerifyTotals() themselves.
      *
      * @param int|null $cartId Cart ID
      * @param string|null $maskedId Masked ID
-     * @param bool $collectTotals Pass false when the caller mutates the quote
-     *        and recollects afterwards, so the load-time collection is skipped
      */
-    public function getCart(?int $cartId = null, ?string $maskedId = null, bool $collectTotals = true): ?\Mage_Sales_Model_Quote
+    public function getCart(?int $cartId = null, ?string $maskedId = null): ?\Mage_Sales_Model_Quote
     {
         if ($maskedId) {
             $cartId = $this->getCartIdFromMaskedId($maskedId);
@@ -123,10 +123,6 @@ class CartService
         if ($quote->getStoreId()) {
             $quote->setStore(\Mage::app()->getStore($quote->getStoreId()));
             StoreContext::applyRequestedCurrencyTo($quote->getStore());
-        }
-
-        if ($collectTotals) {
-            $this->collectAndVerifyTotals($quote);
         }
 
         return $quote;
@@ -169,7 +165,6 @@ class CartService
     public function resolveCartFromRequest(
         array $uriVariables,
         array $context,
-        bool $collectTotals = true,
     ): array {
         $request = $context['request'] ?? null;
         $args = $context['args']['input'] ?? $context['args'] ?? [];
@@ -220,7 +215,7 @@ class CartService
             return ['quote' => null, 'accessedByMaskedId' => false, 'maskedId' => null];
         }
 
-        $quote = $this->getCart($cartId, $maskedId, $collectTotals);
+        $quote = $this->getCart($cartId, $maskedId);
         return ['quote' => $quote, 'accessedByMaskedId' => $maskedId !== null, 'maskedId' => $maskedId];
     }
 
@@ -481,7 +476,7 @@ class CartService
                 $result->setOriginalCustomPrice($customPrice);
             }
 
-            $this->collectAndVerifyTotals($quote);
+            self::collectTotalsInCurrentScope($quote);
 
             $quote->save();
 
@@ -528,7 +523,7 @@ class CartService
                 $item->setOriginalCustomPrice($customPrice);
             }
 
-            $this->collectAndVerifyTotals($quote);
+            self::collectTotalsInCurrentScope($quote);
 
             $quote->save();
 
@@ -552,7 +547,7 @@ class CartService
 
         return self::inQuoteStoreScope($quote, function () use ($quote, $itemId): \Mage_Sales_Model_Quote {
             $quote->removeItem($itemId);
-            $this->collectAndVerifyTotals($quote);
+            self::collectTotalsInCurrentScope($quote);
 
             $quote->save();
 
@@ -1009,8 +1004,7 @@ class CartService
             }
 
             $address->setShippingMethod($shippingMethod);
-            $quote->setTotalsCollectedFlag(false);
-            $quote->collectTotals();
+            self::collectTotalsInCurrentScope($quote);
             $quote->save();
 
             return $quote;
@@ -1026,6 +1020,12 @@ class CartService
      */
     public function setPaymentMethod(\Mage_Sales_Model_Quote $quote, string $methodCode, ?array $additionalData = null): \Mage_Sales_Model_Quote
     {
+        // The quote is loaded without totals collection, and the availability
+        // gate below reads quote totals (Free's zero-total check, payment
+        // restriction rules), so collect them first or persisted stale totals
+        // decide which methods are available
+        self::collectAndVerifyTotals($quote);
+
         // Validate the requested method is among the store's active methods for
         // this quote before applying it, mirroring setShippingMethod(). Without
         // this, importData() would accept any configured method code regardless
@@ -1148,32 +1148,40 @@ class CartService
             throw new NotFoundHttpException('Guest cart not found');
         }
 
-        $customerCart = $this->getCustomerCart($customerId);
+        // Resolve and merge in the guest quote's store scope: getCustomerCart()
+        // scopes its lookup to the ambient store, so without the switch the
+        // merge would land in the API caller's store cart, repricing the items
+        // and hiding the result from the guest cart's own storefront
+        $customerCart = self::inQuoteStoreScope($guestCart, function () use ($guestCart, $customerId): \Mage_Sales_Model_Quote {
+            $customerCart = $this->getCustomerCart($customerId);
 
-        // Merge items from guest cart to customer cart
-        $customerCart->merge($guestCart);
+            // Merge items from guest cart to customer cart
+            $customerCart->merge($guestCart);
 
-        // Import customer default addresses onto the cart so shipping quotes work
-        $customer = \Mage::getModel('customer/customer')->load($customerId);
-        if ($customer->getId()) {
-            $defaultShipping = $customer->getDefaultShippingAddress();
-            if ($defaultShipping && $defaultShipping->getId()) {
-                $shippingAddress = $customerCart->getShippingAddress();
-                if (!$shippingAddress->getFirstname()) {
-                    $shippingAddress->importCustomerAddress($defaultShipping);
-                    $shippingAddress->setSaveInAddressBook(0);
+            // Import customer default addresses onto the cart so shipping quotes work
+            $customer = \Mage::getModel('customer/customer')->load($customerId);
+            if ($customer->getId()) {
+                $defaultShipping = $customer->getDefaultShippingAddress();
+                if ($defaultShipping && $defaultShipping->getId()) {
+                    $shippingAddress = $customerCart->getShippingAddress();
+                    if (!$shippingAddress->getFirstname()) {
+                        $shippingAddress->importCustomerAddress($defaultShipping);
+                        $shippingAddress->setSaveInAddressBook(0);
+                    }
+                }
+                $defaultBilling = $customer->getDefaultBillingAddress();
+                if ($defaultBilling && $defaultBilling->getId()) {
+                    $billingAddress = $customerCart->getBillingAddress();
+                    if (!$billingAddress->getFirstname()) {
+                        $billingAddress->importCustomerAddress($defaultBilling);
+                        $billingAddress->setSaveInAddressBook(0);
+                    }
                 }
             }
-            $defaultBilling = $customer->getDefaultBillingAddress();
-            if ($defaultBilling && $defaultBilling->getId()) {
-                $billingAddress = $customerCart->getBillingAddress();
-                if (!$billingAddress->getFirstname()) {
-                    $billingAddress->importCustomerAddress($defaultBilling);
-                    $billingAddress->setSaveInAddressBook(0);
-                }
-            }
-        }
-        $this->collectAndSave($customerCart);
+            $this->collectAndSave($customerCart);
+
+            return $customerCart;
+        });
 
         // Deactivate guest cart
         $guestCart->setIsActive(0);
@@ -1270,26 +1278,32 @@ class CartService
      * Recollect totals in the quote's store scope, after priming the quote
      * addresses and clearing their cached item lists.
      */
-    private function collectAndVerifyTotals(\Mage_Sales_Model_Quote $quote): void
+    public static function collectAndVerifyTotals(\Mage_Sales_Model_Quote $quote): void
     {
         // Price calculation must use the quote's store, not the admin store (0)
-        self::inQuoteStoreScope($quote, function () use ($quote): void {
-            // Ensure quote has addresses, collectTotals() calculates per-address,
-            // so without addresses all totals (including discounts) return 0
-            $quote->getBillingAddress();
-            $quote->getShippingAddress();
+        self::inQuoteStoreScope($quote, fn() => self::collectTotalsInCurrentScope($quote));
+    }
 
-            // Clear address item cache, getAllItems() caches its result, so if collectTotals
-            // was called before the item was added (e.g. during cart creation), the cache is stale.
-            foreach ($quote->getAllAddresses() as $address) {
-                $address->unsetData('cached_items_all');
-                $address->unsetData('cached_items_nominal');
-                $address->unsetData('cached_items_nonnominal');
-            }
+    /**
+     * The totals-collection body; callers must already hold the quote's store scope.
+     */
+    private static function collectTotalsInCurrentScope(\Mage_Sales_Model_Quote $quote): void
+    {
+        // Ensure quote has addresses, collectTotals() calculates per-address,
+        // so without addresses all totals (including discounts) return 0
+        $quote->getBillingAddress();
+        $quote->getShippingAddress();
 
-            $quote->setTotalsCollectedFlag(false);
-            $quote->collectTotals();
-        });
+        // Clear address item cache, getAllItems() caches its result, so if collectTotals
+        // was called before the item was added (e.g. during cart creation), the cache is stale.
+        foreach ($quote->getAllAddresses() as $address) {
+            $address->unsetData('cached_items_all');
+            $address->unsetData('cached_items_nominal');
+            $address->unsetData('cached_items_nonnominal');
+        }
+
+        $quote->setTotalsCollectedFlag(false);
+        $quote->collectTotals();
     }
 
     /**
@@ -1299,8 +1313,8 @@ class CartService
      */
     private function collectAndSave(\Mage_Sales_Model_Quote $quote): void
     {
-        $this->collectAndVerifyTotals($quote);
         self::inQuoteStoreScope($quote, function () use ($quote): void {
+            self::collectTotalsInCurrentScope($quote);
             $quote->save();
         });
     }

--- a/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
+++ b/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
@@ -84,7 +84,7 @@ class CartMutationHandler
         if (!$sku) {
             throw ValidationException::requiredField('sku');
         }
-        $quote = $this->cartService->getCart((int) $cartId);
+        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -111,7 +111,7 @@ class CartMutationHandler
         if ($qty === null) {
             throw ValidationException::requiredField('qty');
         }
-        $quote = $this->cartService->getCart((int) $cartId);
+        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -133,7 +133,7 @@ class CartMutationHandler
         if (!$itemId) {
             throw ValidationException::requiredField('itemId');
         }
-        $quote = $this->cartService->getCart((int) $cartId);
+        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -156,7 +156,7 @@ class CartMutationHandler
         if (!$couponCode) {
             throw ValidationException::requiredField('couponCode');
         }
-        $quote = $this->cartService->getCart((int) $cartId);
+        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -183,7 +183,6 @@ class CartMutationHandler
             throw ValidationException::invalidValue('couponCode', 'invalid or expired coupon');
         }
 
-        $quote->collectTotals();
         return ['applyCoupon' => $this->mapCart($quote)];
     }
 
@@ -197,12 +196,11 @@ class CartMutationHandler
         if (!$cartId) {
             throw ValidationException::requiredField('cartId');
         }
-        $quote = $this->cartService->getCart((int) $cartId);
+        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
         $this->cartService->removeCoupon($quote);
-        $quote->collectTotals();
         return ['removeCoupon' => $this->mapCart($quote)];
     }
 
@@ -220,7 +218,7 @@ class CartMutationHandler
         if (!$customerId) {
             throw ValidationException::requiredField('customerId');
         }
-        $quote = $this->cartService->getCart((int) $cartId);
+        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -228,9 +226,7 @@ class CartMutationHandler
         if (!$customer->getId()) {
             throw NotFoundException::customer($customerId);
         }
-        $quote->assignCustomer($customer);
-        $quote->collectTotals();
-        $quote->save();
+        $quote = $this->cartService->assignCustomer($quote, $customer);
         return ['assignCustomerToCart' => $this->mapCart($quote)];
     }
 
@@ -292,7 +288,7 @@ class CartMutationHandler
             throw ValidationException::requiredField('code');
         }
 
-        $quote = $this->cartService->getCart((int) $cartId);
+        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -306,11 +302,7 @@ class CartMutationHandler
             throw ValidationException::invalidValue('code', $e->getMessage());
         }
 
-        // Reload quote to get fresh totals, falling back to the in-memory quote
-        // (already collected and saved by applyGiftcard) if the reload comes back
-        // empty, so mapCart() never receives null.
-        $reloaded = $this->cartService->getCart((int) $cartId);
-        return ['applyGiftcardToCart' => $this->mapCart($reloaded ?? $quote)];
+        return ['applyGiftcardToCart' => $this->mapCart($quote)];
     }
 
     /**
@@ -329,7 +321,7 @@ class CartMutationHandler
             throw ValidationException::requiredField('code');
         }
 
-        $quote = $this->cartService->getCart((int) $cartId);
+        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -345,11 +337,7 @@ class CartMutationHandler
             throw ValidationException::invalidValue('code', $e->getMessage());
         }
 
-        // Reload quote to get fresh totals, falling back to the in-memory quote
-        // (already collected and saved above) if the reload comes back empty, so
-        // mapCart() never receives null.
-        $reloaded = $this->cartService->getCart((int) $cartId);
-        return ['removeGiftcardFromCart' => $this->mapCart($reloaded ?? $quote)];
+        return ['removeGiftcardFromCart' => $this->mapCart($quote)];
     }
 
     /**
@@ -365,12 +353,8 @@ class CartMutationHandler
 
         $quote = $this->loadAdminQuote($cartId);
 
-        // Rates must collect in the quote's store scope; the caller's scope is restored after
-        return $this->cartService->inQuoteStoreScope($quote, function () use ($quote): array {
-            if ($quote->getStoreId()) {
-                $quote->setStore(\Mage::app()->getStore($quote->getStoreId()));
-            }
-
+        // Rates must collect in the quote's store scope
+        return CartService::inQuoteStoreScope($quote, function () use ($quote): array {
             $shippingAddress = $quote->getShippingAddress();
             if (!$shippingAddress->getCountryId()) {
                 $defaults = \Maho\ApiPlatform\Service\StoreDefaults::getPosAddress($quote->getStoreId() ? (int) $quote->getStoreId() : null);

--- a/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
+++ b/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
@@ -365,50 +365,52 @@ class CartMutationHandler
 
         $quote = $this->loadAdminQuote($cartId);
 
-        if ($quote->getStoreId()) {
-            \Mage::app()->setCurrentStore($quote->getStoreId());
-            $quote->setStore(\Mage::app()->getStore($quote->getStoreId()));
-        }
-
-        $shippingAddress = $quote->getShippingAddress();
-        if (!$shippingAddress->getCountryId()) {
-            $defaults = \Maho\ApiPlatform\Service\StoreDefaults::getPosAddress($quote->getStoreId() ? (int) $quote->getStoreId() : null);
-            $shippingAddress->setCountryId($defaults['country_id'])->setPostcode($defaults['postcode'])->setRegionId($defaults['region_id'])->setCollectShippingRates(1);
-        }
-
-        $shippingAddress->collectShippingRates();
-        $rates = $shippingAddress->getGroupedAllShippingRates();
-        $store = $quote->getStore();
-        $currency = $store->getCurrentCurrencyCode();
-
-        $methods = [];
-        foreach ($rates as $carrierRates) {
-            foreach ($carrierRates as $rate) {
-                $methods[] = [
-                    'carrierCode' => $rate->getCarrier(),
-                    'carrierTitle' => $rate->getCarrierTitle(),
-                    'methodCode' => $rate->getMethod(),
-                    'methodTitle' => $rate->getMethodTitle(),
-                    // Rate prices are base currency; convert like the collector.
-                    'amount' => (float) $store->convertPrice((float) $rate->getPrice(), false),
-                    'currency' => $currency,
-                    'available' => !$rate->getErrorMessage(),
-                    'errorMessage' => $rate->getErrorMessage(),
-                ];
+        // Rates must collect in the quote's store scope; the caller's scope is restored after
+        return $this->cartService->inQuoteStoreScope($quote, function () use ($quote): array {
+            if ($quote->getStoreId()) {
+                $quote->setStore(\Mage::app()->getStore($quote->getStoreId()));
             }
-        }
-        $hasFreeShipping = array_any($methods, fn($m) => $m['carrierCode'] === 'freeshipping');
-        if (!$hasFreeShipping) {
-            array_unshift($methods, [
-                'carrierCode' => 'freeshipping', 'carrierTitle' => 'Free Shipping',
-                'methodCode' => 'freeshipping', 'methodTitle' => 'POS In-Store Pickup',
-                'amount' => 0.0,
-                'currency' => $currency,
-                'available' => true, 'errorMessage' => null,
-            ]);
-        }
 
-        return ['availableShippingMethods' => $methods];
+            $shippingAddress = $quote->getShippingAddress();
+            if (!$shippingAddress->getCountryId()) {
+                $defaults = \Maho\ApiPlatform\Service\StoreDefaults::getPosAddress($quote->getStoreId() ? (int) $quote->getStoreId() : null);
+                $shippingAddress->setCountryId($defaults['country_id'])->setPostcode($defaults['postcode'])->setRegionId($defaults['region_id'])->setCollectShippingRates(1);
+            }
+
+            $shippingAddress->collectShippingRates();
+            $rates = $shippingAddress->getGroupedAllShippingRates();
+            $store = $quote->getStore();
+            $currency = $store->getCurrentCurrencyCode();
+
+            $methods = [];
+            foreach ($rates as $carrierRates) {
+                foreach ($carrierRates as $rate) {
+                    $methods[] = [
+                        'carrierCode' => $rate->getCarrier(),
+                        'carrierTitle' => $rate->getCarrierTitle(),
+                        'methodCode' => $rate->getMethod(),
+                        'methodTitle' => $rate->getMethodTitle(),
+                        // Rate prices are base currency; convert like the collector.
+                        'amount' => (float) $store->convertPrice((float) $rate->getPrice(), false),
+                        'currency' => $currency,
+                        'available' => !$rate->getErrorMessage(),
+                        'errorMessage' => $rate->getErrorMessage(),
+                    ];
+                }
+            }
+            $hasFreeShipping = array_any($methods, fn($m) => $m['carrierCode'] === 'freeshipping');
+            if (!$hasFreeShipping) {
+                array_unshift($methods, [
+                    'carrierCode' => 'freeshipping', 'carrierTitle' => 'Free Shipping',
+                    'methodCode' => 'freeshipping', 'methodTitle' => 'POS In-Store Pickup',
+                    'amount' => 0.0,
+                    'currency' => $currency,
+                    'available' => true, 'errorMessage' => null,
+                ]);
+            }
+
+            return ['availableShippingMethods' => $methods];
+        });
     }
 
     /**

--- a/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
+++ b/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
@@ -84,7 +84,7 @@ class CartMutationHandler
         if (!$sku) {
             throw ValidationException::requiredField('sku');
         }
-        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
+        $quote = $this->cartService->getCart((int) $cartId);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -111,7 +111,7 @@ class CartMutationHandler
         if ($qty === null) {
             throw ValidationException::requiredField('qty');
         }
-        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
+        $quote = $this->cartService->getCart((int) $cartId);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -133,7 +133,7 @@ class CartMutationHandler
         if (!$itemId) {
             throw ValidationException::requiredField('itemId');
         }
-        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
+        $quote = $this->cartService->getCart((int) $cartId);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -156,7 +156,7 @@ class CartMutationHandler
         if (!$couponCode) {
             throw ValidationException::requiredField('couponCode');
         }
-        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
+        $quote = $this->cartService->getCart((int) $cartId);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -196,7 +196,7 @@ class CartMutationHandler
         if (!$cartId) {
             throw ValidationException::requiredField('cartId');
         }
-        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
+        $quote = $this->cartService->getCart((int) $cartId);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -218,7 +218,7 @@ class CartMutationHandler
         if (!$customerId) {
             throw ValidationException::requiredField('customerId');
         }
-        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
+        $quote = $this->cartService->getCart((int) $cartId);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -288,7 +288,7 @@ class CartMutationHandler
             throw ValidationException::requiredField('code');
         }
 
-        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
+        $quote = $this->cartService->getCart((int) $cartId);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }
@@ -321,7 +321,7 @@ class CartMutationHandler
             throw ValidationException::requiredField('code');
         }
 
-        $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
+        $quote = $this->cartService->getCart((int) $cartId);
         if (!$quote) {
             throw NotFoundException::cart($cartId);
         }

--- a/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
+++ b/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
@@ -360,26 +360,21 @@ class CartMutationHandler
                 $shippingAddress->setCountryId($defaults['country_id'])->setPostcode($defaults['postcode'])->setRegionId($defaults['region_id'])->setCollectShippingRates(1);
             }
 
-            $shippingAddress->collectShippingRates();
-            $rates = $shippingAddress->getGroupedAllShippingRates();
-            $store = $quote->getStore();
-            $currency = $store->getCurrentCurrencyCode();
+            $currency = $quote->getStore()->getCurrentCurrencyCode();
 
+            // CartMapper owns the rate mapping, so REST and GraphQL price identically
             $methods = [];
-            foreach ($rates as $carrierRates) {
-                foreach ($carrierRates as $rate) {
-                    $methods[] = [
-                        'carrierCode' => $rate->getCarrier(),
-                        'carrierTitle' => $rate->getCarrierTitle(),
-                        'methodCode' => $rate->getMethod(),
-                        'methodTitle' => $rate->getMethodTitle(),
-                        // Rate prices are base currency; convert like the collector.
-                        'amount' => (float) $store->convertPrice((float) $rate->getPrice(), false),
-                        'currency' => $currency,
-                        'available' => !$rate->getErrorMessage(),
-                        'errorMessage' => $rate->getErrorMessage(),
-                    ];
-                }
+            foreach ($this->cartMapper->getAvailableShippingMethods($shippingAddress) as $method) {
+                $methods[] = [
+                    'carrierCode' => $method['carrierCode'],
+                    'carrierTitle' => $method['carrierTitle'],
+                    'methodCode' => $method['methodCode'],
+                    'methodTitle' => $method['methodTitle'],
+                    'amount' => $method['price'],
+                    'currency' => $currency,
+                    'available' => $method['available'],
+                    'errorMessage' => $method['errorMessage'],
+                ];
             }
             $hasFreeShipping = array_any($methods, fn($m) => $m['carrierCode'] === 'freeshipping');
             if (!$hasFreeShipping) {

--- a/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
+++ b/app/code/core/Mage/Checkout/Api/GraphQL/CartMutationHandler.php
@@ -353,7 +353,6 @@ class CartMutationHandler
 
         $quote = $this->loadAdminQuote($cartId);
 
-        // Rates must collect in the quote's store scope
         return CartService::inQuoteStoreScope($quote, function () use ($quote): array {
             $shippingAddress = $quote->getShippingAddress();
             if (!$shippingAddress->getCountryId()) {

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -850,6 +850,25 @@ class Mage_Core_Model_App
     }
 
     /**
+     * Run $callback with the current store switched to $storeId, then restore
+     * the caller's store. Only the store scope switches, not design, locale,
+     * or translations (see Mage_Core_Model_App_Emulation for those).
+     */
+    public function withStore(int $storeId, \Closure $callback): mixed
+    {
+        $previousStoreId = (int) $this->getStore()->getId();
+        if ($storeId === $previousStoreId) {
+            return $callback();
+        }
+        $this->setCurrentStore($storeId);
+        try {
+            return $callback();
+        } finally {
+            $this->setCurrentStore($previousStoreId);
+        }
+    }
+
+    /**
      * Initialize application front controller
      *
      * @return $this

--- a/app/code/core/Mage/Sales/Api/OrderProcessor.php
+++ b/app/code/core/Mage/Sales/Api/OrderProcessor.php
@@ -184,19 +184,20 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         // claim e.g. free shipping that the store does not actually offer.
         // Validate before persisting so a bogus method never lands on the saved
         // quote's shipping address (which would corrupt later loads of the cart).
-        if ($validateShippingMethod && !$quote->getShippingAddress()->getShippingRateByCode($shippingMethod)) {
-            throw new BadRequestHttpException('Shipping method is not available for this address');
+        if ($validateShippingMethod) {
+            $rate = $quote->getShippingAddress()->getShippingRateByCode($shippingMethod);
+            // getShippingRateByCode() does not filter rates the refresh marked
+            // deleted, so a stale persisted rate must not satisfy the gate
+            if (!$rate || $rate->isDeleted()) {
+                throw new BadRequestHttpException('Shipping method is not available for this address');
+            }
         }
 
-        // Set payment method + carry payment-method extras (e.g. Stripe
-        // payment_intent_id) into the payment's additional_information so the
-        // payment-method module can finalise the charge at order placement.
+        // Gate the method pre-fee (enabled, min/max total, country, currency):
+        // setMethod() alone accepts any configured code, so without this a
+        // client could force e.g. "free" on a paid cart and place an unpaid
+        // order. Mirrors CartService::setPaymentMethod().
         if ($paymentMethod) {
-            // Validate the method is actually available for this quote (enabled,
-            // and within its min/max total, country and currency constraints)
-            // before applying it. setMethod() alone accepts any configured code,
-            // so without this a client could force e.g. "free" on a paid cart
-            // and place an unpaid order. Mirrors CartService::setPaymentMethod().
             $availableCodes = array_map(
                 fn($method) => $method->getCode(),
                 \Mage::helper('payment')->getStoreMethods($quote->getStoreId(), $quote),

--- a/app/code/core/Mage/Sales/Api/OrderProcessor.php
+++ b/app/code/core/Mage/Sales/Api/OrderProcessor.php
@@ -137,10 +137,12 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         $paymentMethod = $args['paymentMethod'] ?? null;
         $shippingMethod = $args['shippingMethod'] ?? null;
 
-        // Get cart/quote
+        // Get cart/quote; totals are collected explicitly below, after the
+        // body's addresses and methods are applied
         $quote = $this->cartService->getCart(
             $cartId ? (int) $cartId : null,
             $maskedId,
+            collectTotals: false,
         );
 
         if (!$quote) {
@@ -202,8 +204,12 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
             $shippingAddress->setCollectShippingRates(1);
             $validateShippingMethod = true;
         }
-        $quote->setTotalsCollectedFlag(false);
-        $quote->collectTotals();
+        // Collect in the quote's store scope; the caller's scope, which decides
+        // MOTO handling at payment time, is restored before placement continues
+        CartService::inQuoteStoreScope($quote, function () use ($quote): void {
+            $quote->setTotalsCollectedFlag(false);
+            $quote->collectTotals();
+        });
 
         // Reject a method the client made up: after rates are collected the
         // chosen code must resolve to a real rate, otherwise a caller could

--- a/app/code/core/Mage/Sales/Api/OrderProcessor.php
+++ b/app/code/core/Mage/Sales/Api/OrderProcessor.php
@@ -151,17 +151,14 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         // Verify cart ownership
         $this->verifyCartOwnership($quote, $maskedId !== null);
 
-        // Frontend callers send the full checkout state in the body, apply
-        // any provided addresses to the quote before order placement so the
-        // rate calculator and address validations see the right data.
-        $totalsFresh = false;
+        // Frontend callers send the full checkout state in the body. Apply any
+        // provided addresses in-memory; the single collection below prices them
+        // together with the shipping method, and the final save persists them.
         if (isset($args['shippingAddress']) && is_array($args['shippingAddress'])) {
-            $this->cartService->setShippingAddress($quote, $this->cartService->mapAddressInput($args['shippingAddress']));
-            $totalsFresh = true;
+            $this->cartService->applyShippingAddress($quote, $this->cartService->mapAddressInput($args['shippingAddress']));
         }
         if (isset($args['billingAddress']) && is_array($args['billingAddress'])) {
-            $this->cartService->setBillingAddress($quote, $this->cartService->mapAddressInput($args['billingAddress']));
-            $totalsFresh = true;
+            $this->cartService->applyBillingAddress($quote, $this->cartService->mapAddressInput($args['billingAddress']));
         }
 
         // Set customer email from the body if provided (guest checkout)
@@ -169,17 +166,36 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
             $quote->setCustomerEmail($guestEmail);
         }
 
+        // Set shipping method directly on the in-memory address. The frontend
+        // sends a composite carrier_method string in the body, and we preserve
+        // the in-memory quote state through to placeAdminOrder rather than
+        // save + reload through cartService->setShippingMethod.
+        $validateShippingMethod = false;
+        if ($shippingMethod && !$quote->isVirtual()) {
+            $shippingAddress = $quote->getShippingAddress();
+            $shippingAddress->setShippingMethod($shippingMethod);
+            $shippingAddress->setCollectShippingRates(1);
+            $validateShippingMethod = true;
+        }
+        // Collect once in the quote's store scope: this prices the applied
+        // addresses and shipping method, and gives the payment gate below fresh
+        // totals. The caller's scope, which decides MOTO handling at payment
+        // time, is restored before placement continues.
+        CartService::collectAndVerifyTotals($quote);
+
+        // Reject a method the client made up: after rates are collected the
+        // chosen code must resolve to a real rate, otherwise a caller could
+        // claim e.g. free shipping that the store does not actually offer.
+        // Validate before persisting so a bogus method never lands on the saved
+        // quote's shipping address (which would corrupt later loads of the cart).
+        if ($validateShippingMethod && !$quote->getShippingAddress()->getShippingRateByCode($shippingMethod)) {
+            throw new BadRequestHttpException('Shipping method is not available for this address');
+        }
+
         // Set payment method + carry payment-method extras (e.g. Stripe
         // payment_intent_id) into the payment's additional_information so the
         // payment-method module can finalise the charge at order placement.
         if ($paymentMethod) {
-            // The availability gate reads quote totals (Free's zero-total check,
-            // payment restriction rules), and the quote was loaded without a
-            // totals collection: collect first unless an address body already did
-            if (!$totalsFresh) {
-                CartService::collectAndVerifyTotals($quote);
-            }
-
             // Validate the method is actually available for this quote (enabled,
             // and within its min/max total, country and currency constraints)
             // before applying it. setMethod() alone accepts any configured code,
@@ -200,30 +216,10 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
                     $payment->setAdditionalInformation((string) $key, $value);
                 }
             }
-        }
 
-        // Set shipping method directly on the in-memory address. The frontend
-        // sends a composite carrier_method string in the body, and we preserve
-        // the in-memory quote state through to placeAdminOrder rather than
-        // save + reload through cartService->setShippingMethod.
-        $validateShippingMethod = false;
-        if ($shippingMethod && !$quote->isVirtual()) {
-            $shippingAddress = $quote->getShippingAddress();
-            $shippingAddress->setShippingMethod($shippingMethod);
-            $shippingAddress->setCollectShippingRates(1);
-            $validateShippingMethod = true;
-        }
-        // Collect in the quote's store scope; the caller's scope, which decides
-        // MOTO handling at payment time, is restored before placement continues
-        CartService::collectAndVerifyTotals($quote);
-
-        // Reject a method the client made up: after rates are collected the
-        // chosen code must resolve to a real rate, otherwise a caller could
-        // claim e.g. free shipping that the store does not actually offer.
-        // Validate before persisting so a bogus method never lands on the saved
-        // quote's shipping address (which would corrupt later loads of the cart).
-        if ($validateShippingMethod && !$quote->getShippingAddress()->getShippingRateByCode($shippingMethod)) {
-            throw new BadRequestHttpException('Shipping method is not available for this address');
+            // Recollect so payment-dependent totals (e.g. payment fees) land on
+            // the order; the consumed rates flag keeps the validated rates.
+            CartService::collectAndVerifyTotals($quote);
         }
 
         $placeOrder = function () use ($quote, $paymentMethod, $shippingMethod, $guestEmail, $orderNote, $cashTendered, $employeeId): array {

--- a/app/code/core/Mage/Sales/Api/OrderProcessor.php
+++ b/app/code/core/Mage/Sales/Api/OrderProcessor.php
@@ -186,25 +186,18 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         // quote's shipping address (which would corrupt later loads of the cart).
         if ($validateShippingMethod) {
             $rate = $quote->getShippingAddress()->getShippingRateByCode($shippingMethod);
-            // getShippingRateByCode() does not filter rates the refresh marked
-            // deleted, so a stale persisted rate must not satisfy the gate
-            if (!$rate || $rate->isDeleted()) {
+            // A carrier failure produces a rate whose code is the carrier's
+            // error entry; it must not be orderable (it would price at 0)
+            if (!$rate || $rate->getErrorMessage()) {
                 throw new BadRequestHttpException('Shipping method is not available for this address');
             }
         }
 
-        // Gate the method pre-fee (enabled, min/max total, country, currency):
-        // setMethod() alone accepts any configured code, so without this a
-        // client could force e.g. "free" on a paid cart and place an unpaid
-        // order. Mirrors CartService::setPaymentMethod().
+        // Gate the method pre-fee: setMethod() alone accepts any configured
+        // code, so without this a client could force e.g. "free" on a paid
+        // cart and place an unpaid order.
         if ($paymentMethod) {
-            $availableCodes = array_map(
-                fn($method) => $method->getCode(),
-                \Mage::helper('payment')->getStoreMethods($quote->getStoreId(), $quote),
-            );
-            if (!in_array($paymentMethod, $availableCodes, true)) {
-                throw new BadRequestHttpException('Payment method is not available for this cart');
-            }
+            $this->cartService->assertPaymentMethodAvailable($quote, $paymentMethod);
 
             $payment = $quote->getPayment();
             $payment->setMethod($paymentMethod);

--- a/app/code/core/Mage/Sales/Api/OrderProcessor.php
+++ b/app/code/core/Mage/Sales/Api/OrderProcessor.php
@@ -142,7 +142,6 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         $quote = $this->cartService->getCart(
             $cartId ? (int) $cartId : null,
             $maskedId,
-            collectTotals: false,
         );
 
         if (!$quote) {
@@ -155,11 +154,14 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         // Frontend callers send the full checkout state in the body, apply
         // any provided addresses to the quote before order placement so the
         // rate calculator and address validations see the right data.
+        $totalsFresh = false;
         if (isset($args['shippingAddress']) && is_array($args['shippingAddress'])) {
             $this->cartService->setShippingAddress($quote, $this->cartService->mapAddressInput($args['shippingAddress']));
+            $totalsFresh = true;
         }
         if (isset($args['billingAddress']) && is_array($args['billingAddress'])) {
             $this->cartService->setBillingAddress($quote, $this->cartService->mapAddressInput($args['billingAddress']));
+            $totalsFresh = true;
         }
 
         // Set customer email from the body if provided (guest checkout)
@@ -171,6 +173,13 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         // payment_intent_id) into the payment's additional_information so the
         // payment-method module can finalise the charge at order placement.
         if ($paymentMethod) {
+            // The availability gate reads quote totals (Free's zero-total check,
+            // payment restriction rules), and the quote was loaded without a
+            // totals collection: collect first unless an address body already did
+            if (!$totalsFresh) {
+                CartService::collectAndVerifyTotals($quote);
+            }
+
             // Validate the method is actually available for this quote (enabled,
             // and within its min/max total, country and currency constraints)
             // before applying it. setMethod() alone accepts any configured code,
@@ -206,10 +215,7 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         }
         // Collect in the quote's store scope; the caller's scope, which decides
         // MOTO handling at payment time, is restored before placement continues
-        CartService::inQuoteStoreScope($quote, function () use ($quote): void {
-            $quote->setTotalsCollectedFlag(false);
-            $quote->collectTotals();
-        });
+        CartService::collectAndVerifyTotals($quote);
 
         // Reject a method the client made up: after rates are collected the
         // chosen code must resolve to a real rate, otherwise a caller could
@@ -220,24 +226,34 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
             throw new BadRequestHttpException('Shipping method is not available for this address');
         }
 
-        $quote->save();
+        $placeOrder = function () use ($quote, $paymentMethod, $shippingMethod, $guestEmail, $orderNote, $cashTendered, $employeeId): array {
+            $quote->save();
 
-        // Allow modules to prepare the quote before order placement
-        // (e.g. POS module sets default address, shipping, payment for admin orders)
-        \Mage::dispatchEvent('sales_api_place_order_before', [
-            'quote' => $quote,
-            'payment_method' => $paymentMethod,
-            'shipping_method' => $shippingMethod,
-        ]);
+            // Allow modules to prepare the quote before order placement
+            // (e.g. POS module sets default address, shipping, payment for admin orders)
+            \Mage::dispatchEvent('sales_api_place_order_before', [
+                'quote' => $quote,
+                'payment_method' => $paymentMethod,
+                'shipping_method' => $shippingMethod,
+            ]);
 
-        // Place order
-        $result = $this->orderService->placeAdminOrder(
-            $quote,
-            $guestEmail,
-            $orderNote,
-            $cashTendered,
-            $employeeId,
-        );
+            return $this->orderService->placeAdminOrder(
+                $quote,
+                $guestEmail,
+                $orderNote,
+                $cashTendered,
+                $employeeId,
+            );
+        };
+
+        // An admin-scoped caller places in admin scope so payment methods apply
+        // MOTO handling (issue #1337). Any other caller places in the quote's
+        // store scope, so store-scoped inventory config (can_subtract,
+        // backorders) and save observers resolve against the order's own store
+        // even when the caller's X-Store-Code names a different one.
+        $result = \Mage::app()->getStore()->isAdmin()
+            ? $placeOrder()
+            : CartService::inQuoteStoreScope($quote, $placeOrder);
 
         $order = $result['order'];
         $accessToken = $result['accessToken'];

--- a/app/code/core/Mage/Sales/Api/OrderProcessor.php
+++ b/app/code/core/Mage/Sales/Api/OrderProcessor.php
@@ -137,8 +137,6 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         $paymentMethod = $args['paymentMethod'] ?? null;
         $shippingMethod = $args['shippingMethod'] ?? null;
 
-        // Get cart/quote; totals are collected explicitly below, after the
-        // body's addresses and methods are applied
         $quote = $this->cartService->getCart(
             $cartId ? (int) $cartId : null,
             $maskedId,
@@ -177,10 +175,8 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
             $shippingAddress->setCollectShippingRates(1);
             $validateShippingMethod = true;
         }
-        // Collect once in the quote's store scope: this prices the applied
-        // addresses and shipping method, and gives the payment gate below fresh
-        // totals. The caller's scope, which decides MOTO handling at payment
-        // time, is restored before placement continues.
+        // Collect once: this prices the applied addresses and shipping method,
+        // and gives the payment gate below fresh totals
         CartService::collectAndVerifyTotals($quote);
 
         // Reject a method the client made up: after rates are collected the

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -2022,7 +2022,21 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
         // collect totals and save me, if required
         if ($this->getData('trigger_recollect') == 1) {
             $this->setTriggerRecollect(0)->getResource()->save($this);
-            $this->collectTotals()->save();
+            // Collect in the quote's own store scope: an admin- or cross-store
+            // caller would otherwise persist totals priced in its own scope, and
+            // the totals-collected flag set here makes later reads trust them
+            $storeId = (int) $this->getStoreId();
+            $previousStoreId = (int) Mage::app()->getStore()->getId();
+            if ($storeId && $storeId !== $previousStoreId) {
+                Mage::app()->setCurrentStore($storeId);
+                try {
+                    $this->collectTotals()->save();
+                } finally {
+                    Mage::app()->setCurrentStore($previousStoreId);
+                }
+            } else {
+                $this->collectTotals()->save();
+            }
         }
         return parent::_afterLoad();
     }

--- a/app/code/core/Mage/Sales/Model/Quote.php
+++ b/app/code/core/Mage/Sales/Model/Quote.php
@@ -2026,14 +2026,8 @@ class Mage_Sales_Model_Quote extends Mage_Core_Model_Abstract
             // caller would otherwise persist totals priced in its own scope, and
             // the totals-collected flag set here makes later reads trust them
             $storeId = (int) $this->getStoreId();
-            $previousStoreId = (int) Mage::app()->getStore()->getId();
-            if ($storeId && $storeId !== $previousStoreId) {
-                Mage::app()->setCurrentStore($storeId);
-                try {
-                    $this->collectTotals()->save();
-                } finally {
-                    Mage::app()->setCurrentStore($previousStoreId);
-                }
+            if ($storeId) {
+                Mage::app()->withStore($storeId, fn() => $this->collectTotals()->save());
             } else {
                 $this->collectTotals()->save();
             }

--- a/app/code/core/Mage/Sales/Model/Quote/Address.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Address.php
@@ -868,7 +868,10 @@ class Mage_Sales_Model_Quote_Address extends Mage_Customer_Model_Address_Abstrac
     public function getShippingRateByCode($code)
     {
         foreach ($this->getShippingRatesCollection() as $rate) {
-            if ($rate->getCode() == $code) {
+            // A rate removeAllShippingRates() marked deleted precedes the fresh
+            // rate a refresh appended under the same code; skip it like
+            // getAllShippingRates() does, or it shadows the live rate
+            if ($rate->getCode() == $code && !$rate->isDeleted()) {
                 return $rate;
             }
         }

--- a/app/code/core/Mage/Wishlist/Api/WishlistProcessor.php
+++ b/app/code/core/Mage/Wishlist/Api/WishlistProcessor.php
@@ -249,9 +249,9 @@ final class WishlistProcessor extends \Maho\ApiPlatform\Processor
             // Use CartService to load the cart properly (handles numeric or masked IDs)
             $accessedByMaskedId = !is_numeric($cartId);
             if ($accessedByMaskedId) {
-                $quote = $this->cartService->getCart(null, $cartId);
+                $quote = $this->cartService->getCart(null, $cartId, collectTotals: false);
             } else {
-                $quote = $this->cartService->getCart((int) $cartId);
+                $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
             }
 
             // getCart() applies no ownership filtering, verify the caller owns

--- a/app/code/core/Mage/Wishlist/Api/WishlistProcessor.php
+++ b/app/code/core/Mage/Wishlist/Api/WishlistProcessor.php
@@ -249,9 +249,9 @@ final class WishlistProcessor extends \Maho\ApiPlatform\Processor
             // Use CartService to load the cart properly (handles numeric or masked IDs)
             $accessedByMaskedId = !is_numeric($cartId);
             if ($accessedByMaskedId) {
-                $quote = $this->cartService->getCart(null, $cartId, collectTotals: false);
+                $quote = $this->cartService->getCart(null, $cartId);
             } else {
-                $quote = $this->cartService->getCart((int) $cartId, collectTotals: false);
+                $quote = $this->cartService->getCart((int) $cartId);
             }
 
             // getCart() applies no ownership filtering, verify the caller owns

--- a/app/code/core/Maho/ApiPlatform/symfony/Kernel.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Kernel.php
@@ -399,6 +399,12 @@ class Kernel extends BaseKernel
             ->arg('$debug', '%kernel.debug%')
             ->tag('kernel.event_subscriber');
 
+        // Priority 140: outside every metadata factory but the cache, like the
+        // MCP factory at 150, so operations arrive fully resolved.
+        $services->set(Metadata\SelfResolvingWriteResourceMetadataCollectionFactory::class)
+            ->decorate('api_platform.metadata.resource.metadata_collection_factory', null, 140)
+            ->arg('$decorated', new Reference(Metadata\SelfResolvingWriteResourceMetadataCollectionFactory::class . '.inner'));
+
         // Publishes has_backend_access('<resource>') to every security expression,
         // including the per-property ones the serializer evaluates. Tagged by
         // hand: FrameworkBundle autoconfigures ExpressionFunctionProviderInterface

--- a/app/code/core/Maho/ApiPlatform/symfony/Metadata/SelfResolvingWriteResourceMetadataCollectionFactory.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Metadata/SelfResolvingWriteResourceMetadataCollectionFactory.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Defaults `read: false` on the writes of self-resolving resources.
+ *
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Maho_ApiPlatform
+ */
+
+declare(strict_types=1);
+
+namespace Maho\ApiPlatform\Metadata;
+
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\NotExposed;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use Maho\Config\ApiResource as MahoApiResource;
+
+/**
+ * A resource declaring `mahoSelfResolvingWrites: true` promises that its write
+ * processors resolve and verify their own state, so the provider read pass
+ * before them is discarded work. This factory turns that promise into
+ * `read: false` on every item-scoped HTTP write operation and every GraphQL
+ * mutation, instead of each operation repeating the flag.
+ *
+ * An operation is left alone when it sets `read:` explicitly or when one of
+ * its security expressions references `object`: those need the provider-loaded
+ * state to evaluate.
+ */
+final class SelfResolvingWriteResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+{
+    public function __construct(
+        private readonly ResourceMetadataCollectionFactoryInterface $decorated,
+    ) {}
+
+    #[\Override]
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        $collection = $this->decorated->create($resourceClass);
+
+        foreach ($collection as $index => $resource) {
+            if (!$resource instanceof MahoApiResource || !$resource->mahoSelfResolvingWrites) {
+                continue;
+            }
+
+            $operations = $resource->getOperations();
+            if ($operations !== null) {
+                $changes = [];
+                foreach ($operations as $name => $operation) {
+                    if ($this->isSelfResolvingHttpWrite($operation)) {
+                        $changes[(string) $name] = $operation->withRead(false);
+                    }
+                }
+                foreach ($changes as $name => $operation) {
+                    $operations->add($name, $operation);
+                }
+            }
+
+            $graphQlOperations = $resource->getGraphQlOperations();
+            if ($graphQlOperations !== null) {
+                $changed = false;
+                foreach ($graphQlOperations as $name => $operation) {
+                    if ($this->isSelfResolvingMutation($operation)) {
+                        $graphQlOperations[$name] = $operation->withRead(false);
+                        $changed = true;
+                    }
+                }
+                if ($changed) {
+                    $collection[$index] = $resource->withGraphQlOperations($graphQlOperations);
+                }
+            }
+        }
+
+        return $collection;
+    }
+
+    private function isSelfResolvingHttpWrite(Operation $operation): bool
+    {
+        if (!$operation instanceof HttpOperation || $operation instanceof NotExposed) {
+            return false;
+        }
+        if (!in_array(strtoupper($operation->getMethod()), ['POST', 'PUT', 'PATCH', 'DELETE'], true)) {
+            return false;
+        }
+
+        // Collection writes (creates) have no state to resolve; leave their
+        // read handling to API Platform's own defaults
+        if (!$operation->getUriVariables()) {
+            return false;
+        }
+
+        return $operation->canRead() === null && !$this->securityReadsObject($operation);
+    }
+
+    private function isSelfResolvingMutation(GraphQlOperation $operation): bool
+    {
+        return $operation instanceof Mutation
+            && $operation->canRead() === null
+            && !$this->securityReadsObject($operation);
+    }
+
+    private function securityReadsObject(Operation $operation): bool
+    {
+        return array_any(
+            [$operation->getSecurity(), $operation->getSecurityPostDenormalize(), $operation->getSecurityPostValidation()],
+            fn(?string $expression) => $expression !== null && str_contains($expression, 'object'),
+        );
+    }
+}

--- a/app/code/core/Maho/ApiPlatform/symfony/Service/StoreContext.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Service/StoreContext.php
@@ -143,10 +143,15 @@ final class StoreContext implements ResetInterface
      * otherwise see the caller's store while the app already serves $storeId.
      * The previous mirror value is restored verbatim, since it may be null in a
      * CLI process that never resolved a request context.
+     * Deliberately narrower than Mage_Core_Model_App_Emulation: only the store
+     * scope switches, not design, locale, or translations.
      */
     public static function withStore(int $storeId, \Closure $callback): mixed
     {
         $previousStoreId = (int) \Mage::app()->getStore()->getId();
+        if ($storeId === $previousStoreId && self::$currentStoreId === $storeId) {
+            return $callback();
+        }
         $previousContextStoreId = self::$currentStoreId;
         \Mage::app()->setCurrentStore($storeId);
         self::$currentStoreId = $storeId;

--- a/app/code/core/Maho/ApiPlatform/symfony/Service/StoreContext.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Service/StoreContext.php
@@ -137,6 +137,28 @@ final class StoreContext implements ResetInterface
     }
 
     /**
+     * Run $callback with both the app scope and this context switched to
+     * $storeId, then restore the caller's scope. The context mirror must follow
+     * the app switch: a consumer reading getStoreId() inside the callback would
+     * otherwise see the caller's store while the app already serves $storeId.
+     * The previous mirror value is restored verbatim, since it may be null in a
+     * CLI process that never resolved a request context.
+     */
+    public static function withStore(int $storeId, \Closure $callback): mixed
+    {
+        $previousStoreId = (int) \Mage::app()->getStore()->getId();
+        $previousContextStoreId = self::$currentStoreId;
+        \Mage::app()->setCurrentStore($storeId);
+        self::$currentStoreId = $storeId;
+        try {
+            return $callback();
+        } finally {
+            \Mage::app()->setCurrentStore($previousStoreId);
+            self::$currentStoreId = $previousContextStoreId;
+        }
+    }
+
+    /**
      * Get the current store ID
      */
     public static function getStoreId(): int

--- a/app/code/core/Maho/ApiPlatform/symfony/Service/StoreContext.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Service/StoreContext.php
@@ -75,6 +75,17 @@ final class StoreContext implements ResetInterface
     }
 
     /**
+     * Apply the request's display currency to the quote's store and, on a change,
+     * drop the totals flag so an already-collected quote reprices in it.
+     */
+    public static function applyRequestedCurrencyToQuote(\Mage_Sales_Model_Quote $quote): void
+    {
+        if ($quote->getStoreId() && self::applyRequestedCurrencyTo($quote->getStore())) {
+            $quote->setTotalsCollectedFlag(false);
+        }
+    }
+
+    /**
      * Record a store the request's display currency was applied to, so reset()
      * knows which shared store objects to undo it on.
      */

--- a/app/code/core/Maho/ApiPlatform/symfony/Service/StoreContext.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Service/StoreContext.php
@@ -25,6 +25,7 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 final class StoreContext implements ResetInterface
 {
+    /** Ensured marker and reset() bookkeeping; the live scope is read from Mage::app(). */
     private static ?int $currentStoreId = null;
     private static ?int $explicitStoreId = null;
     private static ?string $requestedCurrencyCode = null;
@@ -54,12 +55,14 @@ final class StoreContext implements ResetInterface
      * store, or refuse when that store cannot serve it. A resource served by its
      * own store (a cart belongs to the store it was created in) wins over the
      * API context, so the header would otherwise be silently dropped.
+     * Returns whether the store's currency was changed, so callers can discard
+     * totals collected before the change.
      */
-    public static function applyRequestedCurrencyTo(\Mage_Core_Model_Store $store): void
+    public static function applyRequestedCurrencyTo(\Mage_Core_Model_Store $store): bool
     {
         $code = self::$requestedCurrencyCode;
         if ($code === null || (int) $store->getId() === self::getStoreId()) {
-            return;
+            return false;
         }
 
         if (!isset($store->getServeableCurrencyRates()[$code])) {
@@ -68,6 +71,7 @@ final class StoreContext implements ResetInterface
 
         $store->setRequestedCurrencyCode($code);
         self::rememberCurrencyApplied($store);
+        return true;
     }
 
     /**
@@ -137,38 +141,24 @@ final class StoreContext implements ResetInterface
     }
 
     /**
-     * Run $callback with both the app scope and this context switched to
-     * $storeId, then restore the caller's scope. The previous mirror value is
-     * restored verbatim: it may be null in a CLI process with no request context.
-     * Narrower than Mage_Core_Model_App_Emulation: only the store scope
-     * switches, not design, locale, or translations.
+     * Run $callback with the app scope switched to $storeId, then restore the
+     * caller's scope.
      */
     public static function withStore(int $storeId, \Closure $callback): mixed
     {
-        $previousStoreId = (int) \Mage::app()->getStore()->getId();
-        if ($storeId === $previousStoreId && self::$currentStoreId === $storeId) {
-            return $callback();
-        }
-        $previousContextStoreId = self::$currentStoreId;
-        \Mage::app()->setCurrentStore($storeId);
-        self::$currentStoreId = $storeId;
-        try {
-            return $callback();
-        } finally {
-            \Mage::app()->setCurrentStore($previousStoreId);
-            self::$currentStoreId = $previousContextStoreId;
-        }
+        return \Mage::app()->withStore($storeId, $callback);
     }
 
     /**
-     * Get the current store ID
+     * Get the current store ID. Once ensured, this reads the live app scope,
+     * so a store switch made in core code cannot desync the two answers.
      */
     public static function getStoreId(): int
     {
         if (self::$currentStoreId === null) {
             return self::ensureStore();
         }
-        return self::$currentStoreId;
+        return (int) \Mage::app()->getStore()->getId();
     }
 
     /**

--- a/app/code/core/Maho/ApiPlatform/symfony/Service/StoreContext.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Service/StoreContext.php
@@ -138,13 +138,10 @@ final class StoreContext implements ResetInterface
 
     /**
      * Run $callback with both the app scope and this context switched to
-     * $storeId, then restore the caller's scope. The context mirror must follow
-     * the app switch: a consumer reading getStoreId() inside the callback would
-     * otherwise see the caller's store while the app already serves $storeId.
-     * The previous mirror value is restored verbatim, since it may be null in a
-     * CLI process that never resolved a request context.
-     * Deliberately narrower than Mage_Core_Model_App_Emulation: only the store
-     * scope switches, not design, locale, or translations.
+     * $storeId, then restore the caller's scope. The previous mirror value is
+     * restored verbatim: it may be null in a CLI process with no request context.
+     * Narrower than Mage_Core_Model_App_Emulation: only the store scope
+     * switches, not design, locale, or translations.
      */
     public static function withStore(int $storeId, \Closure $callback): mixed
     {

--- a/app/code/core/Maho/ApiPlatform/symfony/Trait/AdminQuoteTrait.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Trait/AdminQuoteTrait.php
@@ -33,8 +33,10 @@ trait AdminQuoteTrait
         if (!$quote->getId()) {
             throw NotFoundException::cart($cartId);
         }
-        if ($quote->getStoreId()) {
-            StoreContext::applyRequestedCurrencyTo($quote->getStore());
+        if ($quote->getStoreId() && StoreContext::applyRequestedCurrencyTo($quote->getStore())) {
+            // A trigger_recollect load collected before the currency change;
+            // drop the flag so the next collect reprices in the new currency
+            $quote->setTotalsCollectedFlag(false);
         }
         return $quote;
     }

--- a/app/code/core/Maho/ApiPlatform/symfony/Trait/AdminQuoteTrait.php
+++ b/app/code/core/Maho/ApiPlatform/symfony/Trait/AdminQuoteTrait.php
@@ -33,11 +33,7 @@ trait AdminQuoteTrait
         if (!$quote->getId()) {
             throw NotFoundException::cart($cartId);
         }
-        if ($quote->getStoreId() && StoreContext::applyRequestedCurrencyTo($quote->getStore())) {
-            // A trigger_recollect load collected before the currency change;
-            // drop the flag so the next collect reprices in the new currency
-            $quote->setTotalsCollectedFlag(false);
-        }
+        StoreContext::applyRequestedCurrencyToQuote($quote);
         return $quote;
     }
 }

--- a/lib/Maho/Config/ApiResource.php
+++ b/lib/Maho/Config/ApiResource.php
@@ -117,6 +117,15 @@ class ApiResource extends BaseApiResource
      *   endpoints, auth handshakes, anything an agent has no business calling).
      *   An explicit `mcp: [...]` on the attribute always wins over derivation.
      *
+     * @param bool $mahoSelfResolvingWrites
+     *   The resource's processor resolves and verifies its own state on writes,
+     *   so `Maho\ApiPlatform\Metadata\SelfResolvingWriteResourceMetadataCollectionFactory`
+     *   defaults `read: false` on every item-scoped HTTP write operation and
+     *   every GraphQL mutation. An operation keeps the read pass when it sets
+     *   `read:` explicitly or when a security expression references `object`.
+     *   Only set this when the write processors ignore the provider result:
+     *   with the read pass off, a PUT no longer merges the body into loaded state.
+     *
      * @param mixed $operations
      *
      * @phpstan-param mixed $rules
@@ -133,6 +142,7 @@ class ApiResource extends BaseApiResource
         public ?bool $mahoPublicRead = null,
         public bool $mahoCustomerScoped = false,
         public ?bool $mahoMcp = null,
+        public bool $mahoSelfResolvingWrites = false,
         // ---- Mirror of ApiPlatform\Metadata\ApiResource constructor ----
         ?string $uriTemplate = null,
         ?string $shortName = null,
@@ -225,6 +235,7 @@ class ApiResource extends BaseApiResource
             $parentArgs['mahoPublicRead'],
             $parentArgs['mahoCustomerScoped'],
             $parentArgs['mahoMcp'],
+            $parentArgs['mahoSelfResolvingWrites'],
         );
         parent::__construct(...$parentArgs);
     }

--- a/tests/Backend/Integration/ApiPlatform/SelfResolvingWritesTest.php
+++ b/tests/Backend/Integration/ApiPlatform/SelfResolvingWritesTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use Maho\ApiPlatform\Kernel;
+use Maho\Config\ApiResource as MahoApiResource;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Tests\MahoBackendTestCase;
+
+uses(MahoBackendTestCase::class);
+
+/*
+ * SelfResolvingWriteResourceMetadataCollectionFactory coverage: a resource
+ * declaring `mahoSelfResolvingWrites: true` (Cart) gets `read: false` on its
+ * item-scoped HTTP writes and GraphQL mutations without repeating the flag
+ * per operation, while creates and unflagged resources keep the default.
+ */
+
+final class SelfResolvingWritesKernel extends Kernel
+{
+    #[\Override]
+    protected function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new class implements CompilerPassInterface {
+            #[\Override]
+            public function process(ContainerBuilder $container): void
+            {
+                $id = ResourceMetadataCollectionFactoryInterface::class;
+                if ($container->hasAlias($id)) {
+                    $container->getAlias($id)->setPublic(true);
+                } elseif ($container->hasDefinition($id)) {
+                    $container->getDefinition($id)->setPublic(true);
+                }
+            }
+        });
+    }
+}
+
+/** @return MahoApiResource[] */
+function selfResolvingWritesMetadata(string $resourceClass): array
+{
+    static $factory = null;
+    if ($factory === null) {
+        Mage::app();
+        $kernel = new SelfResolvingWritesKernel('test', true);
+        $kernel->boot();
+        $factory = $kernel->getContainer()->get(ResourceMetadataCollectionFactoryInterface::class);
+    }
+
+    $resources = [];
+    foreach ($factory->create($resourceClass) as $resource) {
+        if ($resource instanceof MahoApiResource) {
+            $resources[] = $resource;
+        }
+    }
+    return $resources;
+}
+
+describe('self-resolving write read defaults', function (): void {
+
+    it('defaults read to false on Cart item-scoped HTTP writes', function (): void {
+        $writes = 0;
+        foreach (selfResolvingWritesMetadata(Mage\Checkout\Api\Cart::class) as $resource) {
+            foreach ($resource->getOperations() ?? [] as $operation) {
+                if (!$operation instanceof HttpOperation
+                    || !in_array($operation->getMethod(), ['POST', 'PUT', 'PATCH', 'DELETE'], true)
+                    || !$operation->getUriVariables()
+                ) {
+                    continue;
+                }
+                $writes++;
+                expect($operation->canRead())
+                    ->toBeFalse("{$operation->getMethod()} {$operation->getUriTemplate()} should not run the provider read pass");
+            }
+        }
+
+        expect($writes)->toBeGreaterThan(20);
+    });
+
+    it('defaults read to false on Cart mutations', function (): void {
+        $mutations = 0;
+        foreach (selfResolvingWritesMetadata(Mage\Checkout\Api\Cart::class) as $resource) {
+            foreach ($resource->getGraphQlOperations() ?? [] as $operation) {
+                if (!$operation instanceof Mutation) {
+                    continue;
+                }
+                $mutations++;
+                expect($operation->canRead())
+                    ->toBeFalse("mutation {$operation->getName()} should not run the provider read pass");
+            }
+        }
+
+        expect($mutations)->toBeGreaterThan(10);
+    });
+
+    it('leaves the Cart create operation on the default read handling', function (): void {
+        $found = false;
+        foreach (selfResolvingWritesMetadata(Mage\Checkout\Api\Cart::class) as $resource) {
+            foreach ($resource->getOperations() ?? [] as $operation) {
+                if ($operation instanceof HttpOperation
+                    && $operation->getMethod() === 'POST'
+                    && $operation->getUriTemplate() === '/carts'
+                ) {
+                    $found = true;
+                    expect($operation->canRead())->toBeNull();
+                }
+            }
+        }
+
+        expect($found)->toBeTrue();
+    });
+
+    it('leaves resources without the flag untouched', function (): void {
+        $writes = 0;
+        foreach (selfResolvingWritesMetadata(Mage\Sales\Api\Order::class) as $resource) {
+            expect($resource->mahoSelfResolvingWrites)->toBeFalse();
+            foreach ($resource->getOperations() ?? [] as $operation) {
+                if (!$operation instanceof HttpOperation
+                    || !in_array($operation->getMethod(), ['POST', 'PUT', 'PATCH', 'DELETE'], true)
+                ) {
+                    continue;
+                }
+                $writes++;
+                expect($operation->canRead())->toBeNull();
+            }
+        }
+
+        expect($writes)->toBeGreaterThan(0);
+    });
+
+});

--- a/tests/Backend/Integration/Checkout/Api/CartAssignCustomerPricingTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartAssignCustomerPricingTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Mage\Checkout\Api\CartMapper;
+use Mage\Checkout\Api\CartService;
+use Mage\Checkout\Api\GraphQL\CartMutationHandler;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Assigning a customer changes the quote's customer group, so the totals must
+ * recollect: group prices and group-based tax classes only apply then. The
+ * handlers used to call collectTotals() on an already-collected quote, which
+ * the totals-collected flag turned into a no-op, so the guest-priced subtotal
+ * was saved for the customer.
+ */
+
+/** A product priced 20.00, with a 15.00 group price for the General group (id 1). */
+function cartAssignCreateGroupPricedProduct(): Mage_Catalog_Model_Product
+{
+    $product = Mage::getModel('catalog/product');
+    $product->setName('Cart assign group priced product');
+    $product->setSku('cart-assign-group-' . bin2hex(random_bytes(4)));
+    $product->setTypeId(Mage_Catalog_Model_Product_Type::TYPE_SIMPLE);
+    $product->setAttributeSetId(4);
+    $product->setStatus(Mage_Catalog_Model_Product_Status::STATUS_ENABLED);
+    $product->setVisibility(Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH);
+    $product->setPrice(20.00);
+    $product->setGroupPrice([[
+        'website_id' => 0,
+        'cust_group' => 1,
+        'price' => 15.00,
+    ]]);
+    $product->setTaxClassId(0);
+    $product->setWebsiteIds([1]);
+    $product->setStockData([
+        'qty' => 100,
+        'is_in_stock' => 1,
+    ]);
+    $product->save();
+    return $product;
+}
+
+function cartAssignCreateGeneralGroupCustomer(): Mage_Customer_Model_Customer
+{
+    $customer = Mage::getModel('customer/customer');
+    $customer->setWebsiteId(1);
+    $customer->setGroupId(1);
+    $customer->setFirstname('Group');
+    $customer->setLastname('Pricing');
+    $customer->setEmail('cart-assign-group-' . bin2hex(random_bytes(4)) . '@example.com');
+    $customer->save();
+    return $customer;
+}
+
+describe('customer assignment pricing', function (): void {
+
+    it('applies the customer group price when a customer is assigned to a cart', function (): void {
+        $product = cartAssignCreateGroupPricedProduct();
+        $customer = cartAssignCreateGeneralGroupCustomer();
+        // Reload: only a loaded product carries the stock item the qty observer needs
+        $product = Mage::getModel('catalog/product')->setStoreId(1)->load($product->getId());
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+        $quote->addProduct($product, 2);
+        // Totals collect per address, so a quote without addresses collects 0
+        $quote->getBillingAddress();
+        $quote->getShippingAddress();
+        $quote->collectTotals();
+        $quote->save();
+
+        try {
+            expect((float) $quote->getSubtotal())->toBe(40.0);
+
+            $handler = new CartMutationHandler(new CartService(), new CartMapper());
+            $result = $handler->handleAssignCustomer([
+                'cartId' => (int) $quote->getId(),
+                'customerId' => (int) $customer->getId(),
+            ]);
+
+            expect((float) $result['assignCustomerToCart']['prices']['subtotal'])->toBe(30.0);
+
+            $reloaded = Mage::getModel('sales/quote')->loadByIdWithoutStore((int) $quote->getId());
+            expect((float) $reloaded->getSubtotal())->toBe(30.0);
+        } finally {
+            $quote->delete();
+            $customer->delete();
+            $product->delete();
+        }
+    });
+
+});

--- a/tests/Backend/Integration/Checkout/Api/CartAssignCustomerPricingTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartAssignCustomerPricingTest.php
@@ -24,27 +24,18 @@ uses(Tests\MahoBackendTestCase::class);
 /** A product priced 20.00, with a 15.00 group price for the General group (id 1). */
 function cartAssignCreateGroupPricedProduct(): Mage_Catalog_Model_Product
 {
-    $product = Mage::getModel('catalog/product');
-    $product->setName('Cart assign group priced product');
-    $product->setSku('cart-assign-group-' . bin2hex(random_bytes(4)));
-    $product->setTypeId(Mage_Catalog_Model_Product_Type::TYPE_SIMPLE);
-    $product->setAttributeSetId(4);
-    $product->setStatus(Mage_Catalog_Model_Product_Status::STATUS_ENABLED);
-    $product->setVisibility(Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH);
-    $product->setPrice(20.00);
-    $product->setGroupPrice([[
-        'website_id' => 0,
-        'cust_group' => 1,
-        'price' => 15.00,
-    ]]);
-    $product->setTaxClassId(0);
-    $product->setWebsiteIds([1]);
-    $product->setStockData([
-        'qty' => 100,
-        'is_in_stock' => 1,
+    return createPriceWebsiteProduct('cart-assign-group', 20.00, data: [
+        'group_price' => [[
+            'website_id' => 0,
+            'cust_group' => 1,
+            'price' => 15.00,
+        ]],
+        'tax_class_id' => 0,
+        'stock_data' => [
+            'qty' => 100,
+            'is_in_stock' => 1,
+        ],
     ]);
-    $product->save();
-    return $product;
 }
 
 function cartAssignCreateGeneralGroupCustomer(): Mage_Customer_Model_Customer
@@ -66,14 +57,7 @@ describe('customer assignment pricing', function (): void {
         $customer = cartAssignCreateGeneralGroupCustomer();
         // Reload: only a loaded product carries the stock item the qty observer needs
         $product = Mage::getModel('catalog/product')->setStoreId(1)->load($product->getId());
-        $quote = Mage::getModel('sales/quote');
-        $quote->setStoreId(1);
-        $quote->addProduct($product, 2);
-        // Totals collect per address, so a quote without addresses collects 0
-        $quote->getBillingAddress();
-        $quote->getShippingAddress();
-        $quote->collectTotals();
-        $quote->save();
+        $quote = createPricedQuote($product);
 
         try {
             expect((float) $quote->getSubtotal())->toBe(40.0);

--- a/tests/Backend/Integration/Checkout/Api/CartStoreScopeTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartStoreScopeTest.php
@@ -36,6 +36,18 @@ function cartApiLeaveScope(int $previousStoreId): void
     Mage::app()->setCurrentStore($previousStoreId);
 }
 
+function cartScopeCreateCustomer(): Mage_Customer_Model_Customer
+{
+    $customer = Mage::getModel('customer/customer');
+    $customer->setWebsiteId(1);
+    $customer->setGroupId(1);
+    $customer->setFirstname('Merge');
+    $customer->setLastname('Scope');
+    $customer->setEmail('cart-scope-merge-' . bin2hex(random_bytes(4)) . '@example.com');
+    $customer->save();
+    return $customer;
+}
+
 /** A dedicated product with finite stock, so the storefront qty check can fail deterministically. */
 function cartScopeCreateStockLimitedProduct(): Mage_Catalog_Model_Product
 {
@@ -125,6 +137,36 @@ describe('cart service store scope (issue #1337)', function (): void {
             cartApiLeaveScope($previousStoreId);
             $quote->delete();
             $product->delete();
+        }
+    });
+
+    it('merges an admin-scoped guest cart into the customer cart of the guest store', function (): void {
+        $product = loadSimplePricedProduct();
+        $service = new CartService();
+
+        $customer = cartScopeCreateCustomer();
+        // The customer's existing store-1 cart. The merge must land here: a
+        // lookup scoped to the caller's store (admin, 0) would miss it and
+        // create a fresh cart instead.
+        $existing = $service->getCustomerCart((int) $customer->getId());
+
+        $guestCart = createPricedQuote($product);
+        $guestCart->setData('masked_quote_id', bin2hex(random_bytes(16)));
+        $guestCart->setIsActive(1);
+        $guestCart->save();
+
+        $previousStoreId = cartApiEnterAdminScope();
+        try {
+            $merged = $service->mergeCarts((string) $guestCart->getData('masked_quote_id'), (int) $customer->getId());
+
+            expect((int) $merged->getId())->toBe((int) $existing->getId())
+                ->and((int) $merged->getStoreId())->toBe(1)
+                ->and((int) Mage::app()->getStore()->getId())->toBe(0);
+        } finally {
+            cartApiLeaveScope($previousStoreId);
+            $guestCart->delete();
+            $existing->delete();
+            $customer->delete();
         }
     });
 

--- a/tests/Backend/Integration/Checkout/Api/CartStoreScopeTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartStoreScopeTest.php
@@ -36,9 +36,34 @@ function cartApiLeaveScope(int $previousStoreId): void
     Mage::app()->setCurrentStore($previousStoreId);
 }
 
+/** A dedicated product with finite stock, so the storefront qty check can fail deterministically. */
+function cartScopeCreateStockLimitedProduct(): Mage_Catalog_Model_Product
+{
+    $product = Mage::getModel('catalog/product');
+    $product->setName('Cart scope stock limited product');
+    $product->setSku('cart-scope-stock-' . bin2hex(random_bytes(4)));
+    $product->setTypeId(Mage_Catalog_Model_Product_Type::TYPE_SIMPLE);
+    $product->setAttributeSetId(4);
+    $product->setStatus(Mage_Catalog_Model_Product_Status::STATUS_ENABLED);
+    $product->setVisibility(Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH);
+    $product->setPrice(20.00);
+    $product->setTaxClassId(0);
+    $product->setWebsiteIds([1]);
+    $product->setStockData([
+        'qty' => 5,
+        'is_in_stock' => 1,
+        'use_config_manage_stock' => 0,
+        'manage_stock' => 1,
+        'use_config_backorders' => 0,
+        'backorders' => 0,
+    ]);
+    $product->save();
+    return $product;
+}
+
 describe('cart service store scope (issue #1337)', function (): void {
 
-    it('keeps the admin scope across addItem()', function (): void {
+    it('keeps the admin scope across addItem() while pricing in the quote store', function (): void {
         $product = loadSimplePricedProduct();
         $quote = Mage::getModel('sales/quote');
         $quote->setStoreId(1);
@@ -46,10 +71,11 @@ describe('cart service store scope (issue #1337)', function (): void {
 
         $previousStoreId = cartApiEnterAdminScope();
         try {
-            (new CartService())->addItem($quote, $product->getSku(), 1);
+            (new CartService())->addItem($quote, $product->getSku(), 2);
 
             expect((int) Mage::app()->getStore()->getId())->toBe(0)
-                ->and(Mage::app()->getStore()->isAdmin())->toBeTrue();
+                ->and(Mage::app()->getStore()->isAdmin())->toBeTrue()
+                ->and((float) $quote->getSubtotal())->toBeGreaterThan(0.0);
         } finally {
             cartApiLeaveScope($previousStoreId);
             $quote->delete();
@@ -72,6 +98,45 @@ describe('cart service store scope (issue #1337)', function (): void {
         }
     });
 
+    it('keeps StoreContext in sync with the app scope inside inQuoteStoreScope()', function (): void {
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+
+        $previousStoreId = cartApiEnterAdminScope();
+        try {
+            CartService::inQuoteStoreScope($quote, function (): void {
+                expect((int) Mage::app()->getStore()->getId())->toBe(1)
+                    ->and(StoreContext::getStoreId())->toBe(1);
+            });
+
+            expect((int) Mage::app()->getStore()->getId())->toBe(0)
+                ->and(StoreContext::getStoreId())->toBe(0);
+        } finally {
+            cartApiLeaveScope($previousStoreId);
+        }
+    });
+
+    it('enforces the quote store stock limits during an admin-scoped addItem()', function (): void {
+        $product = cartScopeCreateStockLimitedProduct();
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+        $quote->save();
+
+        $previousStoreId = cartApiEnterAdminScope();
+        try {
+            // checkQty() passes any qty when the ambient store is admin, so this
+            // rejection only happens when addItem() really switched to the quote store
+            expect(fn() => (new CartService())->addItem($quote, $product->getSku(), 10))
+                ->toThrow(Mage_Core_Exception::class, 'The requested quantity');
+
+            expect((int) Mage::app()->getStore()->getId())->toBe(0);
+        } finally {
+            cartApiLeaveScope($previousStoreId);
+            $quote->delete();
+            $product->delete();
+        }
+    });
+
     it('keeps the admin scope across handleShippingMethods()', function (): void {
         $product = loadSimplePricedProduct();
         $quote = createPricedQuote($product);
@@ -81,28 +146,15 @@ describe('cart service store scope (issue #1337)', function (): void {
             $handler = new CartMutationHandler(new CartService(), new CartMapper());
             $result = $handler->handleShippingMethods(['cartId' => (int) $quote->getId()]);
 
-            expect($result['availableShippingMethods'])->not->toBeEmpty()
-                ->and((int) Mage::app()->getStore()->getId())->toBe(0);
+            // A real carrier must have produced a rate; the handler always
+            // injects a synthetic freeshipping row, so not-empty proves nothing
+            $carriers = array_column($result['availableShippingMethods'], 'carrierCode');
+            expect((int) Mage::app()->getStore()->getId())->toBe(0)
+                ->and($carriers)->toContain('flatrate');
         } finally {
             cartApiLeaveScope($previousStoreId);
             $quote->delete();
         }
     });
 
-    it('still collects item prices in the quote store scope', function (): void {
-        $product = loadSimplePricedProduct();
-        $quote = Mage::getModel('sales/quote');
-        $quote->setStoreId(1);
-        $quote->save();
-
-        $previousStoreId = cartApiEnterAdminScope();
-        try {
-            (new CartService())->addItem($quote, $product->getSku(), 2);
-
-            expect((float) $quote->getSubtotal())->toBeGreaterThan(0.0);
-        } finally {
-            cartApiLeaveScope($previousStoreId);
-            $quote->delete();
-        }
-    });
 });

--- a/tests/Backend/Integration/Checkout/Api/CartStoreScopeTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartStoreScopeTest.php
@@ -119,6 +119,21 @@ describe('cart service store scope (issue #1337)', function (): void {
         }
     });
 
+    it('reflects a core-level withStore() switch in StoreContext::getStoreId()', function (): void {
+        $previousStoreId = cartApiEnterAdminScope();
+        try {
+            Mage::app()->withStore(1, function (): void {
+                expect((int) Mage::app()->getStore()->getId())->toBe(1)
+                    ->and(StoreContext::getStoreId())->toBe(1);
+            });
+
+            expect((int) Mage::app()->getStore()->getId())->toBe(0)
+                ->and(StoreContext::getStoreId())->toBe(0);
+        } finally {
+            cartApiLeaveScope($previousStoreId);
+        }
+    });
+
     it('enforces the quote store stock limits during an admin-scoped addItem()', function (): void {
         $product = cartScopeCreateStockLimitedProduct();
         $quote = Mage::getModel('sales/quote');

--- a/tests/Backend/Integration/Checkout/Api/CartStoreScopeTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartStoreScopeTest.php
@@ -39,26 +39,17 @@ function cartApiLeaveScope(int $previousStoreId): void
 /** A dedicated product with finite stock, so the storefront qty check can fail deterministically. */
 function cartScopeCreateStockLimitedProduct(): Mage_Catalog_Model_Product
 {
-    $product = Mage::getModel('catalog/product');
-    $product->setName('Cart scope stock limited product');
-    $product->setSku('cart-scope-stock-' . bin2hex(random_bytes(4)));
-    $product->setTypeId(Mage_Catalog_Model_Product_Type::TYPE_SIMPLE);
-    $product->setAttributeSetId(4);
-    $product->setStatus(Mage_Catalog_Model_Product_Status::STATUS_ENABLED);
-    $product->setVisibility(Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH);
-    $product->setPrice(20.00);
-    $product->setTaxClassId(0);
-    $product->setWebsiteIds([1]);
-    $product->setStockData([
-        'qty' => 5,
-        'is_in_stock' => 1,
-        'use_config_manage_stock' => 0,
-        'manage_stock' => 1,
-        'use_config_backorders' => 0,
-        'backorders' => 0,
+    return createPriceWebsiteProduct('cart-scope-stock', 20.00, data: [
+        'tax_class_id' => 0,
+        'stock_data' => [
+            'qty' => 5,
+            'is_in_stock' => 1,
+            'use_config_manage_stock' => 0,
+            'manage_stock' => 1,
+            'use_config_backorders' => 0,
+            'backorders' => 0,
+        ],
     ]);
-    $product->save();
-    return $product;
 }
 
 describe('cart service store scope (issue #1337)', function (): void {

--- a/tests/Backend/Integration/Checkout/Api/CartStoreScopeTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartStoreScopeTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Mage\Checkout\Api\CartMapper;
+use Mage\Checkout\Api\CartService;
+use Mage\Checkout\Api\GraphQL\CartMutationHandler;
+use Maho\ApiPlatform\Service\StoreContext;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Regression tests for issue #1337: addItem() and collectAndVerifyTotals()
+ * switched the app to the quote's store for price calculation and never
+ * switched back. An admin-scoped request (X-Store-Code: admin) then reached
+ * order placement in storefront scope, so payment methods keying MOTO handling
+ * off Mage::app()->getStore()->isAdmin() sent 3DS-required storefront sales.
+ */
+
+/** Simulate the admin scope StoreContextListener sets for X-Store-Code: admin. */
+function cartApiEnterAdminScope(): int
+{
+    $previousStoreId = (int) Mage::app()->getStore()->getId();
+    StoreContext::setExplicitStore(0);
+    return $previousStoreId;
+}
+
+function cartApiLeaveScope(int $previousStoreId): void
+{
+    (new StoreContext())->reset();
+    Mage::app()->setCurrentStore($previousStoreId);
+}
+
+describe('cart service store scope (issue #1337)', function (): void {
+
+    it('keeps the admin scope across addItem()', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+        $quote->save();
+
+        $previousStoreId = cartApiEnterAdminScope();
+        try {
+            (new CartService())->addItem($quote, $product->getSku(), 1);
+
+            expect((int) Mage::app()->getStore()->getId())->toBe(0)
+                ->and(Mage::app()->getStore()->isAdmin())->toBeTrue();
+        } finally {
+            cartApiLeaveScope($previousStoreId);
+            $quote->delete();
+        }
+    });
+
+    it('keeps the admin scope across getCart()', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+
+        $previousStoreId = cartApiEnterAdminScope();
+        try {
+            $loaded = (new CartService())->getCart((int) $quote->getId());
+
+            expect($loaded)->not->toBeNull()
+                ->and((int) Mage::app()->getStore()->getId())->toBe(0);
+        } finally {
+            cartApiLeaveScope($previousStoreId);
+            $quote->delete();
+        }
+    });
+
+    it('keeps the admin scope across handleShippingMethods()', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+
+        $previousStoreId = cartApiEnterAdminScope();
+        try {
+            $handler = new CartMutationHandler(new CartService(), new CartMapper());
+            $result = $handler->handleShippingMethods(['cartId' => (int) $quote->getId()]);
+
+            expect($result['availableShippingMethods'])->not->toBeEmpty()
+                ->and((int) Mage::app()->getStore()->getId())->toBe(0);
+        } finally {
+            cartApiLeaveScope($previousStoreId);
+            $quote->delete();
+        }
+    });
+
+    it('still collects item prices in the quote store scope', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+        $quote->save();
+
+        $previousStoreId = cartApiEnterAdminScope();
+        try {
+            (new CartService())->addItem($quote, $product->getSku(), 2);
+
+            expect((float) $quote->getSubtotal())->toBeGreaterThan(0.0);
+        } finally {
+            cartApiLeaveScope($previousStoreId);
+            $quote->delete();
+        }
+    });
+});

--- a/tests/Backend/Integration/Checkout/Api/CartTotalsCollectionTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartTotalsCollectionTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Mage\Checkout\Api\CartMapper;
+use Mage\Checkout\Api\CartService;
+use Mage\Checkout\Api\GraphQL\CartMutationHandler;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Every cart mutation request used to collect totals at least twice: once when
+ * getCart() loaded the quote and again after the mutation. Only the
+ * post-mutation collection produces the persisted totals, so the load-time
+ * collection is pure waste. These tests pin the collection count per request.
+ */
+
+const CART_COLLECT_TIMER = 'DISPATCH EVENT:sales_quote_collect_totals_before';
+
+/** Run $request while counting real totals collections (the flag-guarded no-ops do not dispatch). */
+function cartCountTotalsCollections(Closure $request): int
+{
+    \Maho\Profiler::enable();
+    \Maho\Profiler::reset(CART_COLLECT_TIMER);
+    try {
+        $request();
+        return (int) \Maho\Profiler::fetch(CART_COLLECT_TIMER, 'count');
+    } finally {
+        \Maho\Profiler::disable();
+    }
+}
+
+describe('cart mutation totals collection count', function (): void {
+
+    it('collects totals only once for an add-to-cart mutation', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+        $quote->save();
+
+        $handler = new CartMutationHandler(new CartService(), new CartMapper());
+        try {
+            $collections = cartCountTotalsCollections(fn() => $handler->handleAddToCart([
+                'cartId' => (int) $quote->getId(),
+                'sku' => $product->getSku(),
+                'qty' => 1,
+            ]));
+
+            expect($collections)->toBe(1);
+        } finally {
+            $quote->delete();
+        }
+    });
+
+    it('collects totals only once for an update-quantity mutation', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+        $itemId = (int) $quote->getAllVisibleItems()[0]->getId();
+
+        $handler = new CartMutationHandler(new CartService(), new CartMapper());
+        try {
+            $collections = cartCountTotalsCollections(fn() => $handler->handleUpdateQty([
+                'cartId' => (int) $quote->getId(),
+                'itemId' => $itemId,
+                'qty' => 3,
+            ]));
+
+            expect($collections)->toBe(1);
+        } finally {
+            $quote->delete();
+        }
+    });
+
+    it('still collects totals for a get-cart query', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+
+        $handler = new CartMutationHandler(new CartService(), new CartMapper());
+        try {
+            $collections = cartCountTotalsCollections(fn() => $handler->handleGetCart([
+                'cartId' => (int) $quote->getId(),
+            ]));
+
+            expect($collections)->toBe(1);
+        } finally {
+            $quote->delete();
+        }
+    });
+
+});

--- a/tests/Backend/Integration/Checkout/Api/CartTotalsCollectionTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartTotalsCollectionTest.php
@@ -76,6 +76,23 @@ describe('cart mutation totals collection count', function (): void {
         }
     });
 
+    it('collects totals only once for a set-payment-method call', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+
+        try {
+            $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+            $collections = cartCountTotalsCollections(
+                fn() => (new CartService())->setPaymentMethod($loaded, 'checkmo'),
+            );
+
+            expect($collections)->toBe(1)
+                ->and($loaded->getPayment()->getMethod())->toBe('checkmo');
+        } finally {
+            $quote->delete();
+        }
+    });
+
     it('still collects totals for a get-cart query', function (): void {
         $product = loadSimplePricedProduct();
         $quote = createPricedQuote($product);

--- a/tests/Backend/Integration/Sales/Model/QuoteAddressShippingRateTest.php
+++ b/tests/Backend/Integration/Sales/Model/QuoteAddressShippingRateTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * A rate refresh (removeAllShippingRates() + requestShippingRates()) marks the
+ * DB-loaded rates deleted and appends fresh ones under the same codes.
+ * getShippingRateByCode() used to return the first code match, the deleted
+ * stale rate, which made the place-order gate reject every method whose rates
+ * were persisted by an earlier request.
+ */
+function quoteAddressRate(string $carrier, string $method): Mage_Sales_Model_Quote_Address_Rate
+{
+    /** @var Mage_Sales_Model_Quote_Address_Rate $rate */
+    $rate = Mage::getModel('sales/quote_address_rate');
+    $rate->setCode($carrier . '_' . $method)
+        ->setCarrier($carrier)
+        ->setMethod($method)
+        ->setPrice(5.0);
+    return $rate;
+}
+
+describe('quote address shipping rate lookup', function (): void {
+
+    it('returns the fresh rate when a deleted rate shares its code', function (): void {
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+        $quote->save();
+
+        try {
+            $address = $quote->getShippingAddress();
+            $address->addShippingRate(quoteAddressRate('flatrate', 'flatrate'));
+            $address->removeAllShippingRates();
+            $fresh = quoteAddressRate('flatrate', 'flatrate');
+            $address->addShippingRate($fresh);
+
+            $rate = $address->getShippingRateByCode('flatrate_flatrate');
+            expect($rate)->toBe($fresh)
+                ->and($rate->isDeleted())->toBeFalse();
+        } finally {
+            $quote->delete();
+        }
+    });
+
+    it('returns false when only deleted rates match', function (): void {
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+        $quote->save();
+
+        try {
+            $address = $quote->getShippingAddress();
+            $address->addShippingRate(quoteAddressRate('flatrate', 'flatrate'));
+            $address->removeAllShippingRates();
+
+            expect($address->getShippingRateByCode('flatrate_flatrate'))->toBeFalse();
+        } finally {
+            $quote->delete();
+        }
+    });
+
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -679,12 +679,13 @@ function dropCurrencyRates(string ...$currencies): void
 }
 
 /**
- * An enabled, visible simple product priced at default scope and assigned to website 1 and the
- * given one; $data adds or overrides attributes before the save.
+ * An enabled, visible simple product priced at default scope and assigned to website 1 (plus the
+ * given one, when passed); $data adds or overrides attributes before the save (e.g. stock_data,
+ * group_price, tax_class_id).
  *
  * @param array<string, mixed> $data
  */
-function createPriceWebsiteProduct(string $skuPrefix, float $price, Mage_Core_Model_Website $website, array $data = []): Mage_Catalog_Model_Product
+function createPriceWebsiteProduct(string $skuPrefix, float $price, ?Mage_Core_Model_Website $website = null, array $data = []): Mage_Catalog_Model_Product
 {
     /** @var Mage_Catalog_Model_Product $product */
     $product = Mage::getModel('catalog/product');
@@ -697,7 +698,7 @@ function createPriceWebsiteProduct(string $skuPrefix, float $price, Mage_Core_Mo
         ->setVisibility(Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH)
         ->setTypeId(Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)
         ->setAttributeSetId(4)
-        ->setWebsiteIds([1, (int) $website->getId()])
+        ->setWebsiteIds($website ? [1, (int) $website->getId()] : [1])
         ->save();
 
     return $product;


### PR DESCRIPTION
Fixes #1337.

`CartService::addItem()` and `collectAndVerifyTotals()`, plus the admin GraphQL `availableShippingMethods` handler, switched the app to the quote's store and never switched back. An admin-scoped request (`X-Store-Code: admin`) then reached order placement in storefront scope, so payment methods that key MOTO handling off `Mage::app()->getStore()->isAdmin()` sent phone orders as storefront 3DS sales.

The switches now run inside `CartService::inQuoteStoreScope()`, which restores the previous store in a `finally` block. Order placement keeps the admin caller's scope for MOTO, while any other caller places in the quote's store so store-scoped inventory config resolves against the order's own store.

On top of the scope fix, the branch restructures how cart totals are collected:

- Loaders never collect: `getCart()`/`resolveCartFromRequest()` just load. Mutations recollect through their service methods, and `CartMapper` collects at the read boundary when the quote's totals flag shows nothing collected in the request, so no call site threads a collect-on-load flag.
- REST and GraphQL cart write operations declare `read: false`; the processor resolves and verifies the cart itself, so the provider's discarded read pass (quote load, access check, DTO build) is skipped entirely.
- `placeOrder()` applies body addresses in-memory and collects once for addresses, shipping method and the payment gate, recollecting only when a payment method lands.
- Stale-totals gates fixed: payment-method availability (cart setter and place-order) now decides on freshly collected totals instead of persisted values, and the place-order shipping gate rejects a rate the refresh marked deleted, so a method the store no longer offers cannot place an order.
- `Quote::_afterLoad()` runs its `trigger_recollect` collection in the quote's own store scope, so the totals it persists (and the flag the read boundary trusts) are correct even when an admin-scoped request loads the quote.
- `mergeCarts()` pins the customer-cart lookup to the guest quote's store only for admin-scoped callers; a storefront login on another store view keeps its merged cart visible to later lookups.
- `applyCoupon()` collects and verifies the rule before persisting, so an invalid code never reaches the database and never clears a coupon already on the cart.
- The GraphQL `availableShippingMethods` handler reuses `CartMapper::getAvailableShippingMethods()` (extended with `available`/`errorMessage`), so REST and GraphQL share one rate mapping and currency conversion.
- The no-address shipping-methods branch sets `collect_shipping_rates` before collecting, so the endpoint returns fresh rates instead of stale persisted ones.
- Address sanitization caps street input per line in both the array and string paths, so copying a multi-line shipping street to billing no longer truncates it.
- The admin product GraphQL handlers (`searchProducts`, `getCategories`) route their store switch through `StoreContext::withStore()`, so the requested store no longer leaks past the query and the `StoreContext` mirror stays in sync with the app scope.

Regression tests cover `addItem()`, `getCart()`, `handleShippingMethods()`, the merge-cart store scope, customer-group repricing on assignment, and the totals-collection count per mutation.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->
