### PR TITLE
Validated the order status against the order state on every write path

### DIFF
--- a/app/code/core/Mage/Sales/Api/OrderService.php
+++ b/app/code/core/Mage/Sales/Api/OrderService.php
@@ -544,7 +544,7 @@ class OrderService
      * @param string $note Note text
      * @param bool $notifyCustomer Notify customer
      * @param bool $visibleOnFront Visible on frontend
-     * @param string|null $status New order status; caller must validate it against the order's state
+     * @param string|null $status New order status; the order refuses one not assigned to its current state
      */
     public function addOrderNote(
         \Mage_Sales_Model_Order $order,

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -1120,6 +1120,9 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
                 );
             }
         }
+        if (is_string($status)) {
+            $this->_assertStatusValidForState($status, $state);
+        }
         $this->setData('state', $state);
 
         // add status history
@@ -1148,6 +1151,14 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
     }
 
     /**
+     * Whether the status is assigned to the given state (defaults to the order's current state)
+     */
+    public function isStatusValidForState(string $status, ?string $state = null): bool
+    {
+        return $this->getConfig()->isStatusAssignedToState($status, $state ?? (string) $this->getState());
+    }
+
+    /**
      * Retrieve label of order status
      *
      * @return string
@@ -1172,6 +1183,9 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
         } elseif ($status === true) {
             $status = $this->getConfig()->getStateDefaultStatus($this->getState());
         } else {
+            if ($status !== $this->getStatus()) {
+                $this->_assertStatusValidForState($status, $this->getState());
+            }
             $this->setStatus($status);
         }
         $history = Mage::getModel('sales/order_status_history')
@@ -1233,7 +1247,12 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
         if (!$this->canUnhold()) {
             Mage::throwException(Mage::helper('sales')->__('Unhold action is not available.'));
         }
-        $this->setState($this->getHoldBeforeState(), $this->getHoldBeforeStatus() ?: true);
+        $state = $this->getHoldBeforeState();
+        $status = $this->getHoldBeforeStatus();
+        if (!$status || !$this->isStatusValidForState($status, $state)) {
+            $status = true;
+        }
+        $this->setState($state, $status);
         $this->setHoldBeforeState(null);
         $this->setHoldBeforeStatus(null);
         return $this;
@@ -2317,6 +2336,7 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
     {
         parent::_beforeSave();
         $this->_checkState();
+        $this->_checkStatus();
         if (!$this->getId()) {
             $store = $this->getStore();
             $name = [$store->getWebsite()->getName(),$store->getGroup()->getName(),$store->getName()];
@@ -2405,6 +2425,36 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
             $this->setState(self::STATE_PROCESSING, true, '', $userNotification);
         }
         return $this;
+    }
+
+    protected function _assertStatusValidForState(string $status, ?string $state): void
+    {
+        if ($status === '' || $state === null || $state === '' || $this->isStatusValidForState($status, $state)) {
+            return;
+        }
+        Mage::throwException(
+            Mage::helper('sales')->__('The order status "%s" is not assigned to the order state "%s".', $status, $state),
+        );
+    }
+
+    /**
+     * Safety net for status writes that bypass setState() and addStatusHistoryComment().
+     * A state change that leaves a stale status behind falls back to the state's default status.
+     * A pair already stored is left alone, since only new writes are the caller's responsibility.
+     */
+    protected function _checkStatus(): void
+    {
+        $state = (string) $this->getState();
+        $status = (string) $this->getStatus();
+        if ($state === '' || $status === '' || $this->isStatusValidForState($status, $state)) {
+            return;
+        }
+        if ($status !== (string) $this->getOrigData('status')) {
+            $this->_assertStatusValidForState($status, $state);
+        }
+        if ($state !== (string) $this->getOrigData('state')) {
+            $this->setData('status', $this->getConfig()->getStateDefaultStatus($state));
+        }
     }
 
     /**

--- a/app/code/core/Mage/Sales/Model/Order/Config.php
+++ b/app/code/core/Mage/Sales/Model/Order/Config.php
@@ -174,6 +174,11 @@ class Mage_Sales_Model_Order_Config extends Mage_Core_Model_Config_Base
         return $statuses;
     }
 
+    public function isStatusAssignedToState(string $status, string $state): bool
+    {
+        return in_array($status, $this->getStateStatuses($state, false), true);
+    }
+
     /**
      * Retrieve state available for status
      * Get all assigned states for specified status

--- a/app/code/core/Mage/Sales/Model/Order/Payment.php
+++ b/app/code/core/Mage/Sales/Model/Order/Payment.php
@@ -399,14 +399,8 @@ class Mage_Sales_Model_Order_Payment extends Mage_Payment_Model_Info
             $orderIsNotified = $stateObject->getIsNotified();
         } else {
             $orderStatus = $methodInstance->getConfigData('order_status');
-            if (!$orderStatus) {
+            if (!$orderStatus || !$order->getConfig()->isStatusAssignedToState($orderStatus, $orderState)) {
                 $orderStatus = $order->getConfig()->getStateDefaultStatus($orderState);
-            } else {
-                // check if $orderStatus has assigned a state
-                $states = $order->getConfig()->getStatusStates($orderStatus);
-                if (count($states) == 0) {
-                    $orderStatus = $order->getConfig()->getStateDefaultStatus($orderState);
-                }
             }
         }
         $isCustomerNotified = $orderIsNotified ?? $order->getCustomerNoteNotify();

--- a/app/locale/en_US/Mage_Sales.csv
+++ b/app/locale/en_US/Mage_Sales.csv
@@ -771,6 +771,7 @@
 "The order has been released from holding status.","The order has been released from holding status."
 "The order has not been cancelled.","The order has not been cancelled."
 "The Order State ""%s"" must not be set manually.","The Order State ""%s"" must not be set manually."
+"The order status ""%s"" is not assigned to the order state ""%s"".","The order status ""%s"" is not assigned to the order state ""%s""."
 "The order status has been assigned.","The order status has been assigned."
 "The order status has been saved.","The order status has been saved."
 "The order status has been unassigned.","The order status has been unassigned."

--- a/tests/Backend/Integration/CustomerSegmentation/Model/ClvConditionTest.php
+++ b/tests/Backend/Integration/CustomerSegmentation/Model/ClvConditionTest.php
@@ -591,13 +591,8 @@ describe('CLV Condition Tests - Profit and Refunds Focus', function () {
                 $order->setStoreId(1);
                 $order->setCreatedAt(date('Y-m-d H:i:s', strtotime('-' . rand(1, 90) . ' days')));
 
-                if ($orderData['status'] === 'canceled') {
-                    $order->setState(Mage_Sales_Model_Order::STATE_CANCELED);
-                    $order->setStatus('canceled');
-                } else {
-                    $order->setState(Mage_Sales_Model_Order::STATE_NEW);
-                    $order->setStatus($orderData['status']);
-                }
+                $order->setData('state', orderStateForStatus($orderData['status']));
+                $order->setStatus($orderData['status']);
 
                 $order->save();
 

--- a/tests/Backend/Integration/CustomerSegmentation/Model/ComplexConditionCombinationsTest.php
+++ b/tests/Backend/Integration/CustomerSegmentation/Model/ComplexConditionCombinationsTest.php
@@ -503,8 +503,8 @@ describe('Complex Condition Combinations', function () {
                 $order->setCustomerId($customer->getId());
                 $order->setCustomerEmail($customer->getEmail());
                 $order->setGrandTotal($orderData[$orderIndex]['grand_total']);
+                $order->setData('state', orderStateForStatus($orderData[$orderIndex]['status']));
                 $order->setStatus($orderData[$orderIndex]['status']);
-                $order->setState(Mage_Sales_Model_Order::STATE_NEW);
                 $order->save();
 
                 $orderIndex++;

--- a/tests/Backend/Integration/CustomerSegmentation/Model/Condition/Order/OrderAttributesIntegrationTest.php
+++ b/tests/Backend/Integration/CustomerSegmentation/Model/Condition/Order/OrderAttributesIntegrationTest.php
@@ -1166,14 +1166,8 @@ describe('Order Attributes Condition Integration Tests', function () {
                 $order->setDiscountAmount($orderData['discount_amount']);
                 $order->setTotalQtyOrdered($orderData['total_qty_ordered']);
 
-                // Set order status and state according to Maho patterns
-                if ($orderData['status'] === 'canceled') {
-                    $order->setState(Mage_Sales_Model_Order::STATE_CANCELED);
-                    $order->setStatus('canceled');
-                } else {
-                    $order->setState(Mage_Sales_Model_Order::STATE_NEW);
-                    $order->setStatus($orderData['status']);
-                }
+                $order->setData('state', orderStateForStatus($orderData['status']));
+                $order->setStatus($orderData['status']);
 
                 // Set currency
                 $order->setOrderCurrencyCode($orderData['currency_code']);

--- a/tests/Backend/Integration/CustomerSegmentation/Model/CustomerAttributesIntegrationTest.php
+++ b/tests/Backend/Integration/CustomerSegmentation/Model/CustomerAttributesIntegrationTest.php
@@ -1009,14 +1009,8 @@ describe('Customer Attributes Integration Tests', function () {
                 $order->setCustomerEmail($customer->getEmail());
                 $order->setGrandTotal($orderData['total']);
 
-                // Set state and status according to Maho patterns
-                if ($orderData['status'] === 'canceled') {
-                    $order->setState(Mage_Sales_Model_Order::STATE_CANCELED);
-                    $order->setStatus('canceled');
-                } else {
-                    $order->setState(Mage_Sales_Model_Order::STATE_NEW);
-                    $order->setStatus($orderData['status']);
-                }
+                $order->setData('state', orderStateForStatus($orderData['status']));
+                $order->setStatus($orderData['status']);
 
                 $order->setStoreId(1);
                 $orderCreatedAt = date('Y-m-d H:i:s', strtotime("-{$orderData['days_ago']} days"));

--- a/tests/Backend/Integration/CustomerSegmentation/Model/RefreshOperationsTest.php
+++ b/tests/Backend/Integration/CustomerSegmentation/Model/RefreshOperationsTest.php
@@ -318,8 +318,8 @@ describe('Segment Refresh Operations', function () {
                 $order->setCustomerId($customer->getId());
                 $order->setCustomerEmail($customer->getEmail());
                 $order->setGrandTotal($orderData[$orderIndex]['grand_total']);
+                $order->setData('state', orderStateForStatus($orderData[$orderIndex]['status']));
                 $order->setStatus($orderData[$orderIndex]['status']);
-                $order->setState(Mage_Sales_Model_Order::STATE_NEW);
                 $order->save();
 
                 $orderIndex++;

--- a/tests/Backend/Integration/CustomerSegmentation/Model/SegmentMatchingTest.php
+++ b/tests/Backend/Integration/CustomerSegmentation/Model/SegmentMatchingTest.php
@@ -778,8 +778,8 @@ describe('Segment Matching Integration', function () {
                 $order->setCustomerId($customer->getId());
                 $order->setCustomerEmail($customer->getEmail());
                 $order->setGrandTotal($orderValues[$i % count($orderValues)]);
-                $order->setStatus('pending');
                 $order->setState(Mage_Sales_Model_Order::STATE_NEW);
+                $order->setStatus('pending');
                 $order->setStoreId(1);
                 $order->save();
 
@@ -839,8 +839,8 @@ describe('Segment Matching Integration', function () {
                 $order->setCustomerId($customer->getId());
                 $order->setCustomerEmail($customer->getEmail());
                 $order->setGrandTotal($orderData[$orderIndex]['grand_total']);
+                $order->setData('state', orderStateForStatus($orderData[$orderIndex]['status']));
                 $order->setStatus($orderData[$orderIndex]['status']);
-                $order->setState(Mage_Sales_Model_Order::STATE_NEW);
                 $order->save();
 
                 $orderIndex++;

--- a/tests/Backend/Integration/CustomerSegmentation/Model/TimebasedConditionsEnhancedTest.php
+++ b/tests/Backend/Integration/CustomerSegmentation/Model/TimebasedConditionsEnhancedTest.php
@@ -532,7 +532,7 @@ describe('Enhanced Time-based Customer Conditions', function () {
                 $order->setCustomerId($customer->getId());
                 $order->setCustomerEmail($customer->getEmail());
                 $order->setGrandTotal($orderData['total']);
-                $order->setState(Mage_Sales_Model_Order::STATE_NEW);
+                $order->setData('state', orderStateForStatus($orderData['status']));
                 $order->setStatus($orderData['status']);
                 $order->setStoreId(1);
 

--- a/tests/Backend/Integration/CustomerSegmentation/Model/TimebasedConditionsTest.php
+++ b/tests/Backend/Integration/CustomerSegmentation/Model/TimebasedConditionsTest.php
@@ -785,15 +785,8 @@ describe('Time-based Customer Conditions', function () {
                 $order->setCustomerEmail($customer->getEmail());
                 $order->setGrandTotal($orderData['total']);
 
-                // Set state and status according to Maho patterns
-                if ($orderData['status'] === 'canceled') {
-                    $order->setState(Mage_Sales_Model_Order::STATE_CANCELED);
-                    $order->setStatus('canceled');
-                } else {
-                    // Use STATE_NEW for all non-canceled orders and set status separately
-                    $order->setState(Mage_Sales_Model_Order::STATE_NEW);
-                    $order->setStatus($orderData['status']);
-                }
+                $order->setData('state', orderStateForStatus($orderData['status']));
+                $order->setStatus($orderData['status']);
 
                 $order->setStoreId(1);
 

--- a/tests/Backend/Integration/Giftcard/Observer/OrderFlowTest.php
+++ b/tests/Backend/Integration/Giftcard/Observer/OrderFlowTest.php
@@ -799,8 +799,8 @@ describe('Observer: Refund Gift Card on Order Cancel', function (): void {
         $order = Mage::getModel('sales/order');
         $order->setIncrementId('CANCEL-TEST-' . uniqid());
         $order->setStoreId(1);
-        $order->setState(Mage_Sales_Model_Order::STATE_NEW);
-        $order->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+        $order->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+        $order->setStatus('pending_payment');
         $order->setGrandTotal(50.00);
         $order->setBaseGrandTotal(50.00);
         $order->setGiftcardAmount(50.00);
@@ -872,8 +872,8 @@ describe('Observer: Refund Gift Card on Order Cancel', function (): void {
         $order = Mage::getModel('sales/order');
         $order->setIncrementId('CANCEL-MULTI-' . uniqid());
         $order->setStoreId(1);
-        $order->setState(Mage_Sales_Model_Order::STATE_NEW);
-        $order->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+        $order->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+        $order->setStatus('pending_payment');
         $order->setGrandTotal(120.00);
         $order->setBaseGrandTotal(120.00);
         $order->setGiftcardAmount(120.00);
@@ -920,8 +920,8 @@ describe('Observer: Refund Gift Card on Order Cancel', function (): void {
         $order = Mage::getModel('sales/order');
         $order->setIncrementId('CANCEL-NOGC-' . uniqid());
         $order->setStoreId(1);
-        $order->setState(Mage_Sales_Model_Order::STATE_NEW);
-        $order->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+        $order->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+        $order->setStatus('pending_payment');
         $order->setGrandTotal(100.00);
         $order->setBaseGrandTotal(100.00);
         $order->save();
@@ -954,8 +954,8 @@ describe('Observer: Refund Gift Card on Order Cancel', function (): void {
         $order = Mage::getModel('sales/order');
         $order->setIncrementId('CANCEL-EXPIRE-' . uniqid());
         $order->setStoreId(1);
-        $order->setState(Mage_Sales_Model_Order::STATE_NEW);
-        $order->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+        $order->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+        $order->setStatus('pending_payment');
         $order->setGrandTotal(50.00);
         $order->setBaseGrandTotal(50.00);
         $order->setGiftcardAmount(50.00);

--- a/tests/Backend/Integration/Sales/Api/OrderNoteStatusTest.php
+++ b/tests/Backend/Integration/Sales/Api/OrderNoteStatusTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ */
+
+declare(strict_types=1);
+
+use Mage\Sales\Api\OrderService;
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * The REST contract says the optional status of addComment "must be one assigned to
+ * the order's current state". The model enforces it, so the service needs no check
+ * of its own and an integration cannot leave a closed order listed as in progress.
+ */
+
+function orderNoteStatusOrder(): Mage_Sales_Model_Order
+{
+    $order = Mage::getModel('sales/order')->setStoreId(1)
+        ->setData('state', Mage_Sales_Model_Order::STATE_CLOSED)
+        ->setData('status', 'closed')
+        ->setCustomerIsGuest(1)
+        ->setCustomerEmail('order-note-status@example.com')
+        ->setBaseCurrencyCode('USD')
+        ->setOrderCurrencyCode('USD')
+        ->setGlobalCurrencyCode('USD')
+        ->setBaseToGlobalRate(1)
+        ->setBaseToOrderRate(1)
+        ->setGrandTotal(100)->setBaseGrandTotal(100)
+        ->setTotalPaid(100)->setBaseTotalPaid(100)
+        ->setTotalRefunded(100)->setBaseTotalRefunded(100)
+        ->save();
+
+    return Mage::getModel('sales/order')->load($order->getId());
+}
+
+it('rejects a note status that is not assigned to the order state', function (): void {
+    $order = orderNoteStatusOrder();
+
+    expect(fn() => (new OrderService())->addOrderNote($order, 'Refund synced', false, false, 'processing'))
+        ->toThrow(Mage_Core_Exception::class);
+
+    $reloaded = Mage::getModel('sales/order')->load($order->getId());
+    expect($reloaded->getStatus())->toBe('closed');
+    expect($reloaded->getStatusHistoryCollection()->count())->toBe(0);
+});
+
+it('adds the note when no status is given', function (): void {
+    $order = orderNoteStatusOrder();
+
+    (new OrderService())->addOrderNote($order, 'Refund synced');
+
+    $reloaded = Mage::getModel('sales/order')->load($order->getId());
+    expect($reloaded->getStatus())->toBe('closed');
+    expect($reloaded->getStatusHistoryCollection()->count())->toBe(1);
+});

