### PR TITLE
Served the Api and Browser suites from one HTTP server

### DIFF
--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -170,22 +170,28 @@ jobs:
 
       - name: Start built-in web server
         run: |
-          # Serve the API at the URL the JWT issuer is pinned to, and pre-seed a
-          # deterministic signing secret, so tokens the test helper signs validate
-          # against the server (otherwise every authenticated API test 401s).
-          ./maho config:set web/unsecure/base_url http://127.0.0.1:8080/ --scope default --scope-id 0 --silent
-          ./maho config:set web/secure/base_url http://127.0.0.1:8080/ --scope default --scope-id 0 --silent
+          # One server for every suite that speaks HTTP: the Api tests over curl and the
+          # Browser tests through Playwright. It binds the host:port the store was
+          # installed with, so base_url already matches and is never rewritten at runtime.
+          # That matters twice over: redirect_to_base bounces a request whose host differs,
+          # and JwtService::getIssuer() derives the issuer from base_url, so a mismatch
+          # 401s every authenticated API call. Pre-seed a deterministic signing secret so
+          # the tokens the test helper signs validate against the server.
           ./maho config:set apiplatform/oauth2/secret 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef --encrypt --scope default --scope-id 0 --silent
           ./maho cache:flush
-          # Enable GraphQL introspection for the test server (off in production) so the
-          # introspection tests in tests/Api/V2/Read/GraphQLBasicTest.php can query __schema/__type.
-          # OPcache is off in the CLI SAPI, so without -d every API request recompiles
-          # the whole bootstrap (~500 files). Timestamps stay validated per request.
-          MAHO_GRAPHQL_INTROSPECTION=1 php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1 \
-            -d opcache.revalidate_freq=0 -S 127.0.0.1:8080 -t public tests/router.php > /tmp/php-server.log 2>&1 < /dev/null &
+          # MAHO_GRAPHQL_INTROSPECTION: off in production, but the introspection tests in
+          # tests/Api/V2/Read/GraphQLBasicTest.php query __schema/__type.
+          # PHP_CLI_SERVER_WORKERS: the built-in server is single-threaded, so a browser's
+          # parallel asset requests would serialize and stall.
+          # OPcache is off in the CLI SAPI, so without -d every request recompiles the
+          # whole bootstrap (~500 files). Timestamps stay validated per request.
+          MAHO_GRAPHQL_INTROSPECTION=1 PHP_CLI_SERVER_WORKERS=8 \
+            php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1 \
+            -d opcache.revalidate_freq=0 -S "$MAHO_BROWSER_HOST:8901" -t public tests/router.php \
+            > /tmp/php-server.log 2>&1 < /dev/null &
           for i in $(seq 1 20); do
-            if curl -fsS http://127.0.0.1:8080/api/rest/v2/store-config -o /dev/null 2>&1 || \
-               curl -fsS http://127.0.0.1:8080/ -o /dev/null 2>&1; then
+            if curl -fsS "http://$MAHO_BROWSER_HOST:8901/api/rest/v2/store-config" -o /dev/null 2>&1 || \
+               curl -fsS "http://$MAHO_BROWSER_HOST:8901/" -o /dev/null 2>&1; then
               echo "Web server is up"
               exit 0
             fi
@@ -213,7 +219,7 @@ jobs:
 
       - name: Run Pest Tests
         env:
-          API_BASE_URL: http://127.0.0.1:8080
+          API_BASE_URL: http://${{ env.MAHO_BROWSER_HOST }}:8901
           PAYPAL_SANDBOX_CLIENT_ID: ${{ secrets.PAYPAL_SANDBOX_CLIENT_ID }}
           PAYPAL_SANDBOX_CLIENT_SECRET: ${{ secrets.PAYPAL_SANDBOX_CLIENT_SECRET }}
         run: |
@@ -307,22 +313,28 @@ jobs:
 
       - name: Start built-in web server
         run: |
