### PR TITLE
Sped up the Pest suite and served every HTTP suite from one server

### DIFF
--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -170,22 +170,28 @@ jobs:
 
       - name: Start built-in web server
         run: |
-          # Serve the API at the URL the JWT issuer is pinned to, and pre-seed a
-          # deterministic signing secret, so tokens the test helper signs validate
-          # against the server (otherwise every authenticated API test 401s).
-          ./maho config:set web/unsecure/base_url http://127.0.0.1:8080/ --scope default --scope-id 0 --silent
-          ./maho config:set web/secure/base_url http://127.0.0.1:8080/ --scope default --scope-id 0 --silent
+          # One server for every suite that speaks HTTP: the Api tests over curl and the
+          # Browser tests through Playwright. It binds the host:port the store was
+          # installed with, so base_url already matches and is never rewritten at runtime.
+          # That matters twice over: redirect_to_base bounces a request whose host differs,
+          # and JwtService::getIssuer() derives the issuer from base_url, so a mismatch
+          # 401s every authenticated API call. Pre-seed a deterministic signing secret so
+          # the tokens the test helper signs validate against the server.
           ./maho config:set apiplatform/oauth2/secret 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef --encrypt --scope default --scope-id 0 --silent
           ./maho cache:flush
-          # Enable GraphQL introspection for the test server (off in production) so the
-          # introspection tests in tests/Api/V2/Read/GraphQLBasicTest.php can query __schema/__type.
-          # OPcache is off in the CLI SAPI, so without -d every API request recompiles
-          # the whole bootstrap (~500 files). Timestamps stay validated per request.
-          MAHO_GRAPHQL_INTROSPECTION=1 php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1 \
-            -d opcache.revalidate_freq=0 -S 127.0.0.1:8080 -t public tests/router.php > /tmp/php-server.log 2>&1 < /dev/null &
+          # MAHO_GRAPHQL_INTROSPECTION: off in production, but the introspection tests in
+          # tests/Api/V2/Read/GraphQLBasicTest.php query __schema/__type.
+          # PHP_CLI_SERVER_WORKERS: the built-in server is single-threaded, so a browser's
+          # parallel asset requests would serialize and stall.
+          # OPcache is off in the CLI SAPI, so without -d every request recompiles the
+          # whole bootstrap (~500 files). Timestamps stay validated per request.
+          MAHO_GRAPHQL_INTROSPECTION=1 PHP_CLI_SERVER_WORKERS=8 \
+            php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1 \
+            -d opcache.revalidate_freq=0 -S "$MAHO_BROWSER_HOST:8901" -t public tests/router.php \
+            > /tmp/php-server.log 2>&1 < /dev/null &
           for i in $(seq 1 20); do
-            if curl -fsS http://127.0.0.1:8080/api/rest/v2/store-config -o /dev/null 2>&1 || \
-               curl -fsS http://127.0.0.1:8080/ -o /dev/null 2>&1; then
+            if curl -fsS "http://$MAHO_BROWSER_HOST:8901/api/rest/v2/store-config" -o /dev/null 2>&1 || \
+               curl -fsS "http://$MAHO_BROWSER_HOST:8901/" -o /dev/null 2>&1; then
               echo "Web server is up"
               exit 0
             fi
@@ -213,7 +219,7 @@ jobs:
 
       - name: Run Pest Tests
         env:
-          API_BASE_URL: http://127.0.0.1:8080
+          API_BASE_URL: http://${{ env.MAHO_BROWSER_HOST }}:8901
           PAYPAL_SANDBOX_CLIENT_ID: ${{ secrets.PAYPAL_SANDBOX_CLIENT_ID }}
           PAYPAL_SANDBOX_CLIENT_SECRET: ${{ secrets.PAYPAL_SANDBOX_CLIENT_SECRET }}
         run: |
@@ -307,22 +313,28 @@ jobs:
 
       - name: Start built-in web server
         run: |
-          # Serve the API at the URL the JWT issuer is pinned to, and pre-seed a
-          # deterministic signing secret, so tokens the test helper signs validate
-          # against the server (otherwise every authenticated API test 401s).
-          ./maho config:set web/unsecure/base_url http://127.0.0.1:8080/ --scope default --scope-id 0 --silent
-          ./maho config:set web/secure/base_url http://127.0.0.1:8080/ --scope default --scope-id 0 --silent
+          # One server for every suite that speaks HTTP: the Api tests over curl and the
+          # Browser tests through Playwright. It binds the host:port the store was
+          # installed with, so base_url already matches and is never rewritten at runtime.
+          # That matters twice over: redirect_to_base bounces a request whose host differs,
+          # and JwtService::getIssuer() derives the issuer from base_url, so a mismatch
+          # 401s every authenticated API call. Pre-seed a deterministic signing secret so
+          # the tokens the test helper signs validate against the server.
           ./maho config:set apiplatform/oauth2/secret 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef --encrypt --scope default --scope-id 0 --silent
           ./maho cache:flush
-          # Enable GraphQL introspection for the test server (off in production) so the
-          # introspection tests in tests/Api/V2/Read/GraphQLBasicTest.php can query __schema/__type.
-          # OPcache is off in the CLI SAPI, so without -d every API request recompiles
-          # the whole bootstrap (~500 files). Timestamps stay validated per request.
-          MAHO_GRAPHQL_INTROSPECTION=1 php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1 \
-            -d opcache.revalidate_freq=0 -S 127.0.0.1:8080 -t public tests/router.php > /tmp/php-server.log 2>&1 < /dev/null &
+          # MAHO_GRAPHQL_INTROSPECTION: off in production, but the introspection tests in
+          # tests/Api/V2/Read/GraphQLBasicTest.php query __schema/__type.
+          # PHP_CLI_SERVER_WORKERS: the built-in server is single-threaded, so a browser's
+          # parallel asset requests would serialize and stall.
+          # OPcache is off in the CLI SAPI, so without -d every request recompiles the
+          # whole bootstrap (~500 files). Timestamps stay validated per request.
+          MAHO_GRAPHQL_INTROSPECTION=1 PHP_CLI_SERVER_WORKERS=8 \
+            php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1 \
+            -d opcache.revalidate_freq=0 -S "$MAHO_BROWSER_HOST:8901" -t public tests/router.php \
+            > /tmp/php-server.log 2>&1 < /dev/null &
           for i in $(seq 1 20); do