--- a/tests/Backend/Unit/Sales/Model/Order/ConfigStatusStateTest.php
+++ b/tests/Backend/Unit/Sales/Model/Order/ConfigStatusStateTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Mage_Sales
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+describe('Mage_Sales_Model_Order_Config::isStatusAssignedToState', function (): void {
+    it('accepts a status assigned to the state', function (): void {
+        $config = Mage::getSingleton('sales/order_config');
+
+        expect($config->isStatusAssignedToState('processing', Mage_Sales_Model_Order::STATE_PROCESSING))->toBeTrue()
+            ->and($config->isStatusAssignedToState('fraud', Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW))->toBeTrue();
+    });
+
+    it('rejects a status assigned to another state', function (): void {
+        $config = Mage::getSingleton('sales/order_config');
+
+        expect($config->isStatusAssignedToState('processing', Mage_Sales_Model_Order::STATE_CLOSED))->toBeFalse()
+            ->and($config->isStatusAssignedToState('pending', Mage_Sales_Model_Order::STATE_PROCESSING))->toBeFalse();
+    });
+
+    it('rejects an unknown status or an unknown state', function (): void {
+        $config = Mage::getSingleton('sales/order_config');
+
+        expect($config->isStatusAssignedToState('no_such_status', Mage_Sales_Model_Order::STATE_NEW))->toBeFalse()
+            ->and($config->isStatusAssignedToState('pending', 'no_such_state'))->toBeFalse();
+    });
+});
+
+describe('Mage_Sales_Model_Order::isStatusValidForState', function (): void {
+    it('checks against the order state by default', function (): void {
+        $order = Mage::getModel('sales/order')->setData('state', Mage_Sales_Model_Order::STATE_CLOSED);
+
+        expect($order->isStatusValidForState('closed'))->toBeTrue()
+            ->and($order->isStatusValidForState('processing'))->toBeFalse();
+    });
+
+    it('checks against an explicit state when one is given', function (): void {
+        $order = Mage::getModel('sales/order')->setData('state', Mage_Sales_Model_Order::STATE_CLOSED);
+
+        expect($order->isStatusValidForState('processing', Mage_Sales_Model_Order::STATE_PROCESSING))->toBeTrue();
+    });
+});

