### PR TITLE
Limited the category autosuggest to the category tree of the current store

### DIFF
--- a/app/code/core/Mage/CatalogSearch/Block/Autocomplete/Category/List.php
+++ b/app/code/core/Mage/CatalogSearch/Block/Autocomplete/Category/List.php
@@ -80,14 +80,19 @@ class Mage_CatalogSearch_Block_Autocomplete_Category_List extends Mage_Core_Bloc
             // Only show active categories
             $collection->addAttributeToFilter('is_active', 1);
 
-            // Exclude root categories (level 0 and 1)
-            $collection->addAttributeToFilter('level', ['gt' => 1]);
-
             // Only show categories that are included in menu (optional, but often desired)
             $collection->addAttributeToFilter('include_in_menu', 1);
 
             // Apply store filter
             $collection->setStoreId(Mage::app()->getStore()->getId());
+
+            // Keep only the descendants of the root category of the current store
+            $rootPath = $this->getStoreRootPath();
+            if ($rootPath !== '') {
+                $collection->addParentPathFilter($rootPath);
+            } else {
+                $collection->addAttributeToFilter('level', ['gt' => 1]);
+            }
 
             // Limit results based on configuration
             $limit = (int) Mage::getStoreConfig('catalog/search/category_autosuggest_limit');
@@ -117,6 +122,19 @@ class Mage_CatalogSearch_Block_Autocomplete_Category_List extends Mage_Core_Bloc
     }
 
     /**
+     * Path of the root category of the current store, empty when the store has no root category
+     */
+    public function getStoreRootPath(): string
+    {
+        $rootCategoryId = (int) Mage::app()->getStore()->getRootCategoryId();
+        if ($rootCategoryId === 0) {
+            return '';
+        }
+
+        return (string) Mage::getModel('catalog/category')->load($rootCategoryId)->getPath();
+    }
+
+    /**
      * Get category path as array (excluding root categories and current category)
      */
     public function getCategoryPath(Mage_Catalog_Model_Category $category): array
@@ -124,8 +142,9 @@ class Mage_CatalogSearch_Block_Autocomplete_Category_List extends Mage_Core_Bloc
         $path = [];
         $pathIds = explode('/', $category->getPath());
 
-        // Remove root category IDs (typically 1 and 2)
-        $pathIds = array_slice($pathIds, 2);
+        $rootPath = $this->getStoreRootPath();
+        $rootDepth = $rootPath === '' ? 2 : count(explode('/', $rootPath));
+        $pathIds = array_slice($pathIds, $rootDepth);
 
         foreach ($pathIds as $categoryId) {
             if ($categoryId == $category->getId()) {

--- a/tests/Frontend/Integration/CatalogSearch/AutocompleteCategoryScopeTest.php
+++ b/tests/Frontend/Integration/CatalogSearch/AutocompleteCategoryScopeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Mage_CatalogSearch
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoFrontendTestCase::class);
+
+const AUTOCOMPLETE_SCOPE_TOKEN = 'Zzautosuggest';
+
+function autocompleteScopeCleanup(): void
+{
+    $keys = ['zzautosuggest-foreign-root', 'zzautosuggest-foreign', 'zzautosuggest-local'];
+    foreach (Mage::getResourceModel('catalog/category_collection')->addAttributeToFilter('url_key', ['in' => $keys]) as $category) {
+        Mage::getModel('catalog/category')->load($category->getId())->delete();
+    }
+}
+
+function makeAutocompleteCategory(string $name, string $urlKey, string $parentPath): Mage_Catalog_Model_Category
+{
+    /** @var Mage_Catalog_Model_Category $category */
+    $category = Mage::getModel('catalog/category')
+        ->setStoreId(0)
+        ->setName($name)
+        ->setUrlKey($urlKey)
+        ->setIsActive(1)
+        ->setIncludeInMenu(1);
+    $category->setAttributeSetId($category->getDefaultAttributeSetId())->setPath($parentPath)->save();
+
+    return $category;
+}
+
+beforeEach(fn() => autocompleteScopeCleanup());
+afterEach(fn() => autocompleteScopeCleanup());
+
+it('suggests only the categories of the current store', function (): void {
+    $store = Mage::app()->getDefaultStoreView();
+    Mage::app()->setCurrentStore($store->getId());
+
+    $storeRoot = Mage::getModel('catalog/category')->load($store->getRootCategoryId());
+    expect($storeRoot->getId())->not->toBeEmpty();
+
+    $foreignRoot = makeAutocompleteCategory(
+        AUTOCOMPLETE_SCOPE_TOKEN . ' Foreign Root',
+        'zzautosuggest-foreign-root',
+        (string) Mage_Catalog_Model_Category::TREE_ROOT_ID,
+    );
+    $foreign = makeAutocompleteCategory(AUTOCOMPLETE_SCOPE_TOKEN . ' Foreign', 'zzautosuggest-foreign', $foreignRoot->getPath());
+    $local = makeAutocompleteCategory(AUTOCOMPLETE_SCOPE_TOKEN . ' Local', 'zzautosuggest-local', $storeRoot->getPath());
+
+    Mage::app()->getRequest()->setParam('q', AUTOCOMPLETE_SCOPE_TOKEN);
+
+    /** @var Mage_CatalogSearch_Block_Autocomplete_Category_List $block */
+    $block = Mage::app()->getLayout()->createBlock('catalogsearch/autocomplete_category_list');
+    $ids = array_map(intval(...), $block->getCategoryCollection()->getAllIds());
+
+    expect($ids)->toContain((int) $local->getId());
+    expect($ids)->not->toContain((int) $foreign->getId());
+    expect($ids)->not->toContain((int) $foreignRoot->getId());
+});


### PR DESCRIPTION
The search autosuggest showed categories from other stores. The block relied on `setStoreId()`, which only scopes attribute values, and on a `level > 1` filter that removed every root category but kept the children of all of them.

The collection now filters on the path of the root category of the current store. `getCategoryPath()` also cuts the breadcrumb at the depth of that root, instead of the hard-coded depth of two.

Example on a multi-store install, store `kids` (root category 11), query `oo`:

- Before: Books (1/11/74), Books (1/2/87), Cooking (1/6/23), Food (1/2/86), Outdoor (1/11/76)
- After: Books (1/11/74), Outdoor (1/11/76)

Added `tests/Frontend/Integration/CatalogSearch/AutocompleteCategoryScopeTest.php`.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->