### PR TITLE
Fixed order items losing additional_options set on the quote item

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Default.php
+++ b/app/code/core/Mage/Adminhtml/Block/Sales/Items/Column/Default.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
  * SPDX-FileCopyrightText: 2022-2024 The OpenMage Contributors <https://openmage.org>
  * SPDX-FileCopyrightText: 2006-2020 Magento, Inc. <https://magento.com>
  * SPDX-License-Identifier: OSL-3.0
@@ -24,9 +25,7 @@ class Mage_Adminhtml_Block_Sales_Items_Column_Default extends Mage_Adminhtml_Blo
             if (isset($options['options'])) {
                 $result = array_merge($result, $options['options']);
             }
-            if (isset($options['additional_options'])) {
-                $result = array_merge($result, $options['additional_options']);
-            }
+            $result = array_merge($result, $this->getItem()->getProductAdditionalOptions());
             if (!empty($options['attributes_info'])) {
                 $result = array_merge($options['attributes_info'], $result);
             }

--- a/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
+++ b/app/code/core/Mage/Adminhtml/Model/Sales/Order/Create.php
@@ -1494,10 +1494,6 @@ class Mage_Adminhtml_Model_Sales_Order_Create extends \Maho\DataObject implement
                 $productOptions['info_buyRequest']['options'] = $this->_prepareOptionsForRequest($item);
                 $options = $productOptions;
             }
-            $addOptions = $item->getOptionByCode('additional_options');
-            if ($addOptions) {
-                $options['additional_options'] = Mage::helper('core/string')->unserialize($addOptions->getValue());
-            }
             $item->setProductOrderOptions($options);
         }
         return $this;

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/Items/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/Items/Renderer.php
@@ -153,9 +153,7 @@ class Mage_Bundle_Block_Adminhtml_Sales_Order_Items_Renderer extends Mage_Adminh
             if (isset($options['options'])) {
                 $result = array_merge($result, $options['options']);
             }
-            if (isset($options['additional_options'])) {
-                $result = array_merge($result, $options['additional_options']);
-            }
+            $result = array_merge($result, $this->getOrderItem()->getProductAdditionalOptions());
             if (!empty($options['attributes_info'])) {
                 $result = array_merge($options['attributes_info'], $result);
             }

--- a/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/View/Items/Renderer.php
+++ b/app/code/core/Mage/Bundle/Block/Adminhtml/Sales/Order/View/Items/Renderer.php
@@ -113,9 +113,7 @@ class Mage_Bundle_Block_Adminhtml_Sales_Order_View_Items_Renderer extends Mage_A
             if (isset($options['options'])) {
                 $result = array_merge($result, $options['options']);
             }
-            if (isset($options['additional_options'])) {
-                $result = array_merge($result, $options['additional_options']);
-            }
+            $result = array_merge($result, $this->getItem()->getProductAdditionalOptions());
             if (!empty($options['attributes_info'])) {
                 $result = array_merge($options['attributes_info'], $result);
             }

--- a/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Bundle/Model/Sales/Order/Pdf/Items/Abstract.php
@@ -184,9 +184,7 @@ abstract class Mage_Bundle_Model_Sales_Order_Pdf_Items_Abstract extends Mage_Sal
             if (isset($options['options'])) {
                 $result = array_merge($result, $options['options']);
             }
-            if (isset($options['additional_options'])) {
-                $result = array_merge($result, $options['additional_options']);
-            }
+            $result = array_merge($result, $this->getOrderItem()->getProductAdditionalOptions());
             if (!empty($options['attributes_info'])) {
                 $result = array_merge($options['attributes_info'], $result);
             }

--- a/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
+++ b/app/code/core/Mage/Catalog/Model/Product/Type/Abstract.php
@@ -580,6 +580,15 @@ abstract class Mage_Catalog_Model_Product_Type_Abstract
             ];
         }
 
+        // Display-only notes attached to the quote item. Order-side renderers array_merge() this
+        // key, so a value that does not decode to an array is dropped rather than stored.
+        if ($additionalOptions = $this->getProduct($product)->getCustomOption('additional_options')) {
+            $decoded = Mage::helper('core/string')->unserialize($additionalOptions->getValue());
+            if (is_array($decoded) && $decoded !== []) {
+                $optionArr['additional_options'] = $decoded;
+            }
+        }
+
         return $optionArr;
     }
 

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items/Default.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items/Default.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
  * SPDX-FileCopyrightText: 2020-2024 The OpenMage Contributors <https://openmage.org>
  * SPDX-FileCopyrightText: 2006-2020 Magento, Inc. <https://magento.com>
  * SPDX-License-Identifier: OSL-3.0