--- a/tests/Backend/Unit/Sales/Model/Order/PaymentPlaceStatusTest.php
+++ b/tests/Backend/Unit/Sales/Model/Order/PaymentPlaceStatusTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Mage_Sales
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * A payment method's configured "New Order Status" is applied to the state the
+ * placement computes. When the two do not match, the state wins and the status
+ * falls back to that state's default.
+ */
+
+function paymentPlaceOrder(): Mage_Sales_Model_Order
+{
+    $order = Mage::getModel('sales/order')->setStoreId(1)
+        ->setCustomerIsGuest(1)
+        ->setBaseCurrencyCode('USD')
+        ->setOrderCurrencyCode('USD')
+        ->setGrandTotal(100)
+        ->setBaseGrandTotal(100);
+    $order->setBillingAddress(Mage::getModel('sales/order_address')->setAddressType('billing')->setCountryId('US'));
+    $order->setPayment(Mage::getModel('sales/order_payment')->setMethod('checkmo'));
+
+    return $order;
+}
+
+afterEach(function (): void {
+    Mage::app()->getStore(1)->setConfig('payment/checkmo/order_status', 'pending');
+});
+
+it('falls back to the default status of the state when the configured status belongs to another state', function (): void {
+    Mage::app()->getStore(1)->setConfig('payment/checkmo/order_status', 'processing');
+    $order = paymentPlaceOrder();
+
+    $order->getPayment()->place();
+
+    expect($order->getState())->toBe(Mage_Sales_Model_Order::STATE_NEW);
+    expect($order->getStatus())->toBe('pending');
+});
+
+it('keeps a configured status that is assigned to the state', function (): void {
+    Mage::app()->getStore(1)->setConfig('payment/checkmo/order_status', 'pending');
+    $order = paymentPlaceOrder();
+
+    $order->getPayment()->place();
+
+    expect($order->getState())->toBe(Mage_Sales_Model_Order::STATE_NEW);
+    expect($order->getStatus())->toBe('pending');
+});