-          # Serve the API at the URL the JWT issuer is pinned to, and pre-seed a
-          # deterministic signing secret, so tokens the test helper signs validate
-          # against the server (otherwise every authenticated API test 401s).
-          ./maho config:set web/unsecure/base_url http://127.0.0.1:8080/ --scope default --scope-id 0 --silent
-          ./maho config:set web/secure/base_url http://127.0.0.1:8080/ --scope default --scope-id 0 --silent
+          # One server for every suite that speaks HTTP: the Api tests over curl and the
+          # Browser tests through Playwright. It binds the host:port the store was
+          # installed with, so base_url already matches and is never rewritten at runtime.
+          # That matters twice over: redirect_to_base bounces a request whose host differs,
+          # and JwtService::getIssuer() derives the issuer from base_url, so a mismatch
+          # 401s every authenticated API call. Pre-seed a deterministic signing secret so
+          # the tokens the test helper signs validate against the server.
           ./maho config:set apiplatform/oauth2/secret 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef --encrypt --scope default --scope-id 0 --silent
           ./maho cache:flush
-          # Enable GraphQL introspection for the test server (off in production) so the
-          # introspection tests in tests/Api/V2/Read/GraphQLBasicTest.php can query __schema/__type.
-          # OPcache is off in the CLI SAPI, so without -d every API request recompiles
-          # the whole bootstrap (~500 files). Timestamps stay validated per request.
-          MAHO_GRAPHQL_INTROSPECTION=1 php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1 \
-            -d opcache.revalidate_freq=0 -S 127.0.0.1:8080 -t public tests/router.php > /tmp/php-server.log 2>&1 < /dev/null &
+          # MAHO_GRAPHQL_INTROSPECTION: off in production, but the introspection tests in
+          # tests/Api/V2/Read/GraphQLBasicTest.php query __schema/__type.
+          # PHP_CLI_SERVER_WORKERS: the built-in server is single-threaded, so a browser's
+          # parallel asset requests would serialize and stall.
+          # OPcache is off in the CLI SAPI, so without -d every request recompiles the
+          # whole bootstrap (~500 files). Timestamps stay validated per request.
+          MAHO_GRAPHQL_INTROSPECTION=1 PHP_CLI_SERVER_WORKERS=8 \
+            php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1 \
+            -d opcache.revalidate_freq=0 -S "$MAHO_BROWSER_HOST:8901" -t public tests/router.php \
+            > /tmp/php-server.log 2>&1 < /dev/null &
           for i in $(seq 1 20); do
-            if curl -fsS http://127.0.0.1:8080/api/rest/v2/store-config -o /dev/null 2>&1 || \
-               curl -fsS http://127.0.0.1:8080/ -o /dev/null 2>&1; then
+            if curl -fsS "http://$MAHO_BROWSER_HOST:8901/api/rest/v2/store-config" -o /dev/null 2>&1 || \
+               curl -fsS "http://$MAHO_BROWSER_HOST:8901/" -o /dev/null 2>&1; then
               echo "Web server is up"
               exit 0
             fi
@@ -350,7 +362,7 @@ jobs:
 
       - name: Run Pest Tests
         env:
-          API_BASE_URL: http://127.0.0.1:8080
+          API_BASE_URL: http://${{ env.MAHO_BROWSER_HOST }}:8901
           PAYPAL_SANDBOX_CLIENT_ID: ${{ secrets.PAYPAL_SANDBOX_CLIENT_ID }}
           PAYPAL_SANDBOX_CLIENT_SECRET: ${{ secrets.PAYPAL_SANDBOX_CLIENT_SECRET }}
         # See the matrix comment above: the live-service groups run in one job only.