-            if curl -fsS http://127.0.0.1:8080/api/rest/v2/store-config -o /dev/null 2>&1 || \
-               curl -fsS http://127.0.0.1:8080/ -o /dev/null 2>&1; then
+            if curl -fsS "http://$MAHO_BROWSER_HOST:8901/api/rest/v2/store-config" -o /dev/null 2>&1 || \
+               curl -fsS "http://$MAHO_BROWSER_HOST:8901/" -o /dev/null 2>&1; then
               echo "Web server is up"
               exit 0
             fi
@@ -350,7 +362,7 @@ jobs:
 
       - name: Run Pest Tests
         env:
-          API_BASE_URL: http://127.0.0.1:8080
+          API_BASE_URL: http://${{ env.MAHO_BROWSER_HOST }}:8901
           PAYPAL_SANDBOX_CLIENT_ID: ${{ secrets.PAYPAL_SANDBOX_CLIENT_ID }}
           PAYPAL_SANDBOX_CLIENT_SECRET: ${{ secrets.PAYPAL_SANDBOX_CLIENT_SECRET }}
         # See the matrix comment above: the live-service groups run in one job only.

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -170,21 +170,12 @@ jobs:
 
       - name: Start built-in web server
         run: |
-          # One server for every suite that speaks HTTP: the Api tests over curl and the
-          # Browser tests through Playwright. It binds the host:port the store was
-          # installed with, so base_url already matches and is never rewritten at runtime.
-          # That matters twice over: redirect_to_base bounces a request whose host differs,
-          # and JwtService::getIssuer() derives the issuer from base_url, so a mismatch
-          # 401s every authenticated API call. Pre-seed a deterministic signing secret so
-          # the tokens the test helper signs validate against the server.
+          # One server for the Api and Browser suites, bound to the host:port the store
+          # was installed with so base_url needs no rewrite (see Tests\Browser\MahoServer).
           ./maho config:set apiplatform/oauth2/secret 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef --encrypt --scope default --scope-id 0 --silent
           ./maho cache:flush
-          # MAHO_GRAPHQL_INTROSPECTION: off in production, but the introspection tests in
-          # tests/Api/V2/Read/GraphQLBasicTest.php query __schema/__type.
-          # PHP_CLI_SERVER_WORKERS: the built-in server is single-threaded, so a browser's
-          # parallel asset requests would serialize and stall.
-          # OPcache is off in the CLI SAPI, so without -d every request recompiles the
-          # whole bootstrap (~500 files). Timestamps stay validated per request.
+          # Introspection is off in production but the schema tests need it. OPcache is off
+          # in the CLI SAPI, so without -d every request recompiles the whole bootstrap.
           MAHO_GRAPHQL_INTROSPECTION=1 PHP_CLI_SERVER_WORKERS=8 \
             php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1 \
             -d opcache.revalidate_freq=0 -S "$MAHO_BROWSER_HOST:8901" -t public tests/router.php \
@@ -313,21 +304,12 @@ jobs:
 
       - name: Start built-in web server
         run: |
-          # One server for every suite that speaks HTTP: the Api tests over curl and the
-          # Browser tests through Playwright. It binds the host:port the store was
-          # installed with, so base_url already matches and is never rewritten at runtime.
-          # That matters twice over: redirect_to_base bounces a request whose host differs,
-          # and JwtService::getIssuer() derives the issuer from base_url, so a mismatch
-          # 401s every authenticated API call. Pre-seed a deterministic signing secret so
-          # the tokens the test helper signs validate against the server.
+          # One server for the Api and Browser suites, bound to the host:port the store
+          # was installed with so base_url needs no rewrite (see Tests\Browser\MahoServer).
           ./maho config:set apiplatform/oauth2/secret 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef --encrypt --scope default --scope-id 0 --silent
           ./maho cache:flush
-          # MAHO_GRAPHQL_INTROSPECTION: off in production, but the introspection tests in
-          # tests/Api/V2/Read/GraphQLBasicTest.php query __schema/__type.
-          # PHP_CLI_SERVER_WORKERS: the built-in server is single-threaded, so a browser's
-          # parallel asset requests would serialize and stall.
-          # OPcache is off in the CLI SAPI, so without -d every request recompiles the
-          # whole bootstrap (~500 files). Timestamps stay validated per request.
+          # Introspection is off in production but the schema tests need it. OPcache is off
+          # in the CLI SAPI, so without -d every request recompiles the whole bootstrap.
           MAHO_GRAPHQL_INTROSPECTION=1 PHP_CLI_SERVER_WORKERS=8 \
             php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1 \
             -d opcache.revalidate_freq=0 -S "$MAHO_BROWSER_HOST:8901" -t public tests/router.php \

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -100,7 +100,7 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: 8.3
-          extensions: ${{ matrix.db_engine == 'pgsql' && 'pdo_pgsql' || '' }}
+          extensions: ${{ matrix.db_engine == 'pgsql' && 'opcache, pdo_pgsql' || 'opcache' }}
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -179,7 +179,10 @@ jobs:
           ./maho cache:flush
           # Enable GraphQL introspection for the test server (off in production) so the
           # introspection tests in tests/Api/V2/Read/GraphQLBasicTest.php can query __schema/__type.
-          MAHO_GRAPHQL_INTROSPECTION=1 php -S 127.0.0.1:8080 -t public tests/router.php > /tmp/php-server.log 2>&1 < /dev/null &
+          # OPcache is off in the CLI SAPI, so without -d every API request recompiles
+          # the whole bootstrap (~500 files). Timestamps stay validated per request.
+          MAHO_GRAPHQL_INTROSPECTION=1 php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1 \
+            -d opcache.revalidate_freq=0 -S 127.0.0.1:8080 -t public tests/router.php > /tmp/php-server.log 2>&1 < /dev/null &
           for i in $(seq 1 20); do
             if curl -fsS http://127.0.0.1:8080/api/rest/v2/store-config -o /dev/null 2>&1 || \
                curl -fsS http://127.0.0.1:8080/ -o /dev/null 2>&1; then