@@ -29,9 +30,7 @@ class Mage_Sales_Block_Order_Email_Items_Default extends Mage_Core_Block_Templat
             if (isset($options['options'])) {
                 $result = array_merge($result, $options['options']);
             }
-            if (isset($options['additional_options'])) {
-                $result = array_merge($result, $options['additional_options']);
-            }
+            $result = array_merge($result, $this->getItem()->getOrderItem()->getProductAdditionalOptions());
             if (isset($options['attributes_info'])) {
                 $result = array_merge($result, $options['attributes_info']);
             }

--- a/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Default.php
+++ b/app/code/core/Mage/Sales/Block/Order/Email/Items/Order/Default.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
  * SPDX-FileCopyrightText: 2020-2024 The OpenMage Contributors <https://openmage.org>
  * SPDX-FileCopyrightText: 2006-2020 Magento, Inc. <https://magento.com>
  * SPDX-License-Identifier: OSL-3.0
@@ -32,9 +33,7 @@ class Mage_Sales_Block_Order_Email_Items_Order_Default extends Mage_Core_Block_T
             if (isset($options['options'])) {
                 $result = array_merge($result, $options['options']);
             }
-            if (isset($options['additional_options'])) {
-                $result = array_merge($result, $options['additional_options']);
-            }
+            $result = array_merge($result, $this->getItem()->getProductAdditionalOptions());
             if (isset($options['attributes_info'])) {
                 $result = array_merge($result, $options['attributes_info']);
             }

--- a/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Default.php
+++ b/app/code/core/Mage/Sales/Block/Order/Item/Renderer/Default.php
@@ -58,9 +58,7 @@ class Mage_Sales_Block_Order_Item_Renderer_Default extends Mage_Core_Block_Templ
             if (isset($options['options'])) {
                 $result = array_merge($result, $options['options']);
             }
-            if (isset($options['additional_options'])) {
-                $result = array_merge($result, $options['additional_options']);
-            }
+            $result = array_merge($result, $this->getOrderItem()->getProductAdditionalOptions());
             if (isset($options['attributes_info'])) {
                 $result = array_merge($result, $options['attributes_info']);
             }

