### PR TITLE
Fixed categories losing the URL suffix when they take back a previous URL key

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -762,7 +762,7 @@ class Mage_Catalog_Model_Url
 
         $fullPath = $requestPath . $categoryUrlSuffix;
         if ($this->_deleteOldTargetPath($fullPath, $idPath, $storeId)) {
-            return $requestPath;
+            return $fullPath;
         }
 
         return $this->getUnusedPathByUrlKey($storeId, $fullPath, $this->generatePath('id', null, $category), $urlKey);

--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -738,6 +738,8 @@ class Mage_Catalog_Model_Url
         if (isset($this->_rewrites[$idPath])) {
             $this->_rewrite = $this->_rewrites[$idPath];
             $existingRequestPath = $this->_rewrites[$idPath]->getRequestPath();
+        } else {
+            $this->_rewrite = null;
         }
 
         $locale = Mage::getStoreConfig(Mage_Core_Model_Locale::XML_PATH_DEFAULT_LOCALE, $category->getStoreId());
@@ -765,7 +767,7 @@ class Mage_Catalog_Model_Url
             return $fullPath;
         }
 
-        return $this->getUnusedPathByUrlKey($storeId, $fullPath, $this->generatePath('id', null, $category), $urlKey);
+        return $this->getUnusedPathByUrlKey($storeId, $fullPath, $idPath, $urlKey);
     }
 
     /**

--- a/tests/Backend/Integration/Catalog/CategoryUrlPathTest.php
+++ b/tests/Backend/Integration/Catalog/CategoryUrlPathTest.php
@@ -37,6 +37,8 @@ it('keeps the url suffix when a category takes back a url key it used before', f
     $storeId = (int) Mage::app()->getDefaultStoreView()->getId();
     // The default suffix is empty, and without one the broken and the correct request path are identical
     Mage::app()->getStore($storeId)->setConfig(Mage_Catalog_Helper_Category::XML_PATH_CATEGORY_URL_SUFFIX, '.html');
+    // The helper caches the suffix per store on first read, so a stale cache would silently make the test pass
+    expect(Mage::helper('catalog/category')->getCategoryUrlSuffix($storeId))->toBe('.html');
     Mage::getSingleton('catalog/url')->setShouldSaveRewritesHistory(true);
 
     $root = Mage::getModel('catalog/category')->load(Mage::app()->getStore($storeId)->getRootCategoryId());

--- a/tests/Backend/Integration/Catalog/CategoryUrlPathTest.php
+++ b/tests/Backend/Integration/Catalog/CategoryUrlPathTest.php
@@ -12,7 +12,7 @@ uses(Tests\MahoBackendTestCase::class);
 
 function urlPathCleanup(): void
 {
-    foreach (Mage::getResourceModel('catalog/category_collection')->addAttributeToFilter('url_key', ['in' => ['urlpath-root', 'urlpath-top', 'urlpath-child']]) as $category) {
+    foreach (Mage::getResourceModel('catalog/category_collection')->addAttributeToFilter('url_key', ['in' => ['urlpath-root', 'urlpath-top', 'urlpath-child', 'urlpath-first', 'urlpath-second']]) as $category) {
         Mage::getModel('catalog/category')->load($category->getId())->delete();
     }
 }
@@ -31,4 +31,30 @@ it('builds the url path of a category below a root without a leading slash', fun
     expect(Mage::getModel('catalog/category')->load($root->getId())->getUrlPath())->toBe('');
     expect(Mage::getModel('catalog/category')->load($top->getId())->setUrlPath(null)->getUrlPath())->toBe('urlpath-top');
     expect(Mage::getModel('catalog/category')->load($child->getId())->setUrlPath(null)->getUrlPath())->toBe('urlpath-top/urlpath-child');
+});
+
+it('keeps the url suffix when a category takes back a url key it used before', function (): void {
+    $storeId = (int) Mage::app()->getDefaultStoreView()->getId();
+    // The default suffix is empty, and without one the broken and the correct request path are identical
+    Mage::app()->getStore($storeId)->setConfig(Mage_Catalog_Helper_Category::XML_PATH_CATEGORY_URL_SUFFIX, '.html');
+    Mage::getSingleton('catalog/url')->setShouldSaveRewritesHistory(true);
+
+    $root = Mage::getModel('catalog/category')->load(Mage::app()->getStore($storeId)->getRootCategoryId());
+    $category = Mage::getModel('catalog/category')->setStoreId(0)->setName('Urlpath Reclaim')->setUrlKey('urlpath-first')->setIsActive(1);
+    $category->setAttributeSetId($category->getDefaultAttributeSetId())->setPath($root->getPath())->save();
+
+    // saveAttribute() skips the URL indexer, so each change gets exactly one refresh: a second one repairs the path
+    $changeUrlKey = function (string $urlKey) use ($category, $storeId): string {
+        $category->setUrlKey($urlKey);
+        $category->getResource()->saveAttribute($category, 'url_key');
+        Mage::getSingleton('catalog/url')->refreshCategoryRewrite($category->getId(), $storeId, false);
+
+        return Mage::getModel('core/url_rewrite')->setStoreId($storeId)->loadByIdPath('category/' . $category->getId())->getRequestPath();
+    };
+
+    expect($changeUrlKey('urlpath-first'))->toBe('urlpath-first.html')
+        ->and($changeUrlKey('urlpath-second'))->toBe('urlpath-second.html')
+        ->and(Mage::getModel('core/url_rewrite')->setStoreId($storeId)->loadByRequestPath('urlpath-first.html')->getTargetPath())
+        ->toBe('urlpath-second.html')
+        ->and($changeUrlKey('urlpath-first'))->toBe('urlpath-first.html');
 });


### PR DESCRIPTION
`getCategoryRequestPath()` returned the path without the category URL suffix after the permanent redirect for the previous URL key was removed. It now returns `$fullPath`, consistent with `getProductRequestPath()`.

Maho's default category URL suffix is empty, so this issue only affects stores that configure a suffix.

**Setup:**

- Catalog > Search Engine Optimizations: Category URL Suffix `.html`
- "Create Permanent Redirect for URLs if URL Key Changed": Yes
- A category under the root category with URL Key `summer-sale`

**Steps to reproduce:**

1. Change the URL Key from `summer-sale` to `summer-deals` and save.
2. Change the URL Key back to `summer-sale` and save.

**Result after the last save:**

| | Category URL rewrite | `summer-sale.html` |
|---|---|---|
| Before fix | `summer-sale` | no rewrite |
| After fix | `summer-sale.html` | rewrites to the category |

Tested on `main` at `4c702b684`, PHP 8.5.7, MySQL 8.4.9.