### PR TITLE
Fixed loadByUsername() leaving admin/API users partially loaded

### DIFF
--- a/app/code/core/Mage/Admin/Model/Resource/User.php
+++ b/app/code/core/Mage/Admin/Model/Resource/User.php
@@ -59,27 +59,6 @@ class Mage_Admin_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstrac
     }
 
     /**
-     * Load data by specified username
-     *
-     * @param string $username
-     * @return false|array
-     */
-    public function loadByUsername(#[\SensitiveParameter] $username)
-    {
-        $adapter = $this->_getReadAdapter();
-
-        $select = $adapter->select()
-            ->from($this->getMainTable())
-            ->where('username=:username');
-
-        $binds = [
-            'username' => $username,
-        ];
-
-        return $adapter->fetchRow($select, $binds);
-    }
-
-    /**
      * Check if user is assigned to any role
      *
      * @param int|Mage_Core_Model_Abstract|Mage_Admin_Model_User $user
@@ -439,8 +418,12 @@ class Mage_Admin_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstrac
     protected function _unserializeExtraData(Mage_Core_Model_Abstract $user)
     {
         try {
-            $unsterilizedData = Mage::helper('core/unserializeArray')->unserialize($user->getExtra());
-            $user->setExtra($unsterilizedData);
+            $extra = Mage::helper('core/unserializeArray')->unserialize($user->getExtra());
+            // Rows saved through the old loadByUsername() path hold a JSON string inside JSON
+            while (is_string($extra) && json_validate($extra)) {
+                $extra = Mage::helper('core')->jsonDecode($extra);
+            }
+            $user->setExtra($extra);
         } catch (\Throwable) {
             // Catch Throwable, not Exception — PHP 8's TypeError extends
             // Error (not Exception), and the helper called above can throw

--- a/app/code/core/Mage/Admin/Model/User.php
+++ b/app/code/core/Mage/Admin/Model/User.php
@@ -129,7 +129,7 @@ class Mage_Admin_Model_User extends Mage_Core_Model_Abstract
             'lastname'  => $this->getLastname(),
             'email'     => $this->getEmail(),
             'modified'  => Mage::app()->getLocale()->formatDateForDb('now'),
-            'extra'     => Mage::helper('core')->jsonEncode($this->getExtra()),
+            'extra'     => is_string($extra = $this->getExtra()) ? $extra : Mage::helper('core')->jsonEncode($extra),
         ];
 
         if ($this->getId() > 0) {
@@ -613,14 +613,13 @@ class Mage_Admin_Model_User extends Mage_Core_Model_Abstract
         return $this;
     }
 
-    /**
-     * Load user by its username
-     *
-     * @param string $username
-     * @return $this
-     */
-    public function loadByUsername(#[\SensitiveParameter] $username)
+    public function loadByUsername(#[\SensitiveParameter] string $username): static
     {
+        // MySQL strips NUL bytes from a varchar value and SQLite refuses to quote them,
+        // so 'admin\0' must never resolve to 'admin' nor turn into a 500
+        if (str_contains($username, "\0")) {
+            return $this;
+        }
         return $this->load($username, 'username');
     }
 

--- a/app/code/core/Mage/Admin/Model/User.php
+++ b/app/code/core/Mage/Admin/Model/User.php
@@ -621,8 +621,7 @@ class Mage_Admin_Model_User extends Mage_Core_Model_Abstract
      */
     public function loadByUsername(#[\SensitiveParameter] $username)
     {
-        $this->setData($this->getResource()->loadByUsername($username));
-        return $this;
+        return $this->load($username, 'username');
     }
 
     /**

--- a/app/code/core/Mage/Api/Model/Resource/User.php
+++ b/app/code/core/Mage/Api/Model/Resource/User.php
@@ -119,20 +119,6 @@ class Mage_Api_Model_Resource_User extends Mage_Core_Model_Resource_Db_Abstract
     }
 
     /**
-     * Load data by username
-     *
-     * @param string $username
-     * @return array
-     */
-    public function loadByUsername(#[\SensitiveParameter] $username)
-    {
-        $adapter = $this->_getReadAdapter();
-        $select = $adapter->select()->from($this->getTable('api/user'))
-            ->where('username=:username');
-        return $adapter->fetchRow($select, ['username' => $username]);
-    }
-
-    /**
      * load by session id
      *
      * @param string $sessId

--- a/app/code/core/Mage/Api/Model/Session.php
+++ b/app/code/core/Mage/Api/Model/Session.php
@@ -137,7 +137,6 @@ class Mage_Api_Model_Session extends Mage_Core_Model_Session_Abstract
             $this->setAcl(Mage::getResourceModel('api/acl')->loadAcl());
         }
         if ($user->getReloadAclFlag()) {
-            $user->unsetData('api_key');
             $user->setReloadAclFlag('0')->save();
         }
         return $this;

--- a/app/code/core/Mage/Api/Model/User.php
+++ b/app/code/core/Mage/Api/Model/User.php
@@ -292,14 +292,13 @@ class Mage_Api_Model_User extends Mage_Core_Model_Abstract
         return $this;
     }
 
-    /**
-     * Load user by username
-     *
-     * @param string $username
-     * @return $this
-     */
-    public function loadByUsername(#[\SensitiveParameter] $username)
+    public function loadByUsername(#[\SensitiveParameter] string $username): static
     {
+        // MySQL strips NUL bytes from a varchar value and SQLite refuses to quote them,
+        // so 'user\0' must never resolve to 'user' nor turn into a 500
+        if (str_contains($username, "\0")) {
+            return $this;
+        }
         return $this->load($username, 'username');
     }
 
@@ -311,7 +310,10 @@ class Mage_Api_Model_User extends Mage_Core_Model_Abstract
      */
     public function loadBySessId($sessId)
     {
-        $this->setData($this->getResource()->loadBySessId($sessId));
+        $session = $this->getResource()->loadBySessId($sessId);
+        if ($session) {
+            $this->load($session['user_id'])->addData($session);
+        }
         return $this;
     }
 

--- a/app/code/core/Mage/Api/Model/User.php
+++ b/app/code/core/Mage/Api/Model/User.php
@@ -300,8 +300,7 @@ class Mage_Api_Model_User extends Mage_Core_Model_Abstract
      */
     public function loadByUsername(#[\SensitiveParameter] $username)
     {
-        $this->setData($this->getResource()->loadByUsername($username));
-        return $this;
+        return $this->load($username, 'username');
     }
 
     /**

--- a/tests/Backend/Integration/Admin/Model/UserLoadByUsernameTest.php
+++ b/tests/Backend/Integration/Admin/Model/UserLoadByUsernameTest.php
@@ -9,23 +9,6 @@ declare(strict_types=1);
 
 uses(Tests\MahoBackendTestCase::class);
 
-function adminLoadByUsernameCreateUser(string $password): Mage_Admin_Model_User
-{
-    $suffix = substr(md5(uniqid()), 0, 8);
-
-    /** @var Mage_Admin_Model_User $user */
-    $user = Mage::getModel('admin/user');
-    $user->setUsername('lbu_' . $suffix)
-        ->setFirstname('Load')
-        ->setLastname('ByUsername')
-        ->setEmail("lbu_{$suffix}@example.com")
-        ->setPassword($password)
-        ->setIsActive(1)
-        ->save();
-
-    return $user;
-}
-
 function adminLoadByUsernameStoredColumn(int $userId, string $column): string
 {
     $resource = Mage::getSingleton('core/resource');
@@ -38,58 +21,92 @@ function adminLoadByUsernameStoredColumn(int $userId, string $column): string
     );
 }
 
+beforeEach(function () {
+    $suffix = substr(md5(uniqid()), 0, 8);
+    $this->password = 'Lbu-P4ssword-1';
+
+    /** @var Mage_Admin_Model_User $user */
+    $user = Mage::getModel('admin/user');
+    $user->setUsername('lbu_' . $suffix)
+        ->setFirstname('Load')
+        ->setLastname('ByUsername')
+        ->setEmail("lbu_{$suffix}@example.com")
+        ->setPassword($this->password)
+        ->setIsActive(1)
+        ->save();
+
+    $this->user = $user;
+    $this->userId = (int) $user->getId();
+    $this->username = (string) $user->getUsername();
+});
+
+afterEach(function () {
+    $this->user->delete();
+});
+
 it('decodes extra the way load() does', function () {
-    $user = adminLoadByUsernameCreateUser('Lbu-P4ssword-1');
-    $userId = (int) $user->getId();
+    $this->user->saveExtra(['configState' => ['catalog_frontend' => 1]]);
 
-    try {
-        $user->saveExtra(['configState' => ['catalog_frontend' => 1]]);
+    $extra = Mage::getModel('admin/user')->loadByUsername($this->username)->getExtra();
 
-        $extra = Mage::getModel('admin/user')->loadByUsername($user->getUsername())->getExtra();
-
-        expect($extra)->toBeArray()
-            ->and($extra['configState']['catalog_frontend'] ?? false)->toBe(1);
-    } finally {
-        Mage::getModel('admin/user')->load($userId)->delete();
-    }
+    expect($extra)->toBeArray()
+        ->and($extra['configState']['catalog_frontend'] ?? false)->toBe(1);
 });
 
 // admin:user:enable, admin:user:disable and admin:user:twofa-reset all save a user loaded this way.
 it('keeps the stored password when a user loaded by username is saved', function () {
-    $password = 'Lbu-P4ssword-1';
-    $user = adminLoadByUsernameCreateUser($password);
-    $userId = (int) $user->getId();
-    $username = (string) $user->getUsername();
+    $storedHash = adminLoadByUsernameStoredColumn($this->userId, 'password');
 
-    try {
-        $storedHash = adminLoadByUsernameStoredColumn($userId, 'password');
+    Mage::getModel('admin/user')->loadByUsername($this->username)->setIsActive(0)->save();
 
-        Mage::getModel('admin/user')->loadByUsername($username)->setIsActive(0)->save();
-
-        $afterSave = adminLoadByUsernameStoredColumn($userId, 'password');
-        expect($afterSave)->toBe($storedHash)
-            ->and(Mage::helper('core')->validateHash($password, $afterSave))->toBeTrue()
-            ->and((int) Mage::getModel('admin/user')->load($userId)->getIsActive())->toBe(0);
-    } finally {
-        Mage::getModel('admin/user')->load($userId)->delete();
-    }
+    $afterSave = adminLoadByUsernameStoredColumn($this->userId, 'password');
+    expect($afterSave)->toBe($storedHash)
+        ->and(Mage::helper('core')->validateHash($this->password, $afterSave))->toBeTrue()
+        ->and(adminLoadByUsernameStoredColumn($this->userId, 'is_active'))->toBe('0');
 });
 
 it('does not add a json layer to extra when a user loaded by username is saved', function () {
-    $user = adminLoadByUsernameCreateUser('Lbu-P4ssword-1');
-    $userId = (int) $user->getId();
-    $username = (string) $user->getUsername();
+    $this->user->saveExtra(['configState' => ['catalog_frontend' => 1]]);
+    $storedExtra = adminLoadByUsernameStoredColumn($this->userId, 'extra');
 
-    try {
-        $user->saveExtra(['configState' => ['catalog_frontend' => 1]]);
-        $storedExtra = adminLoadByUsernameStoredColumn($userId, 'extra');
+    Mage::getModel('admin/user')->loadByUsername($this->username)->setIsActive(0)->save();
 
-        foreach ([1, 0, 1] as $isActive) {
-            Mage::getModel('admin/user')->loadByUsername($username)->setIsActive($isActive)->save();
-        }
+    expect(adminLoadByUsernameStoredColumn($this->userId, 'extra'))->toBe($storedExtra);
+});
 
-        expect(adminLoadByUsernameStoredColumn($userId, 'extra'))->toBe($storedExtra);
-    } finally {
-        Mage::getModel('admin/user')->load($userId)->delete();
+// A collection hydrates the model without the resource _afterLoad(), so extra stays a JSON string.
+it('does not add a json layer to extra when a collection-loaded user is saved', function () {
+    $this->user->saveExtra(['configState' => ['catalog_frontend' => 1]]);
+    $storedExtra = adminLoadByUsernameStoredColumn($this->userId, 'extra');
+
+    $collection = Mage::getResourceModel('admin/user_collection')->addFieldToFilter('user_id', $this->userId);
+    foreach ($collection as $user) {
+        $user->setIsActive(0)->save();
     }
+
+    expect(adminLoadByUsernameStoredColumn($this->userId, 'extra'))->toBe($storedExtra);
+});
+
+it('repairs extra that an earlier save encoded twice', function () {
+    $twiceEncoded = Mage::helper('core')->jsonEncode(
+        Mage::helper('core')->jsonEncode(['configState' => ['catalog_frontend' => 1]]),
+    );
+    $resource = Mage::getSingleton('core/resource');
+    $resource->getConnection('core_write')->update(
+        $resource->getTableName('admin/user'),
+        ['extra' => $twiceEncoded],
+        ['user_id = ?' => $this->userId],
+    );
+
+    $extra = Mage::getModel('admin/user')->load($this->userId)->getExtra();
+
+    expect($extra)->toBeArray()
+        ->and($extra['configState']['catalog_frontend'] ?? false)->toBe(1);
+});
+
+// MySQL drops NUL bytes from a varchar value, so "name\0" would otherwise resolve to "name".
+it('does not load a user when the username carries a NUL byte', function () {
+    $user = Mage::getModel('admin/user')->loadByUsername($this->username . "\0");
+
+    expect($user->getId())->toBeNull();
 });

--- a/tests/Backend/Integration/Admin/Model/UserLoadByUsernameTest.php
+++ b/tests/Backend/Integration/Admin/Model/UserLoadByUsernameTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+function adminLoadByUsernameCreateUser(string $password): Mage_Admin_Model_User
+{
+    $suffix = substr(md5(uniqid()), 0, 8);
+
+    /** @var Mage_Admin_Model_User $user */
+    $user = Mage::getModel('admin/user');
+    $user->setUsername('lbu_' . $suffix)
+        ->setFirstname('Load')
+        ->setLastname('ByUsername')
+        ->setEmail("lbu_{$suffix}@example.com")
+        ->setPassword($password)
+        ->setIsActive(1)
+        ->save();
+
+    return $user;
+}
+
+function adminLoadByUsernameStoredColumn(int $userId, string $column): string
+{
+    $resource = Mage::getSingleton('core/resource');
+    $read = $resource->getConnection('core_read');
+
+    return (string) $read->fetchOne(
+        $read->select()
+            ->from($resource->getTableName('admin/user'), $column)
+            ->where('user_id = ?', $userId),
+    );
+}
+
+it('decodes extra the way load() does', function () {
+    $user = adminLoadByUsernameCreateUser('Lbu-P4ssword-1');
+    $userId = (int) $user->getId();
+
+    try {
+        $user->saveExtra(['configState' => ['catalog_frontend' => 1]]);
+
+        $extra = Mage::getModel('admin/user')->loadByUsername($user->getUsername())->getExtra();
+
+        expect($extra)->toBeArray()
+            ->and($extra['configState']['catalog_frontend'] ?? false)->toBe(1);
+    } finally {
+        Mage::getModel('admin/user')->load($userId)->delete();
+    }
+});
+
+// admin:user:enable, admin:user:disable and admin:user:twofa-reset all save a user loaded this way.
+it('keeps the stored password when a user loaded by username is saved', function () {
+    $password = 'Lbu-P4ssword-1';
+    $user = adminLoadByUsernameCreateUser($password);
+    $userId = (int) $user->getId();
+    $username = (string) $user->getUsername();
+
+    try {
+        $storedHash = adminLoadByUsernameStoredColumn($userId, 'password');
+
+        Mage::getModel('admin/user')->loadByUsername($username)->setIsActive(0)->save();
+
+        $afterSave = adminLoadByUsernameStoredColumn($userId, 'password');
+        expect($afterSave)->toBe($storedHash)
+            ->and(Mage::helper('core')->validateHash($password, $afterSave))->toBeTrue()
+            ->and((int) Mage::getModel('admin/user')->load($userId)->getIsActive())->toBe(0);
+    } finally {
+        Mage::getModel('admin/user')->load($userId)->delete();
+    }
+});
+
+it('does not add a json layer to extra when a user loaded by username is saved', function () {
+    $user = adminLoadByUsernameCreateUser('Lbu-P4ssword-1');
+    $userId = (int) $user->getId();
+    $username = (string) $user->getUsername();
+
+    try {
+        $user->saveExtra(['configState' => ['catalog_frontend' => 1]]);
+        $storedExtra = adminLoadByUsernameStoredColumn($userId, 'extra');
+
+        foreach ([1, 0, 1] as $isActive) {
+            Mage::getModel('admin/user')->loadByUsername($username)->setIsActive($isActive)->save();
+        }
+
+        expect(adminLoadByUsernameStoredColumn($userId, 'extra'))->toBe($storedExtra);
+    } finally {
+        Mage::getModel('admin/user')->load($userId)->delete();
+    }
+});

--- a/tests/Backend/Integration/Api/UserApiKeyTest.php
+++ b/tests/Backend/Integration/Api/UserApiKeyTest.php
@@ -69,3 +69,23 @@ it('hashes a new api key typed on an existing user', function () {
         Mage::getModel('api/user')->load($userId)->delete();
     }
 });
+
+it('keeps the stored api key when a user loaded by username is saved', function () {
+    $apiKey = 'Api-K3y-ByUsername-1';
+    $user = apiKeyTestCreateUser($apiKey);
+    $userId = (int) $user->getId();
+    $username = (string) $user->getUsername();
+
+    try {
+        $storedHash = (string) Mage::getModel('api/user')->load($userId)->getApiKey();
+
+        Mage::getModel('api/user')->loadByUsername($username)->setFirstname('Renamed')->save();
+
+        $afterSave = Mage::getModel('api/user')->load($userId);
+        expect($afterSave->getFirstname())->toBe('Renamed')
+            ->and((string) $afterSave->getApiKey())->toBe($storedHash)
+            ->and(Mage::getModel('api/user')->authenticate($username, $apiKey))->toBeTrue();
+    } finally {
+        Mage::getModel('api/user')->load($userId)->delete();
+    }
+});

--- a/tests/Backend/Integration/Api/UserApiKeyTest.php
+++ b/tests/Backend/Integration/Api/UserApiKeyTest.php
@@ -73,19 +73,53 @@ it('hashes a new api key typed on an existing user', function () {
 it('keeps the stored api key when a user loaded by username is saved', function () {
     $apiKey = 'Api-K3y-ByUsername-1';
     $user = apiKeyTestCreateUser($apiKey);
-    $userId = (int) $user->getId();
     $username = (string) $user->getUsername();
 
     try {
-        $storedHash = (string) Mage::getModel('api/user')->load($userId)->getApiKey();
+        $storedHash = (string) $user->getApiKey();
 
         Mage::getModel('api/user')->loadByUsername($username)->setFirstname('Renamed')->save();
 
-        $afterSave = Mage::getModel('api/user')->load($userId);
+        $afterSave = Mage::getModel('api/user')->load($user->getId());
         expect($afterSave->getFirstname())->toBe('Renamed')
             ->and((string) $afterSave->getApiKey())->toBe($storedHash)
             ->and(Mage::getModel('api/user')->authenticate($username, $apiKey))->toBeTrue();
     } finally {
-        Mage::getModel('api/user')->load($userId)->delete();
+        $user->delete();
+    }
+});
+
+it('keeps the stored api key when a user loaded by session id is saved', function () {
+    $apiKey = 'Api-K3y-BySessId-1';
+    $user = apiKeyTestCreateUser($apiKey);
+    $username = (string) $user->getUsername();
+    $sessId = md5(uniqid());
+
+    try {
+        $storedHash = (string) $user->getApiKey();
+        $user->setSessid($sessId)->getResource()->recordSession($user);
+
+        $bySession = Mage::getModel('api/user')->loadBySessId($sessId);
+        expect((int) $bySession->getId())->toBe((int) $user->getId())
+            ->and($bySession->getSessid())->toBe($sessId);
+
+        $bySession->setFirstname('Renamed')->save();
+
+        $afterSave = Mage::getModel('api/user')->load($user->getId());
+        expect($afterSave->getFirstname())->toBe('Renamed')
+            ->and((string) $afterSave->getApiKey())->toBe($storedHash)
+            ->and(Mage::getModel('api/user')->authenticate($username, $apiKey))->toBeTrue();
+    } finally {
+        $user->delete();
+    }
+});
+
+it('does not load a user when the username carries a NUL byte', function () {
+    $user = apiKeyTestCreateUser('Api-K3y-Nul-1');
+
+    try {
+        expect(Mage::getModel('api/user')->loadByUsername($user->getUsername() . "\0")->getId())->toBeNull();
+    } finally {
+        $user->delete();
     }
 });


### PR DESCRIPTION
`Mage_Admin_Model_User::loadByUsername()` populated the model directly with `setData()`, bypassing the resource `_afterLoad()` and `setOrigData()` logic normally performed by `load()`.

This caused two issues on subsequent saves:

* **`extra` was JSON-encoded repeatedly.** Each `loadByUsername()` → `save()` added another JSON layer, causing `extra` to grow until MySQL rejected the write. String-shaped `extra` also broke System Config collapse state handling and could discard existing states.
* **The stored password hash was re-hashed.** Without orig data, `_beforeSave()` treated the password as changed and bcrypt-hashed the existing hash again. As a result, `admin:user:enable`, `admin:user:disable`, and `admin:user:twofa-reset` could lock the admin out. `admin:user:change-password` avoided the password issue but still corrupted `extra`.

`Mage_Api_Model_User::loadByUsername()` had the same orig-data problem, causing an existing `api_key` hash to be re-hashed when saved.

Both methods now delegate to `load()`, ensuring `_afterLoad()` and orig data are initialized correctly.

## Reproduce

Against `b14d40e81` without the patch:

```bash
./maho db:query "SELECT password, extra, LENGTH(extra) FROM admin_user WHERE username = 'admin'"
printf 'admin\n' | ./maho admin:user:disable
printf 'admin\n' | ./maho admin:user:enable
./maho db:query "SELECT password, extra, LENGTH(extra) FROM admin_user WHERE username = 'admin'"
```

The password hash changes and the old password no longer works; `extra` gains another JSON layer on each save.

