### PR TITLE
Fixed revocation emails failing once the config section is saved in the admin

### DIFF
--- a/app/code/core/Maho/Revocation/etc/config.xml
+++ b/app/code/core/Maho/Revocation/etc/config.xml
@@ -44,16 +44,16 @@ SPDX-License-Identifier: OSL-3.0
         </resources>
         <template>
             <email>
-                <revocation_email_received translate="label" module="revocation">
+                <revocation_email_received_template translate="label" module="revocation">
                     <label>Revocation Receipt Confirmation</label>
                     <file>revocation_received.html</file>
                     <type>html</type>
-                </revocation_email_received>
-                <revocation_email_merchant translate="label" module="revocation">
+                </revocation_email_received_template>
+                <revocation_email_merchant_template translate="label" module="revocation">
                     <label>Revocation Merchant Notification</label>
                     <file>revocation_merchant_notification.html</file>
                     <type>html</type>
-                </revocation_email_merchant>
+                </revocation_email_merchant_template>
             </email>
         </template>
     </global>
@@ -100,8 +100,8 @@ SPDX-License-Identifier: OSL-3.0
                 <cooling_off_days>14</cooling_off_days>
             </general>
             <email>
-                <received_template>revocation_email_received</received_template>
-                <merchant_template>revocation_email_merchant</merchant_template>
+                <received_template>revocation_email_received_template</received_template>
+                <merchant_template>revocation_email_merchant_template</merchant_template>
                 <identity>general</identity>
             </email>
             <abuse>

--- a/tests/Backend/Integration/Core/Model/EmailTemplateCodeConventionTest.php
+++ b/tests/Backend/Integration/Core/Model/EmailTemplateCodeConventionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * adminhtml/system_config_source_email_template offers "<section>_<group>_<field>",
+ * derived from the field's own config path. A template registered under any other
+ * name can never be selected, and saving the section stores an unresolvable code.
+ *
+ * @return array<int, array{path: string, code: string}>
+ */
+function emailTemplateSelectFields(): array
+{
+    $fields = [];
+    foreach (Mage::getSingleton('adminhtml/config')->getSections()->children() as $section) {
+        foreach ($section->groups?->children() ?? [] as $group) {
+            foreach ($group->fields?->children() ?? [] as $field) {
+                if (!str_contains((string) $field->source_model, 'source_email_template')) {
+                    continue;
+                }
+                $fields[] = [
+                    'path' => "{$section->getName()}/{$group->getName()}/{$field->getName()}",
+                    'code' => "{$section->getName()}_{$group->getName()}_{$field->getName()}",
+                ];
+            }
+        }
+    }
+
+    return $fields;
+}
+
+it('registers a template for the code every email template select offers', function () {
+    $registered = Mage_Core_Model_Email_Template::getDefaultTemplates();
+    $fields = emailTemplateSelectFields();
+
+    expect($fields)->not->toBeEmpty();
+
+    foreach ($fields as ['path' => $path, 'code' => $code]) {
+        expect($registered)->toHaveKey($code, message: "no template registered as \"{$code}\" for config field {$path}");
+    }
+});
+
+it('defaults every email template select to a resolvable template code', function () {
+    $registered = Mage_Core_Model_Email_Template::getDefaultTemplates();
+
+    foreach (emailTemplateSelectFields() as ['path' => $path, 'code' => $code]) {
+        $default = (string) Mage::getStoreConfig($path);
+        if ($default === '') {
+            continue;
+        }
+        expect($registered)->toHaveKey($default, message: "config default {$path} points at unregistered template \"{$default}\"");
+    }
+});

--- a/tests/Backend/Integration/Core/Model/EmailTemplateCodeConventionTest.php
+++ b/tests/Backend/Integration/Core/Model/EmailTemplateCodeConventionTest.php
@@ -10,9 +10,7 @@ declare(strict_types=1);
 uses(Tests\MahoBackendTestCase::class);
 
 /**
- * adminhtml/system_config_source_email_template offers "<section>_<group>_<field>",
- * derived from the field's own config path. A template registered under any other
- * name can never be selected, and saving the section stores an unresolvable code.
+ * Path derivation mirrors Mage_Adminhtml_Block_System_Config_Form::_initFields().
  *
  * @return array<int, array{path: string, code: string}>
  */
@@ -20,14 +18,22 @@ function emailTemplateSelectFields(): array
 {
     $fields = [];
     foreach (Mage::getSingleton('adminhtml/config')->getSections()->children() as $section) {
-        foreach ($section->groups?->children() ?? [] as $group) {
+        $groups = iterator_to_array($section->groups?->children() ?? [], false);
+        while ($groups !== []) {
+            $group = array_shift($groups);
             foreach ($group->fields?->children() ?? [] as $field) {
+                if ((string) $field->getAttribute('type') === 'group') {
+                    $groups[] = $field;
+                    continue;
+                }
                 if (!str_contains((string) $field->source_model, 'source_email_template')) {
                     continue;
                 }
+                $path = (string) $field->config_path
+                    ?: "{$section->getName()}/{$group->getName()}/{$field->getName()}";
                 $fields[] = [
-                    'path' => "{$section->getName()}/{$group->getName()}/{$field->getName()}",
-                    'code' => "{$section->getName()}_{$group->getName()}_{$field->getName()}",
+                    'path' => $path,
+                    'code' => str_replace('/', '_', $path),
                 ];
             }
         }
@@ -50,9 +56,10 @@ it('registers a template for the code every email template select offers', funct
 it('defaults every email template select to a resolvable template code', function () {
     $registered = Mage_Core_Model_Email_Template::getDefaultTemplates();
 
-    foreach (emailTemplateSelectFields() as ['path' => $path, 'code' => $code]) {
+    foreach (emailTemplateSelectFields() as ['path' => $path]) {
+        // A numeric value is the id of an admin-created template, loaded from the database.
         $default = (string) Mage::getStoreConfig($path);
-        if ($default === '') {
+        if ($default === '' || is_numeric($default)) {
             continue;
         }
         expect($registered)->toHaveKey($default, message: "config default {$path} points at unregistered template \"{$default}\"");


### PR DESCRIPTION
`adminhtml/system_config_source_email_template` derives its option value from the
field's config path, so `revocation/email/received_template` offers
`revocation_email_received_template`. The templates are registered as
`revocation_email_received` / `revocation_email_merchant`, so saving Sales >
Revocation stores a code no template answers to and both mails die in
`sendTransactional()` with "Invalid transactional email code". The customer still
gets the success page, so the receipt the directive requires silently never
arrives.

Renamed both nodes to the path-derived codes (the convention the other 44 core
email template selects follow) and updated the defaults. Shops that already saved
the section need no migration: the stored value is the new node name.

The added test walks every such select and asserts the offered code is registered
and the config default resolves. Against unfixed `main` it fails with
`no template registered as "revocation_email_received_template" for config field
revocation/email/received_template`.