--- a/tests/Backend/Unit/Sales/Model/Order/StatusStateGuardTest.php
+++ b/tests/Backend/Unit/Sales/Model/Order/StatusStateGuardTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Mage_Sales
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+/**
+ * sales_order_status_state defines which statuses belong to each state. A save must
+ * refuse a status write that leaves the order in a pair the mapping never allowed.
+ */
+
+function statusGuardOrder(string $state, string $status, array $data = []): Mage_Sales_Model_Order
+{
+    $order = Mage::getModel('sales/order');
+    $order->setStoreId(1)
+        ->setData('state', $state)
+        ->setData('status', $status)
+        ->setCustomerIsGuest(1)
+        ->setCustomerEmail('status-guard@example.com')
+        ->setBaseCurrencyCode('USD')
+        ->setOrderCurrencyCode('USD')
+        ->setGlobalCurrencyCode('USD')
+        ->setBaseToGlobalRate(1)
+        ->setBaseToOrderRate(1)
+        ->setGrandTotal(100)
+        ->setBaseGrandTotal(100)
+        ->addData($data);
+    // Without a payment the order counts as free and without items as fully processed,
+    // and either one makes the save move the order to complete on its own
+    $order->setPayment(Mage::getModel('sales/order_payment')->setMethod('checkmo'));
+    $item = Mage::getModel('sales/order_item')->setStoreId(1)
+        ->setProductType('simple')
+        ->setSku('STATUS-GUARD')
+        ->setName('Status guard')
+        ->setQtyOrdered(1)
+        ->setPrice(100)->setBasePrice(100)
+        ->setRowTotal(100)->setBaseRowTotal(100);
+    $order->addItem($item);
+    $order->save();
+
+    return Mage::getModel('sales/order')->load($order->getId());
+}
+
+describe('order status against state on save', function (): void {
+    it('rejects a comment status that is not assigned to the order state', function (): void {
+        $order = statusGuardOrder(Mage_Sales_Model_Order::STATE_CLOSED, 'closed', [
+            'total_paid' => 100,
+            'base_total_paid' => 100,
+            'total_refunded' => 100,
+            'base_total_refunded' => 100,
+        ]);
+
+        expect(fn() => $order->addStatusHistoryComment('Refund synced by integration', 'processing'))->toThrow(
+            Mage_Core_Exception::class,
+            'The order status "processing" is not assigned to the order state "closed".',
+        );
+        expect(Mage::getModel('sales/order')->load($order->getId())->getStatus())->toBe('closed');
+    });
+
+    it('accepts a comment status that is assigned to the order state', function (): void {
+        $order = statusGuardOrder(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW, 'payment_review');
+
+        $order->addStatusHistoryComment('Flagged for review', 'fraud')->setIsCustomerNotified(false);
+        $order->save();
+
+        expect(Mage::getModel('sales/order')->load($order->getId())->getStatus())->toBe('fraud');
+    });
+
+    it('rejects a status that is not assigned to the state given to setState', function (): void {
+        $order = statusGuardOrder(Mage_Sales_Model_Order::STATE_NEW, 'pending');
+
+        expect(fn() => $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING, 'pending'))
+            ->toThrow(Mage_Core_Exception::class);
+        expect($order->getState())->toBe(Mage_Sales_Model_Order::STATE_NEW);
+    });
+
+    it('rejects a direct status write on save', function (): void {
+        $order = statusGuardOrder(Mage_Sales_Model_Order::STATE_NEW, 'pending');
+
+        $order->setStatus('processing');
+
+        expect(fn() => $order->save())->toThrow(Mage_Core_Exception::class);
+    });
+
+    it('rejects an unknown status on a new order', function (): void {
+        $order = Mage::getModel('sales/order')->setStoreId(1)->setData('state', Mage_Sales_Model_Order::STATE_PROCESSING);
+
+        $order->setStatus('no_such_status');
+
+        expect(fn() => $order->save())->toThrow(Mage_Core_Exception::class);
+    });
+
+    it('falls back to the default status when only the state moves and the old status no longer fits', function (): void {
+        $order = statusGuardOrder(Mage_Sales_Model_Order::STATE_NEW, 'pending');
+
+        $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING);
+        $order->save();
+
+        expect(Mage::getModel('sales/order')->load($order->getId())->getStatus())->toBe('processing');
+    });
+
+    it('accepts a comment that re-supplies the stored status even when that status no longer fits', function (): void {
+        $order = statusGuardOrder(Mage_Sales_Model_Order::STATE_PROCESSING, 'processing');
+        $resource = Mage::getSingleton('core/resource');
+        $resource->getConnection('core_write')->update(
+            $resource->getTableName('sales/order'),
+            ['status' => 'pending'],
+            ['entity_id = ?' => $order->getId()],
+        );
+        $order = Mage::getModel('sales/order')->load($order->getId());
+
+        $order->addStatusHistoryComment('Gateway note', $order->getStatus());
+        $order->save();
+
+        expect(Mage::getModel('sales/order')->load($order->getId())->getStatus())->toBe('pending');
+    });
+
+    it('leaves a stored mismatch alone when neither state nor status changes', function (): void {
+        $order = statusGuardOrder(Mage_Sales_Model_Order::STATE_PROCESSING, 'processing');
+        $resource = Mage::getSingleton('core/resource');
+        $resource->getConnection('core_write')->update(
+            $resource->getTableName('sales/order'),
+            ['status' => 'pending'],
+            ['entity_id = ?' => $order->getId()],
+        );
+        $order = Mage::getModel('sales/order')->load($order->getId());
+
+        $order->addStatusHistoryComment('Shipment tracking added');
+        $order->save();
+
+        expect(Mage::getModel('sales/order')->load($order->getId())->getStatus())->toBe('pending');
+    });
+});