--- a/tests/Browser/MahoServer.php
+++ b/tests/Browser/MahoServer.php
@@ -12,20 +12,23 @@ namespace Tests\Browser;
 use Symfony\Component\Process\Process;
 
 /**
- * Boots `./maho serve` for browser tests.
+ * Resolves the one HTTP server the Api and Browser suites share, starting it if nobody
+ * did already.
  *
  * The app is installed with base_url http://<host>:<port>/ and served on that exact
- * host:port. The host comes from MAHO_BROWSER_HOST: CI sets it to the runner's real IP
- * (detected before install), so the browser hits a routable address and sidesteps every
- * loopback caveat (Playwright's Chromium ignores /etc/hosts and is unreliable with bare
- * 127.0.0.1 on CI). Locally it defaults to `localhost`, served on 127.0.0.1 which localhost
- * maps to. The server binds the same host it's addressed by; the port must match base_url or
- * redirect_to_base bounces the browser to an unserved origin.
+ * host:port, so base_url is never rewritten at runtime. The host comes from
+ * MAHO_BROWSER_HOST: CI sets it to the runner's real IP (detected before install), so the
+ * browser hits a routable address and sidesteps every loopback caveat (Playwright's
+ * Chromium ignores /etc/hosts and is unreliable with bare 127.0.0.1 on CI). Locally it
+ * defaults to `localhost`, served on 127.0.0.1 which localhost maps to.
  *
- * The Api suite runs before this one and repoints the store base_url at its own HTTP server
- * (so the JWT issuer matches the tokens it signs), so we can't assume base_url still holds
- * the install value. Repoint it back to this server's URL on start, before serving, so
- * redirect_to_base keeps the browser on the origin we actually serve.
+ * Both suites need that single origin. redirect_to_base bounces a request whose host
+ * differs from base_url, and JwtService::getIssuer() derives the issuer from base_url, so
+ * an API token signed against a different origin 401s.
+ *
+ * The runner (tests/pest-with-test-db.php) and CI both start this server before Pest, so
+ * normally there is one already listening and this class only hands back its URL. Starting
+ * one here covers a bare `vendor/bin/pest` run against an installed store.
  */
 final class MahoServer
 {
@@ -35,15 +38,8 @@ final class MahoServer
 
     public static function start(?int $port = null): string
     {
-        if (self::$process && self::$process->isRunning()) {
+        if (self::$baseUrl !== '' && (self::$process === null || self::$process->isRunning())) {
             return self::$baseUrl;
-        }
-
-        // One server for the whole run: every test file starts it, and it lives until the
-        // process ends rather than being torn down and rebuilt between files.
-        if (!self::$stopRegistered) {
-            register_shutdown_function(self::stop(...));
-            self::$stopRegistered = true;
         }
 
         // Address host (what the browser navigates to) vs bind host (what the server binds).
@@ -54,17 +50,39 @@ final class MahoServer
         $port ??= (int) (getenv('MAHO_BROWSER_PORT') ?: 8901);
         self::$baseUrl = "http://{$addressHost}:{$port}";
 
-        // Repoint base_url at the URL we're about to serve (a prior suite may have moved it),
-        // then flush so the serve workers boot with fresh config. Otherwise redirect_to_base
-        // bounces every navigation to whatever origin base_url currently names.
-        self::syncBaseUrl(self::$baseUrl . '/');
+        // The runner and CI already serve this origin for the Api suite. Reuse it rather
+        // than binding a second server to a port that is taken.
+        if (self::isListening($bindHost, $port)) {
+            return self::$baseUrl;
+        }
 
-        // The PHP built-in server is single-threaded; a browser's parallel asset
-        // requests would serialize and stall. Spawn workers so requests run concurrently.
+        // One server for the whole run: every test file starts it, and it lives until the
+        // process ends rather than being torn down and rebuilt between files.
+        if (!self::$stopRegistered) {
+            register_shutdown_function(self::stop(...));
+            self::$stopRegistered = true;
+        }
+
+        // Same command the runner uses, so a standalone `vendor/bin/pest` serves the API
+        // routes too: `./maho serve` has no router, and without tests/router.php the
+        // /api/* rewrites that public/.htaccess performs in production are missing.
+        // PHP_CLI_SERVER_WORKERS: the built-in server is single-threaded, so a browser's
+        // parallel asset requests would serialize and stall.
         self::$process = new Process(
-            ['./maho', 'serve', (string) $port, '--host', $bindHost],
+            [
+                PHP_BINARY,
+                '-d', 'opcache.enable_cli=1',
+                '-d', 'opcache.validate_timestamps=1',
+                '-d', 'opcache.revalidate_freq=0',
+                '-S', "{$bindHost}:{$port}",
+                '-t', 'public',
+                __DIR__ . '/../router.php',
+            ],
             null,
-            ['PHP_CLI_SERVER_WORKERS' => (string) (getenv('MAHO_BROWSER_WORKERS') ?: 8)],
+            [
+                'PHP_CLI_SERVER_WORKERS' => (string) (getenv('MAHO_BROWSER_WORKERS') ?: 8),
+                'MAHO_GRAPHQL_INTROSPECTION' => '1',
+            ],
         );
         self::$process->setTimeout(null);
         self::$process->start();
@@ -85,13 +103,14 @@ final class MahoServer
         self::$process = null;
     }
 
-    private static function syncBaseUrl(string $url): void
+    private static function isListening(string $host, int $port): bool
     {
-        foreach (['web/unsecure/base_url', 'web/secure/base_url'] as $path) {
-            (new Process(['./maho', 'config:set', $path, $url, '--scope', 'default', '--scope-id', '0', '--silent']))
-                ->mustRun();
+        $conn = @fsockopen($host, $port, $errno, $errstr, 1);
+        if ($conn === false) {
+            return false;
         }
-        (new Process(['./maho', 'cache:flush']))->mustRun();
+        fclose($conn);
+        return true;
     }
 
     private static function waitUntilReady(string $host, int $port, int $timeoutSeconds = 30): void

--- a/tests/pest-with-test-db.php
+++ b/tests/pest-with-test-db.php
@@ -35,7 +35,7 @@ class PestTestRunner
     private array $dbConfig = [];
     private string $testDbName;
     private string $dbType;
-    private ?int $apiServerPid = null;
+    private ?int $serverPid = null;
 
     public function __construct()
     {
@@ -45,9 +45,9 @@ class PestTestRunner
     }
 
     /**
-     * Canonical base URL the test store is installed with. Browser tests serve the app on
-     * this exact host:port (see Tests\Browser\MahoServer), so there is no runtime base_url
-     * rewrite, so all suites share one configuration. The host is `localhost`, deliberately:
+     * Canonical base URL the test store is installed with, and the one origin every suite
+     * talks to: startServer() binds this exact host:port, so base_url is never rewritten at
+     * runtime and all suites share one configuration. The host is `localhost`, deliberately:
      * Playwright's bundled Chromium uses Chromium's built-in DNS resolver, which ignores
      * /etc/hosts (so .test names don't resolve in-browser) and, on CI Linux runners, even
      * reports ERR_NAME_NOT_RESOLVED for the bare loopback IP `127.0.0.1`. It does resolve
@@ -123,9 +123,9 @@ class PestTestRunner
             echo "Setting up fresh test database for local testing ({$this->dbType})...\n";
             $this->setupTestDatabase();
             $this->injectPaypalSandboxConfig();
-            // Serve the freshly-installed app so the Api/V2 HTTP suite can reach
-            // it (mirrors CI). Non-fatal: if it can't start, those tests skip.
-            $this->startApiServer();
+            // Serve the freshly-installed app for the Api and Browser suites
+            // (mirrors CI). Non-fatal: if it can't start, those tests skip.
+            $this->startServer();
             $exitCode = $this->runPest($pestArgs);
 
             // Flush cache after tests complete
@@ -138,7 +138,7 @@ class PestTestRunner
             echo 'Error: ' . $e->getMessage() . "\n";
             return 1;
         } finally {
-            $this->stopApiServer();
+            $this->stopServer();
             $this->restoreLocalXml();
         }
     }
@@ -436,31 +436,27 @@ class PestTestRunner
     }
 
     /**
-     * Start PHP's built-in server on the app so the Api/V2 HTTP tests can reach
-     * it. Sets API_BASE_URL for the Pest subprocess (inherited via passthru).
-     * Non-fatal: a failure to bind just leaves the API suite skipping.
+     * Serve the freshly-installed app for every suite that speaks HTTP: the Api/V2
+     * tests over curl and the Browser tests through Playwright. One server, bound to
+     * the host:port the store was installed with, so base_url already matches the
+     * origin it answers on. That matters twice over: redirect_to_base bounces any
+     * request whose host differs, and JwtService::getIssuer() derives the issuer from
+     * base_url, so a mismatch 401s every authenticated API call.
+     *
+     * Sets API_BASE_URL for the Pest subprocess (inherited via passthru).
+     * Non-fatal: a failure to bind just leaves the HTTP tests skipping.
      */
-    private function startApiServer(): void
+    private function startServer(): void
     {
-        $host = getenv('MAHO_API_TEST_HOST') ?: '127.0.0.1';
-        $port = (int) (getenv('MAHO_API_TEST_PORT') ?: 8080);
-        $baseUrl = "http://{$host}:{$port}";
-
-        // The JWT issuer is pinned to the store base_url (JwtService::getIssuer),
-        // and redirect_to_base bounces any request whose host doesn't match it.
-        // So point the store base_url at the API server URL: this aligns the
-        // issuer with the tokens the helper signs (iss = API_BASE_URL) and stops
-        // the 301 redirect. The test DB is thrown away afterwards, so this is safe.
-        foreach (['web/unsecure/base_url', 'web/secure/base_url'] as $path) {
-            $this->executeCommand(sprintf(
-                './maho config:set %s %s --scope default --scope-id 0 --silent',
-                escapeshellarg($path),
-                escapeshellarg($baseUrl . '/'),
-            ));
-        }
+        $baseUrl = rtrim(self::testBaseUrl(), '/');
+        // Address host vs bind host: they differ only in the local default, where the
+        // browser navigates `localhost` but the server binds 127.0.0.1 (see MahoServer).
+        $envHost = getenv('MAHO_BROWSER_HOST') ?: '';
+        $bindHost = $envHost !== '' ? $envHost : '127.0.0.1';
+        $port = (int) (getenv('MAHO_BROWSER_PORT') ?: 8901);
 
         // Pre-seed a deterministic JWT signing secret. Otherwise the Pest process
-        // (signing tokens via the helper) and the API server process each lazily
+        // (signing tokens via the helper) and the server process each lazily
         // generate their own random secret — with separate config caches they can
         // diverge, so every authenticated request 401s. Seeding it once, encrypted,
         // makes both processes read the same persisted secret.
@@ -478,44 +474,65 @@ class PestTestRunner
         putenv("API_BASE_URL={$baseUrl}");
 
         $router = escapeshellarg(__DIR__ . '/router.php');
-        // Enable GraphQL introspection for the test server (off in production):
-        // the schema/tooling tests rely on it. Set inline so it lands in the
-        // server process environment regardless of parent inheritance.
-        // OPcache is off in the CLI SAPI, so without -d every one of the ~1200
-        // requests this suite makes recompiles the whole bootstrap (49ms -> 30ms).
+        // MAHO_GRAPHQL_INTROSPECTION: off in production, but the schema/tooling tests
+        // query __schema/__type. PHP_CLI_SERVER_WORKERS: the built-in server is
+        // single-threaded, so a browser's parallel asset requests would serialize.
+        // OPcache: off in the CLI SAPI, so without -d every request recompiles the
+        // whole bootstrap, ~500 files (49ms -> 30ms).
         $cmd = sprintf(
-            'MAHO_GRAPHQL_INTROSPECTION=1 php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1'
-            . ' -d opcache.revalidate_freq=0 -S %s:%d -t public %s > /tmp/maho-test-api-server.log 2>&1 & echo $!',
-            $host,
+            'MAHO_GRAPHQL_INTROSPECTION=1 PHP_CLI_SERVER_WORKERS=%d'
+            . ' php -d opcache.enable_cli=1 -d opcache.validate_timestamps=1'
+            . ' -d opcache.revalidate_freq=0 -S %s:%d -t public %s > /tmp/maho-test-server.log 2>&1 & echo $!',
+            (int) (getenv('MAHO_BROWSER_WORKERS') ?: 8),
+            $bindHost,
             $port,
             $router,
         );
         $pid = (int) trim((string) shell_exec($cmd));
         if ($pid <= 0) {
-            echo "⚠ Could not start API test server; Api/V2 HTTP tests will skip.\n";
+            echo "⚠ Could not start the test server; HTTP tests will skip.\n";
             return;
         }
-        $this->apiServerPid = $pid;
+        $this->serverPid = $pid;
 
         for ($i = 0; $i < 40; $i++) {
+            // Check liveness before the probe. The shell reports a pid for a backgrounded
+            // process that then exits, so a port already held by a stale server would
+            // otherwise answer the probe and the whole run would silently test that
+            // server (and its database) instead of ours.
+            if (!$this->isServerAlive()) {
+                $this->serverPid = null;
+                echo "✗ Test server exited instead of binding {$bindHost}:{$port}:\n";
+                echo trim((string) shell_exec('tail -5 /tmp/maho-test-server.log 2>/dev/null')) . "\n";
+                throw new Exception("Test server could not bind {$bindHost}:{$port}");
+            }
             $probe = shell_exec(sprintf(
                 'curl -s -o /dev/null -w "%%{http_code}" %s/api/rest/v2/store-config 2>/dev/null',
                 escapeshellarg($baseUrl),
             ));
             if ((int) trim((string) $probe) > 0) {
-                echo "✓ API test server up at {$baseUrl}\n";
+                echo "✓ Test server up at {$baseUrl}\n";
                 return;
             }
             usleep(250000);
         }
-        echo "⚠ API test server did not become ready; Api/V2 HTTP tests may skip.\n";
+        echo "⚠ Test server did not become ready; HTTP tests may skip.\n";
     }
 
-    private function stopApiServer(): void
+    private function isServerAlive(): bool
     {
-        if ($this->apiServerPid !== null) {
-            shell_exec('kill ' . $this->apiServerPid . ' 2>/dev/null');
-            $this->apiServerPid = null;
+        return $this->serverPid !== null
+            && trim((string) shell_exec('kill -0 ' . $this->serverPid . ' 2>&1')) === '';
+    }
+
+    private function stopServer(): void
+    {
+        if ($this->serverPid !== null) {
+            // Kill the workers too: an orphan keeps the port, and the next run would
+            // then probe green against a server bound to a different database.
+            shell_exec('pkill -P ' . $this->serverPid . ' 2>/dev/null');
+            shell_exec('kill ' . $this->serverPid . ' 2>/dev/null');
+            $this->serverPid = null;
         }
     }
 


### PR DESCRIPTION
Stacked on #1397. Review that one first; this PR's base is `speed-up-pest-suite`, so the diff here is only the server change.

The run started two built-in servers: one on `127.0.0.1:8080` with `tests/router.php` for the Api suite, and one on the install URL via `./maho serve` for the Browser suite. They differ only in the router, and keeping them apart cost more than the extra process.

Both suites need `base_url` to name the origin they talk to. `redirect_to_base` bounces a request whose host differs, and `JwtService::getIssuer()` derives the issuer from `base_url`, so a token signed against another origin 401s. So the run rewrote `base_url` twice, two `config:set` calls and a `cache:flush` each, and the Browser suite only worked because the Api suite had run first and moved it. That ordering rule was load-bearing and written down only in a comment in `MahoServer`.

Now one server runs on the host:port the store was installed with, so `base_url` is never rewritten. `MahoServer` reuses a server that is already listening and starts one only for a bare `vendor/bin/pest` run.

### Two bugs this surfaced, both fixed here

**Orphaned servers.** `MahoServer` ran `./maho serve`, which `passthru`'s `php -S`. `Process::stop()` signalled the wrapper, leaving the real server and its eight workers alive and holding the port. I hit this directly: nine orphans from an earlier run survived, and my next full run probed green against them and reported 715 failures, because it was testing a server bound to a different database. It now spawns `php -S` directly, so `stop()` signals the server itself, and the runner reaps the workers too.

**A readiness probe that accepted any listener.** That is what let the orphans pass as healthy. The probe now checks our own process is still alive before trusting the port, so a failure to bind is reported with the server log instead of silently hidden.

### Verification

Run locally against SQLite, sandbox and currency-live excluded:

| Suite | Result |
|---|---|
| Api | 891 passed, 3 skipped, 0 failed (2656 requests reached the server) |
| Browser | 13 passed, 12 risky, 0 failed |

The 12 risky are pre-existing output-buffer warnings, unchanged from before. No orphaned processes after either run.

The time saving is small, maybe 5 to 8 seconds from the dropped `base_url` rewrites. The point is removing the ordering coupling and the two bugs above.