@@ -242,7 +245,7 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: 8.3
-          extensions: pdo_sqlite
+          extensions: opcache, pdo_sqlite
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -313,7 +316,10 @@ jobs:
           ./maho cache:flush
           # Enable GraphQL introspection for the test server (off in production) so the
           # introspection tests in tests/Api/V2/Read/GraphQLBasicTest.php can query __schema/__type.
-          MAHO_GRAPHQL_INTROSPECTION=1 php -S 127.0.0.1:8080 -t public tests/router.php > /tmp/php-server.log 2>&1 < /dev/null &
+          # OPcache is off in the CLI SAPI, so without -d every API request recompiles
+          # the whole bootstrap (~500 files). Timestamps stay validated per request.
+          MAHO_GRAPHQL_INTROSPECTION=1 php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1 \
+            -d opcache.revalidate_freq=0 -S 127.0.0.1:8080 -t public tests/router.php > /tmp/php-server.log 2>&1 < /dev/null &
           for i in $(seq 1 20); do
             if curl -fsS http://127.0.0.1:8080/api/rest/v2/store-config -o /dev/null 2>&1 || \
                curl -fsS http://127.0.0.1:8080/ -o /dev/null 2>&1; then

--- a/lib/MahoCLI/Commands/Serve.php
+++ b/lib/MahoCLI/Commands/Serve.php
@@ -43,9 +43,8 @@ class Serve extends BaseMahoCommand
             putenv('PHP_CLI_SERVER_WORKERS=8');
         }
 
-        // The CLI SAPI leaves OPcache off, so every request recompiles the whole
-        // bootstrap (~500 files). Timestamps are still validated on each request,
-        // so an edit applies immediately.
+        // The CLI SAPI leaves OPcache off, so every request recompiles the whole bootstrap.
+        // Timestamps stay validated, so an edit still applies immediately.
         $opcache = '-d opcache.enable_cli=1 -d opcache.validate_timestamps=1 -d opcache.revalidate_freq=0';
 
         passthru("php {$opcache} -S " . escapeshellarg("{$host}:{$port}") . ' -t ' . escapeshellarg($docroot));

--- a/lib/MahoCLI/Commands/Serve.php
+++ b/lib/MahoCLI/Commands/Serve.php
@@ -43,7 +43,12 @@ class Serve extends BaseMahoCommand
             putenv('PHP_CLI_SERVER_WORKERS=8');
         }
 
-        passthru('php -S ' . escapeshellarg("{$host}:{$port}") . ' -t ' . escapeshellarg($docroot));
+        // The CLI SAPI leaves OPcache off, so every request recompiles the whole
+        // bootstrap (~500 files). Timestamps are still validated on each request,
+        // so an edit applies immediately.
+        $opcache = '-d opcache.enable_cli=1 -d opcache.validate_timestamps=1 -d opcache.revalidate_freq=0';
+
+        passthru("php {$opcache} -S " . escapeshellarg("{$host}:{$port}") . ' -t ' . escapeshellarg($docroot));
 
         return Command::SUCCESS;
     }

--- a/tests/Backend/Integration/CustomerSegmentation/Model/Condition/Product/ViewedTest.php
+++ b/tests/Backend/Integration/CustomerSegmentation/Model/Condition/Product/ViewedTest.php
@@ -292,8 +292,7 @@ function setupTestData()
     setupProductViewedTestData();
 }
 
-// Built once per run, not once per test: nothing here is mutated, and no
-// assertion counts rows, so a second copy would only add 19x the fixture cost.
+// Built once per run: nothing mutates the fixture and no assertion counts rows.
 function setupProductViewedTestData(): void
 {
     static $built = false;

--- a/tests/Backend/Integration/CustomerSegmentation/Model/Condition/Product/ViewedTest.php
+++ b/tests/Backend/Integration/CustomerSegmentation/Model/Condition/Product/ViewedTest.php
@@ -292,8 +292,16 @@ function setupTestData()
     setupProductViewedTestData();
 }
 
