### PR TITLE
Disabled proxy caching for feed and sitemap files under media

### DIFF
--- a/public/media/.htaccess
+++ b/public/media/.htaccess
@@ -8,3 +8,14 @@ Options All -Indexes
 # Disable CGI scripts execution
 AddHandler cgi-script .php .pl .py .jsp .asp .sh .cgi
 Options -ExecCGI
+
+# Feeds and sitemaps are regenerated in place. The one-week ExpiresDefault
+# in public/.htaccess would let a proxy cache serve a stale copy.
+<FilesMatch "\.(xml|csv|json|jsonl|gz)$">
+    <IfModule mod_expires.c>
+        ExpiresDefault "access plus 0 seconds"
+    </IfModule>
+    <IfModule mod_headers.c>
+        Header set Cache-Control "no-cache, must-revalidate"
+    </IfModule>
+</FilesMatch>


### PR DESCRIPTION
public/.htaccess sets ExpiresDefault to one week, and no more specific rule covers .xml, .csv, .json, .jsonl or .gz. A hosting proxy cache (reported on SiteGround) kept serving the old Google Merchant feed for days until a manual cache flush. This adds a FilesMatch block in public/media/.htaccess that sets Expires to zero and Cache-Control to no-cache for these extensions, so regenerated feeds and sitemaps are always revalidated.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->