### PR TITLE
Fixed the Category Products reindex resetting the URL key and sort options of dynamic categories

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Category/Dynamic/Processor.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Dynamic/Processor.php
@@ -15,7 +15,14 @@ class Mage_Catalog_Model_Category_Dynamic_Processor
             ->addAttributeToFilter('is_dynamic', 1);
 
         foreach ($categoryCollection->getAllIds() as $categoryId) {
-            $this->processDynamicCategory(Mage::getModel('catalog/category')->load($categoryId));
+            try {
+                $category = Mage::getModel('catalog/category')->load($categoryId);
+            } catch (Exception $e) {
+                Mage::logException($e);
+                continue;
+            }
+
+            $this->processDynamicCategory($category);
         }
 
         return $this;

--- a/app/code/core/Mage/Catalog/Model/Category/Dynamic/Processor.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Dynamic/Processor.php
@@ -12,11 +12,10 @@ class Mage_Catalog_Model_Category_Dynamic_Processor
     {
         /** @var Mage_Catalog_Model_Resource_Category_Collection $categoryCollection */
         $categoryCollection = Mage::getModel('catalog/category')->getCollection()
-            ->addAttributeToSelect(['entity_id', 'name', 'is_dynamic'])
             ->addAttributeToFilter('is_dynamic', 1);
 
-        foreach ($categoryCollection as $category) {
-            $this->processDynamicCategory($category);
+        foreach ($categoryCollection->getAllIds() as $categoryId) {
+            $this->processDynamicCategory(Mage::getModel('catalog/category')->load($categoryId));
         }
 
         return $this;

--- a/tests/Backend/Integration/Catalog/DynamicCategoryTest.php
+++ b/tests/Backend/Integration/Catalog/DynamicCategoryTest.php
@@ -50,7 +50,7 @@ function dynRelate(int $parentId, int $childId): void
     );
 }
 
-function dynCategory(array $productPositions = []): Mage_Catalog_Model_Category
+function dynCategory(array $productPositions = [], array $data = []): Mage_Catalog_Model_Category
 {
     $category = Mage::getModel('catalog/category');
     $category->setName('dyncat-' . uniqid());
@@ -60,6 +60,7 @@ function dynCategory(array $productPositions = []): Mage_Catalog_Model_Category
     $category->setDisplayMode(Mage_Catalog_Model_Category::DM_PRODUCT);
     $category->setAttributeSetId($category->getDefaultAttributeSetId());
     $category->setIsDynamic(1);
+    $category->addData($data);
     if ($productPositions !== []) {
         $category->setPostedProducts($productPositions);
     }
@@ -173,6 +174,29 @@ it('still removes products that stop matching', function () {
     dynProcess($category);
 
     expect(array_keys(dynPositions($category)))->toBe([(int) $keep->getId()]);
+});
+
+// Covers the reindex entry point; dynProcess() only exercises processDynamicCategory()
+it('keeps attributes it does not manage when processing every dynamic category', function () {
+    $token = uniqid();
+    $product = dynProduct("dyn-all-$token");
+
+    // Default scope: without a default url_key the URL indexer regenerates it from the name by itself
+    $category = dynCategory([], [
+        'store_id' => Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID,
+        'name' => "Dynamic All $token",
+        'url_key' => "kept-url-key-$token",
+        'available_sort_by' => ['name', 'price'],
+        'default_sort_by' => 'name',
+    ]);
+    dynRule($category, [dynSkuCondition('==', "dyn-all-$token")]);
+
+    Mage::getModel('catalog/category_dynamic_processor')->processAllDynamicCategories();
+
+    $category = Mage::getModel('catalog/category')->load($category->getId());
+    expect(array_keys(dynPositions($category)))->toBe([(int) $product->getId()])
+        ->and(['url_key' => $category->getUrlKey(), 'available_sort_by' => $category->getAvailableSortBy()])
+        ->toBe(['url_key' => "kept-url-key-$token", 'available_sort_by' => ['name', 'price']]);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The reindex saved each dynamic category straight from a collection, which rebuilt the URL key from the
name and cleared a custom "Available Product Listing Sort By". Each category is now loaded with `load()`
first, as the "Refresh Products Now" button already does.

**Setup** (saved on All Store Views):

- Category `Bestsellers`, URL Key `top-picks`
- Untick "Use All Available Attributes", select Name and Price, Default Product Listing Sort By Name
- "Is Dynamic Category" Yes, with a rule matching a product not in the category yet
- Run `./maho index:reindex catalog_category_product`

| After the reindex | URL Key | Available Product Listing Sort By |
|---|---|---|
| Before | `bestsellers` | empty (all attributes) |
| After | `top-picks` | Name, Price |

Tested on `main` at `4c702b684`, PHP 8.5.7, MySQL 8.4.9.