--- a/tests/Backend/Unit/Sales/Model/Order/UnholdStatusTest.php
+++ b/tests/Backend/Unit/Sales/Model/Order/UnholdStatusTest.php
@@ -30,3 +30,16 @@ it('falls back to the default status of the previous state when the order had no
     expect($order->getState())->toBe(Mage_Sales_Model_Order::STATE_NEW);
     expect($order->getStatus())->toBe('pending');
 });
+
+it('falls back to the default status when the status before hold is no longer assigned to its state', function (): void {
+    $order = Mage::getModel('sales/order')->setStoreId(1)
+        ->setState(Mage_Sales_Model_Order::STATE_PROCESSING)
+        ->setStatus('processing');
+
+    $order->hold();
+    $order->setHoldBeforeStatus('pending');
+    $order->unhold();
+
+    expect($order->getState())->toBe(Mage_Sales_Model_Order::STATE_PROCESSING);
+    expect($order->getStatus())->toBe('processing');
+});

--- a/tests/Frontend/Unit/Reports/Block/Product/Widget/BestsellersTest.php
+++ b/tests/Frontend/Unit/Reports/Block/Product/Widget/BestsellersTest.php
@@ -95,7 +95,7 @@ describe('Bestsellers widget block', function () {
 
         // Other suites leave orders behind, so out-sell every one of them rather than assume none
         $orders = [bestsellerOrder($bestseller, $storeId, 1000000)];
-        $orders[] = bestsellerOrder($decoy, $storeId, 3000000)->setState(Mage_Sales_Model_Order::STATE_CANCELED)->save();
+        $orders[] = bestsellerOrder($decoy, $storeId, 3000000)->setState(Mage_Sales_Model_Order::STATE_CANCELED, true)->save();
         if ($otherStoreIds) {
             $orders[] = bestsellerOrder($decoy, (int) reset($otherStoreIds), 2000000);
         }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -832,3 +832,15 @@ function withQueueConfig(string $xml, callable $body): void
         \Maho\Queue\QueueManager::reset();
     }
 }