--- a/app/code/core/Mage/Sales/Model/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Item.php
@@ -632,6 +632,17 @@ class Mage_Sales_Model_Order_Item extends Mage_Core_Model_Abstract
     }
 
     /**
+     * Display-only notes attached to the item, always a list.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getProductAdditionalOptions(): array
+    {
+        $options = $this->getProductOptionByCode('additional_options');
+        return is_array($options) ? $options : [];
+    }
+
+    /**
      * Return real product type of item or NULL if item is not composite
      *
      * @return array|null

--- a/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Order/Pdf/Items/Abstract.php
@@ -282,9 +282,7 @@ abstract class Mage_Sales_Model_Order_Pdf_Items_Abstract extends Mage_Core_Block
             if (isset($options['options'])) {
                 $result = array_merge($result, $options['options']);
             }
-            if (isset($options['additional_options'])) {
-                $result = array_merge($result, $options['additional_options']);
-            }
+            $result = array_merge($result, $this->getOrderItem()->getProductAdditionalOptions());
             if (isset($options['attributes_info'])) {
                 $result = array_merge($result, $options['attributes_info']);
             }

--- a/app/code/core/Maho/Giftcard/Model/Observer.php
+++ b/app/code/core/Maho/Giftcard/Model/Observer.php
@@ -266,7 +266,7 @@ class Maho_Giftcard_Model_Observer
             if ($additionalOptions !== []) {
                 $quoteItem->addOption([
                     'code' => 'additional_options',
-                    'value' => serialize($additionalOptions),
+                    'value' => Mage::helper('core')->jsonEncode($additionalOptions),
                 ]);
             }
         }

--- a/app/code/core/Maho/Giftcard/Model/Product/Type/Giftcard.php
+++ b/app/code/core/Maho/Giftcard/Model/Product/Type/Giftcard.php
@@ -193,7 +193,7 @@ class Maho_Giftcard_Model_Product_Type_Giftcard extends Mage_Catalog_Model_Produ
         $additionalOptions = Mage::helper('giftcard')->buildAdditionalOptions($buyRequest);
 
         if ($additionalOptions !== []) {
-            $product->addCustomOption('additional_options', serialize($additionalOptions));
+            $product->addCustomOption('additional_options', Mage::helper('core')->jsonEncode($additionalOptions));
         }
     }
 
@@ -268,24 +268,6 @@ class Maho_Giftcard_Model_Product_Type_Giftcard extends Mage_Catalog_Model_Produ
     public function hasOptions($product = null)
     {
         return true;
-    }
-
-    /**
-     * Get order options for the product
-     *
-     * Includes additional_options (gift card display options) in the order item
-     */
-    #[\Override]
-    public function getOrderOptions($product = null)
-    {
-        $options = parent::getOrderOptions($product);
-
-        // Add additional_options from custom option (for cart/order display)
-        if ($additionalOption = $this->getProduct($product)->getCustomOption('additional_options')) {
-            $options['additional_options'] = unserialize($additionalOption->getValue(), ['allowed_classes' => false]);
-        }
-
-        return $options;
     }
 
     /**

--- a/tests/Backend/Integration/Sales/Model/AdditionalOptionsTest.php
+++ b/tests/Backend/Integration/Sales/Model/AdditionalOptionsTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+function additionalOptionsProduct(): Mage_Catalog_Model_Product
+{
+    $product = Mage::getModel('catalog/product');
+    $product->setTypeId(Mage_Catalog_Model_Product_Type::TYPE_SIMPLE);
+    $product->setId(1);
+    return $product;
+}
+
+function additionalOptionsNote(): array
+{
+    return [['label' => 'Note', 'value' => 'Hello']];
+}
+
+describe('Mage_Catalog_Model_Product_Type_Abstract::getOrderOptions()', function (): void {
+    test('copies a JSON encoded additional_options custom option', function (): void {
+        $product = additionalOptionsProduct();
+        $product->addCustomOption('additional_options', Mage::helper('core')->jsonEncode(additionalOptionsNote()));
+
+        $options = $product->getTypeInstance(true)->getOrderOptions($product);
+
+        expect($options)->toHaveKey('additional_options');
+        expect($options['additional_options'])->toBe(additionalOptionsNote());
+    });
+
+    test('copies a legacy PHP serialized additional_options custom option', function (): void {
+        $product = additionalOptionsProduct();
+        $product->addCustomOption('additional_options', serialize(additionalOptionsNote()));
+
+        $options = $product->getTypeInstance(true)->getOrderOptions($product);
+
+        expect($options['additional_options'])->toBe(additionalOptionsNote());
+    });
+
+    test('omits the key when the value does not decode to a list', function (): void {
+        $product = additionalOptionsProduct();
+        $product->addCustomOption('additional_options', 'not-a-serialized-array');
+
+        $options = $product->getTypeInstance(true)->getOrderOptions($product);
+
+        expect($options)->not->toHaveKey('additional_options');
+    });
+
+    test('omits the key when the value decodes to an empty array', function (): void {
+        $product = additionalOptionsProduct();
+        $product->addCustomOption('additional_options', Mage::helper('core')->jsonEncode([]));
+
+        $options = $product->getTypeInstance(true)->getOrderOptions($product);
+
+        expect($options)->not->toHaveKey('additional_options');
+    });
+});
+
+describe('Quote item to order item conversion', function (): void {
+    test('carries additional_options into the order item product_options', function (): void {
+        $product = additionalOptionsProduct();
+        $product->setSku('additional-options-fixture');
+        $product->setName('Additional Options Fixture');
+
+        $quote = Mage::getModel('sales/quote');
+        $quote->setStoreId(1);
+
+        $quoteItem = Mage::getModel('sales/quote_item');
+        $quoteItem->setQuote($quote);
+        $quoteItem->setData('product', $product);
+        $quoteItem->setProductId($product->getId());
+        $quoteItem->setProductType($product->getTypeId());
+        $quoteItem->setData('qty', 1);
+        $quoteItem->addOption([
+            'product_id' => $product->getId(),
+            'code' => 'additional_options',
+            'value' => Mage::helper('core')->jsonEncode(additionalOptionsNote()),
+        ]);
+
+        $orderItem = Mage::getModel('sales/convert_quote')->itemToOrderItem($quoteItem);
+
+        expect($orderItem->getProductOptionByCode('additional_options'))->toBe(additionalOptionsNote());
+    });
+});
+
+describe('Order item display', function (): void {
+    test('renders additional_options in the order item renderer', function (): void {
+        $orderItem = Mage::getModel('sales/order_item');
+        $orderItem->setProductOptions(['additional_options' => additionalOptionsNote()]);
+
+        $block = Mage::app()->getLayout()->createBlock('sales/order_item_renderer_default');
+        $block->setItem($orderItem);
+
+        expect($block->getItemOptions())->toBe(additionalOptionsNote());
+    });
+
+    test('ignores a legacy row that stored a scalar instead of a list', function (): void {
+        $orderItem = Mage::getModel('sales/order_item');
+        $orderItem->setProductOptions(['additional_options' => 'legacy scalar']);
+
+        $block = Mage::app()->getLayout()->createBlock('sales/order_item_renderer_default');
+        $block->setItem($orderItem);
+
+        expect($block->getItemOptions())->toBe([]);
+    });
+
+    test('exposes additional_options through the order item accessor', function (): void {
+        $orderItem = Mage::getModel('sales/order_item');
+        $orderItem->setProductOptions(['additional_options' => additionalOptionsNote()]);
+
+        expect($orderItem->getProductAdditionalOptions())->toBe(additionalOptionsNote());
+    });
+
+    test('returns an empty list when the order item has no additional_options', function (): void {
+        $orderItem = Mage::getModel('sales/order_item');
+
+        expect($orderItem->getProductAdditionalOptions())->toBe([]);
+    });
+});


### PR DESCRIPTION
Fixes #1359

`Mage_Catalog_Model_Product_Type_Abstract::getOrderOptions()` built `product_options` from `info_buyRequest`, `option_ids` and `product_type` only. A display-only note attached to a quote item as an `additional_options` option rendered in the cart and then disappeared at order placement, so the order page, the confirmation email, the PDF and the admin order view showed nothing.

Every order-side renderer still reads the key, and two core writers already worked around the gap: `Maho_Giftcard_Model_Product_Type_Giftcard` overrode `getOrderOptions()` for exactly this, and `Mage_Adminhtml_Model_Sales_Order_Create::_prepareQuoteItems()` copied the option by hand. `Mage_Payment_Model_Observer` writes the option for recurring profiles and never reached the order at all.

Note that the issue's claim that Magento 1 and OpenMage had this block is wrong. `OpenMage/magento-lts` main is byte-identical here. The gap is inherited, not a Maho regression.

## What changed

The copy now happens in the base product type. That is the single choke point: `Mage_Sales_Model_Convert_Quote::itemToOrderItem()` and the admin order create both pass through it, and all four type overrides call `parent::`. One edit covers every product type and both checkout paths.

The value is stored only when it decodes to a non-empty array. The readers call `array_merge($result, $options['additional_options'])` with no type check, and `Mage::helper('core/string')->unserialize()` returns the raw string when the input decodes to nothing, so a scalar was a fatal `TypeError` waiting on the order page.

`Mage_Sales_Model_Order_Item::getProductAdditionalOptions()` guards the same read for rows already in the database and replaces eight copies of the same `isset()` block. The two workarounds are now dead code and are removed. Gift card options serialize as JSON like the rest of the platform.

Net `+41 / -48`.

## One thing worth knowing

`additional_options` values reach the templates unescaped: `getFormatedOptionValue()` does not escape, and both the frontend and admin templates echo the value raw. The cart already rendered it raw, so the channel is not new, but reaching the admin order view from a frontend quote is. Treat `additional_options` as a trusted-content channel: a module that puts customer input there must escape it first.

## Tests

`tests/Backend/Integration/Sales/Model/AdditionalOptionsTest.php`, 9 tests, written before the fix and failing against the unfixed code: JSON value, legacy serialized value, scalar rejected, empty array rejected, full quote-to-order conversion, renderer output, legacy scalar row ignored, and the accessor.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->