### PR TITLE
Delivered set-payment-method additionalData flat to payment methods and applied checkout applicability checks

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreateController.php
@@ -477,7 +477,8 @@ class Mage_Adminhtml_Sales_Order_CreateController extends Mage_Adminhtml_Control
             $this->_processActionData('save');
             $paymentData = $this->getRequest()->getPost('payment');
             if ($paymentData) {
-                $paymentData['checks'] = Mage_Payment_Model_Method_Abstract::CHECKS_INTERNAL;
+                // A client must not choose its own checks mask
+                unset($paymentData['checks']);
                 $this->_getOrderCreateModel()->setPaymentData($paymentData);
                 $this->_getOrderCreateModel()->getQuote()->getPayment()->addData($paymentData);
             }

--- a/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreateController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Sales/Order/CreateController.php
@@ -477,11 +477,7 @@ class Mage_Adminhtml_Sales_Order_CreateController extends Mage_Adminhtml_Control
             $this->_processActionData('save');
             $paymentData = $this->getRequest()->getPost('payment');
             if ($paymentData) {
-                $paymentData['checks'] = Mage_Payment_Model_Method_Abstract::CHECK_USE_INTERNAL
-                    | Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_COUNTRY
-                    | Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_CURRENCY
-                    | Mage_Payment_Model_Method_Abstract::CHECK_ORDER_TOTAL_MIN_MAX
-                    | Mage_Payment_Model_Method_Abstract::CHECK_ZERO_TOTAL;
+                $paymentData['checks'] = Mage_Payment_Model_Method_Abstract::CHECKS_INTERNAL;
                 $this->_getOrderCreateModel()->setPaymentData($paymentData);
                 $this->_getOrderCreateModel()->getQuote()->getPayment()->addData($paymentData);
             }

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -469,7 +469,9 @@ class CartMapper
 
             foreach ($availableMethods as $method) {
                 // Same checks setPaymentMethod() enforces, so the list never advertises a rejected method
-                if ($method->isApplicableToQuote($quote, \Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT)) {
+                if (CartService::isMethodUsableOverApi($method)
+                    && $method->isApplicableToQuote($quote, \Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT)
+                ) {
                     $methods[] = [
                         'code' => $method->getCode(),
                         'title' => $method->getTitle(),

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -467,10 +467,12 @@ class CartMapper
             $store = $quote->getStore();
             $availableMethods = \Mage::helper('payment')->getStoreMethods($store, $quote);
 
+            // Same scope-dependent checks the payment import enforces, so the
+            // list never advertises a method the setter or place-order would reject
+            $checks = \Mage_Payment_Model_Method_Abstract::checksForCurrentScope();
             foreach ($availableMethods as $method) {
-                // Same checks setPaymentMethod() enforces, so the list never advertises a rejected method
                 if (CartService::isMethodUsableOverApi($method)
-                    && $method->isApplicableToQuote($quote, \Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT)
+                    && $method->isApplicableToQuote($quote, $checks)
                 ) {
                     $methods[] = [
                         'code' => $method->getCode(),

--- a/app/code/core/Mage/Checkout/Api/CartMapper.php
+++ b/app/code/core/Mage/Checkout/Api/CartMapper.php
@@ -468,7 +468,8 @@ class CartMapper
             $availableMethods = \Mage::helper('payment')->getStoreMethods($store, $quote);
 
             foreach ($availableMethods as $method) {
-                if ($method->canUseForCountry($quote->getBillingAddress()->getCountry())) {
+                // Same checks setPaymentMethod() enforces, so the list never advertises a rejected method
+                if ($method->isApplicableToQuote($quote, \Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT)) {
                     $methods[] = [
                         'code' => $method->getCode(),
                         'title' => $method->getTitle(),

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -1020,29 +1020,33 @@ class CartService
      */
     public function setPaymentMethod(\Mage_Sales_Model_Quote $quote, string $methodCode, ?array $additionalData = null): \Mage_Sales_Model_Quote
     {
-        $paymentData = self::buildPaymentImportData(
-            $methodCode,
-            $additionalData,
-            \Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT,
-        );
+        // Resolve the checks in the caller's scope, before entering the quote's store scope
+        $checks = \Mage_Payment_Model_Method_Abstract::checksForCurrentScope();
 
-        return self::inQuoteStoreScope($quote, function () use ($quote, $methodCode, $paymentData): \Mage_Sales_Model_Quote {
+        return self::inQuoteStoreScope($quote, function () use ($quote, $methodCode, $additionalData, $checks): \Mage_Sales_Model_Quote {
             $this->assertPaymentMethodAvailable($quote, $methodCode);
 
             // Suppress importData()'s recollect; collectAndSave() below runs the real pass
             $quote->setTotalsCollectedFlag(true);
-            // Only a Mage_Core_Exception is the client's fault; anything else must surface as a 500
-            try {
-                $quote->getPayment()->importData($paymentData);
-            } catch (\Mage_Core_Exception $e) {
-                throw new BadRequestHttpException('Payment method is not available: ' . $e->getMessage());
-            }
-            self::backupPaymentAdditionalData($quote->getPayment(), $paymentData);
+            $this->importPaymentData($quote, $methodCode, $additionalData, $checks);
 
             $this->collectAndSave($quote);
 
             return $quote;
         });
+    }
+
+    /** Import sanitized client payment data onto the quote payment and keep the backup copy. */
+    public function importPaymentData(\Mage_Sales_Model_Quote $quote, string $methodCode, ?array $additionalData, int $checks): void
+    {
+        $paymentData = self::buildPaymentImportData($methodCode, $additionalData, $checks);
+        // Only a Mage_Core_Exception is the client's fault; anything else must surface as a 500
+        try {
+            $quote->getPayment()->importData($paymentData);
+        } catch (\Mage_Core_Exception $e) {
+            throw new BadRequestHttpException('Payment method is not available: ' . $e->getMessage());
+        }
+        self::backupPaymentAdditionalData($quote->getPayment(), $paymentData);
     }
 
     public static function buildPaymentImportData(string $methodCode, ?array $additionalData, int $checks): array
@@ -1057,11 +1061,14 @@ class CartService
         ]);
         $paymentData = ['method' => $methodCode];
         if ($additionalData) {
+            // Flat scalars only: cc_* would carry raw card data, and a non-scalar under a
+            // column-backed key (e.g. po_number) would corrupt the quote payment save
             $paymentData = array_merge(
                 array_filter(
                     array_diff_key($additionalData, $reservedKeys),
-                    fn(string $key): bool => !str_starts_with($key, 'cc_'),
-                    ARRAY_FILTER_USE_KEY,
+                    fn(mixed $value, string|int $key): bool => (is_scalar($value) || $value === null)
+                        && !str_starts_with((string) $key, 'cc_'),
+                    ARRAY_FILTER_USE_BOTH,
                 ),
                 $paymentData,
             );
@@ -1081,6 +1088,9 @@ class CartService
         $backup = array_diff_key($paymentImportData, array_flip(['method', 'checks']));
         if ($backup) {
             $payment->setAdditionalInformation(self::PAYMENT_ADDITIONAL_DATA_KEY, $backup);
+        } else {
+            // Clear a previous selection's backup so a method switch cannot carry it onto the order
+            $payment->unsAdditionalInformation(self::PAYMENT_ADDITIONAL_DATA_KEY);
         }
     }
 
@@ -1091,20 +1101,19 @@ class CartService
     }
 
     /**
-     * Gate a payment method on the store's active methods for this quote;
+     * Gate a payment method on availability for this quote;
      * importData()/setMethod() alone accept any configured code.
      */
     public function assertPaymentMethodAvailable(\Mage_Sales_Model_Quote $quote, string $methodCode): void
     {
-        $availableCodes = array_map(
-            fn($method) => $method->getCode(),
-            array_filter(
-                \Mage::helper('payment')->getStoreMethods($quote->getStoreId(), $quote),
-                self::isMethodUsableOverApi(...),
-            ),
-        );
+        $model = \Mage::helper('payment')->getPaymentMethods($quote->getStoreId())[$methodCode]['model'] ?? null;
+        $method = $model ? \Mage::getModel($model) : null;
+        if (!$method instanceof \Mage_Payment_Model_Method_Abstract || !self::isMethodUsableOverApi($method)) {
+            throw new BadRequestHttpException('Payment method is not available for this cart');
+        }
 
-        if (!in_array($methodCode, $availableCodes, true)) {
+        $method->setStore($quote->getStoreId());
+        if (!$method->isAvailable($quote)) {
             throw new BadRequestHttpException('Payment method is not available for this cart');
         }
     }

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -1017,25 +1017,16 @@ class CartService
      */
     public function setPaymentMethod(\Mage_Sales_Model_Quote $quote, string $methodCode, ?array $additionalData = null): \Mage_Sales_Model_Quote
     {
-        // assignData() reads flat keys; method/checks/additional_data are reserved
-        $paymentData = ['method' => $methodCode];
-        if ($additionalData) {
-            unset($additionalData['method'], $additionalData['checks'], $additionalData['additional_data']);
-            $paymentData = array_merge($additionalData, $paymentData);
-        }
-        $paymentData['checks'] = \Mage_Payment_Model_Method_Abstract::CHECK_USE_CHECKOUT
-            | \Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_COUNTRY
-            | \Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_CURRENCY
-            | \Mage_Payment_Model_Method_Abstract::CHECK_ORDER_TOTAL_MIN_MAX
-            | \Mage_Payment_Model_Method_Abstract::CHECK_ZERO_TOTAL;
+        $paymentData = self::buildPaymentImportData(
+            $methodCode,
+            $additionalData,
+            \Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT,
+        );
 
         return self::inQuoteStoreScope($quote, function () use ($quote, $methodCode, $paymentData): \Mage_Sales_Model_Quote {
-            // The gate judges on the persisted totals (current by invariant:
-            // every cart mutation recollects and saves), pre-fee by design
             $this->assertPaymentMethodAvailable($quote, $methodCode);
 
-            // Suppress importData()'s internal recollect; the one real pass
-            // runs in collectAndSave() below with the method set
+            // Suppress importData()'s recollect; collectAndSave() below runs the real pass
             $quote->setTotalsCollectedFlag(true);
             try {
                 $quote->getPayment()->importData($paymentData);
@@ -1050,12 +1041,36 @@ class CartService
     }
 
     /**
-     * Gate a payment method on the store's active methods for this quote.
-     * importData()/setMethod() alone accept any configured code, and this gate
-     * only runs each method's isAvailable() (active flag plus the
-     * payment_method_is_active event); min/max totals, country, and currency
-     * are enforced by the checks bitmask setPaymentMethod() passes to
-     * importData(), so callers that bypass importData() get no such checks.
+     * Build the payload for Mage_Sales_Model_Quote_Payment::importData()
+     * from client-supplied additional data.
+     */
+    public static function buildPaymentImportData(string $methodCode, ?array $additionalData, int $checks): array
+    {
+        // assignData() sprays these flat keys onto the quote payment, so keep
+        // client input away from identity, structural, and card columns
+        $reservedKeys = array_flip([
+            'method', 'checks', 'additional_data', 'additional_information', 'method_instance',
+            'payment_id', 'quote_id', 'parent_id', 'created_at', 'updated_at',
+        ]);
+        $paymentData = ['method' => $methodCode];
+        if ($additionalData) {
+            $paymentData = array_merge(
+                array_filter(
+                    array_diff_key($additionalData, $reservedKeys),
+                    fn(string $key): bool => !str_starts_with($key, 'cc_'),
+                    ARRAY_FILTER_USE_KEY,
+                ),
+                $paymentData,
+            );
+        }
+        $paymentData['checks'] = $checks;
+
+        return $paymentData;
+    }
+
+    /**
+     * Gate a payment method on the store's active methods for this quote;
+     * importData()/setMethod() alone accept any configured code.
      */
     public function assertPaymentMethodAvailable(\Mage_Sales_Model_Quote $quote, string $methodCode): void
     {

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -1017,10 +1017,17 @@ class CartService
      */
     public function setPaymentMethod(\Mage_Sales_Model_Quote $quote, string $methodCode, ?array $additionalData = null): \Mage_Sales_Model_Quote
     {
+        // assignData() reads flat keys; method/checks/additional_data are reserved
         $paymentData = ['method' => $methodCode];
         if ($additionalData) {
-            $paymentData['additional_data'] = $additionalData;
+            unset($additionalData['method'], $additionalData['checks'], $additionalData['additional_data']);
+            $paymentData = array_merge($additionalData, $paymentData);
         }
+        $paymentData['checks'] = \Mage_Payment_Model_Method_Abstract::CHECK_USE_CHECKOUT
+            | \Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_COUNTRY
+            | \Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_CURRENCY
+            | \Mage_Payment_Model_Method_Abstract::CHECK_ORDER_TOTAL_MIN_MAX
+            | \Mage_Payment_Model_Method_Abstract::CHECK_ZERO_TOTAL;
 
         return self::inQuoteStoreScope($quote, function () use ($quote, $methodCode, $paymentData): \Mage_Sales_Model_Quote {
             // The gate judges on the persisted totals (current by invariant:
@@ -1044,10 +1051,11 @@ class CartService
 
     /**
      * Gate a payment method on the store's active methods for this quote.
-     * importData()/setMethod() alone accept any configured code, and neither
-     * this gate nor importData() checks min/max totals, country, or currency:
-     * getStoreMethods() only runs each method's isAvailable() (active flag plus
-     * the payment_method_is_active event).
+     * importData()/setMethod() alone accept any configured code, and this gate
+     * only runs each method's isAvailable() (active flag plus the
+     * payment_method_is_active event); min/max totals, country, and currency
+     * are enforced by the checks bitmask setPaymentMethod() passes to
+     * importData(), so callers that bypass importData() get no such checks.
      */
     public function assertPaymentMethodAvailable(\Mage_Sales_Model_Quote $quote, string $methodCode): void
     {

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -1031,10 +1031,7 @@ class CartService
 
             // Suppress importData()'s recollect; collectAndSave() below runs the real pass
             $quote->setTotalsCollectedFlag(true);
-            // Only a rejected method is the client's fault. Anything else (a
-            // database error, an observer on payment_import_data_before) is a
-            // server fault and must not be reported as a 400 carrying an
-            // internal message.
+            // Only a Mage_Core_Exception is the client's fault; anything else must surface as a 500
             try {
                 $quote->getPayment()->importData($paymentData);
             } catch (\Mage_Core_Exception $e) {
@@ -1048,17 +1045,11 @@ class CartService
         });
     }
 
-    /**
-     * Build the payload for Mage_Sales_Model_Quote_Payment::importData()
-     * from client-supplied additional data.
-     */
     public static function buildPaymentImportData(string $methodCode, ?array $additionalData, int $checks): array
     {
-        // assignData() sprays these flat keys onto the quote payment, so keep
-        // client input away from identity, structural, and card columns.
-        // The paypal_* ids assert "this cart is already paid": the storefront
-        // controller only accepts one after _assertPaypalOrderMatchesQuote()
-        // and _assertPaypalOrderNotAlreadyUsed(), and this path runs neither.
+        // assignData() puts these flat keys straight onto the quote payment. The paypal_*
+        // ids assert "already paid", and the storefront accepts one only after its replay
+        // checks (_assertPaypalOrderMatchesQuote), which this path never runs.
         $reservedKeys = array_flip([
             'method', 'checks', 'additional_data', 'additional_information', 'method_instance',
             'payment_id', 'quote_id', 'parent_id', 'created_at', 'updated_at',
@@ -1081,11 +1072,9 @@ class CartService
     }
 
     /**
-     * Keep a verbatim copy of the accepted client payment data under one
-     * namespaced key. importData() delivers the keys flat, so a method keeps
-     * only the ones it maps to a column of its own and the rest is lost at save
-     * time. The copy is nested, so it cannot reach a method's assignData() nor
-     * match a top-level additional_information lookup.
+     * Keep the accepted client data, which importData() delivers flat and the save then drops
+     * unless the method owns a column for it. Nesting keeps it away from assignData() and from
+     * any top-level additional_information lookup.
      */
     public static function backupPaymentAdditionalData(\Mage_Sales_Model_Quote_Payment $payment, array $paymentImportData): void
     {
@@ -1095,11 +1084,7 @@ class CartService
         }
     }
 
-    /**
-     * Whether the API can carry this method at all. buildPaymentImportData()
-     * strips every cc_* key, so a card method reaches validate() with no card
-     * and always throws. Such a method must not be advertised either.
-     */
+    /** buildPaymentImportData() strips every cc_* key, so a card method always fails validate(). */
     public static function isMethodUsableOverApi(\Mage_Payment_Model_Method_Abstract $method): bool
     {
         return !$method instanceof \Mage_Payment_Model_Method_Cc;

--- a/app/code/core/Mage/Checkout/Api/CartService.php
+++ b/app/code/core/Mage/Checkout/Api/CartService.php
@@ -25,6 +25,9 @@ class CartService
     /** The shape of a masked cart id, bare of delimiters so a route requirement can reuse it. */
     public const MASKED_ID_PATTERN = '[a-f0-9]{32}';
 
+    /** additional_information key that holds the client payment data the API accepted. */
+    public const PAYMENT_ADDITIONAL_DATA_KEY = 'api_additional_data';
+
     public static function isValidMaskedId(mixed $maskedId): bool
     {
         return is_string($maskedId) && preg_match('/^' . self::MASKED_ID_PATTERN . '$/i', $maskedId) === 1;
@@ -1028,11 +1031,16 @@ class CartService
 
             // Suppress importData()'s recollect; collectAndSave() below runs the real pass
             $quote->setTotalsCollectedFlag(true);
+            // Only a rejected method is the client's fault. Anything else (a
+            // database error, an observer on payment_import_data_before) is a
+            // server fault and must not be reported as a 400 carrying an
+            // internal message.
             try {
                 $quote->getPayment()->importData($paymentData);
-            } catch (\Exception $e) {
+            } catch (\Mage_Core_Exception $e) {
                 throw new BadRequestHttpException('Payment method is not available: ' . $e->getMessage());
             }
+            self::backupPaymentAdditionalData($quote->getPayment(), $paymentData);
 
             $this->collectAndSave($quote);
 
@@ -1047,10 +1055,14 @@ class CartService
     public static function buildPaymentImportData(string $methodCode, ?array $additionalData, int $checks): array
     {
         // assignData() sprays these flat keys onto the quote payment, so keep
-        // client input away from identity, structural, and card columns
+        // client input away from identity, structural, and card columns.
+        // The paypal_* ids assert "this cart is already paid": the storefront
+        // controller only accepts one after _assertPaypalOrderMatchesQuote()
+        // and _assertPaypalOrderNotAlreadyUsed(), and this path runs neither.
         $reservedKeys = array_flip([
             'method', 'checks', 'additional_data', 'additional_information', 'method_instance',
             'payment_id', 'quote_id', 'parent_id', 'created_at', 'updated_at',
+            'paypal_order_id', 'paypal_authorization_id', 'paypal_capture_id',
         ]);
         $paymentData = ['method' => $methodCode];
         if ($additionalData) {
@@ -1069,6 +1081,31 @@ class CartService
     }
 
     /**
+     * Keep a verbatim copy of the accepted client payment data under one
+     * namespaced key. importData() delivers the keys flat, so a method keeps
+     * only the ones it maps to a column of its own and the rest is lost at save
+     * time. The copy is nested, so it cannot reach a method's assignData() nor
+     * match a top-level additional_information lookup.
+     */
+    public static function backupPaymentAdditionalData(\Mage_Sales_Model_Quote_Payment $payment, array $paymentImportData): void
+    {
+        $backup = array_diff_key($paymentImportData, array_flip(['method', 'checks']));
+        if ($backup) {
+            $payment->setAdditionalInformation(self::PAYMENT_ADDITIONAL_DATA_KEY, $backup);
+        }
+    }
+
+    /**
+     * Whether the API can carry this method at all. buildPaymentImportData()
+     * strips every cc_* key, so a card method reaches validate() with no card
+     * and always throws. Such a method must not be advertised either.
+     */
+    public static function isMethodUsableOverApi(\Mage_Payment_Model_Method_Abstract $method): bool
+    {
+        return !$method instanceof \Mage_Payment_Model_Method_Cc;
+    }
+
+    /**
      * Gate a payment method on the store's active methods for this quote;
      * importData()/setMethod() alone accept any configured code.
      */
@@ -1076,7 +1113,10 @@ class CartService
     {
         $availableCodes = array_map(
             fn($method) => $method->getCode(),
-            \Mage::helper('payment')->getStoreMethods($quote->getStoreId(), $quote),
+            array_filter(
+                \Mage::helper('payment')->getStoreMethods($quote->getStoreId(), $quote),
+                self::isMethodUsableOverApi(...),
+            ),
         );
 
         if (!in_array($methodCode, $availableCodes, true)) {

--- a/app/code/core/Mage/Checkout/Model/Cart/Payment/Api.php
+++ b/app/code/core/Mage/Checkout/Model/Cart/Payment/Api.php
@@ -177,6 +177,9 @@ class Mage_Checkout_Model_Cart_Payment_Api extends Mage_Checkout_Model_Api_Resou
             }
         }
 
+        // The gate above already validated; 0 also blocks a client-passed mask
+        $paymentData['checks'] = 0;
+
         try {
             $payment = $quote->getPayment();
             $payment->importData($paymentData);

--- a/app/code/core/Mage/Checkout/Model/Type/Onepage.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Onepage.php
@@ -511,7 +511,8 @@ class Mage_Checkout_Model_Type_Onepage
             $quote->getShippingAddress()->setCollectShippingRates(true);
         }
 
-        $data['checks'] = Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT;
+        // A client must not choose its own checks mask
+        unset($data['checks']);
 
         $payment = $quote->getPayment();
         $payment->importData($data);

--- a/app/code/core/Mage/Checkout/Model/Type/Onepage.php
+++ b/app/code/core/Mage/Checkout/Model/Type/Onepage.php
@@ -511,11 +511,7 @@ class Mage_Checkout_Model_Type_Onepage
             $quote->getShippingAddress()->setCollectShippingRates(true);
         }
 
-        $data['checks'] = Mage_Payment_Model_Method_Abstract::CHECK_USE_CHECKOUT
-            | Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_COUNTRY
-            | Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_CURRENCY
-            | Mage_Payment_Model_Method_Abstract::CHECK_ORDER_TOTAL_MIN_MAX
-            | Mage_Payment_Model_Method_Abstract::CHECK_ZERO_TOTAL;
+        $data['checks'] = Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT;
 
         $payment = $quote->getPayment();
         $payment->importData($data);

--- a/app/code/core/Mage/Checkout/controllers/OnepageController.php
+++ b/app/code/core/Mage/Checkout/controllers/OnepageController.php
@@ -674,7 +674,8 @@ class Mage_Checkout_OnepageController extends Mage_Checkout_Controller_Action
 
                 $data = $this->getRequest()->getPost('payment', []);
                 if ($data) {
-                    $data['checks'] = Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT;
+                    // A client must not choose its own checks mask
+                    unset($data['checks']);
                     $this->getOnepage()->getQuote()->getPayment()->importData($data);
                 }
 

--- a/app/code/core/Mage/Checkout/controllers/OnepageController.php
+++ b/app/code/core/Mage/Checkout/controllers/OnepageController.php
@@ -674,11 +674,7 @@ class Mage_Checkout_OnepageController extends Mage_Checkout_Controller_Action
 
                 $data = $this->getRequest()->getPost('payment', []);
                 if ($data) {
-                    $data['checks'] = Mage_Payment_Model_Method_Abstract::CHECK_USE_CHECKOUT
-                        | Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_COUNTRY
-                        | Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_CURRENCY
-                        | Mage_Payment_Model_Method_Abstract::CHECK_ORDER_TOTAL_MIN_MAX
-                        | Mage_Payment_Model_Method_Abstract::CHECK_ZERO_TOTAL;
+                    $data['checks'] = Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT;
                     $this->getOnepage()->getQuote()->getPayment()->importData($data);
                 }
 

--- a/app/code/core/Mage/Payment/Model/Method/Abstract.php
+++ b/app/code/core/Mage/Payment/Model/Method/Abstract.php
@@ -47,6 +47,20 @@ abstract class Mage_Payment_Model_Method_Abstract extends \Maho\DataObject
     public const CHECK_RECURRING_PROFILES    = 64;
     public const CHECK_ZERO_TOTAL            = 128;
 
+    /** Standard applicability checks for storefront checkout flows */
+    public const CHECKS_CHECKOUT = self::CHECK_USE_CHECKOUT
+        | self::CHECK_USE_FOR_COUNTRY
+        | self::CHECK_USE_FOR_CURRENCY
+        | self::CHECK_ORDER_TOTAL_MIN_MAX
+        | self::CHECK_ZERO_TOTAL;
+
+    /** Standard applicability checks for admin order creation */
+    public const CHECKS_INTERNAL = self::CHECK_USE_INTERNAL
+        | self::CHECK_USE_FOR_COUNTRY
+        | self::CHECK_USE_FOR_CURRENCY
+        | self::CHECK_ORDER_TOTAL_MIN_MAX
+        | self::CHECK_ZERO_TOTAL;
+
     /**
      * @var string
      */

--- a/app/code/core/Mage/Payment/Model/Method/Abstract.php
+++ b/app/code/core/Mage/Payment/Model/Method/Abstract.php
@@ -61,6 +61,12 @@ abstract class Mage_Payment_Model_Method_Abstract extends \Maho\DataObject
         | self::CHECK_ORDER_TOTAL_MIN_MAX
         | self::CHECK_ZERO_TOTAL;
 
+    /** Applicability checks for the current store scope: admin (store 0) is a backend/MOTO flow. */
+    public static function checksForCurrentScope(): int
+    {
+        return Mage::app()->getStore()->isAdmin() ? self::CHECKS_INTERNAL : self::CHECKS_CHECKOUT;
+    }
+
     /**
      * @var string
      */

--- a/app/code/core/Mage/Sales/Api/OrderProcessor.php
+++ b/app/code/core/Mage/Sales/Api/OrderProcessor.php
@@ -203,20 +203,13 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         if ($paymentMethod) {
             $this->cartService->assertPaymentMethodAvailable($quote, $paymentMethod);
 
-            $paymentData = CartService::buildPaymentImportData(
+            // Caller-scope read; must stay outside the store-scope switch below
+            $this->cartService->importPaymentData(
+                $quote,
                 $paymentMethod,
                 (isset($args['paymentData']) && is_array($args['paymentData'])) ? $args['paymentData'] : null,
-                $isAdminOrder
-                    ? \Mage_Payment_Model_Method_Abstract::CHECKS_INTERNAL
-                    : \Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT,
+                \Mage_Payment_Model_Method_Abstract::checksForCurrentScope(),
             );
-            // Only a Mage_Core_Exception is the client's fault; anything else must surface as a 500
-            try {
-                $quote->getPayment()->importData($paymentData);
-            } catch (\Mage_Core_Exception $e) {
-                throw new BadRequestHttpException('Payment method is not available: ' . $e->getMessage());
-            }
-            CartService::backupPaymentAdditionalData($quote->getPayment(), $paymentData);
 
             // Recollect so payment-dependent totals (e.g. payment fees) land on
             // the order; the consumed rates flag keeps the validated rates.

--- a/app/code/core/Mage/Sales/Api/OrderProcessor.php
+++ b/app/code/core/Mage/Sales/Api/OrderProcessor.php
@@ -97,10 +97,8 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
      * (cartId / maskedId) OR from the URI (e.g. /guest-carts/{id}/place-order).
      * Also applies shipping/billing address, customer email, and payment data
      * from the request body, frontend callers send the full checkout state in
-     * one shot rather than pre-mutating the cart. paymentData is delivered flat
-     * to the method's assignData(), and a verbatim copy is kept under the
-     * additional_information key CartService::PAYMENT_ADDITIONAL_DATA_KEY, so a
-     * key the method does not map to a column of its own still reaches the order.
+     * one shot rather than pre-mutating the cart. paymentData reaches assignData() flat, with
+     * a copy under CartService::PAYMENT_ADDITIONAL_DATA_KEY so no key is lost at save time.
      */
     private function placeOrder(array $context, array $uriVariables = []): Order
     {
@@ -139,11 +137,8 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         $employeeId = ($isPrivileged && isset($args['employeeId'])) ? (int) $args['employeeId'] : null;
         $paymentMethod = $args['paymentMethod'] ?? null;
         $shippingMethod = $args['shippingMethod'] ?? null;
-        // Scope, not authorization, decides the payment checks below and the
-        // placement branch further down: a caller that asked for the admin
-        // scope (store 0) is placing a backend order, so internal-only methods
-        // apply. A service token that names a real store is a storefront flow,
-        // even when it holds orders/create.
+        // Scope, not authorization: a caller in the admin scope (store 0) places a backend
+        // order, while a service token naming a real store is a storefront flow.
         $isAdminOrder = \Mage::app()->getStore()->isAdmin();
 
         $quote = $this->cartService->getCart(
@@ -215,10 +210,7 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
                     ? \Mage_Payment_Model_Method_Abstract::CHECKS_INTERNAL
                     : \Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT,
             );
-            // Only a rejected method is the client's fault. Anything else (a
-            // database error, an observer on payment_import_data_before) is a
-            // server fault and must not be reported as a 400 carrying an
-            // internal message.
+            // Only a Mage_Core_Exception is the client's fault; anything else must surface as a 500
             try {
                 $quote->getPayment()->importData($paymentData);
             } catch (\Mage_Core_Exception $e) {

--- a/app/code/core/Mage/Sales/Api/OrderProcessor.php
+++ b/app/code/core/Mage/Sales/Api/OrderProcessor.php
@@ -199,12 +199,17 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         if ($paymentMethod) {
             $this->cartService->assertPaymentMethodAvailable($quote, $paymentMethod);
 
-            $payment = $quote->getPayment();
-            $payment->setMethod($paymentMethod);
-            if (isset($args['paymentData']) && is_array($args['paymentData'])) {
-                foreach ($args['paymentData'] as $key => $value) {
-                    $payment->setAdditionalInformation((string) $key, $value);
-                }
+            $paymentData = CartService::buildPaymentImportData(
+                $paymentMethod,
+                (isset($args['paymentData']) && is_array($args['paymentData'])) ? $args['paymentData'] : null,
+                $isPrivileged
+                    ? \Mage_Payment_Model_Method_Abstract::CHECKS_INTERNAL
+                    : \Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT,
+            );
+            try {
+                $quote->getPayment()->importData($paymentData);
+            } catch (\Exception $e) {
+                throw new BadRequestHttpException('Payment method is not available: ' . $e->getMessage());
             }
 
             // Recollect so payment-dependent totals (e.g. payment fees) land on

--- a/app/code/core/Mage/Sales/Api/OrderProcessor.php
+++ b/app/code/core/Mage/Sales/Api/OrderProcessor.php
@@ -95,9 +95,12 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
     /**
      * Place order from cart. Accepts the cart identifier from the request body
      * (cartId / maskedId) OR from the URI (e.g. /guest-carts/{id}/place-order).
-     * Also applies shipping/billing address, customer email, and payment-method
-     * additionalInformation from the request body, frontend callers send the
-     * full checkout state in one shot rather than pre-mutating the cart.
+     * Also applies shipping/billing address, customer email, and payment data
+     * from the request body, frontend callers send the full checkout state in
+     * one shot rather than pre-mutating the cart. paymentData is delivered flat
+     * to the method's assignData(), and a verbatim copy is kept under the
+     * additional_information key CartService::PAYMENT_ADDITIONAL_DATA_KEY, so a
+     * key the method does not map to a column of its own still reaches the order.
      */
     private function placeOrder(array $context, array $uriVariables = []): Order
     {
@@ -136,6 +139,12 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         $employeeId = ($isPrivileged && isset($args['employeeId'])) ? (int) $args['employeeId'] : null;
         $paymentMethod = $args['paymentMethod'] ?? null;
         $shippingMethod = $args['shippingMethod'] ?? null;
+        // Scope, not authorization, decides the payment checks below and the
+        // placement branch further down: a caller that asked for the admin
+        // scope (store 0) is placing a backend order, so internal-only methods
+        // apply. A service token that names a real store is a storefront flow,
+        // even when it holds orders/create.
+        $isAdminOrder = \Mage::app()->getStore()->isAdmin();
 
         $quote = $this->cartService->getCart(
             $cartId ? (int) $cartId : null,
@@ -202,15 +211,20 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
             $paymentData = CartService::buildPaymentImportData(
                 $paymentMethod,
                 (isset($args['paymentData']) && is_array($args['paymentData'])) ? $args['paymentData'] : null,
-                $isPrivileged
+                $isAdminOrder
                     ? \Mage_Payment_Model_Method_Abstract::CHECKS_INTERNAL
                     : \Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT,
             );
+            // Only a rejected method is the client's fault. Anything else (a
+            // database error, an observer on payment_import_data_before) is a
+            // server fault and must not be reported as a 400 carrying an
+            // internal message.
             try {
                 $quote->getPayment()->importData($paymentData);
-            } catch (\Exception $e) {
+            } catch (\Mage_Core_Exception $e) {
                 throw new BadRequestHttpException('Payment method is not available: ' . $e->getMessage());
             }
+            CartService::backupPaymentAdditionalData($quote->getPayment(), $paymentData);
 
             // Recollect so payment-dependent totals (e.g. payment fees) land on
             // the order; the consumed rates flag keeps the validated rates.
@@ -242,7 +256,7 @@ final class OrderProcessor extends \Maho\ApiPlatform\Processor
         // store scope, so store-scoped inventory config (can_subtract,
         // backorders) and save observers resolve against the order's own store
         // even when the caller's X-Store-Code names a different one.
-        $result = \Mage::app()->getStore()->isAdmin()
+        $result = $isAdminOrder
             ? $placeOrder()
             : CartService::inQuoteStoreScope($quote, $placeOrder);
 

--- a/app/code/core/Mage/Sales/Model/Quote/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Quote/Payment.php
@@ -140,8 +140,10 @@ class Mage_Sales_Model_Quote_Payment extends Mage_Payment_Model_Info
          */
         $this->getQuote()->collectTotals();
 
+        // Fail closed: a caller that passes no checks gets the full set for its scope
+        $checks = $data->getChecks() ?? Mage_Payment_Model_Method_Abstract::checksForCurrentScope();
         if (!$method->isAvailable($this->getQuote())
-            || !$method->isApplicableToQuote($this->getQuote(), $data->getChecks())
+            || !$method->isApplicableToQuote($this->getQuote(), $checks)
         ) {
             Mage::throwException(Mage::helper('sales')->__('The requested Payment Method is not available.'));
         }

--- a/app/code/core/Maho/Paypal/Model/Method/Vault.php
+++ b/app/code/core/Maho/Paypal/Model/Method/Vault.php
@@ -139,10 +139,15 @@ class Maho_Paypal_Model_Method_Vault extends Maho_Paypal_Model_Method_Abstract
             /** @var Maho_Paypal_Model_Vault_Token $token */
             $token = Mage::getModel('paypal/vault_token')->load($vaultTokenId);
 
-            $customerId = (int) (Mage::getSingleton('customer/session')->getCustomerId()
-                ?: Mage::getSingleton('adminhtml/session_quote')->getCustomerId());
+            // Quote customer first: stateless API flows have no session
+            $quoteCustomerId = $info instanceof Mage_Sales_Model_Quote_Payment
+                ? (int) $info->getQuote()->getCustomerId()
+                : 0;
+            $customerId = $quoteCustomerId
+                ?: (int) (Mage::getSingleton('customer/session')->getCustomerId()
+                    ?: Mage::getSingleton('adminhtml/session_quote')->getCustomerId());
 
-            if ($token->getId() && (int) $token->getCustomerId() === $customerId) {
+            if ($customerId && $token->getId() && (int) $token->getCustomerId() === $customerId) {
                 $info->setAdditionalInformation('vault_token_id', $vaultTokenId);
                 $info->setAdditionalInformation('vault_label', $token->getDisplayLabel());
             }

--- a/tests/Api/V2/Write/CartCheckoutSettersTest.php
+++ b/tests/Api/V2/Write/CartCheckoutSettersTest.php
@@ -138,6 +138,26 @@ describe('guest cart step-wise checkout setters', function (): void {
         expect($response['json']['selectedPaymentMethod']['code'])->toBe('cashondelivery');
     });
 
+    it('selects a payment method with additionalData', function (): void {
+        [$maskedId] = makeGuestSetterCart();
+
+        apiPut("/api/rest/v2/guest-carts/{$maskedId}/shipping-address", checkoutSetterAddress());
+
+        $cart = apiGet("/api/rest/v2/guest-carts/{$maskedId}");
+        $available = array_column($cart['json']['availablePaymentMethods'] ?? [], 'code');
+        if (!in_array('cashondelivery', $available, true)) {
+            $this->markTestSkipped('cashondelivery is not available in this store');
+        }
+
+        $response = apiPut("/api/rest/v2/guest-carts/{$maskedId}/payment-method", [
+            'methodCode' => 'cashondelivery',
+            'additionalData' => ['note' => 'issue-1335'],
+        ]);
+
+        expect($response['status'])->toBe(200);
+        expect($response['json']['selectedPaymentMethod']['code'])->toBe('cashondelivery');
+    });
+
     it('rejects an unavailable shipping method with a 400', function (): void {
         [$maskedId] = makeGuestSetterCart();
 

--- a/tests/Backend/Integration/Checkout/Api/CartPaymentAdditionalDataTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartPaymentAdditionalDataTest.php
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Mage\Checkout\Api\CartMapper;
 use Mage\Checkout\Api\CartService;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
@@ -27,7 +28,7 @@ function withStoreConfig(string $path, string $value, Closure $callback): void
     try {
         $callback();
     } finally {
-        $store->setConfig($path, (string) $previous);
+        $store->setConfig($path, $previous);
     }
 }
 
@@ -60,10 +61,12 @@ describe('set-payment-method additionalData', function (): void {
                 'method' => 'purchaseorder',
                 'checks' => 0,
                 'additional_data' => ['x' => 'y'],
+                'cc_number' => '4111111111111111',
             ]);
 
             expect($loaded->getPayment()->getMethod())->toBe('checkmo')
-                ->and($loaded->getPayment()->getData('additional_data'))->not->toBeArray();
+                ->and($loaded->getPayment()->getData('additional_data'))->not->toBeArray()
+                ->and($loaded->getPayment()->getData('cc_number'))->toBeNull();
         } finally {
             $quote->delete();
         }
@@ -79,6 +82,22 @@ describe('set-payment-method additionalData', function (): void {
 
                 expect(fn() => (new CartService())->setPaymentMethod($loaded, 'checkmo'))
                     ->toThrow(BadRequestHttpException::class);
+            });
+        } finally {
+            $quote->delete();
+        }
+    });
+
+    it('does not advertise a method the setter would reject', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+
+        try {
+            withStoreConfig('payment/checkmo/min_order_total', '999999', function () use ($quote): void {
+                $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+                $codes = array_column((new CartMapper())->getAvailablePaymentMethods($loaded), 'code');
+
+                expect($codes)->not->toContain('checkmo');
             });
         } finally {
             $quote->delete();

--- a/tests/Backend/Integration/Checkout/Api/CartPaymentAdditionalDataTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartPaymentAdditionalDataTest.php
@@ -17,41 +17,28 @@ uses(Tests\MahoBackendTestCase::class);
  * Issue #1335: additionalData on the set-payment-method API must reach payment
  * methods as top-level keys, because assignData() reads flat keys (as the
  * onepage and SOAP flows deliver them), not an M2-style additional_data array.
+ *
+ * Config changes need no restore: MahoBackendTestCase::tearDown() runs Mage::reset().
  */
-
-/** Set a store-1 config value for one call and restore the previous value. */
-function withStoreConfig(string $path, string $value, Closure $callback): void
-{
-    $store = Mage::app()->getStore(1);
-    $previous = $store->getConfig($path);
-    $store->setConfig($path, $value);
-    try {
-        $callback();
-    } finally {
-        $store->setConfig($path, $previous);
-    }
-}
-
 describe('set-payment-method additionalData', function (): void {
 
     it('delivers additionalData to the payment method as top-level keys', function (): void {
         $product = loadSimplePricedProduct();
         $quote = createPricedQuote($product);
+        Mage::app()->getStore(1)->setConfig('payment/purchaseorder/active', '1');
 
         try {
-            withStoreConfig('payment/purchaseorder/active', '1', function () use ($quote): void {
-                $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
-                (new CartService())->setPaymentMethod($loaded, 'purchaseorder', ['po_number' => 'PO-1335']);
+            $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+            (new CartService())->setPaymentMethod($loaded, 'purchaseorder', ['po_number' => 'PO-1335']);
 
-                expect($loaded->getPayment()->getMethod())->toBe('purchaseorder')
-                    ->and($loaded->getPayment()->getPoNumber())->toBe('PO-1335');
-            });
+            expect($loaded->getPayment()->getMethod())->toBe('purchaseorder')
+                ->and($loaded->getPayment()->getPoNumber())->toBe('PO-1335');
         } finally {
             $quote->delete();
         }
     });
 
-    it('strips reserved keys from additionalData', function (): void {
+    it('strips reserved keys and non-scalar values from additionalData', function (): void {
         $built = CartService::buildPaymentImportData('checkmo', [
             'method' => 'purchaseorder',
             'checks' => 0,
@@ -65,6 +52,7 @@ describe('set-payment-method additionalData', function (): void {
             'paypal_order_id' => 'REPLAYED',
             'paypal_authorization_id' => 'REPLAYED',
             'paypal_capture_id' => 'REPLAYED',
+            'po_comment' => ['x'],
             'po_number' => 'PO-1335',
         ], Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT);
 
@@ -78,22 +66,39 @@ describe('set-payment-method additionalData', function (): void {
     it('keeps a copy of the accepted additionalData on the payment', function (): void {
         $product = loadSimplePricedProduct();
         $quote = createPricedQuote($product);
+        Mage::app()->getStore(1)->setConfig('payment/purchaseorder/active', '1');
 
         try {
-            withStoreConfig('payment/purchaseorder/active', '1', function () use ($quote): void {
-                $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
-                // txn_ref has no column of its own, so the flat delivery alone
-                // would drop it at save time.
-                (new CartService())->setPaymentMethod($loaded, 'purchaseorder', [
-                    'po_number' => 'PO-1335',
-                    'txn_ref' => 'TXN-42',
-                    'cc_number' => '4111111111111111',
-                ]);
+            $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+            // txn_ref has no column of its own, so the flat delivery alone
+            // would drop it at save time.
+            (new CartService())->setPaymentMethod($loaded, 'purchaseorder', [
+                'po_number' => 'PO-1335',
+                'txn_ref' => 'TXN-42',
+                'cc_number' => '4111111111111111',
+            ]);
 
-                $backup = $loaded->getPayment()->getAdditionalInformation(CartService::PAYMENT_ADDITIONAL_DATA_KEY);
+            $backup = $loaded->getPayment()->getAdditionalInformation(CartService::PAYMENT_ADDITIONAL_DATA_KEY);
 
-                expect($backup)->toBe(['po_number' => 'PO-1335', 'txn_ref' => 'TXN-42']);
-            });
+            expect($backup)->toBe(['po_number' => 'PO-1335', 'txn_ref' => 'TXN-42']);
+        } finally {
+            $quote->delete();
+        }
+    });
+
+    it('clears the copy when the client switches to a method without additionalData', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+        Mage::app()->getStore(1)->setConfig('payment/purchaseorder/active', '1');
+
+        try {
+            $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+            $service = new CartService();
+            $service->setPaymentMethod($loaded, 'purchaseorder', ['po_number' => 'PO-1335']);
+            $service->setPaymentMethod($loaded, 'checkmo');
+
+            expect($loaded->getPayment()->getAdditionalInformation(CartService::PAYMENT_ADDITIONAL_DATA_KEY))
+                ->toBeNull();
         } finally {
             $quote->delete();
         }
@@ -102,17 +107,16 @@ describe('set-payment-method additionalData', function (): void {
     it('rejects a method whose minimum order total exceeds the quote total', function (): void {
         $product = loadSimplePricedProduct();
         $quote = createPricedQuote($product);
+        Mage::app()->getStore(1)->setConfig('payment/checkmo/min_order_total', '999999');
 
         try {
-            withStoreConfig('payment/checkmo/min_order_total', '999999', function () use ($quote): void {
-                $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+            $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
 
-                // The message distinguishes the importData() checks from the
-                // earlier assertPaymentMethodAvailable() gate, which would also
-                // throw BadRequestHttpException if checkmo were simply inactive.
-                expect(fn() => (new CartService())->setPaymentMethod($loaded, 'checkmo'))
-                    ->toThrow(BadRequestHttpException::class, 'Payment method is not available: ');
-            });
+            // The message distinguishes the importData() checks from the
+            // earlier assertPaymentMethodAvailable() gate, which would also
+            // throw BadRequestHttpException if checkmo were simply inactive.
+            expect(fn() => (new CartService())->setPaymentMethod($loaded, 'checkmo'))
+                ->toThrow(BadRequestHttpException::class, 'Payment method is not available: ');
         } finally {
             $quote->delete();
         }
@@ -128,14 +132,13 @@ describe('set-payment-method additionalData', function (): void {
     it('does not advertise a method the setter would reject', function (): void {
         $product = loadSimplePricedProduct();
         $quote = createPricedQuote($product);
+        Mage::app()->getStore(1)->setConfig('payment/checkmo/min_order_total', '999999');
 
         try {
-            withStoreConfig('payment/checkmo/min_order_total', '999999', function () use ($quote): void {
-                $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
-                $codes = array_column((new CartMapper())->getAvailablePaymentMethods($loaded), 'code');
+            $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+            $codes = array_column((new CartMapper())->getAvailablePaymentMethods($loaded), 'code');
 
-                expect($codes)->not->toContain('checkmo');
-            });
+            expect($codes)->not->toContain('checkmo');
         } finally {
             $quote->delete();
         }

--- a/tests/Backend/Integration/Checkout/Api/CartPaymentAdditionalDataTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartPaymentAdditionalDataTest.php
@@ -51,22 +51,49 @@ describe('set-payment-method additionalData', function (): void {
         }
     });
 
-    it('ignores reserved keys in additionalData', function (): void {
+    it('strips reserved keys from additionalData', function (): void {
+        $built = CartService::buildPaymentImportData('checkmo', [
+            'method' => 'purchaseorder',
+            'checks' => 0,
+            'additional_data' => ['x' => 'y'],
+            'additional_information' => ['x' => 'y'],
+            'method_instance' => 'x',
+            'quote_id' => 99,
+            'cc_number' => '4111111111111111',
+            'cc_type' => 'VI',
+            // asserts "this cart is already paid" without the storefront's replay checks
+            'paypal_order_id' => 'REPLAYED',
+            'paypal_authorization_id' => 'REPLAYED',
+            'paypal_capture_id' => 'REPLAYED',
+            'po_number' => 'PO-1335',
+        ], Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT);
+
+        expect($built)->toBe([
+            'po_number' => 'PO-1335',
+            'method' => 'checkmo',
+            'checks' => Mage_Payment_Model_Method_Abstract::CHECKS_CHECKOUT,
+        ]);
+    });
+
+    it('keeps a copy of the accepted additionalData on the payment', function (): void {
         $product = loadSimplePricedProduct();
         $quote = createPricedQuote($product);
 
         try {
-            $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
-            (new CartService())->setPaymentMethod($loaded, 'checkmo', [
-                'method' => 'purchaseorder',
-                'checks' => 0,
-                'additional_data' => ['x' => 'y'],
-                'cc_number' => '4111111111111111',
-            ]);
+            withStoreConfig('payment/purchaseorder/active', '1', function () use ($quote): void {
+                $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+                // txn_ref has no column of its own, so the flat delivery alone
+                // would drop it at save time.
+                (new CartService())->setPaymentMethod($loaded, 'purchaseorder', [
+                    'po_number' => 'PO-1335',
+                    'txn_ref' => 'TXN-42',
+                    'cc_number' => '4111111111111111',
+                ]);
 
-            expect($loaded->getPayment()->getMethod())->toBe('checkmo')
-                ->and($loaded->getPayment()->getData('additional_data'))->not->toBeArray()
-                ->and($loaded->getPayment()->getData('cc_number'))->toBeNull();
+                $backup = $loaded->getPayment()->getAdditionalInformation(CartService::PAYMENT_ADDITIONAL_DATA_KEY);
+
+                expect($backup)->toBe(['po_number' => 'PO-1335', 'txn_ref' => 'TXN-42']);
+            });
         } finally {
             $quote->delete();
         }
@@ -80,12 +107,22 @@ describe('set-payment-method additionalData', function (): void {
             withStoreConfig('payment/checkmo/min_order_total', '999999', function () use ($quote): void {
                 $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
 
+                // The message distinguishes the importData() checks from the
+                // earlier assertPaymentMethodAvailable() gate, which would also
+                // throw BadRequestHttpException if checkmo were simply inactive.
                 expect(fn() => (new CartService())->setPaymentMethod($loaded, 'checkmo'))
-                    ->toThrow(BadRequestHttpException::class);
+                    ->toThrow(BadRequestHttpException::class, 'Payment method is not available: ');
             });
         } finally {
             $quote->delete();
         }
+    });
+
+    it('treats a card method as unusable over the API', function (): void {
+        // buildPaymentImportData() strips every cc_* key, so Mage_Payment_Model_Method_Cc::validate()
+        // can never pass. Such a method must not reach the setter nor the advertised list.
+        expect(CartService::isMethodUsableOverApi(new Mage_Paygate_Model_Authorizenet()))->toBeFalse()
+            ->and(CartService::isMethodUsableOverApi(new Mage_Payment_Model_Method_Checkmo()))->toBeTrue();
     });
 
     it('does not advertise a method the setter would reject', function (): void {

--- a/tests/Backend/Integration/Checkout/Api/CartPaymentAdditionalDataTest.php
+++ b/tests/Backend/Integration/Checkout/Api/CartPaymentAdditionalDataTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Mage\Checkout\Api\CartService;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * Issue #1335: additionalData on the set-payment-method API must reach payment
+ * methods as top-level keys, because assignData() reads flat keys (as the
+ * onepage and SOAP flows deliver them), not an M2-style additional_data array.
+ */
+
+/** Set a store-1 config value for one call and restore the previous value. */
+function withStoreConfig(string $path, string $value, Closure $callback): void
+{
+    $store = Mage::app()->getStore(1);
+    $previous = $store->getConfig($path);
+    $store->setConfig($path, $value);
+    try {
+        $callback();
+    } finally {
+        $store->setConfig($path, (string) $previous);
+    }
+}
+
+describe('set-payment-method additionalData', function (): void {
+
+    it('delivers additionalData to the payment method as top-level keys', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+
+        try {
+            withStoreConfig('payment/purchaseorder/active', '1', function () use ($quote): void {
+                $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+                (new CartService())->setPaymentMethod($loaded, 'purchaseorder', ['po_number' => 'PO-1335']);
+
+                expect($loaded->getPayment()->getMethod())->toBe('purchaseorder')
+                    ->and($loaded->getPayment()->getPoNumber())->toBe('PO-1335');
+            });
+        } finally {
+            $quote->delete();
+        }
+    });
+
+    it('ignores reserved keys in additionalData', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+
+        try {
+            $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+            (new CartService())->setPaymentMethod($loaded, 'checkmo', [
+                'method' => 'purchaseorder',
+                'checks' => 0,
+                'additional_data' => ['x' => 'y'],
+            ]);
+
+            expect($loaded->getPayment()->getMethod())->toBe('checkmo')
+                ->and($loaded->getPayment()->getData('additional_data'))->not->toBeArray();
+        } finally {
+            $quote->delete();
+        }
+    });
+
+    it('rejects a method whose minimum order total exceeds the quote total', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+
+        try {
+            withStoreConfig('payment/checkmo/min_order_total', '999999', function () use ($quote): void {
+                $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+
+                expect(fn() => (new CartService())->setPaymentMethod($loaded, 'checkmo'))
+                    ->toThrow(BadRequestHttpException::class);
+            });
+        } finally {
+            $quote->delete();
+        }
+    });
+
+});

--- a/tests/Backend/Integration/Paypal/VaultAssignDataTest.php
+++ b/tests/Backend/Integration/Paypal/VaultAssignDataTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class)->group('backend', 'paypal');
+
+function vaultAssignDataCreateCustomer(): Mage_Customer_Model_Customer
+{
+    $customer = Mage::getModel('customer/customer');
+    $customer->setWebsiteId(1);
+    $customer->setGroupId(1);
+    $customer->setFirstname('Vault');
+    $customer->setLastname('Owner');
+    $customer->setEmail('vault-assign-' . bin2hex(random_bytes(4)) . '@example.com');
+    $customer->save();
+    return $customer;
+}
+
+function vaultAssignDataCreateToken(int $customerId): Maho_Paypal_Model_Vault_Token
+{
+    $paypalTokenId = 'test-token-' . bin2hex(random_bytes(8));
+    $token = Mage::getModel('paypal/vault_token');
+    $token->setCustomerId($customerId);
+    $token->setPaypalTokenId($paypalTokenId);
+    $token->setPaypalTokenIdHash(hash('sha256', $paypalTokenId));
+    $token->setPaymentSourceType('paypal');
+    $token->setPayerEmail('vault-assign@example.com');
+    $token->save();
+    return $token;
+}
+
+describe('paypal vault assignData ownership', function (): void {
+
+    it('accepts a token owned by the quote customer without any session', function (): void {
+        $customer = vaultAssignDataCreateCustomer();
+        $token = vaultAssignDataCreateToken((int) $customer->getId());
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+
+        try {
+            $quote->setCustomerId((int) $customer->getId());
+            $payment = $quote->getPayment();
+
+            $method = new Maho_Paypal_Model_Method_Vault();
+            $method->setInfoInstance($payment);
+            $method->assignData(['vault_token_id' => (int) $token->getId()]);
+
+            expect($payment->getAdditionalInformation('vault_token_id'))->toBe((int) $token->getId());
+        } finally {
+            $quote->delete();
+            $token->delete();
+            $customer->delete();
+        }
+    });
+
+    it('rejects a token owned by another customer', function (): void {
+        $owner = vaultAssignDataCreateCustomer();
+        $other = vaultAssignDataCreateCustomer();
+        $token = vaultAssignDataCreateToken((int) $owner->getId());
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+
+        try {
+            $quote->setCustomerId((int) $other->getId());
+            $payment = $quote->getPayment();
+
+            $method = new Maho_Paypal_Model_Method_Vault();
+            $method->setInfoInstance($payment);
+            $method->assignData(['vault_token_id' => (int) $token->getId()]);
+
+            expect($payment->getAdditionalInformation('vault_token_id'))->toBeNull();
+        } finally {
+            $quote->delete();
+            $token->delete();
+            $other->delete();
+            $owner->delete();
+        }
+    });
+
+});

--- a/tests/Backend/Integration/Sales/Model/QuotePaymentImportDataTest.php
+++ b/tests/Backend/Integration/Sales/Model/QuotePaymentImportDataTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('quote payment importData applicability checks', function (): void {
+
+    it('applies the full checks by default when the caller passes none', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+        Mage::app()->getStore(1)->setConfig('payment/checkmo/min_order_total', '999999');
+
+        try {
+            $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+
+            expect(fn() => $loaded->getPayment()->importData(['method' => 'checkmo']))
+                ->toThrow(Mage_Core_Exception::class);
+        } finally {
+            $quote->delete();
+        }
+    });
+
+    it('honors an explicit narrower mask from the caller', function (): void {
+        $product = loadSimplePricedProduct();
+        $quote = createPricedQuote($product);
+        Mage::app()->getStore(1)->setConfig('payment/checkmo/min_order_total', '999999');
+
+        try {
+            $loaded = Mage::getModel('sales/quote')->setStoreId(1)->load($quote->getId());
+            $loaded->getPayment()->importData([
+                'method' => 'checkmo',
+                'checks' => Mage_Payment_Model_Method_Abstract::CHECK_USE_FOR_COUNTRY,
+            ]);
+
+            expect($loaded->getPayment()->getMethod())->toBe('checkmo');
+        } finally {
+            $quote->delete();
+        }
+    });
+
+});


### PR DESCRIPTION
Fixes #1335.

`CartService::setPaymentMethod()` nested `additionalData` under an `additional_data` key. Payment methods read top-level keys in `assignData()`, so the data never reached them. The onepage checkout and the SOAP API pass flat data.

Changes:

- Merge `additionalData` flat into the payment data, with `method` protected. Strip the reserved keys `method`, `checks`, and `additional_data` from caller input. The last one maps to a legacy DB column, so a nested copy would pollute it through the base `assignData()` dump.
- Pass the same checks bitmask that onepage passes to `importData()`. Before this change the API skipped country, currency, min/max total, and zero-total rules, and a method hidden from `availablePaymentMethods` by country could still be set.
- Add three integration tests at the `CartService::setPaymentMethod()` seam and one HTTP test on the guest-cart endpoint. The flattening test and the min-total test fail against the unfixed code.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->