+
+/**
+ * The state a fixture order must carry for a status: an order refuses a status that
+ * is not assigned to its state, so a fixture derives one from the other.
+ */
+function orderStateForStatus(string $status): string
+{
+    foreach (Mage::getSingleton('sales/order_config')->getStatusStates($status) as $state) {
+        return (string) $state->getState();
+    }
+    throw new InvalidArgumentException("No order state has the status \"$status\" assigned");
+}


### PR DESCRIPTION
Fixes #1364

Think of an order as a package on a conveyor belt. The **state** is the belt section it is on: new, processing, complete, closed. The **status** is the sticker on the box that people read in the admin grid. Each belt section has its own set of allowed stickers, and that list lives in `sales_order_status_state`. Until now nobody looked at the list before putting a sticker on. Any code that added a comment with a status, or called `setStatus()`, could put a "Processing" sticker on a box that was already refunded and closed. The grid then showed that box as live work, and nothing ever fixed it.

Now the order checks the list:

- `setState($state, $status)` and `addStatusHistoryComment($comment, $status)` throw a `Mage_Core_Exception` when the status is not allowed for the state. The REST API turns that into a 422, so the `addComment` description "must be one assigned to the order's current state" is now true instead of a hope.
- The save itself is a safety net for direct `setStatus()` or `setData()` writes. A new status that does not fit is rejected. A state change that leaves an old status behind falls back to the default status of the new state. A pair that is already in the database is left alone, so orders whose status an admin later unassigned still save.
- `isStatusAssignedToState()` on the order config and `isStatusValidForState()` on the order let integrations check before they write.
- `unhold()` and payment placement fall back to the default status instead of writing a mismatch. Payment placement used to accept a configured "New Order Status" that belonged to any state; it now has to belong to the state the placement computes. Zero Subtotal Checkout configured with "Processing" while the order stays in state `new` gets `pending` now; set the payment action to invoice automatically to reach the processing state.