### PR TITLE
Fixed memory exhaustion when downloading sample data during install

### DIFF
--- a/lib/MahoCLI/Commands/Install.php
+++ b/lib/MahoCLI/Commands/Install.php
@@ -135,9 +135,10 @@ class Install extends BaseMahoCommand
             $tempFile = tempnam(sys_get_temp_dir(), 'maho_sample_data');
             $targetDir = Mage::getBaseDir();
 
-            // Download the file
-            if (file_put_contents($tempFile, file_get_contents($sampleDataUrl)) === false) {
+            // Stream the download to disk, do not load the whole archive into memory
+            if (@copy($sampleDataUrl, $tempFile) === false) {
                 $output->writeln('<error>Failed to download sample data</error>');
+                unlink($tempFile);
                 return Command::FAILURE;
             }
 


### PR DESCRIPTION
## Summary

`./maho install --sample_data` loaded the whole sample-data archive into memory with `file_get_contents()` before it wrote the file to disk. With the default `memory_limit=256M` the install stopped with a fatal error:

```
Fatal error: Allowed memory size of 268435456 bytes exhausted (tried to allocate 132120608 bytes) in lib/MahoCLI/Commands/Install.php on line 139
```

The archive for branch 25.9 is 58 MB. PHP grows the string buffer in steps, so the peak memory is more than the file size.

## Changes

- Replace `file_put_contents($tempFile, file_get_contents($sampleDataUrl))` with `copy($sampleDataUrl, $tempFile)`. The `copy()` function streams the HTTP response to disk in small blocks and follows the GitHub redirect.
- Remove the temp file when the download fails.

## Test plan

- [x] Downloaded the real 25.9 archive with `copy()` under `memory_limit=32M`. Result: 58 MB on disk, peak PHP memory 2 MB.
- [x] `php -l lib/MahoCLI/Commands/Install.php` passes.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->