### PR TITLE
Read fresh statistics in the table bloat scanner instead of MySQL's daily cache

### DIFF
--- a/lib/MahoCLI/Helper/TableBloatScanner.php
+++ b/lib/MahoCLI/Helper/TableBloatScanner.php
@@ -118,6 +118,10 @@ class TableBloatScanner
      */
     public static function totalSize(AdapterInterface $adapter, string $table): ?int
     {
+        if ($adapter instanceof Mysql) {
+            self::useFreshMysqlStats($adapter);
+        }
+
         $size = match (true) {
             $adapter instanceof Mysql => $adapter->fetchOne(
                 'SELECT DATA_LENGTH + INDEX_LENGTH + DATA_FREE FROM information_schema.TABLES'
@@ -144,6 +148,8 @@ class TableBloatScanner
         if (!self::mysqlFilePerTable($adapter)) {
             return [];
         }
+
+        self::useFreshMysqlStats($adapter);
 
         // Restricted to InnoDB: any other engine is already reported by the storage
         // engine check, and converting it rebuilds the table anyway.
@@ -265,6 +271,21 @@ class TableBloatScanner
             $rows,
             static fn(array $row): bool => str_starts_with((string) $row[$column], $tablePrefix),
         ));
+    }
+
+    /**
+     * MySQL 8.0+ serves information_schema table statistics from a cache refreshed
+     * only every information_schema_stats_expiry seconds (a day by default), so a
+     * read right after a purge or a rebuild reports stale sizes: the scan keeps
+     * warning about space already freed, and OPTIMIZE appears to free 0 bytes.
+     */
+    private static function useFreshMysqlStats(Mysql $adapter): void
+    {
+        try {
+            $adapter->query('SET SESSION information_schema_stats_expiry = 0');
+        } catch (\Exception) {
+            // MariaDB and MySQL < 8.0 have no such variable and no cache.
+        }
     }
 
     private static function mysqlFilePerTable(Mysql $adapter): bool

--- a/tests/Backend/Integration/Db/Adapter/TableBloatScannerTest.php
+++ b/tests/Backend/Integration/Db/Adapter/TableBloatScannerTest.php
@@ -9,6 +9,7 @@
 declare(strict_types=1);
 
 use MahoCLI\Helper\TableBloatScanner;
+use Maho\Db\Adapter\Pdo\Mysql;
 use Maho\Db\Adapter\Pdo\Pgsql;
 use Maho\Db\Adapter\Pdo\Sqlite;
 
@@ -20,9 +21,9 @@ uses(Tests\MahoBackendTestCase::class);
  * statement that only parses on MySQL fails here on PostgreSQL and SQLite.
  *
  * Deliberately absent: a test that creates bloat and asserts the scan finds it.
- * MySQL caches information_schema statistics for a day by default and PostgreSQL
- * updates its tuple counters asynchronously, so that assertion would be flaky
- * everywhere except SQLite.
+ * MySQL reports DATA_FREE per 1MB extent, so a small probe table reads as zero
+ * free space, and PostgreSQL updates its tuple counters asynchronously, so that
+ * assertion would be flaky everywhere except SQLite.
  */
 function bloatProbeTable(\Maho\Db\Adapter\AdapterInterface $adapter): string
 {
@@ -50,6 +51,28 @@ it('runs its bloat introspection against this backend', function () {
         expect($finding['total'])->toBeGreaterThanOrEqual(TableBloatScanner::MIN_TOTAL_BYTES);
         expect($finding['ratio'])->toBeGreaterThanOrEqual(TableBloatScanner::MIN_RECLAIMABLE_RATIO);
     }
+});
+
+it('reads fresh statistics instead of the daily information_schema cache', function () {
+    $adapter = Mage::getSingleton('core/resource')->getConnection('core_write');
+    if (!$adapter instanceof Mysql) {
+        $this->markTestSkipped('Only MySQL serves information_schema table statistics from a cache.');
+    }
+
+    try {
+        $adapter->query('SET SESSION information_schema_stats_expiry = 86400');
+    } catch (\Exception) {
+        $this->markTestSkipped('This server has no information_schema statistics cache (MariaDB, MySQL < 8.0).');
+    }
+
+    // Without a fresh read, a scan right after ./maho log:clean or db:optimize
+    // reports numbers up to a day old and keeps warning about space already freed.
+    TableBloatScanner::scan($adapter);
+    expect((string) $adapter->fetchOne('SELECT @@SESSION.information_schema_stats_expiry'))->toBe('0');
+
+    $adapter->query('SET SESSION information_schema_stats_expiry = 86400');
+    TableBloatScanner::totalSize($adapter, 'core_config_data');
+    expect((string) $adapter->fetchOne('SELECT @@SESSION.information_schema_stats_expiry'))->toBe('0');
 });
 
 it('honors the thresholds it is given', function () {


### PR DESCRIPTION
MySQL 8.0+ serves information_schema table statistics from a cache refreshed only every `information_schema_stats_expiry` seconds (86400 by default). A scan right after `log:clean` or `db:optimize` therefore read stale sizes: `health-check` kept warning about space already freed, and `db:optimize` reported "freed 0 B" (reported by a user on their production server).

The scanner now sets the session expiry to 0 before it reads `information_schema`, in both `mysqlCandidates()` and `totalSize()`. MariaDB and MySQL < 8.0 have no such variable and no cache, so the statement fails silently there. PostgreSQL and SQLite read live counters and are untouched. A new test asserts the session variable is 0 after `scan()` and `totalSize()`, and skips itself on backends without the cache.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->