### PR TITLE
Added form key validation to storefront state-changing actions

### DIFF
--- a/app/code/core/Mage/Catalog/controllers/Product/CompareController.php
+++ b/app/code/core/Mage/Catalog/controllers/Product/CompareController.php
@@ -96,6 +96,13 @@ class Mage_Catalog_Product_CompareController extends Mage_Core_Controller_Front_
     #[Maho\Config\Route('/catalog/product_compare/remove', name: 'catalog.product.compare.remove', methods: ['POST'])]
     public function removeAction(): void
     {
+        if (!$this->_validateFormKey()) {
+            if (!$this->getRequest()->getParam('isAjax', false)) {
+                $this->_redirectReferer();
+            }
+            return;
+        }
+
         $productId = (int) $this->getRequest()->getParam('product');
         if ($this->isProductAvailable($productId)) {
             $product = Mage::getModel('catalog/product')
@@ -139,6 +146,11 @@ class Mage_Catalog_Product_CompareController extends Mage_Core_Controller_Front_
     #[Maho\Config\Route('/catalog/product_compare/clear', name: 'catalog.product.compare.clear', methods: ['POST'])]
     public function clearAction(): void
     {
+        if (!$this->_validateFormKey()) {
+            $this->_redirectReferer();
+            return;
+        }
+
         $items = Mage::getResourceModel('catalog/product_compare_item_collection');
 
         if (Mage::getSingleton('customer/session')->isLoggedIn()) {

--- a/app/code/core/Mage/Checkout/controllers/CartController.php
+++ b/app/code/core/Mage/Checkout/controllers/CartController.php
@@ -585,6 +585,19 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
         $region     = (string) $this->getRequest()->getParam('region');
         $isAjax     = (bool) $this->getRequest()->getParam('isAjax');
 
+        if (!$this->_validateFormKey()) {
+            if ($isAjax) {
+                $this->getResponse()->setBodyJson([
+                    'success' => false,
+                    'error' => true,
+                    'message' => $this->__('Invalid form key. Please refresh the page.'),
+                ]);
+                return;
+            }
+            $this->_goBack();
+            return;
+        }
+
         try {
             Mage::getModel('directory/country')->loadByCode($country);
         } catch (Mage_Core_Exception $e) {
@@ -642,6 +655,18 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
         $code = (string) $this->getRequest()->getParam('estimate_method');
         $isAjax = (bool) $this->getRequest()->getParam('isAjax');
 
+        if (!$this->_validateFormKey()) {
+            if ($isAjax) {
+                $this->getResponse()->setBodyJson([
+                    'success' => false,
+                    'error' => $this->__('Invalid form key. Please refresh the page.'),
+                ]);
+                return;
+            }
+            $this->_goBack();
+            return;
+        }
+
         if (!empty($code)) {
             $this->_getQuote()->getShippingAddress()->setShippingMethod($code)->save();
             $this->_getQuote()->collectTotals()->save();
@@ -666,6 +691,18 @@ class Mage_Checkout_CartController extends Mage_Core_Controller_Front_Action
     public function couponPostAction(): void
     {
         $isAjax = (bool) $this->getRequest()->getParam('isAjax');
+
+        if (!$this->_validateFormKey()) {
+            if ($isAjax) {
+                $this->getResponse()->setBodyJson([
+                    'success' => false,
+                    'message' => $this->__('Invalid form key. Please refresh the page.'),
+                ]);
+                return;
+            }
+            $this->_goBack();
+            return;
+        }
 
         // Check for empty cart
         if (!$this->_getCart()->getQuote()->getItemsCount()) {

--- a/app/code/core/Mage/Checkout/controllers/OnepageController.php
+++ b/app/code/core/Mage/Checkout/controllers/OnepageController.php
@@ -349,6 +349,10 @@ class Mage_Checkout_OnepageController extends Mage_Checkout_Controller_Action
             return;
         }
 
+        if (!$this->_validateFormKey()) {
+            return;
+        }
+
         if ($this->getRequest()->isPost()) {
             $method = $this->getRequest()->getPost('method');
             $result = $this->getOnepage()->saveCheckoutMethod($method);

--- a/app/code/core/Mage/Directory/Model/Resource/Country.php
+++ b/app/code/core/Mage/Directory/Model/Resource/Country.php
@@ -83,7 +83,7 @@ class Mage_Directory_Model_Resource_Country extends Mage_Core_Model_Resource_Db_
                 break;
 
             default:
-                Mage::throwException(Mage::helper('directory')->__('Invalid country code: %s', $code));
+                Mage::throwException(Mage::helper('directory')->__('Invalid country code: %s', Mage::helper('core')->escapeHtml($code)));
         }
 
         return $this->load($country, $code, $field);

--- a/app/code/core/Mage/Paygate/controllers/Authorizenet/PaymentController.php
+++ b/app/code/core/Mage/Paygate/controllers/Authorizenet/PaymentController.php
@@ -13,10 +13,15 @@ class Mage_Paygate_Authorizenet_PaymentController extends Mage_Core_Controller_F
     /**
      * Cancel active partail authorizations
      */
-    #[Maho\Config\Route('/paygate/authorizenet_payment/cancel')]
+    #[Maho\Config\Route('/paygate/authorizenet_payment/cancel', methods: ['POST'])]
     public function cancelAction(): void
     {
         $result['success'] = false;
+        if (!$this->_validateFormKey()) {
+            $result['error_message'] = $this->__('Invalid form key. Please refresh the page.');
+            $this->getResponse()->setBody(Mage::helper('core')->jsonEncode($result));
+            return;
+        }
         try {
             $paymentMethod = Mage::helper('payment')->getMethodInstance(Mage_Paygate_Model_Authorizenet::METHOD_CODE);
             if ($paymentMethod) {

--- a/app/code/core/Mage/ProductAlert/controllers/AddController.php
+++ b/app/code/core/Mage/ProductAlert/controllers/AddController.php
@@ -27,17 +27,27 @@ class Mage_ProductAlert_AddController extends Mage_Core_Controller_Front_Action
         return $this;
     }
 
-    #[Maho\Config\Route('/productalert/add/testObserver', name: 'productalert.add.testobserver')]
+    #[Maho\Config\Route('/productalert/add/testObserver', name: 'productalert.add.testobserver', methods: ['POST'])]
     public function testObserverAction(): void
     {
+        if (!$this->_validateFormKey()) {
+            $this->_redirectReferer();
+            return;
+        }
+
         $object = new \Maho\DataObject();
         $observer = Mage::getSingleton('productalert/observer');
         $observer->process($object);
     }
 
-    #[Maho\Config\Route('/productalert/add/price', name: 'productalert.add.price')]
+    #[Maho\Config\Route('/productalert/add/price', name: 'productalert.add.price', methods: ['POST'])]
     public function priceAction(): void
     {
+        if (!$this->_validateFormKey()) {
+            $this->_redirectReferer();
+            return;
+        }
+
         $session = Mage::getSingleton('catalog/session');
         $backUrl    = $this->getRequest()->getParam(Mage_Core_Controller_Front_Action::PARAM_NAME_URL_ENCODED);
         $productId  = (int) $this->getRequest()->getParam('product_id');
@@ -72,9 +82,14 @@ class Mage_ProductAlert_AddController extends Mage_Core_Controller_Front_Action
         $this->_redirectReferer();
     }
 
-    #[Maho\Config\Route('/productalert/add/stock', name: 'productalert.add.stock')]
+    #[Maho\Config\Route('/productalert/add/stock', name: 'productalert.add.stock', methods: ['POST'])]
     public function stockAction(): void
     {
+        if (!$this->_validateFormKey()) {
+            $this->_redirectReferer();
+            return;
+        }
+
         $session = Mage::getSingleton('catalog/session');
         /** @var Mage_Catalog_Model_Session $session */
         $backUrl    = $this->getRequest()->getParam(Mage_Core_Controller_Front_Action::PARAM_NAME_URL_ENCODED);

--- a/app/code/core/Mage/Sales/Controller/Abstract.php
+++ b/app/code/core/Mage/Sales/Controller/Abstract.php
@@ -108,10 +108,18 @@ abstract class Mage_Sales_Controller_Abstract extends Mage_Core_Controller_Front
      */
     public function reorderAction(): void
     {
+        if (!$this->_validateFormKey()) {
+            $this->_redirectReferer();
+            return;
+        }
         if (!$this->_loadValidOrder()) {
             return;
         }
         $order = Mage::registry('current_order');
+        if (!Mage::helper('sales/reorder')->canReorder($order)) {
+            $this->_redirect('*/*/view', ['order_id' => $order->getId()]);
+            return;
+        }
         /** @var Mage_Checkout_Model_Cart $cart */
         $cart = Mage::getSingleton('checkout/cart');
 

--- a/app/code/core/Mage/Sales/controllers/Billing/AgreementController.php
+++ b/app/code/core/Mage/Sales/controllers/Billing/AgreementController.php
@@ -156,6 +156,11 @@ class Mage_Sales_Billing_AgreementController extends Mage_Core_Controller_Front_
     #[Maho\Config\Route('/sales/billing_agreement/cancel', name: 'sales.billing_agreement.cancel', methods: ['POST'])]
     public function cancelAction(): void
     {
+        if (!$this->_validateFormKey()) {
+            $this->_redirectReferer();
+            return;
+        }
+
         $agreement = $this->_initAgreement();
         if (!$agreement) {
             $this->_redirect('*/*/view', ['_current' => true]);

--- a/app/code/core/Mage/Sales/controllers/GuestController.php
+++ b/app/code/core/Mage/Sales/controllers/GuestController.php
@@ -66,6 +66,13 @@ class Mage_Sales_GuestController extends Mage_Sales_Controller_Abstract
     }
 
     #[\Override]
+    #[Maho\Config\Route('/sales/guest/reorder', name: 'sales.guest.reorder', methods: ['POST'])]
+    public function reorderAction(): void
+    {
+        parent::reorderAction();
+    }
+
+    #[\Override]
     public function printInvoiceAction(): void
     {
         if (!$this->_loadValidOrder()) {

--- a/app/code/core/Mage/Sales/controllers/OrderController.php
+++ b/app/code/core/Mage/Sales/controllers/OrderController.php
@@ -49,6 +49,13 @@ class Mage_Sales_OrderController extends Mage_Sales_Controller_Abstract
         $this->renderLayout();
     }
 
+    #[\Override]
+    #[Maho\Config\Route('/sales/order/reorder', name: 'sales.order.reorder', methods: ['POST'])]
+    public function reorderAction(): void
+    {
+        parent::reorderAction();
+    }
+
     /**
      * Associate guest orders with current customer
      */

--- a/app/code/core/Mage/Sales/controllers/Recurring/ProfileController.php
+++ b/app/code/core/Mage/Sales/controllers/Recurring/ProfileController.php
@@ -77,6 +77,11 @@ class Mage_Sales_Recurring_ProfileController extends Mage_Core_Controller_Front_
     #[Maho\Config\Route('/sales/recurring_profile/updateState', name: 'sales.recurring_profile.updateState', methods: ['POST'])]
     public function updateStateAction(): void
     {
+        if (!$this->_validateFormKey()) {
+            $this->_redirectReferer();
+            return;
+        }
+
         $profile = null;
         try {
             $profile = $this->_initProfile();
@@ -112,6 +117,11 @@ class Mage_Sales_Recurring_ProfileController extends Mage_Core_Controller_Front_
     #[Maho\Config\Route('/sales/recurring_profile/updateProfile', name: 'sales.recurring_profile.updateProfile', methods: ['POST'])]
     public function updateProfileAction(): void
     {
+        if (!$this->_validateFormKey()) {
+            $this->_redirectReferer();
+            return;
+        }
+
         $profile = null;
         try {
             $profile = $this->_initProfile();

--- a/app/code/core/Mage/Tag/controllers/CustomerController.php
+++ b/app/code/core/Mage/Tag/controllers/CustomerController.php
@@ -100,6 +100,11 @@ class Mage_Tag_CustomerController extends Mage_Core_Controller_Front_Action
             return;
         }
 
+        if (!$this->_validateFormKey()) {
+            $this->_redirect('*/*/');
+            return;
+        }
+
         $tagId = $this->_getTagId();
         if ($tagId) {
             try {

--- a/app/code/core/Mage/Tag/controllers/IndexController.php
+++ b/app/code/core/Mage/Tag/controllers/IndexController.php
@@ -13,7 +13,7 @@ class Mage_Tag_IndexController extends Mage_Core_Controller_Front_Action
     /**
      * Saving tag and relation between tag, customer, product and store
      */
-    #[Maho\Config\Route('/tag/index/save', name: 'tag.index.save')]
+    #[Maho\Config\Route('/tag/index/save', name: 'tag.index.save', methods: ['POST'])]
     public function saveAction(): void
     {
         $helper = Mage::helper('tag');
@@ -26,7 +26,11 @@ class Mage_Tag_IndexController extends Mage_Core_Controller_Front_Action
         if (!$customerSession->authenticate($this)) {
             return;
         }
-        $tagName    = (string) $this->getRequest()->getQuery('productTagName');
+        if (!$this->_validateFormKey()) {
+            $this->_redirectReferer();
+            return;
+        }
+        $tagName    = (string) $this->getRequest()->getParam('productTagName');
         $productId  = (int) $this->getRequest()->getParam('product');
 
         if (strlen($tagName) && $productId) {

--- a/app/code/core/Mage/Wishlist/Block/Share/Email/Items.php
+++ b/app/code/core/Mage/Wishlist/Block/Share/Email/Items.php
@@ -47,6 +47,18 @@ class Mage_Wishlist_Block_Share_Email_Items extends Mage_Wishlist_Block_Abstract
     }
 
     /**
+     * Retrieve URL of the shared wishlist page, where the recipient can add the item to the cart.
+     *
+     * An email cannot carry a form key, so it links to the page instead of the add-to-cart action.
+     *
+     * @param Mage_Wishlist_Model_Item $item
+     */
+    public function getSharedWishlistUrl($item): string
+    {
+        return Mage::helper('wishlist')->getSharedWishlistUrl($item);
+    }
+
+    /**
      * Check whether wishlist item has description
      *
      * @param Mage_Wishlist_Model_Item $item

--- a/app/code/core/Mage/Wishlist/Helper/Data.php
+++ b/app/code/core/Mage/Wishlist/Helper/Data.php
@@ -304,6 +304,18 @@ class Mage_Wishlist_Helper_Data extends Mage_Core_Helper_Abstract
     }
 
     /**
+     * Retrieve URL of the shared wishlist page holding the given item
+     *
+     * @param string|Mage_Catalog_Model_Product|Mage_Wishlist_Model_Item $item
+     */
+    public function getSharedWishlistUrl($item): string
+    {
+        return $this->_getUrlStore($item)->getUrl('wishlist/shared/index', [
+            'code' => $this->getWishlist()->getSharingCode(),
+        ]);
+    }
+
+    /**
      * Retrieve customer wishlist url
      *
      * @param int|null $wishlistId

--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -739,7 +739,6 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
                         'customer'       => $customer,
                         'salable'        => $wishlist->isSalable() ? 'yes' : '',
                         'items'          => $wishlistBlock,
-                        'addAllLink'     => Mage::getUrl('*/shared/allcart', ['code' => $sharingCode]),
                         'viewOnSiteLink' => Mage::getUrl('*/shared/index', ['code' => $sharingCode]),
                         'message'        => $message,
                     ],

--- a/app/code/core/Mage/Wishlist/controllers/IndexController.php
+++ b/app/code/core/Mage/Wishlist/controllers/IndexController.php
@@ -300,6 +300,11 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
     #[Maho\Config\Route('/wishlist/index/updateItemOptions', name: 'wishlist.index.updateItemOptions', methods: ['POST'])]
     public function updateItemOptionsAction(): void
     {
+        if (!$this->_validateFormKey()) {
+            $this->_redirect('*/');
+            return;
+        }
+
         $session = Mage::getSingleton('customer/session');
         $productId = (int) $this->getRequest()->getParam('product');
         if (!$productId) {
@@ -576,6 +581,10 @@ class Mage_Wishlist_IndexController extends Mage_Wishlist_Controller_Abstract
     #[Maho\Config\Route('/wishlist/index/fromcart', name: 'wishlist.index.fromcart', methods: ['POST'])]
     public function fromcartAction()
     {
+        if (!$this->_validateFormKey()) {
+            return $this->_redirectUrl(Mage::helper('checkout/cart')->getCartUrl());
+        }
+
         $wishlist = $this->_getWishlist();
         if (!$wishlist) {
             $this->norouteAction();

--- a/app/code/core/Mage/Wishlist/controllers/SharedController.php
+++ b/app/code/core/Mage/Wishlist/controllers/SharedController.php
@@ -11,12 +11,6 @@
 class Mage_Wishlist_SharedController extends Mage_Wishlist_Controller_Abstract
 {
     /**
-     * Is need check a Formkey
-     * @var bool
-     */
-    protected $_isCheckFormKey = false;
-
-    /**
      * Retrieve wishlist instance by requested code
      *
      * @return Mage_Wishlist_Model_Wishlist|false
@@ -59,6 +53,16 @@ class Mage_Wishlist_SharedController extends Mage_Wishlist_Controller_Abstract
         $this->_initLayoutMessages('checkout/session');
         $this->_initLayoutMessages('wishlist/session');
         $this->renderLayout();
+    }
+
+    /**
+     * Add every shared wishlist item to the shopping cart
+     */
+    #[\Override]
+    #[Maho\Config\Route('/wishlist/shared/allcart', name: 'wishlist.shared.allcart', methods: ['POST'])]
+    public function allcartAction(): void
+    {
+        parent::allcartAction();
     }
 
     /**

--- a/app/code/core/Mage/Wishlist/controllers/SharedController.php
+++ b/app/code/core/Mage/Wishlist/controllers/SharedController.php
@@ -72,11 +72,15 @@ class Mage_Wishlist_SharedController extends Mage_Wishlist_Controller_Abstract
     {
         $itemId = (int) $this->getRequest()->getParam('item');
         $code = $this->getRequest()->getParam('code');
+        $redirectUrl = Mage::getUrl('*/*/index', ['code' => $code]);
+
+        if (!$this->_validateFormKey()) {
+            return $this->_redirectUrl($redirectUrl);
+        }
 
         /** @var Mage_Wishlist_Model_Item $item */
         $item = Mage::getModel('wishlist/item')->load($itemId);
         $wishlist = Mage::getModel('wishlist/wishlist')->loadByCode($code);
-        $redirectUrl = Mage::getUrl('*/*/index', ['code' => $code]);
 
         /** @var Mage_Wishlist_Model_Session $session */
         $session    = Mage::getSingleton('wishlist/session');

--- a/app/design/frontend/base/default/template/catalog/product/compare/list.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/compare/list.phtml
@@ -174,7 +174,7 @@
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded'
                 },
-                body: 'isAjax=1'
+                body: new URLSearchParams({ isAjax: 1, form_key: '<?= $this->getFormKey() ?>' })
             })
                 .then(response => {
                     if (!response.ok) {

--- a/app/design/frontend/base/default/template/catalog/product/compare/sidebar.phtml
+++ b/app/design/frontend/base/default/template/catalog/product/compare/sidebar.phtml
@@ -27,14 +27,20 @@ $_items = $_helper->getItemCount() > 0 ? $_helper->getItemCollection() : null;
         <?php foreach ($_items as $_index => $_item): ?>
             <li class="item">
                 <input type="hidden" class="compare-item-id" value="<?= $_item->getId() ?>">
-                <a href="<?= $_helper->getRemoveUrl($_item) ?>" title="<?= $this->quoteEscape($this->__('Remove This Item')) ?>" class="btn-remove" onclick="return confirm('<?= $this->jsQuoteEscape($this->__('Are you sure you would like to remove this item from the compare products?')) ?>');"><?= $this->__('Remove This Item') ?></a>
+                <form action="<?= $this->escapeUrl($_helper->getRemoveUrl($_item)) ?>" method="post" class="inline" onsubmit="return confirm('<?= $this->jsQuoteEscape($this->__('Are you sure you would like to remove this item from the compare products?')) ?>')">
+                    <?= $this->getBlockHtml('formkey') ?>
+                    <button type="submit" title="<?= $this->quoteEscape($this->__('Remove This Item')) ?>" class="btn-link btn-remove"><?= $this->__('Remove This Item') ?></button>
+                </form>
                 <p class="product-name"><a href="<?= $this->getProductUrl($_item) ?>"><?= $this->helper('catalog/output')->productAttribute($_item, $_item->getName(), 'name') ?></a></p>
             </li>
         <?php endforeach ?>
         </ol>
         <div class="actions">
             <button type="button" title="<?= $this->quoteEscape($this->__('Compare')) ?>" class="button" onclick="popWin('<?= $_helper->getListUrl() ?>','compare','top:0,left:0,width=820,height=600,resizable=yes,scrollbars=yes')"><?= $this->__('Compare') ?></button>
-            <a href="<?= $_helper->getClearListUrl() ?>" onclick="return confirm('<?= $this->jsQuoteEscape($this->__('Are you sure you would like to remove all products from your comparison?')) ?>');"><?= $this->__('Clear All') ?></a>
+            <form action="<?= $this->escapeUrl($_helper->getClearListUrl()) ?>" method="post" class="inline" onsubmit="return confirm('<?= $this->jsQuoteEscape($this->__('Are you sure you would like to remove all products from your comparison?')) ?>')">
+                <?= $this->getBlockHtml('formkey') ?>
+                <button type="submit" class="btn-link"><?= $this->__('Clear All') ?></button>
+            </form>
         </div>
     <?php else: ?>
         <p class="empty"><?= $this->__('You have no items to compare.') ?></p>

--- a/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/item/default.phtml
@@ -181,7 +181,8 @@ $_weeeAmount = $_item->getWeeeTaxAppliedAmount();
         <?php endif ?>
 
         <?php if ($this->helper('wishlist')->isAllowInCart() && $isVisibleProduct): ?>
-            <a href="<?= $this->helper('wishlist')->getMoveFromCartUrl($_item->getId()) ?>" class="link-wishlist use-ajax" title="<?= $this->quoteEscape($this->__('Move to wishlist')) ?>">
+            <a href="#" class="link-wishlist" title="<?= $this->quoteEscape($this->__('Move to wishlist')) ?>"
+               onclick="customFormSubmit('<?= $this->helper('wishlist')->getMoveFromCartUrl($_item->getId()) ?>', '<?= $_params ?>', 'post')">
                 <?= $this->getIconSvg('heart') ?>
                 <?= $this->__('Move to wishlist') ?>
             </a>

--- a/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
+++ b/app/design/frontend/base/default/template/checkout/cart/shipping.phtml
@@ -12,6 +12,7 @@
     <h2><?= $this->__('Estimate Shipping and Tax') ?></h2>
     <div class="shipping-form">
        <form action="<?= $this->getFormActionUrl() ?>" method="post" id="shipping-zip-form">
+            <?= $this->getBlockHtml('formkey') ?>
             <div class="shipping-fields-grid">
                 <div class="form-field">
                     <label for="country" class="required"><em>*</em> <?= $this->__('Country') ?></label>

--- a/app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/downloadable/checkout/cart/item/default.phtml
@@ -303,7 +303,8 @@ $_deleteUrl = $this->getDeleteUrlCustom(false);
     <?php endif ?>
 
     <?php if ($this->helper('wishlist')->isAllowInCart() && $isVisibleProduct): ?>
-        <a href="<?= $this->helper('wishlist')->getMoveFromCartUrl($_item->getId()) ?>" class="link-wishlist use-ajax" title="<?= $this->quoteEscape($this->__('Move to wishlist')) ?>">
+        <a href="#" class="link-wishlist" title="<?= $this->quoteEscape($this->__('Move to wishlist')) ?>"
+           onclick="customFormSubmit('<?= $this->helper('wishlist')->getMoveFromCartUrl($_item->getId()) ?>', '<?= $_params ?>', 'post')">
             <?= $this->getIconSvg('heart') ?>
             <?= $this->__('Move to wishlist') ?>
         </a>

--- a/app/design/frontend/base/default/template/paygate/form/cc.phtml
+++ b/app/design/frontend/base/default/template/paygate/form/cc.phtml
@@ -43,7 +43,7 @@
                         'Content-Type': 'application/x-www-form-urlencoded'
                     },
                     body: new URLSearchParams({
-                        form_key: typeof FORM_KEY !== 'undefined' ? FORM_KEY : ''
+                        form_key: '<?= $this->getFormKey() ?>'
                     }).toString()
                 })
                     .then(response => {

--- a/app/design/frontend/base/default/template/productalert/product/view.phtml
+++ b/app/design/frontend/base/default/template/productalert/product/view.phtml
@@ -8,6 +8,9 @@
  */
 ?>
 <?php /** @var Mage_ProductAlert_Block_Product_View $this */?>
-<p class="<?= $this->getHtmlClass() ?>">
-    <a href="<?= $this->escapeHtml($this->getSignupUrl()) ?>" title="<?= $this->escapeHtml($this->__($this->getSignupLabel())) ?>"><?= $this->escapeHtml($this->__($this->getSignupLabel())) ?></a>
-</p>
+<div class="<?= $this->getHtmlClass() ?>">
+    <form action="<?= $this->escapeUrl($this->getSignupUrl()) ?>" method="post" class="inline">
+        <?= $this->getBlockHtml('formkey') ?>
+        <button type="submit" class="btn-link" title="<?= $this->escapeHtml($this->__($this->getSignupLabel())) ?>"><?= $this->escapeHtml($this->__($this->getSignupLabel())) ?></button>
+    </form>
+</div>

--- a/app/design/frontend/base/default/template/sales/billing/agreement/view.phtml
+++ b/app/design/frontend/base/default/template/sales/billing/agreement/view.phtml
@@ -11,7 +11,10 @@
 <div class="page-title title-buttons billing-agreement-view-header-wrapper">
     <h1 class="heading"><?= $this->__('Billing Agreement # %s', $this->escapeHtml($this->getReferenceId())) ?></h1>
     <?php if ($this->getCanCancel()): ?>
-        <button type="button" title="<?= $this->quoteEscape($this->__('Cancel')) ?>" class="button" onclick="if( confirm('<?= $this->jsQuoteEscape($this->__('Are you sure you want to do this?')) ?>') ) { window.location.href = '<?= $this->getCancelUrl() ?>'; } return false;"><?= $this->__('Cancel') ?></button>
+        <form action="<?= $this->escapeUrl($this->getCancelUrl()) ?>" method="post" onsubmit="return confirm('<?= $this->jsQuoteEscape($this->__('Are you sure you want to do this?')) ?>')">
+            <?= $this->getBlockHtml('formkey') ?>
+            <button type="submit" title="<?= $this->quoteEscape($this->__('Cancel')) ?>" class="button"><?= $this->__('Cancel') ?></button>
+        </form>
     <?php endif ?>
 </div>
 <?= $this->getMessagesBlock()->toHtml() ?>

--- a/app/design/frontend/base/default/template/sales/order/history.phtml
+++ b/app/design/frontend/base/default/template/sales/order/history.phtml
@@ -45,7 +45,11 @@
             <td class="a-center view">
                 <span class="nobr"><a href="<?= $this->getViewUrl($_order) ?>"><?= $this->__('View') ?></a>
                     <?php if ($this->helper('sales/reorder')->canReorder($_order)): ?>
-                    <span class="separator">|</span> <a href="<?= $this->getReorderUrl($_order) ?>" class="link-reorder"><?= $this->__('Reorder') ?></a>
+                    <span class="separator">|</span>
+                    <form action="<?= $this->escapeUrl($this->getReorderUrl($_order)) ?>" method="post" class="inline">
+                        <?= $this->getBlockHtml('formkey') ?>
+                        <button type="submit" class="btn-link link-reorder"><?= $this->__('Reorder') ?></button>
+                    </form>
                 <?php endif ?>
                 </span>
             </td>

--- a/app/design/frontend/base/default/template/sales/order/info/buttons.phtml
+++ b/app/design/frontend/base/default/template/sales/order/info/buttons.phtml
@@ -15,7 +15,10 @@
     <span class="separator">|</span>
 <?php endif ?>
 <?php if ($this->helper('sales/reorder')->canReorder($_order)): ?>
-    <a href="<?= $this->getReorderUrl($_order) ?>" class="link-reorder"><?= $this->__('Reorder') ?></a>
+    <form action="<?= $this->escapeUrl($this->getReorderUrl($_order)) ?>" method="post" class="inline">
+        <?= $this->getBlockHtml('formkey') ?>
+        <button type="submit" class="link-reorder"><?= $this->__('Reorder') ?></button>
+    </form>
     <span class="separator">|</span>
 <?php endif ?>
 <a href="<?= $this->getPrintUrl($_order) ?>" class="link-print" onclick="this.target='_blank';"><?= $this->__('Print Order') ?></a>

--- a/app/design/frontend/base/default/template/sales/order/recent.phtml
+++ b/app/design/frontend/base/default/template/sales/order/recent.phtml
@@ -45,7 +45,11 @@
                         <span class="nobr">
                         <a href="<?= $this->getViewUrl($_order) ?>"><?= $this->__('View') ?></a>
                         <?php if ($this->helper('sales/reorder')->canReorder($_order)): ?>
-                            <span class="separator">|</span> <a href="<?= $this->getReorderUrl($_order) ?>" class="link-reorder"><?= $this->__('Reorder') ?></a>
+                            <span class="separator">|</span>
+                            <form action="<?= $this->escapeUrl($this->getReorderUrl($_order)) ?>" method="post" class="inline">
+                                <?= $this->getBlockHtml('formkey') ?>
+                                <button type="submit" class="btn-link link-reorder"><?= $this->__('Reorder') ?></button>
+                            </form>
                         <?php endif ?>
                         </span>
                     </td>

--- a/app/design/frontend/base/default/template/sales/recurring/profile/view.phtml
+++ b/app/design/frontend/base/default/template/sales/recurring/profile/view.phtml
@@ -16,17 +16,30 @@
     <h1><?= $this->__('Recurring Profile # %s', $this->escapeHtml($this->getReferenceId())) ?></h1>
 </div>
 <div class="title-buttons recurring-profiles-title-buttons">
+    <?php $confirm = $this->jsQuoteEscape($this->getConfirmationMessage()) ?>
     <?php if ($this->getCanCancel()): ?>
-        <button type="button" title="<?= $this->quoteEscape($this->__('Cancel')) ?>" class="button" onclick="if( confirm('<?= $this->getConfirmationMessage() ?>') ) { window.location.href = '<?= $this->getCancelUrl() ?>'; } return false;"><?= $this->__('Cancel') ?></button>
+        <form action="<?= $this->escapeUrl($this->getCancelUrl()) ?>" method="post" onsubmit="return confirm('<?= $confirm ?>')">
+            <?= $this->getBlockHtml('formkey') ?>
+            <button type="submit" title="<?= $this->quoteEscape($this->__('Cancel')) ?>" class="button"><?= $this->__('Cancel') ?></button>
+        </form>
     <?php endif ?>
     <?php if ($this->getCanSuspend()): ?>
-        <button type="button" title="<?= $this->quoteEscape($this->__('Suspend')) ?>" class="button" onclick="if( confirm('<?= $this->getConfirmationMessage() ?>') ) { window.location.href = '<?= $this->getSuspendUrl() ?>'; } return false;"><?= $this->__('Suspend') ?></button>
+        <form action="<?= $this->escapeUrl($this->getSuspendUrl()) ?>" method="post" onsubmit="return confirm('<?= $confirm ?>')">
+            <?= $this->getBlockHtml('formkey') ?>
+            <button type="submit" title="<?= $this->quoteEscape($this->__('Suspend')) ?>" class="button"><?= $this->__('Suspend') ?></button>
+        </form>
     <?php endif ?>
     <?php if ($this->getCanActivate()): ?>
-        <button type="button" title="<?= $this->quoteEscape($this->__('Activate')) ?>" class="button" onclick="if( confirm('<?= $this->getConfirmationMessage() ?>') ) { window.location.href = '<?= $this->getActivateUrl() ?>'; } return false;"><?= $this->__('Activate') ?></button>
+        <form action="<?= $this->escapeUrl($this->getActivateUrl()) ?>" method="post" onsubmit="return confirm('<?= $confirm ?>')">
+            <?= $this->getBlockHtml('formkey') ?>
+            <button type="submit" title="<?= $this->quoteEscape($this->__('Activate')) ?>" class="button"><?= $this->__('Activate') ?></button>
+        </form>
     <?php endif ?>
     <?php if ($this->getCanUpdate()): ?>
-        <button type="button" title="<?= $this->quoteEscape($this->__('Get Update')) ?>" class="button" onclick="if( confirm('<?= $this->getConfirmationMessage() ?>') ) { window.location.href = '<?= $this->getUpdateUrl() ?>'; } return false;"><?= $this->__('Get Update') ?></button>
+        <form action="<?= $this->escapeUrl($this->getUpdateUrl()) ?>" method="post" onsubmit="return confirm('<?= $confirm ?>')">
+            <?= $this->getBlockHtml('formkey') ?>
+            <button type="submit" title="<?= $this->quoteEscape($this->__('Get Update')) ?>" class="button"><?= $this->__('Get Update') ?></button>
+        </form>
     <?php endif ?>
 </div>
 

--- a/app/design/frontend/base/default/template/tag/customer/view.phtml
+++ b/app/design/frontend/base/default/template/tag/customer/view.phtml
@@ -13,10 +13,13 @@
     <h1><?= $this->__('My Tags') ?></h1>
 </div>
 <?= $this->getMessagesBlock()->toHtml() ?>
-<p class="my-tag-edit">
-    <a href="#" title="<?= $this->quoteEscape($this->__('Delete')) ?>" onclick="if(confirm('<?= $this->quoteEscape($this->__('Are you sure you want to delete this tag?'), true) ?>')) window.location='<?= $this->getTagInfo()->getRemoveTagUrl() ?>'; return false;" class="button btn-remove"><span><?= $this->__('Delete') ?></span></a>
+<div class="my-tag-edit">
+    <form action="<?= $this->escapeUrl($this->getTagInfo()->getRemoveTagUrl()) ?>" method="post" class="inline" onsubmit="return confirm('<?= $this->jsQuoteEscape($this->__('Are you sure you want to delete this tag?')) ?>')">
+        <?= $this->getBlockHtml('formkey') ?>
+        <button type="submit" title="<?= $this->quoteEscape($this->__('Delete')) ?>" class="button btn-remove"><span><?= $this->__('Delete') ?></span></button>
+    </form>
     <?= $this->__('<strong>Tag Name:</strong> %s', $this->escapeHtml($this->getTagInfo()->getName())) ?>
-</p>
+</div>
 <div class="clearer"></div>
 <?= $this->getToolbarHtml() ?>
 <table class="data-table" id="my-tags-table">

--- a/app/design/frontend/base/default/template/tag/list.phtml
+++ b/app/design/frontend/base/default/template/tag/list.phtml
@@ -19,7 +19,8 @@
     <?php endif ?>
 
     <?php if ($this->helper('tag')->isAddingTagsEnabledOnFrontend()): ?>
-        <form id="addTagForm" action="<?= $this->getFormAction() ?>" method="get">
+        <form id="addTagForm" action="<?= $this->getFormAction() ?>" method="post">
+            <?= $this->getBlockHtml('formkey') ?>
             <div class="form-add">
                 <label for="productTagName"><?= $this->__('Add Your Tags:') ?></label>
                 <div class="input-box">

--- a/app/design/frontend/base/default/template/wishlist/email/items.phtml
+++ b/app/design/frontend/base/default/template/wishlist/email/items.phtml
@@ -22,7 +22,7 @@
             <p align="center" style="font-size:12px;"><a href="<?= $this->getProductUrl($_product) ?>" style="color:#203548;"><strong><?= $this->escapeHtml($_product->getName()) ?></strong></a></p>
             <?php if ($this->hasDescription($item)): ?><p align="center" style="font-size:12px;"><?= $this->__('Comment') ?>:<br><?= $this->getEscapedDescription($item) ?></p><?php endif ?>
             <p align="center" style="font-size:12px;"><a href="<?= $this->getProductUrl($_product) ?>" style="color:#1E7EC8;"><?= $this->__('View Product') ?></a> <small>
-            <?php if ($_product->getIsSalable()): ?>|</small> <a href="<?= $this->getSharedItemAddToCartUrl($item) ?>" style="color:#1E7EC8;"><strong><?= $this->__('Add to Cart') ?></strong></a><?php endif ?>
+            <?php if ($_product->getIsSalable()): ?>|</small> <a href="<?= $this->getSharedWishlistUrl($item) ?>" style="color:#1E7EC8;"><strong><?= $this->__('Add to Cart') ?></strong></a><?php endif ?>
             </p></td>
         <?php if ($i % 3 != 0): ?>
             <td width="2%"></td>

--- a/app/design/frontend/base/default/template/wishlist/email/items.phtml
+++ b/app/design/frontend/base/default/template/wishlist/email/items.phtml
@@ -22,7 +22,7 @@
             <p align="center" style="font-size:12px;"><a href="<?= $this->getProductUrl($_product) ?>" style="color:#203548;"><strong><?= $this->escapeHtml($_product->getName()) ?></strong></a></p>
             <?php if ($this->hasDescription($item)): ?><p align="center" style="font-size:12px;"><?= $this->__('Comment') ?>:<br><?= $this->getEscapedDescription($item) ?></p><?php endif ?>
             <p align="center" style="font-size:12px;"><a href="<?= $this->getProductUrl($_product) ?>" style="color:#1E7EC8;"><?= $this->__('View Product') ?></a> <small>
-            <?php if ($_product->getIsSalable()): ?>|</small> <a href="<?= $this->getSharedWishlistUrl($item) ?>" style="color:#1E7EC8;"><strong><?= $this->__('Add to Cart') ?></strong></a><?php endif ?>
+            <?php if ($_product->getIsSalable()): ?>|</small> <a href="<?= $this->getSharedWishlistUrl($item) ?>" style="color:#1E7EC8;"><strong><?= $this->__('Add to Cart on Site') ?></strong></a><?php endif ?>
             </p></td>
         <?php if ($i % 3 != 0): ?>
             <td width="2%"></td>

--- a/app/design/frontend/base/default/template/wishlist/shared.phtml
+++ b/app/design/frontend/base/default/template/wishlist/shared.phtml
@@ -48,7 +48,7 @@
                     <td class="a-center">
                     <?php if ($product->isSaleable()): ?>
                         <?php if ($isVisibleProduct): ?>
-                            <button type="button" title="<?= $this->quoteEscape($this->__('Add to Cart')) ?>" onclick="setLocation('<?= $this->getSharedItemAddToCartUrl($item) ?>')" class="button btn-cart"><?= $this->__('Add to Cart') ?></button>
+                            <button type="button" title="<?= $this->quoteEscape($this->__('Add to Cart')) ?>" onclick="customFormSubmit('<?= $this->getSharedItemAddToCartUrl($item) ?>', '<?= $_params ?>', 'post')" class="button btn-cart"><?= $this->__('Add to Cart') ?></button>
                         <?php endif ?>
                     <?php endif ?>
                         <p>

--- a/app/design/frontend/base/default/template/wishlist/shared.phtml
+++ b/app/design/frontend/base/default/template/wishlist/shared.phtml
@@ -70,7 +70,7 @@
         <div class="buttons-set">
             <p class="back-link"><a href="<?= $this->escapeUrl($this->getBackUrl()) ?>"><small>&laquo; </small><?= $this->__('Back') ?></a></p>
             <?php if ($this->isSaleable()): ?>
-                <button type="button" title="<?= $this->quoteEscape($this->__('Add All to Cart')) ?>" onclick="setLocation('<?= $this->getUrl('*/*/allcart', ['_current' => true]) ?>')" class="button"><?= $this->__('Add All to Cart') ?></button>
+                <button type="button" title="<?= $this->quoteEscape($this->__('Add All to Cart')) ?>" onclick="customFormSubmit('<?= $this->getUrl('*/*/allcart', ['_current' => true]) ?>', '<?= $_params ?>', 'post')" class="button"><?= $this->__('Add All to Cart') ?></button>
             <?php endif ?>
         </div>
     </form>

--- a/app/locale/en_US/Mage_Paygate.csv
+++ b/app/locale/en_US/Mage_Paygate.csv
@@ -28,6 +28,7 @@
 "Invalid amount for capture.","Invalid amount for capture."
 "Invalid amount for partial authorization.","Invalid amount for partial authorization."
 "Invalid amount for refund.","Invalid amount for refund."
+"Invalid form key. Please refresh the page.","Invalid form key. Please refresh the page."
 "Invalid split tenderId ID.","Invalid split tenderId ID."
 "Maximum Order Total","Maximum Order Total"
 "Merchant's Email","Merchant's Email"

--- a/app/locale/en_US/Mage_Wishlist.csv
+++ b/app/locale/en_US/Mage_Wishlist.csv
@@ -10,6 +10,7 @@
 "Add All to Cart","Add All to Cart"
 "Added From","Added From"
 "Add to Cart","Add to Cart"
+"Add to Cart on Site","Add to Cart on Site"
 "Add to Compare","Add to Compare"
 "Add to Wishlist","Add to Wishlist"
 "An error occurred while adding item to wishlist.","An error occurred while adding item to wishlist."

--- a/app/locale/en_US/template/email/wishlist_share.html
+++ b/app/locale/en_US/template/email/wishlist_share.html
@@ -25,10 +25,7 @@
                             </tr>
                         </table>
                         {{var items}}
-                        {{depend salable}}
-                        <p><strong><a href="{{var addAllLink}}">Add all items to shopping cart</a></strong> |
-                        {{/depend}}
-                        <strong><a href="{{var viewOnSiteLink}}">View all wishlist items</a></strong></p>
+                        <p><strong><a href="{{var viewOnSiteLink}}">View all wishlist items</a></strong></p>
                     </td>
                 </tr>
             </table>

--- a/public/skin/frontend/legacy/default/css/styles.css
+++ b/public/skin/frontend/legacy/default/css/styles.css
@@ -939,6 +939,33 @@ a.button:hover {
   text-decoration: none;
 }
 
+/* A state-changing action is a form button, not a link. Keep the form inline and
+   strip the browser chrome so the button reads like the link it replaces */
+form.inline {
+  display: inline;
+}
+
+button.btn-link,
+button.link-reorder {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: var(--maho-color-primary);
+  cursor: pointer;
+}
+
+button.btn-link:hover,
+button.link-reorder:hover {
+  text-decoration: underline;
+}
+
+button.btn-remove {
+  background: none;
+  padding: 0;
+  cursor: pointer;
+}
+
 .btn-previous:after {
   content: '';
   position: absolute;

--- a/tests/Backend/Unit/Directory/CountryCodeMessageTest.php
+++ b/tests/Backend/Unit/Directory/CountryCodeMessageTest.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoBackendTestCase::class);
+
+it('escapes the rejected country code in the error message', function () {
+    try {
+        Mage::getModel('directory/country')->loadByCode('<b>x</b>');
+        $this->fail('An invalid country code must raise an exception.');
+    } catch (Mage_Core_Exception $e) {
+        expect($e->getMessage())->toContain('&lt;b&gt;x&lt;/b&gt;')->not->toContain('<b>');
+    }
+});

--- a/tests/Frontend/Integration/Catalog/CompareFormKeyTest.php
+++ b/tests/Frontend/Integration/Catalog/CompareFormKeyTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+uses(Tests\MahoFrontendTestCase::class);
+
+function cmpfkController(string $action, array $post): Mage_Catalog_Product_CompareController
+{
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/catalog/product_compare/' . $action, 'POST', $post),
+    );
+    $request->setPathInfo('/catalog/product_compare/' . $action);
+    $request->setRouteName('catalog')
+        ->setControllerName('product_compare')
+        ->setActionName($action)
+        ->setControllerModule('Mage_Catalog')
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+
+    $controller = new Mage_Catalog_Product_CompareController($request, new Mage_Core_Controller_Response_Http());
+    Mage::dispatchEvent('controller_action_predispatch', ['controller_action' => $controller]);
+
+    return $controller;
+}
+
+function cmpfkCompareCount(): int
+{
+    return (int) Mage::getResourceModel('catalog/product_compare_item_collection')
+        ->setVisitorId(Mage::getSingleton('log/visitor')->getId())
+        ->getSize();
+}
+
+beforeEach(function () {
+    Mage::unregister(Mage_Core_Model_Session_Abstract::REGISTRY_KEY);
+    $session = new Session(new MockArraySessionStorage());
+    $session->start();
+    Mage::register(Mage_Core_Model_Session_Abstract::REGISTRY_KEY, $session);
+
+    Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
+    Mage::app()->getStore()->setConfig('catalog/recently_products/enabled_product_compare', '1');
+    Mage::app()->getStore()->setConfig('system/log/enable_log', '2');
+    Mage::app()->addEventArea('frontend');
+    Mage::getSingleton('customer/session')->logout();
+    Mage::getSingleton('catalog/session')->getMessages(true);
+});
+
+it('refuses to clear the comparison list without a form key', function () {
+    $controller = cmpfkController('clear', []);
+
+    $controller->clearAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(Mage::getSingleton('catalog/session')->getMessages()->count())->toBe(0);
+});
+
+it('refuses to remove a compared product without a form key', function () {
+    $controller = cmpfkController('remove', ['product' => 1]);
+
+    $controller->removeAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(Mage::getSingleton('catalog/session')->getMessages()->count())->toBe(0);
+});
+
+it('clears the comparison list when the form key is valid', function () {
+    $product = Mage::getModel('catalog/product')->getCollection()
+        ->addAttributeToFilter('status', Mage_Catalog_Model_Product_Status::STATUS_ENABLED)
+        ->setPageSize(1)
+        ->getFirstItem();
+
+    $addController = cmpfkController('add', [
+        'product' => $product->getId(),
+        'form_key' => Mage::getSingleton('core/session')->getFormKey(),
+    ]);
+    $addController->addAction();
+    expect(cmpfkCompareCount())->toBeGreaterThan(0);
+
+    $controller = cmpfkController('clear', ['form_key' => Mage::getSingleton('core/session')->getFormKey()]);
+    $controller->clearAction();
+
+    expect(cmpfkCompareCount())->toBe(0);
+});

--- a/tests/Frontend/Integration/Checkout/CartEstimateFormKeyTest.php
+++ b/tests/Frontend/Integration/Checkout/CartEstimateFormKeyTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+uses(Tests\MahoFrontendTestCase::class);
+
+function cefkController(string $action, array $post): Mage_Checkout_CartController
+{
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/checkout/cart/' . $action, 'POST', $post),
+    );
+    $request->setRouteName('checkout')
+        ->setControllerName('cart')
+        ->setActionName($action)
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+
+    return new Mage_Checkout_CartController($request, new Mage_Core_Controller_Response_Http());
+}
+
+beforeEach(function () {
+    Mage::unregister(Mage_Core_Model_Session_Abstract::REGISTRY_KEY);
+    $session = new Session(new MockArraySessionStorage());
+    $session->start();
+    Mage::register(Mage_Core_Model_Session_Abstract::REGISTRY_KEY, $session);
+    Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
+    Mage::getSingleton('checkout/session')->getMessages(true);
+});
+
+it('ignores a shipping estimate without a form key', function () {
+    $controller = cefkController('estimatePost', ['country_id' => 'XXXX', 'estimate_postcode' => '12345']);
+
+    $controller->estimatePostAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(Mage::getSingleton('checkout/session')->getMessages()->count())->toBe(0);
+});
+
+it('escapes the rejected country code in the estimate error', function () {
+    $controller = cefkController('estimatePost', [
+        'country_id' => '<b>x</b>',
+        'form_key' => Mage::getSingleton('core/session')->getFormKey(),
+    ]);
+
+    $controller->estimatePostAction();
+
+    $message = Mage::getSingleton('checkout/session')->getMessages()->getLastAddedMessage();
+    expect($message)->not->toBeNull();
+    expect($message->getText())->toContain('&lt;b&gt;x&lt;/b&gt;')->not->toContain('<b>');
+});
+
+it('ignores a shipping method update without a form key', function () {
+    $controller = cefkController('estimateUpdatePost', ['estimate_method' => 'flatrate_flatrate']);
+
+    $controller->estimateUpdatePostAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(Mage::getSingleton('checkout/session')->getQuote()->getShippingAddress()->getShippingMethod())->toBeEmpty();
+});
+
+it('refuses a coupon without a form key', function () {
+    $controller = cefkController('couponPost', ['coupon_code' => 'NOPE', 'isAjax' => 1]);
+
+    $controller->couponPostAction();
+
+    $result = Mage::helper('core')->jsonDecode($controller->getResponse()->getBody());
+    expect($result['success'])->toBeFalse();
+    expect($result['message'])->toBe('Invalid form key. Please refresh the page.');
+});

--- a/tests/Frontend/Integration/Paygate/CancelFormKeyTest.php
+++ b/tests/Frontend/Integration/Paygate/CancelFormKeyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+uses(Tests\MahoFrontendTestCase::class);
+
+beforeEach(function () {
+    Mage::unregister(Mage_Core_Model_Session_Abstract::REGISTRY_KEY);
+    $session = new Session(new MockArraySessionStorage());
+    $session->start();
+    Mage::register(Mage_Core_Model_Session_Abstract::REGISTRY_KEY, $session);
+    Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
+});
+
+it('refuses to cancel partial authorizations without a form key', function () {
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/paygate/authorizenet_payment/cancel', 'POST', []),
+    );
+    $request->setRouteName('paygate')
+        ->setControllerName('authorizenet_payment')
+        ->setActionName('cancel')
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+
+    $controller = new Mage_Paygate_Authorizenet_PaymentController($request, new Mage_Core_Controller_Response_Http());
+    $controller->cancelAction();
+
+    $result = Mage::helper('core')->jsonDecode($controller->getResponse()->getBody());
+    expect($result['success'])->toBeFalse();
+    expect($result['error_message'])->toBe('Invalid form key. Please refresh the page.');
+});

--- a/tests/Frontend/Integration/ProductAlert/AddFormKeyTest.php
+++ b/tests/Frontend/Integration/ProductAlert/AddFormKeyTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+uses(Tests\MahoFrontendTestCase::class);
+
+function pafkCreateCustomer(): Mage_Customer_Model_Customer
+{
+    $customer = Mage::getModel('customer/customer')
+        ->setWebsiteId(Mage::app()->getStore()->getWebsiteId())
+        ->setStore(Mage::app()->getStore())
+        ->setEmail('alert-' . uniqid() . '@example.com')
+        ->setFirstname('Alert')
+        ->setLastname('Tester')
+        ->setForceConfirmed(true)
+        ->setPassword('SomePassword123!');
+    $customer->save();
+    return $customer;
+}
+
+function pafkController(string $action, array $post): Mage_ProductAlert_AddController
+{
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/productalert/add/' . $action, 'POST', $post),
+    );
+    $request->setRouteName('productalert')
+        ->setControllerName('add')
+        ->setActionName($action)
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+
+    return new Mage_ProductAlert_AddController($request, new Mage_Core_Controller_Response_Http());
+}
+
+beforeEach(function () {
+    Mage::unregister(Mage_Core_Model_Session_Abstract::REGISTRY_KEY);
+    $session = new Session(new MockArraySessionStorage());
+    $session->start();
+    Mage::register(Mage_Core_Model_Session_Abstract::REGISTRY_KEY, $session);
+    Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
+    Mage::getSingleton('customer/session')->logout();
+    $this->customer = pafkCreateCustomer();
+    Mage::getSingleton('customer/session')->setCustomer($this->customer);
+    Mage::getSingleton('catalog/session')->getMessages(true);
+});
+
+afterEach(function () {
+    Mage::register('isSecureArea', true, true);
+    foreach (['productalert/stock', 'productalert/price'] as $type) {
+        $alerts = Mage::getModel($type)->getCollection()->addFieldToFilter('customer_id', $this->customer->getId());
+        foreach ($alerts as $alert) {
+            $alert->delete();
+        }
+    }
+    $this->customer->delete();
+    Mage::unregister('isSecureArea');
+    Mage::getSingleton('customer/session')->logout();
+});
+
+it('refuses a stock alert signup without a form key', function () {
+    $controller = pafkController('stock', [
+        'product_id' => 1,
+        Mage_Core_Controller_Front_Action::PARAM_NAME_URL_ENCODED => Mage::helper('core')->urlEncode('http://localhost/'),
+    ]);
+
+    $controller->stockAction();
+
+    $alerts = Mage::getModel('productalert/stock')->getCollection()
+        ->addFieldToFilter('customer_id', $this->customer->getId());
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(Mage::getSingleton('catalog/session')->getMessages()->count())->toBe(0);
+    expect($alerts->getSize())->toBe(0);
+});
+
+it('refuses a price alert signup without a form key', function () {
+    $controller = pafkController('price', [
+        'product_id' => 1,
+        Mage_Core_Controller_Front_Action::PARAM_NAME_URL_ENCODED => Mage::helper('core')->urlEncode('http://localhost/'),
+    ]);
+
+    $controller->priceAction();
+
+    $alerts = Mage::getModel('productalert/price')->getCollection()
+        ->addFieldToFilter('customer_id', $this->customer->getId());
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(Mage::getSingleton('catalog/session')->getMessages()->count())->toBe(0);
+    expect($alerts->getSize())->toBe(0);
+});

--- a/tests/Frontend/Integration/Sales/BillingAgreementFormKeyTest.php
+++ b/tests/Frontend/Integration/Sales/BillingAgreementFormKeyTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+uses(Tests\MahoFrontendTestCase::class);
+
+function bafkCreateCustomer(): Mage_Customer_Model_Customer
+{
+    $customer = Mage::getModel('customer/customer')
+        ->setWebsiteId(Mage::app()->getStore()->getWebsiteId())
+        ->setStore(Mage::app()->getStore())
+        ->setEmail('agreement-' . uniqid() . '@example.com')
+        ->setFirstname('Agreement')
+        ->setLastname('Tester')
+        ->setForceConfirmed(true)
+        ->setPassword('SomePassword123!');
+    $customer->save();
+    return $customer;
+}
+
+function bafkController(array $post): Mage_Sales_Billing_AgreementController
+{
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/sales/billing_agreement/cancel', 'POST', $post),
+    );
+    $request->setRouteName('sales')
+        ->setControllerName('billing_agreement')
+        ->setActionName('cancel')
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+
+    return new Mage_Sales_Billing_AgreementController($request, new Mage_Core_Controller_Response_Http());
+}
+
+beforeEach(function () {
+    Mage::unregister(Mage_Core_Model_Session_Abstract::REGISTRY_KEY);
+    $session = new Session(new MockArraySessionStorage());
+    $session->start();
+    Mage::register(Mage_Core_Model_Session_Abstract::REGISTRY_KEY, $session);
+    Mage::getSingleton('customer/session')->logout();
+    $this->customer = bafkCreateCustomer();
+    Mage::getSingleton('customer/session')->setCustomer($this->customer);
+    Mage::getSingleton('customer/session')->getMessages(true);
+});
+
+afterEach(function () {
+    Mage::register('isSecureArea', true, true);
+    $this->customer->delete();
+    Mage::unregister('isSecureArea');
+    Mage::getSingleton('customer/session')->logout();
+});
+
+it('refuses a cancellation without a form key', function () {
+    $controller = bafkController(['agreement' => 999999]);
+
+    $controller->cancelAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(Mage::getSingleton('customer/session')->getMessages()->count())->toBe(0);
+});
+
+it('reports a missing agreement when the form key is valid', function () {
+    $controller = bafkController([
+        'agreement' => 999999,
+        'form_key' => Mage::getSingleton('core/session')->getFormKey(),
+    ]);
+
+    $controller->cancelAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(Mage::getSingleton('customer/session')->getMessages()->count())->toBe(1);
+});

--- a/tests/Frontend/Integration/Sales/RecurringProfileFormKeyTest.php
+++ b/tests/Frontend/Integration/Sales/RecurringProfileFormKeyTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+uses(Tests\MahoFrontendTestCase::class);
+
+function rpfkCreateCustomer(): Mage_Customer_Model_Customer
+{
+    $customer = Mage::getModel('customer/customer')
+        ->setWebsiteId(Mage::app()->getStore()->getWebsiteId())
+        ->setStore(Mage::app()->getStore())
+        ->setEmail('recurring-' . uniqid() . '@example.com')
+        ->setFirstname('Recurring')
+        ->setLastname('Tester')
+        ->setForceConfirmed(true)
+        ->setPassword('SomePassword123!');
+    $customer->save();
+    return $customer;
+}
+
+function rpfkController(string $action, array $post): Mage_Sales_Recurring_ProfileController
+{
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/sales/recurring_profile/' . $action, 'POST', $post),
+    );
+    $request->setRouteName('sales')
+        ->setControllerName('recurring_profile')
+        ->setActionName($action)
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+
+    return new class ($request, new Mage_Core_Controller_Response_Http()) extends Mage_Sales_Recurring_ProfileController {
+        public function __construct(Mage_Core_Controller_Request_Http $request, Mage_Core_Controller_Response_Http $response)
+        {
+            parent::__construct($request, $response);
+            $this->_session = Mage::getSingleton('customer/session');
+        }
+    };
+}
+
+beforeEach(function () {
+    Mage::unregister(Mage_Core_Model_Session_Abstract::REGISTRY_KEY);
+    $session = new Session(new MockArraySessionStorage());
+    $session->start();
+    Mage::register(Mage_Core_Model_Session_Abstract::REGISTRY_KEY, $session);
+    Mage::getSingleton('customer/session')->logout();
+    $this->customer = rpfkCreateCustomer();
+    Mage::getSingleton('customer/session')->setCustomer($this->customer);
+    Mage::getSingleton('customer/session')->getMessages(true);
+});
+
+afterEach(function () {
+    Mage::register('isSecureArea', true, true);
+    $this->customer->delete();
+    Mage::unregister('isSecureArea');
+    Mage::getSingleton('customer/session')->logout();
+});
+
+it('refuses a profile state change without a form key', function () {
+    $controller = rpfkController('updateState', ['profile' => 999999, 'action' => 'cancel']);
+
+    $controller->updateStateAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(Mage::getSingleton('customer/session')->getMessages()->count())->toBe(0);
+});
+
+it('refuses a profile update without a form key', function () {
+    $controller = rpfkController('updateProfile', ['profile' => 999999]);
+
+    $controller->updateProfileAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(Mage::getSingleton('customer/session')->getMessages()->count())->toBe(0);
+});
+
+it('reports a missing profile when the form key is valid', function () {
+    $controller = rpfkController('updateState', [
+        'profile' => 999999,
+        'action' => 'cancel',
+        'form_key' => Mage::getSingleton('core/session')->getFormKey(),
+    ]);
+
+    $controller->updateStateAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(Mage::getSingleton('customer/session')->getMessages()->count())->toBe(1);
+});

--- a/tests/Frontend/Integration/Sales/ReorderTest.php
+++ b/tests/Frontend/Integration/Sales/ReorderTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+uses(Tests\MahoFrontendTestCase::class);
+
+function reorderCreateCustomer(): Mage_Customer_Model_Customer
+{
+    $customer = Mage::getModel('customer/customer')
+        ->setWebsiteId(Mage::app()->getStore()->getWebsiteId())
+        ->setStore(Mage::app()->getStore())
+        ->setEmail('reorder-' . uniqid() . '@example.com')
+        ->setFirstname('Reorder')
+        ->setLastname('Tester')
+        ->setForceConfirmed(true)
+        ->setPassword('SomePassword123!');
+    $customer->save();
+    return $customer;
+}
+
+function reorderCreateOrder(int $customerId): Mage_Sales_Model_Order
+{
+    $order = Mage::getModel('sales/order')
+        ->setIncrementId('REORDER-' . uniqid())
+        ->setCustomerId($customerId)
+        ->setCustomerIsGuest(0)
+        ->setStoreId((int) Mage::app()->getStore()->getId())
+        ->setSubtotal(0)
+        ->setGrandTotal(0)
+        ->setTotalQtyOrdered(0)
+        ->setData('state', Mage_Sales_Model_Order::STATE_COMPLETE)
+        ->setData('status', Mage_Sales_Model_Order::STATE_COMPLETE);
+    $order->save();
+    return $order;
+}
+
+function reorderController(array $post): Mage_Sales_OrderController
+{
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/sales/order/reorder', 'POST', $post),
+    );
+    $request->setRouteName('sales')
+        ->setControllerName('order')
+        ->setActionName('reorder')
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+
+    return new Mage_Sales_OrderController($request, new Mage_Core_Controller_Response_Http());
+}
+
+function reorderRedirectLocation(Mage_Core_Controller_Response_Http $response): ?string
+{
+    foreach ($response->getHeaders() as $header) {
+        if (strcasecmp($header['name'], 'Location') === 0) {
+            return $header['value'];
+        }
+    }
+    return null;
+}
+
+beforeEach(function () {
+    Mage::unregister(Mage_Core_Model_Session_Abstract::REGISTRY_KEY);
+    $session = new Session(new MockArraySessionStorage());
+    $session->start();
+    Mage::register(Mage_Core_Model_Session_Abstract::REGISTRY_KEY, $session);
+    Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
+    Mage::getSingleton('customer/session')->logout();
+    $this->customer = reorderCreateCustomer();
+    $this->order = null;
+    Mage::getSingleton('customer/session')->setCustomer($this->customer);
+});
+
+afterEach(function () {
+    Mage::register('isSecureArea', true, true);
+    $this->order?->delete();
+    $this->customer->delete();
+    Mage::unregister('isSecureArea');
+    Mage::getSingleton('customer/session')->logout();
+});
+
+it('refuses a reorder without a form key', function () {
+    $controller = reorderController([]);
+
+    $controller->reorderAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect($controller->getRequest()->getActionName())->toBe('reorder');
+});
+
+it('refuses a reorder when reorders are disabled for the store', function () {
+    $this->order = reorderCreateOrder((int) $this->customer->getId());
+    Mage::app()->getStore()->setConfig(Mage_Sales_Helper_Reorder::XML_PATH_SALES_REORDER_ALLOW, '0');
+
+    $controller = reorderController([
+        'order_id' => $this->order->getId(),
+        'form_key' => Mage::getSingleton('core/session')->getFormKey(),
+    ]);
+
+    $controller->reorderAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(reorderRedirectLocation($controller->getResponse()))->toContain('sales/order/view');
+});

--- a/tests/Frontend/Integration/Tag/CustomerRemoveFormKeyTest.php
+++ b/tests/Frontend/Integration/Tag/CustomerRemoveFormKeyTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+uses(Tests\MahoFrontendTestCase::class);
+
+function tagfkCreateCustomer(): Mage_Customer_Model_Customer
+{
+    $customer = Mage::getModel('customer/customer')
+        ->setWebsiteId(Mage::app()->getStore()->getWebsiteId())
+        ->setStore(Mage::app()->getStore())
+        ->setEmail('tag-' . uniqid() . '@example.com')
+        ->setFirstname('Tag')
+        ->setLastname('Tester')
+        ->setForceConfirmed(true)
+        ->setPassword('SomePassword123!');
+    $customer->save();
+    return $customer;
+}
+
+function tagfkController(array $post): Mage_Tag_CustomerController
+{
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/tag/customer/remove', 'POST', $post),
+    );
+    $request->setRouteName('tag')
+        ->setControllerName('customer')
+        ->setActionName('remove')
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+
+    return new Mage_Tag_CustomerController($request, new Mage_Core_Controller_Response_Http());
+}
+
+beforeEach(function () {
+    Mage::unregister(Mage_Core_Model_Session_Abstract::REGISTRY_KEY);
+    $session = new Session(new MockArraySessionStorage());
+    $session->start();
+    Mage::register(Mage_Core_Model_Session_Abstract::REGISTRY_KEY, $session);
+    Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
+    Mage::getSingleton('customer/session')->logout();
+    $this->customer = tagfkCreateCustomer();
+    Mage::getSingleton('customer/session')->setCustomer($this->customer);
+});
+
+afterEach(function () {
+    Mage::register('isSecureArea', true, true);
+    $this->customer->delete();
+    Mage::unregister('isSecureArea');
+    Mage::getSingleton('customer/session')->logout();
+});
+
+it('refuses a tag removal without a form key', function () {
+    $controller = tagfkController(['tagId' => 999999]);
+
+    $controller->removeAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect($controller->getRequest()->getActionName())->toBe('remove');
+});

--- a/tests/Frontend/Integration/Wishlist/WishlistFormKeyTest.php
+++ b/tests/Frontend/Integration/Wishlist/WishlistFormKeyTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+uses(Tests\MahoFrontendTestCase::class);
+
+function wlfkCreateCustomer(): Mage_Customer_Model_Customer
+{
+    $customer = Mage::getModel('customer/customer')
+        ->setWebsiteId(Mage::app()->getStore()->getWebsiteId())
+        ->setStore(Mage::app()->getStore())
+        ->setEmail('wishlist-' . uniqid() . '@example.com')
+        ->setFirstname('Wishlist')
+        ->setLastname('Tester')
+        ->setForceConfirmed(true)
+        ->setPassword('SomePassword123!');
+    $customer->save();
+    return $customer;
+}
+
+function wlfkRequest(string $controller, string $action, array $post): Mage_Core_Controller_Request_Http
+{
+    $request = new Mage_Core_Controller_Request_Http(
+        SymfonyRequest::create('/wishlist/' . $controller . '/' . $action, 'POST', $post),
+    );
+    $request->setRouteName('wishlist')
+        ->setControllerName($controller)
+        ->setActionName($action)
+        ->setDispatched(true);
+    Mage::app()->setRequest($request);
+    return $request;
+}
+
+function wlfkMessageCount(): int
+{
+    return Mage::getSingleton('checkout/session')->getMessages()->count()
+        + Mage::getSingleton('customer/session')->getMessages()->count()
+        + Mage::getSingleton('wishlist/session')->getMessages()->count()
+        + Mage::getSingleton('catalog/session')->getMessages()->count();
+}
+
+beforeEach(function () {
+    Mage::unregister(Mage_Core_Model_Session_Abstract::REGISTRY_KEY);
+    $session = new Session(new MockArraySessionStorage());
+    $session->start();
+    Mage::register(Mage_Core_Model_Session_Abstract::REGISTRY_KEY, $session);
+    Mage::app()->setCurrentStore(Mage::app()->getDefaultStoreView());
+    Mage::getSingleton('customer/session')->logout();
+    $this->customer = wlfkCreateCustomer();
+    Mage::getSingleton('customer/session')->setCustomer($this->customer);
+    foreach (['checkout/session', 'customer/session', 'wishlist/session', 'catalog/session'] as $type) {
+        Mage::getSingleton($type)->getMessages(true);
+    }
+});
+
+afterEach(function () {
+    Mage::register('isSecureArea', true, true);
+    $this->customer->delete();
+    Mage::unregister('isSecureArea');
+    Mage::getSingleton('customer/session')->logout();
+});
+
+it('refuses to move a cart item to the wishlist without a form key', function () {
+    $request = wlfkRequest('index', 'fromcart', ['item' => 999999]);
+    $controller = new Mage_Wishlist_IndexController($request, new Mage_Core_Controller_Response_Http());
+
+    $controller->fromcartAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(wlfkMessageCount())->toBe(0);
+});
+
+it('refuses to update wishlist item options without a form key', function () {
+    $request = wlfkRequest('index', 'updateItemOptions', ['product' => 999999, 'id' => 999999]);
+    $controller = new Mage_Wishlist_IndexController($request, new Mage_Core_Controller_Response_Http());
+
+    $controller->updateItemOptionsAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(wlfkMessageCount())->toBe(0);
+});
+
+it('refuses to add a shared wishlist item to the cart without a form key', function () {
+    $request = wlfkRequest('shared', 'cart', ['item' => 999999, 'code' => 'nope']);
+    $controller = new Mage_Wishlist_SharedController($request, new Mage_Core_Controller_Response_Http());
+
+    $controller->cartAction();
+
+    expect($controller->getResponse()->isRedirect())->toBeTrue();
+    expect(wlfkMessageCount())->toBe(0);
+});

--- a/tests/Frontend/Integration/Wishlist/WishlistFormKeyTest.php
+++ b/tests/Frontend/Integration/Wishlist/WishlistFormKeyTest.php
@@ -99,3 +99,13 @@ it('refuses to add a shared wishlist item to the cart without a form key', funct
     expect($controller->getResponse()->isRedirect())->toBeTrue();
     expect(wlfkMessageCount())->toBe(0);
 });
+
+it('refuses to add every shared wishlist item to the cart without a form key', function () {
+    $request = wlfkRequest('shared', 'allcart', ['code' => 'nope']);
+    $controller = new Mage_Wishlist_SharedController($request, new Mage_Core_Controller_Response_Http());
+
+    $controller->allcartAction();
+
+    expect($controller->getRequest()->getActionName())->toBe('noRoute');
+    expect(wlfkMessageCount())->toBe(0);
+});

--- a/tests/Frontend/Unit/Core/StateChangingActionFormTest.php
+++ b/tests/Frontend/Unit/Core/StateChangingActionFormTest.php
@@ -39,6 +39,7 @@ dataset('post only routes', [
     'price alert signup' => ['/productalert/add/price', 'priceAction'],
     'stock alert signup' => ['/productalert/add/stock', 'stockAction'],
     'partial authorization cancel' => ['/paygate/authorizenet_payment/cancel', 'cancelAction'],
+    'shared wishlist add all to cart' => ['/wishlist/shared/allcart', 'allcartAction'],
 ]);
 
 dataset('state changing templates', [
@@ -109,8 +110,8 @@ dataset('state changing templates', [
     ],
     'shared wishlist' => [
         'wishlist/shared.phtml',
-        ['getSharedItemAddToCartUrl'],
-        '/setLocation\(\'<\?= \$this->getSharedItemAddToCartUrl/',
+        ['getSharedItemAddToCartUrl', 'customFormSubmit', "getUrl('*/*/allcart'"],
+        '/setLocation\(/',
     ],
     'partial authorization form' => [
         'paygate/form/cc.phtml',

--- a/tests/Frontend/Unit/Core/StateChangingActionFormTest.php
+++ b/tests/Frontend/Unit/Core/StateChangingActionFormTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+uses(Tests\MahoFrontendTestCase::class);
+
+/**
+ * A storefront action that changes state accepts POST only, and every template that
+ * offers it submits a form carrying the form key instead of navigating with a link.
+ */
+
+function stateChangingTemplate(string $path): string
+{
+    return (string) file_get_contents(
+        Mage::getBaseDir('design') . '/frontend/base/default/template/' . $path,
+    );
+}
+
+function stateChangingMatcher(string $method): \Symfony\Component\Routing\Matcher\UrlMatcherInterface
+{
+    $context = new \Symfony\Component\Routing\RequestContext();
+    $context->setMethod($method);
+    return \Maho\Routing\RouteCollectionBuilder::createMatcher($context);
+}
+
+dataset('post only routes', [
+    'recurring profile state' => ['/sales/recurring_profile/updateState', 'updateStateAction'],
+    'recurring profile update' => ['/sales/recurring_profile/updateProfile', 'updateProfileAction'],
+    'billing agreement cancel' => ['/sales/billing_agreement/cancel', 'cancelAction'],
+    'customer reorder' => ['/sales/order/reorder', 'reorderAction'],
+    'guest reorder' => ['/sales/guest/reorder', 'reorderAction'],
+    'tag save' => ['/tag/index/save', 'saveAction'],
+    'price alert signup' => ['/productalert/add/price', 'priceAction'],
+    'stock alert signup' => ['/productalert/add/stock', 'stockAction'],
+    'partial authorization cancel' => ['/paygate/authorizenet_payment/cancel', 'cancelAction'],
+]);
+
+dataset('state changing templates', [
+    'recurring profile view' => [
+        'sales/recurring/profile/view.phtml',
+        ['method="post"', "getBlockHtml('formkey')"],
+        '/window\.location/',
+    ],
+    'billing agreement view' => [
+        'sales/billing/agreement/view.phtml',
+        ['method="post"', "getBlockHtml('formkey')"],
+        '/window\.location/',
+    ],
+    'order history' => [
+        'sales/order/history.phtml',
+        ['method="post"', "getBlockHtml('formkey')"],
+        '/<a\b[^>]*getReorderUrl/',
+    ],
+    'recent orders' => [
+        'sales/order/recent.phtml',
+        ['method="post"', "getBlockHtml('formkey')"],
+        '/<a\b[^>]*getReorderUrl/',
+    ],
+    'order info buttons' => [
+        'sales/order/info/buttons.phtml',
+        ['method="post"', "getBlockHtml('formkey')"],
+        '/<a\b[^>]*getReorderUrl/',
+    ],
+    'compare sidebar' => [
+        'catalog/product/compare/sidebar.phtml',
+        ['method="post"', "getBlockHtml('formkey')"],
+        '/<a\b[^>]*(getRemoveUrl|getClearListUrl)/',
+    ],
+    'compare list' => [
+        'catalog/product/compare/list.phtml',
+        ['form_key'],
+        '/body:\s*\'isAjax=1\'/',
+    ],
+    'customer tag view' => [
+        'tag/customer/view.phtml',
+        ['method="post"', "getBlockHtml('formkey')"],
+        '/window\.location/',
+    ],
+    'product tag form' => [
+        'tag/list.phtml',
+        ['method="post"', "getBlockHtml('formkey')"],
+        '/method="get"/',
+    ],
+    'product alert signup' => [
+        'productalert/product/view.phtml',
+        ['method="post"', "getBlockHtml('formkey')"],
+        '/<a\b[^>]*getSignupUrl/',
+    ],
+    'shipping estimate' => [
+        'checkout/cart/shipping.phtml',
+        ["getBlockHtml('formkey')"],
+        null,
+    ],
+    'cart item' => [
+        'checkout/cart/item/default.phtml',
+        ['getMoveFromCartUrl'],
+        '/<a\b[^>]*href="<\?= \$this->helper\(\'wishlist\'\)->getMoveFromCartUrl/',
+    ],
+    'downloadable cart item' => [
+        'downloadable/checkout/cart/item/default.phtml',
+        ['getMoveFromCartUrl'],
+        '/<a\b[^>]*href="<\?= \$this->helper\(\'wishlist\'\)->getMoveFromCartUrl/',
+    ],
+    'shared wishlist' => [
+        'wishlist/shared.phtml',
+        ['getSharedItemAddToCartUrl'],
+        '/setLocation\(\'<\?= \$this->getSharedItemAddToCartUrl/',
+    ],
+    'partial authorization form' => [
+        'paygate/form/cc.phtml',
+        ['getFormKey()'],
+        '/typeof FORM_KEY/',
+    ],
+]);
+
+describe('Storefront state-changing routes accept POST only', function () {
+    it('rejects GET', function (string $path, string $action) {
+        expect(fn() => stateChangingMatcher('GET')->match($path))
+            ->toThrow(\Symfony\Component\Routing\Exception\MethodNotAllowedException::class);
+    })->with('post only routes');
+
+    it('accepts POST', function (string $path, string $action) {
+        expect(stateChangingMatcher('POST')->match($path)['_maho_action'] ?? null)->toBe($action);
+    })->with('post only routes');
+});
+
+describe('Storefront templates submit state changes with a form key', function () {
+    it('offers the action as a POST form', function (string $path, array $required, ?string $forbidden) {
+        $template = stateChangingTemplate($path);
+
+        foreach ($required as $needle) {
+            expect($template)->toContain($needle);
+        }
+        if ($forbidden !== null) {
+            expect($template)->not->toMatch($forbidden);
+        }
+    })->with('state changing templates');
+});


### PR DESCRIPTION
- Every storefront action that changes state now validates the form key and accepts POST only: recurring profile state/update, billing agreement cancel, customer and guest reorder, cart shipping estimate, shipping method update and coupon, wishlist move-from-cart, wishlist item options, shared wishlist add-to-cart and add-all-to-cart, compare remove and clear, tag save and tag remove, price and stock alert signup, one-page checkout method, and the partial authorization cancel.
- The templates that offer those actions now submit a POST form with the `core/formkey` block, or post through `customFormSubmit()` where the control sits inside another form, instead of a GET link or a `window.location` jump. That also repairs several buttons that pointed at POST-only routes and answered 405: recurring profile, billing agreement cancel, shared wishlist add-to-cart and the cart "Move to wishlist" link.
- Reorder now also honors the `sales/reorder/allow` setting, which the storefront links already checked but the action did not.
- The shipping estimate error escapes the rejected country code where the message enters the cart page, so a value that reaches the session messages cannot carry markup. The country resource model keeps a plain message for the CLI and API callers.
- The wishlist share email links each item to the shared wishlist page, and no longer offers the "Add all items" link: an email cannot carry a form key. The controller no longer passes the unused `salable` variable. A merchant with a saved copy of the old email template must drop the `{{depend salable}}` block.
- The shared wishlist add-to-cart action refuses an item that does not belong to the wishlist named by the sharing code.
- A guest interrupted by a POST-only action returns to the page that held the form after login, whatever the "redirect to dashboard after login" setting says, the same as an interrupted GET already did.
- The product alert `testObserver` endpoint is gone. Nothing referenced it, and it let any logged-in customer run the full alert mail job.
- Public-by-design endpoints are unchanged: product alert unsubscribe links, newsletter unsubscribe, payment webhooks, OAuth endpoints and the API protocol endpoints.
- Frontend and backend tests cover a refused request per action, POST-only routing, the escaped country code, the shared item ownership check, the post-login target, and the templates that must post a form key.

A central storefront form key check is tracked in #1436.

<!-- ai-assisted-note:begin -->
> [!NOTE]
> **Developed with the help of AI.**<br>As part of our commitment to GenAI transparency, we flag pull requests produced with AI assistance alongside human work. As with every change in Maho, a maintainer reviews and validates it before merge, we never merge purely AI-generated changes. See the [GenAI transparency](https://github.com/MahoCommerce/maho#genai-transparency) section for details.
<!-- ai-assisted-note:end -->