+// Built once per run, not once per test: nothing here is mutated, and no
+// assertion counts rows, so a second copy would only add 19x the fixture cost.
 function setupProductViewedTestData(): void
 {
+    static $built = false;
+    if ($built) {
+        return;
+    }
+    $built = true;
+
     $uniqueId = uniqid('viewed_', true);
 
     // Ensure we have test categories

--- a/tests/Backend/Integration/CustomerSegmentation/Model/Condition/Product/WishlistTest.php
+++ b/tests/Backend/Integration/CustomerSegmentation/Model/Condition/Product/WishlistTest.php
@@ -997,9 +997,18 @@ describe('Product Wishlist Condition Integration Tests', function () {
 
 });
 
-// Helper method to set up comprehensive wishlist test data
+// Helper method to set up comprehensive wishlist test data.
+// Built once per run, not once per test: nothing here is mutated, and every
+// assertion below verifies each matched customer on its own rather than
+// counting rows, so a second copy would only add 51x the fixture cost.
 function setupWishlistTestData(): void
 {
+    static $built = false;
+    if ($built) {
+        return;
+    }
+    $built = true;
+
     $uniqueId = uniqid('wishlist_', true);
 
     // Create test categories

--- a/tests/Backend/Integration/CustomerSegmentation/Model/Condition/Product/WishlistTest.php
+++ b/tests/Backend/Integration/CustomerSegmentation/Model/Condition/Product/WishlistTest.php
@@ -997,10 +997,8 @@ describe('Product Wishlist Condition Integration Tests', function () {
 
 });
 
-// Helper method to set up comprehensive wishlist test data.
-// Built once per run, not once per test: nothing here is mutated, and every
-// assertion below verifies each matched customer on its own rather than
-// counting rows, so a second copy would only add 51x the fixture cost.
+// Built once per run: nothing mutates the fixture, and every assertion below checks
+// each matched customer on its own rather than counting rows.
 function setupWishlistTestData(): void
 {
     static $built = false;

--- a/tests/Backend/Integration/Giftcard/Observer/OrderFlowTest.php
+++ b/tests/Backend/Integration/Giftcard/Observer/OrderFlowTest.php
@@ -25,9 +25,12 @@ describe('Observer: Set Giftcard Price on Quote Item', function (): void {
         $quote->setStoreId(1);
         $quote->save();
 
-        // Load an existing simple product from sample data to avoid stock item issues
+        // Load an existing simple product from sample data to avoid stock item issues.
+        // Order explicitly: without ORDER BY, PostgreSQL returns rows in physical order,
+        // so the "first" product changes as unrelated tests add and remove rows.
         $productCollection = Mage::getResourceModel('catalog/product_collection')
             ->addAttributeToFilter('type_id', 'simple')
+            ->setOrder('entity_id', 'ASC')
             ->setPageSize(1);
         $existingProduct = $productCollection->getFirstItem();
 
@@ -109,6 +112,7 @@ describe('Integration: Quote → Order → Admin Totals with Gift Card', functio
             ->addAttributeToFilter('type_id', 'simple')
             ->addAttributeToFilter('status', 1)
             ->addAttributeToSelect(['price', 'name'])
+            ->setOrder('entity_id', 'ASC')
             ->setPageSize(1);
         $this->product = $productCollection->getFirstItem();
 

--- a/tests/Backend/Integration/Giftcard/Observer/OrderFlowTest.php
+++ b/tests/Backend/Integration/Giftcard/Observer/OrderFlowTest.php
@@ -26,8 +26,7 @@ describe('Observer: Set Giftcard Price on Quote Item', function (): void {
         $quote->save();
 
         // Load an existing simple product from sample data to avoid stock item issues.
-        // Order explicitly: without ORDER BY, PostgreSQL returns rows in physical order,
-        // so the "first" product changes as unrelated tests add and remove rows.
+        // Ordered: without ORDER BY the "first" product moves on PostgreSQL.
         $productCollection = Mage::getResourceModel('catalog/product_collection')
             ->addAttributeToFilter('type_id', 'simple')
             ->setOrder('entity_id', 'ASC')

--- a/tests/Browser/MahoServer.php
+++ b/tests/Browser/MahoServer.php
@@ -12,23 +12,16 @@ namespace Tests\Browser;
 use Symfony\Component\Process\Process;
 
 /**
- * Resolves the one HTTP server the Api and Browser suites share, starting it if nobody
- * did already.
+ * Resolves the one HTTP server the Api and Browser suites share, starting it only when
+ * nobody did already (a bare `vendor/bin/pest`; the runner and CI start it themselves).
  *
- * The app is installed with base_url http://<host>:<port>/ and served on that exact
- * host:port, so base_url is never rewritten at runtime. The host comes from
- * MAHO_BROWSER_HOST: CI sets it to the runner's real IP (detected before install), so the
- * browser hits a routable address and sidesteps every loopback caveat (Playwright's
- * Chromium ignores /etc/hosts and is unreliable with bare 127.0.0.1 on CI). Locally it
- * defaults to `localhost`, served on 127.0.0.1 which localhost maps to.
+ * It serves the exact host:port the store was installed with, so base_url is never
+ * rewritten. Both suites depend on that: redirect_to_base bounces a request whose host
+ * differs, and JwtService::getIssuer() derives the issuer from base_url, so a token signed
+ * against another origin 401s.
  *
- * Both suites need that single origin. redirect_to_base bounces a request whose host
- * differs from base_url, and JwtService::getIssuer() derives the issuer from base_url, so
- * an API token signed against a different origin 401s.
- *
- * The runner (tests/pest-with-test-db.php) and CI both start this server before Pest, so
- * normally there is one already listening and this class only hands back its URL. Starting
- * one here covers a bare `vendor/bin/pest` run against an installed store.
+ * The host comes from MAHO_BROWSER_HOST, the runner's real IP on CI: Playwright's Chromium
+ * ignores /etc/hosts and is unreliable with bare 127.0.0.1 there.
  */
 final class MahoServer
 {
@@ -50,8 +43,7 @@ final class MahoServer
         $port ??= (int) (getenv('MAHO_BROWSER_PORT') ?: 8901);
         self::$baseUrl = "http://{$addressHost}:{$port}";
 
-        // The runner and CI already serve this origin for the Api suite. Reuse it rather
-        // than binding a second server to a port that is taken.
+        // Already served for the Api suite: reuse it rather than fight for the port.
         if (self::isListening($bindHost, $port)) {
             return self::$baseUrl;
         }
@@ -63,11 +55,9 @@ final class MahoServer
             self::$stopRegistered = true;
         }
 
-        // Same command the runner uses, so a standalone `vendor/bin/pest` serves the API
-        // routes too: `./maho serve` has no router, and without tests/router.php the
-        // /api/* rewrites that public/.htaccess performs in production are missing.
-        // PHP_CLI_SERVER_WORKERS: the built-in server is single-threaded, so a browser's
-        // parallel asset requests would serialize and stall.
+        // router.php, not `./maho serve`, which has no router: without it the /api/*
+        // rewrites public/.htaccess performs in production are missing. Workers because
+        // the built-in server is single-threaded and parallel asset requests would stall.
         self::$process = new Process(
             [
                 PHP_BINARY,

--- a/tests/Browser/MahoServer.php
+++ b/tests/Browser/MahoServer.php
@@ -12,20 +12,23 @@ namespace Tests\Browser;
 use Symfony\Component\Process\Process;
 
 /**
- * Boots `./maho serve` for browser tests.
+ * Resolves the one HTTP server the Api and Browser suites share, starting it if nobody
+ * did already.
  *
  * The app is installed with base_url http://<host>:<port>/ and served on that exact
- * host:port. The host comes from MAHO_BROWSER_HOST: CI sets it to the runner's real IP
- * (detected before install), so the browser hits a routable address and sidesteps every
- * loopback caveat (Playwright's Chromium ignores /etc/hosts and is unreliable with bare
- * 127.0.0.1 on CI). Locally it defaults to `localhost`, served on 127.0.0.1 which localhost
- * maps to. The server binds the same host it's addressed by; the port must match base_url or
- * redirect_to_base bounces the browser to an unserved origin.
+ * host:port, so base_url is never rewritten at runtime. The host comes from
+ * MAHO_BROWSER_HOST: CI sets it to the runner's real IP (detected before install), so the
+ * browser hits a routable address and sidesteps every loopback caveat (Playwright's
+ * Chromium ignores /etc/hosts and is unreliable with bare 127.0.0.1 on CI). Locally it
+ * defaults to `localhost`, served on 127.0.0.1 which localhost maps to.
  *
- * The Api suite runs before this one and repoints the store base_url at its own HTTP server
- * (so the JWT issuer matches the tokens it signs), so we can't assume base_url still holds
- * the install value. Repoint it back to this server's URL on start, before serving, so
- * redirect_to_base keeps the browser on the origin we actually serve.
+ * Both suites need that single origin. redirect_to_base bounces a request whose host
+ * differs from base_url, and JwtService::getIssuer() derives the issuer from base_url, so
+ * an API token signed against a different origin 401s.
+ *
+ * The runner (tests/pest-with-test-db.php) and CI both start this server before Pest, so
+ * normally there is one already listening and this class only hands back its URL. Starting
+ * one here covers a bare `vendor/bin/pest` run against an installed store.
  */
 final class MahoServer
 {
@@ -35,15 +38,8 @@ final class MahoServer
 
     public static function start(?int $port = null): string
     {
-        if (self::$process && self::$process->isRunning()) {
+        if (self::$baseUrl !== '' && (self::$process === null || self::$process->isRunning())) {
             return self::$baseUrl;
-        }
-
-        // One server for the whole run: every test file starts it, and it lives until the
-        // process ends rather than being torn down and rebuilt between files.
-        if (!self::$stopRegistered) {
-            register_shutdown_function(self::stop(...));
-            self::$stopRegistered = true;
         }
 
         // Address host (what the browser navigates to) vs bind host (what the server binds).
@@ -54,17 +50,39 @@ final class MahoServer
         $port ??= (int) (getenv('MAHO_BROWSER_PORT') ?: 8901);
         self::$baseUrl = "http://{$addressHost}:{$port}";
 
-        // Repoint base_url at the URL we're about to serve (a prior suite may have moved it),
-        // then flush so the serve workers boot with fresh config. Otherwise redirect_to_base
-        // bounces every navigation to whatever origin base_url currently names.
-        self::syncBaseUrl(self::$baseUrl . '/');
+        // The runner and CI already serve this origin for the Api suite. Reuse it rather
+        // than binding a second server to a port that is taken.
+        if (self::isListening($bindHost, $port)) {
+            return self::$baseUrl;
+        }
 
-        // The PHP built-in server is single-threaded; a browser's parallel asset
-        // requests would serialize and stall. Spawn workers so requests run concurrently.
+        // One server for the whole run: every test file starts it, and it lives until the
+        // process ends rather than being torn down and rebuilt between files.
+        if (!self::$stopRegistered) {
+            register_shutdown_function(self::stop(...));
+            self::$stopRegistered = true;
+        }
+
+        // Same command the runner uses, so a standalone `vendor/bin/pest` serves the API
+        // routes too: `./maho serve` has no router, and without tests/router.php the
+        // /api/* rewrites that public/.htaccess performs in production are missing.
+        // PHP_CLI_SERVER_WORKERS: the built-in server is single-threaded, so a browser's
+        // parallel asset requests would serialize and stall.
         self::$process = new Process(
-            ['./maho', 'serve', (string) $port, '--host', $bindHost],
+            [
+                PHP_BINARY,
+                '-d', 'opcache.enable_cli=1',
+                '-d', 'opcache.validate_timestamps=1',
+                '-d', 'opcache.revalidate_freq=0',
+                '-S', "{$bindHost}:{$port}",
+                '-t', 'public',
+                __DIR__ . '/../router.php',
+            ],
             null,
-            ['PHP_CLI_SERVER_WORKERS' => (string) (getenv('MAHO_BROWSER_WORKERS') ?: 8)],
+            [
+                'PHP_CLI_SERVER_WORKERS' => (string) (getenv('MAHO_BROWSER_WORKERS') ?: 8),
+                'MAHO_GRAPHQL_INTROSPECTION' => '1',
+            ],
         );
         self::$process->setTimeout(null);
         self::$process->start();
@@ -85,13 +103,14 @@ final class MahoServer
         self::$process = null;
     }
 
-    private static function syncBaseUrl(string $url): void
+    private static function isListening(string $host, int $port): bool
     {
-        foreach (['web/unsecure/base_url', 'web/secure/base_url'] as $path) {
-            (new Process(['./maho', 'config:set', $path, $url, '--scope', 'default', '--scope-id', '0', '--silent']))
-                ->mustRun();
+        $conn = @fsockopen($host, $port, $errno, $errstr, 1);
+        if ($conn === false) {
+            return false;
         }
-        (new Process(['./maho', 'cache:flush']))->mustRun();
+        fclose($conn);
+        return true;
     }
 
     private static function waitUntilReady(string $host, int $port, int $timeoutSeconds = 30): void

--- a/tests/Helpers/ApiV2Helper.php
+++ b/tests/Helpers/ApiV2Helper.php
@@ -1132,10 +1132,8 @@ class ApiV2Helper
      * @return array{id: int|null, sku: string|null}
      */
     /**
-     * The fixture row every product test acts on. Order explicitly: without ORDER BY,
-     * PostgreSQL returns rows in physical order, so the "first" product changes as
-     * unrelated tests add and remove rows, and these fixtures silently move to a
-     * product with different stores, images or price.
+     * Order explicitly: without ORDER BY, PostgreSQL returns physical order, so the
+     * "first" product moves as unrelated tests add and remove rows.
      */
     private static function lookupProduct(): array
     {

--- a/tests/Helpers/ApiV2Helper.php
+++ b/tests/Helpers/ApiV2Helper.php
@@ -1131,12 +1131,19 @@ class ApiV2Helper
     /**
      * @return array{id: int|null, sku: string|null}
      */
+    /**
+     * The fixture row every product test acts on. Order explicitly: without ORDER BY,
+     * PostgreSQL returns rows in physical order, so the "first" product changes as
+     * unrelated tests add and remove rows, and these fixtures silently move to a
+     * product with different stores, images or price.
+     */
     private static function lookupProduct(): array
     {
         try {
             $product = \Mage::getModel('catalog/product')->getCollection()
                 ->addFieldToFilter('type_id', \Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)
                 ->addFieldToFilter('status', \Mage_Catalog_Model_Product_Status::STATUS_ENABLED)
+                ->setOrder('entity_id', 'ASC')
                 ->setPageSize(1)
                 ->getFirstItem();
             if ($product->getId()) {
@@ -1153,6 +1160,7 @@ class ApiV2Helper
             $product = \Mage::getModel('catalog/product')->getCollection()
                 ->addFieldToFilter('type_id', \Mage_Catalog_Model_Product_Type::TYPE_CONFIGURABLE)
                 ->addFieldToFilter('status', \Mage_Catalog_Model_Product_Status::STATUS_ENABLED)
+                ->setOrder('entity_id', 'ASC')
                 ->setPageSize(1)
                 ->getFirstItem();
             return $product->getId() ? $product->getSku() : null;
@@ -1169,6 +1177,7 @@ class ApiV2Helper
                 ->addFieldToFilter('path', ['like' => "1/{$rootId}/%"])
                 ->addFieldToFilter('level', ['gt' => 1])
                 ->addFieldToFilter('is_active', 1)
+                ->setOrder('entity_id', 'ASC')
                 ->setPageSize(1)
                 ->getFirstItem();
             return $category->getId() ? (int) $category->getId() : null;

--- a/tests/pest-with-test-db.php
+++ b/tests/pest-with-test-db.php
@@ -481,8 +481,11 @@ class PestTestRunner
         // Enable GraphQL introspection for the test server (off in production):
         // the schema/tooling tests rely on it. Set inline so it lands in the
         // server process environment regardless of parent inheritance.
+        // OPcache is off in the CLI SAPI, so without -d every one of the ~1200
+        // requests this suite makes recompiles the whole bootstrap (49ms -> 30ms).
         $cmd = sprintf(
-            'MAHO_GRAPHQL_INTROSPECTION=1 php -S %s:%d -t public %s > /tmp/maho-test-api-server.log 2>&1 & echo $!',
+            'MAHO_GRAPHQL_INTROSPECTION=1 php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1'
+            . ' -d opcache.revalidate_freq=0 -S %s:%d -t public %s > /tmp/maho-test-api-server.log 2>&1 & echo $!',
             $host,
             $port,
             $router,

--- a/tests/pest-with-test-db.php
+++ b/tests/pest-with-test-db.php
@@ -123,8 +123,7 @@ class PestTestRunner
             echo "Setting up fresh test database for local testing ({$this->dbType})...\n";
             $this->setupTestDatabase();
             $this->injectPaypalSandboxConfig();
-            // Serve the freshly-installed app for the Api and Browser suites
-            // (mirrors CI). Non-fatal: if it can't start, those tests skip.
+            // Mirrors CI. Non-fatal: if it can't start, the HTTP tests skip.
             $this->startServer();
             $exitCode = $this->runPest($pestArgs);
 
@@ -436,21 +435,14 @@ class PestTestRunner
     }
 
     /**
-     * Serve the freshly-installed app for every suite that speaks HTTP: the Api/V2
-     * tests over curl and the Browser tests through Playwright. One server, bound to
-     * the host:port the store was installed with, so base_url already matches the
-     * origin it answers on. That matters twice over: redirect_to_base bounces any
-     * request whose host differs, and JwtService::getIssuer() derives the issuer from
-     * base_url, so a mismatch 401s every authenticated API call.
-     *
+     * Serve the freshly-installed app for the Api and Browser suites, on the host:port it
+     * was installed with so base_url needs no rewrite (see Tests\Browser\MahoServer).
      * Sets API_BASE_URL for the Pest subprocess (inherited via passthru).
-     * Non-fatal: a failure to bind just leaves the HTTP tests skipping.
      */
     private function startServer(): void
     {
         $baseUrl = rtrim(self::testBaseUrl(), '/');
-        // Address host vs bind host: they differ only in the local default, where the
-        // browser navigates `localhost` but the server binds 127.0.0.1 (see MahoServer).
+        // Bind 127.0.0.1 where the browser navigates `localhost` (see MahoServer).
         $envHost = getenv('MAHO_BROWSER_HOST') ?: '';
         $bindHost = $envHost !== '' ? $envHost : '127.0.0.1';
         $port = (int) (getenv('MAHO_BROWSER_PORT') ?: 8901);
@@ -474,11 +466,8 @@ class PestTestRunner
         putenv("API_BASE_URL={$baseUrl}");
 
         $router = escapeshellarg(__DIR__ . '/router.php');
-        // MAHO_GRAPHQL_INTROSPECTION: off in production, but the schema/tooling tests
-        // query __schema/__type. PHP_CLI_SERVER_WORKERS: the built-in server is
-        // single-threaded, so a browser's parallel asset requests would serialize.
-        // OPcache: off in the CLI SAPI, so without -d every request recompiles the
-        // whole bootstrap, ~500 files (49ms -> 30ms).
+        // Introspection is off in production but the schema tests need it. OPcache is off
+        // in the CLI SAPI, so without -d every request recompiles the bootstrap.
         $cmd = sprintf(
             'MAHO_GRAPHQL_INTROSPECTION=1 PHP_CLI_SERVER_WORKERS=%d'
             . ' php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1'
@@ -496,10 +485,9 @@ class PestTestRunner
         $this->serverPid = $pid;
 
         for ($i = 0; $i < 40; $i++) {
-            // Check liveness before the probe. The shell reports a pid for a backgrounded
-            // process that then exits, so a port already held by a stale server would
-            // otherwise answer the probe and the whole run would silently test that
-            // server (and its database) instead of ours.
+            // Before the probe: the shell reports a pid even for a process that then
+            // exits, so a stale server on the port would answer and the whole run would
+            // silently test that server's database instead of ours.
             if (!$this->isServerAlive()) {
                 $this->serverPid = null;
                 echo "✗ Test server exited instead of binding {$bindHost}:{$port}:\n";
@@ -528,8 +516,7 @@ class PestTestRunner
     private function stopServer(): void
     {
         if ($this->serverPid !== null) {
-            // Kill the workers too: an orphan keeps the port, and the next run would
-            // then probe green against a server bound to a different database.
+            // Workers too: an orphan keeps the port and poisons the next run.
             shell_exec('pkill -P ' . $this->serverPid . ' 2>/dev/null');
             shell_exec('kill ' . $this->serverPid . ' 2>/dev/null');
             $this->serverPid = null;

--- a/tests/pest-with-test-db.php
+++ b/tests/pest-with-test-db.php
@@ -35,7 +35,7 @@ class PestTestRunner
     private array $dbConfig = [];
     private string $testDbName;
     private string $dbType;
-    private ?int $apiServerPid = null;
+    private ?int $serverPid = null;
 
     public function __construct()
     {
@@ -45,9 +45,9 @@ class PestTestRunner
     }
 
     /**
-     * Canonical base URL the test store is installed with. Browser tests serve the app on
-     * this exact host:port (see Tests\Browser\MahoServer), so there is no runtime base_url
-     * rewrite, so all suites share one configuration. The host is `localhost`, deliberately:
+     * Canonical base URL the test store is installed with, and the one origin every suite
+     * talks to: startServer() binds this exact host:port, so base_url is never rewritten at
+     * runtime and all suites share one configuration. The host is `localhost`, deliberately:
      * Playwright's bundled Chromium uses Chromium's built-in DNS resolver, which ignores
      * /etc/hosts (so .test names don't resolve in-browser) and, on CI Linux runners, even
      * reports ERR_NAME_NOT_RESOLVED for the bare loopback IP `127.0.0.1`. It does resolve
@@ -123,9 +123,9 @@ class PestTestRunner
             echo "Setting up fresh test database for local testing ({$this->dbType})...\n";
             $this->setupTestDatabase();
             $this->injectPaypalSandboxConfig();
-            // Serve the freshly-installed app so the Api/V2 HTTP suite can reach
-            // it (mirrors CI). Non-fatal: if it can't start, those tests skip.
-            $this->startApiServer();
+            // Serve the freshly-installed app for the Api and Browser suites
+            // (mirrors CI). Non-fatal: if it can't start, those tests skip.
+            $this->startServer();
             $exitCode = $this->runPest($pestArgs);
 
             // Flush cache after tests complete
@@ -138,7 +138,7 @@ class PestTestRunner
             echo 'Error: ' . $e->getMessage() . "\n";
             return 1;
         } finally {
-            $this->stopApiServer();
+            $this->stopServer();
             $this->restoreLocalXml();
         }
     }
@@ -436,31 +436,27 @@ class PestTestRunner
     }
 
     /**
-     * Start PHP's built-in server on the app so the Api/V2 HTTP tests can reach
-     * it. Sets API_BASE_URL for the Pest subprocess (inherited via passthru).
-     * Non-fatal: a failure to bind just leaves the API suite skipping.
+     * Serve the freshly-installed app for every suite that speaks HTTP: the Api/V2
+     * tests over curl and the Browser tests through Playwright. One server, bound to
+     * the host:port the store was installed with, so base_url already matches the
+     * origin it answers on. That matters twice over: redirect_to_base bounces any
+     * request whose host differs, and JwtService::getIssuer() derives the issuer from
+     * base_url, so a mismatch 401s every authenticated API call.
+     *
+     * Sets API_BASE_URL for the Pest subprocess (inherited via passthru).
+     * Non-fatal: a failure to bind just leaves the HTTP tests skipping.
      */
-    private function startApiServer(): void
+    private function startServer(): void
     {
-        $host = getenv('MAHO_API_TEST_HOST') ?: '127.0.0.1';
-        $port = (int) (getenv('MAHO_API_TEST_PORT') ?: 8080);
-        $baseUrl = "http://{$host}:{$port}";
-
-        // The JWT issuer is pinned to the store base_url (JwtService::getIssuer),
-        // and redirect_to_base bounces any request whose host doesn't match it.
-        // So point the store base_url at the API server URL: this aligns the
-        // issuer with the tokens the helper signs (iss = API_BASE_URL) and stops
-        // the 301 redirect. The test DB is thrown away afterwards, so this is safe.
-        foreach (['web/unsecure/base_url', 'web/secure/base_url'] as $path) {
-            $this->executeCommand(sprintf(
-                './maho config:set %s %s --scope default --scope-id 0 --silent',
-                escapeshellarg($path),
-                escapeshellarg($baseUrl . '/'),
-            ));
-        }
+        $baseUrl = rtrim(self::testBaseUrl(), '/');
+        // Address host vs bind host: they differ only in the local default, where the
+        // browser navigates `localhost` but the server binds 127.0.0.1 (see MahoServer).
+        $envHost = getenv('MAHO_BROWSER_HOST') ?: '';
+        $bindHost = $envHost !== '' ? $envHost : '127.0.0.1';
+        $port = (int) (getenv('MAHO_BROWSER_PORT') ?: 8901);
 
         // Pre-seed a deterministic JWT signing secret. Otherwise the Pest process
-        // (signing tokens via the helper) and the API server process each lazily
+        // (signing tokens via the helper) and the server process each lazily
         // generate their own random secret — with separate config caches they can
         // diverge, so every authenticated request 401s. Seeding it once, encrypted,
         // makes both processes read the same persisted secret.
@@ -478,44 +474,65 @@ class PestTestRunner
         putenv("API_BASE_URL={$baseUrl}");
 
         $router = escapeshellarg(__DIR__ . '/router.php');
-        // Enable GraphQL introspection for the test server (off in production):
-        // the schema/tooling tests rely on it. Set inline so it lands in the
-        // server process environment regardless of parent inheritance.
-        // OPcache is off in the CLI SAPI, so without -d every one of the ~1200
-        // requests this suite makes recompiles the whole bootstrap (49ms -> 30ms).
+        // MAHO_GRAPHQL_INTROSPECTION: off in production, but the schema/tooling tests
+        // query __schema/__type. PHP_CLI_SERVER_WORKERS: the built-in server is
+        // single-threaded, so a browser's parallel asset requests would serialize.
+        // OPcache: off in the CLI SAPI, so without -d every request recompiles the
+        // whole bootstrap, ~500 files (49ms -> 30ms).
         $cmd = sprintf(
-            'MAHO_GRAPHQL_INTROSPECTION=1 php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1'
-            . ' -d opcache.revalidate_freq=0 -S %s:%d -t public %s > /tmp/maho-test-api-server.log 2>&1 & echo $!',
-            $host,
+            'MAHO_GRAPHQL_INTROSPECTION=1 PHP_CLI_SERVER_WORKERS=%d'
+            . ' php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1'
+            . ' -d opcache.revalidate_freq=0 -S %s:%d -t public %s > /tmp/maho-test-server.log 2>&1 & echo $!',
+            (int) (getenv('MAHO_BROWSER_WORKERS') ?: 8),
+            $bindHost,
             $port,
             $router,
         );
         $pid = (int) trim((string) shell_exec($cmd));
         if ($pid <= 0) {
-            echo "⚠ Could not start API test server; Api/V2 HTTP tests will skip.\n";
+            echo "⚠ Could not start the test server; HTTP tests will skip.\n";
             return;
         }
-        $this->apiServerPid = $pid;
+        $this->serverPid = $pid;
 
         for ($i = 0; $i < 40; $i++) {
+            // Check liveness before the probe. The shell reports a pid for a backgrounded
+            // process that then exits, so a port already held by a stale server would
+            // otherwise answer the probe and the whole run would silently test that
+            // server (and its database) instead of ours.
+            if (!$this->isServerAlive()) {
+                $this->serverPid = null;
+                echo "✗ Test server exited instead of binding {$bindHost}:{$port}:\n";
+                echo trim((string) shell_exec('tail -5 /tmp/maho-test-server.log 2>/dev/null')) . "\n";
+                throw new Exception("Test server could not bind {$bindHost}:{$port}");
+            }
             $probe = shell_exec(sprintf(
                 'curl -s -o /dev/null -w "%%{http_code}" %s/api/rest/v2/store-config 2>/dev/null',
                 escapeshellarg($baseUrl),
             ));
             if ((int) trim((string) $probe) > 0) {
-                echo "✓ API test server up at {$baseUrl}\n";
+                echo "✓ Test server up at {$baseUrl}\n";
                 return;
             }
             usleep(250000);
         }
-        echo "⚠ API test server did not become ready; Api/V2 HTTP tests may skip.\n";
+        echo "⚠ Test server did not become ready; HTTP tests may skip.\n";
     }
 
-    private function stopApiServer(): void
+    private function isServerAlive(): bool
     {
-        if ($this->apiServerPid !== null) {
-            shell_exec('kill ' . $this->apiServerPid . ' 2>/dev/null');
-            $this->apiServerPid = null;
+        return $this->serverPid !== null
+            && trim((string) shell_exec('kill -0 ' . $this->serverPid . ' 2>&1')) === '';
+    }
+
+    private function stopServer(): void
+    {
+        if ($this->serverPid !== null) {
+            // Kill the workers too: an orphan keeps the port, and the next run would
+            // then probe green against a server bound to a different database.
+            shell_exec('pkill -P ' . $this->serverPid . ' 2>/dev/null');
+            shell_exec('kill ' . $this->serverPid . ' 2>/dev/null');
+            $this->serverPid = null;
         }
     }
 


### PR DESCRIPTION
Three changes. Measured against a full local SQLite run of 11 minutes (42s setup, 626s tests).

### Fixtures built once per run

The CustomerSegmentation wishlist and viewed-product fixtures sat in a `beforeEach`, so the Nth test ran against N copies of the same categories, products, customers and wishlists. Nothing mutates the fixture, and every assertion verifies each matched customer on its own rather than counting rows, so one copy is enough.

| | before | after |
|---|---:|---:|
| `WishlistTest` (46 tests) | 71.7s | 1.4s |
| `ViewedTest` (19 tests) | 12.8s | ~1.0s |

About 82 seconds, and backend-independent: that work is simply no longer done.

### OPcache on the built-in web servers

The CLI SAPI leaves OPcache off, so every request through `php -S` recompiled the whole bootstrap: ~500 files, 3.3MB. A bootstrap drops from 49ms to 30ms. Timestamps stay validated per request, so `./maho serve` still picks up an edit immediately; disabling that check measured only 1.6ms, which does not justify a dev server that ignores your edits. CI needs the extension loaded explicitly for the flags to do anything.

This one is estimated, not measured end to end.

### One HTTP server for the Api and Browser suites

The run started two built-in servers, differing only in the router. Keeping them apart cost more than the extra process: both suites need `base_url` to name the origin they talk to, because `redirect_to_base` bounces a mismatched host and `JwtService::getIssuer()` derives the issuer from `base_url`. So the run rewrote `base_url` twice, and the Browser suite only worked because the Api suite had run first and moved it. That ordering rule was load-bearing and written down only in a comment.

Now one server runs on the host:port the store was installed with, so `base_url` is never rewritten.

### Three bugs this surfaced

**Order-unstable fixture lookups.** Removing ~280 product rows broke three tests on PostgreSQL only. `lookupProduct()` and friends took `setPageSize(1)->getFirstItem()` with no `ORDER BY`. InnoDB scans in primary-key order, so MySQL always returned the lowest `entity_id` and the tests were written against that row; PostgreSQL returns physical order, so the fixture moved to a product another test had created, with different stores, no image and a different price. Now ordered by `entity_id` ascending, which is what MySQL was giving all along. `lookupOrderId()` already did this.

**Orphaned servers.** `MahoServer` ran `./maho serve`, which `passthru`s `php -S`. `Process::stop()` signalled the wrapper, leaving the real server and its eight workers holding the port. It now spawns `php -S` directly, and the runner reaps the workers too.

**A readiness probe that accepted any listener.** That is what let the orphans pass as healthy: a run went green against a server bound to a different database and reported 715 bogus failures. The probe now checks our own process is alive first, so a bind failure is reported with the server log instead of hidden.

### Verification

Locally against SQLite, sandbox and currency-live excluded:

| Suite | Result |
|---|---|
| Api | 891 passed, 3 skipped, 0 failed (2656 requests reached the server) |
| Browser | 13 passed, 12 risky, 0 failed |
| CustomerSegmentation | 280 passed |

The 12 risky are pre-existing output-buffer warnings. No orphaned processes after either run.

### Honest scale

The Pest step is most of each CI job (sqlite 16.5 of 18.1 min; pgsql-15 19.3 of 22.9 min), so optimising it is the right target. But the measured saving is ~7% of that step, and CI variance between near-identical jobs on the same code is far larger: on the baseline run, pgsql-15 took 1160s while pgsql-latest took 1495s. A single before-and-after comparison cannot show a 7% change through that noise.

This does not get the suite to 5 minutes. The lever that would is parallel workers, which needs per-worker database isolation: 32 test files write global store config, 17 fixtures use a literal SKU, and two call `reindexEverything()`. `var/cache`, `var/session` and `var/log` are easy by comparison (pass `var_dir` and friends to `Mage::app()`).

Also left on the table: caching the installed test database instead of reinstalling (42s locally on SQLite, 1.6 to 3.6 min on CI).