### PR TITLE
Fixed duplicated countries in the general/region/state_required config seed

### DIFF
--- a/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -22,6 +22,7 @@ $installer->getConnection()->insert(
 
 $select = $installer->getConnection()->select()
     ->from($installer->getTable('directory/country_region'), 'country_id')
+    ->distinct()
     ->order('country_id');
 $countries = $installer->getConnection()->fetchCol($select);
 


### PR DESCRIPTION
The 1.6.0.0-1.6.0.1 data upgrade selected `country_id` from `directory_country_region` without `DISTINCT`, so a fresh install stored one entry per region (484) instead of one per country (12). Added `->distinct()` to the select.

The duplicates are harmless at runtime (the helper only checks membership), so existing installs get no repair script. To clean the stored value manually, use one of these two options.

**Option 1: save from the admin (recommended, keeps a customized list)**

1. Go to System > Configuration > General > General > States Options.
2. Click Save Config. The save deduplicates the "State is required for" value.

**Option 2: SQL (only if you never customized the list, it resets the value to every country that has regions)**

MySQL/MariaDB:
```sql
UPDATE core_config_data
SET value = (SELECT GROUP_CONCAT(DISTINCT country_id ORDER BY country_id SEPARATOR ',') FROM directory_country_region)
WHERE path = 'general/region/state_required';
```

PostgreSQL:
```sql
UPDATE core_config_data
SET value = (SELECT STRING_AGG(DISTINCT country_id, ',' ORDER BY country_id) FROM directory_country_region)
WHERE path = 'general/region/state_required';
```

Fixes #1345

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->