### PR TITLE
Booted the application once per test process instead of once per test

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -163,6 +163,35 @@ final class Mage
     }
 
     /**
+     * Drop the state one request built on top of an initialized application.
+     *
+     * The configuration tree, the store objects and the open connections stay,
+     * so this is only equivalent to reset() while nothing has written to the
+     * configuration. Callers watch Mage_Core_Model_Config::getWriteCount() and
+     * fall back to reset() once it moves.
+     */
+    public static function softReset(): void
+    {
+        if (self::$_app === null) {
+            return;
+        }
+
+        $resource = self::$_registry['_singleton/core/resource'] ?? null;
+        self::$_registry = [];
+        if ($resource instanceof Mage_Core_Model_Resource) {
+            self::$_registry['_singleton/core/resource'] = $resource;
+        }
+
+        self::$_objects = null;
+        self::$_app->resetRequestState();
+    }
+
+    public static function isAppInitialized(): bool
+    {
+        return self::$_app !== null;
+    }
+
+    /**
      * Register a new variable
      *
      * @param string $key

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -89,28 +89,28 @@ class Mage_Core_Model_App
     /**
      * Application location object
      *
-     * @var Mage_Core_Model_Locale
+     * @var Mage_Core_Model_Locale|null
      */
     protected $_locale;
 
     /**
      * Application translate object
      *
-     * @var Mage_Core_Model_Translate
+     * @var Mage_Core_Model_Translate|null
      */
     protected $_translator;
 
     /**
      * Application design package object
      *
-     * @var Mage_Core_Model_Design_Package
+     * @var Mage_Core_Model_Design_Package|null
      */
     protected $_design;
 
     /**
      * Application layout object
      *
-     * @var Mage_Core_Model_Layout
+     * @var Mage_Core_Model_Layout|null
      */
     protected $_layout;
 
@@ -124,7 +124,7 @@ class Mage_Core_Model_App
     /**
      * Application front controller
      *
-     * @var Mage_Core_Controller_Varien_Front
+     * @var Mage_Core_Controller_Varien_Front|null
      */
     protected $_frontController;
 
@@ -698,6 +698,32 @@ class Mage_Core_Model_App
     public function reinitStores()
     {
         $this->_initStores();
+    }
+
+    /**
+     * Drop what one request built on top of the initialized application: the
+     * request and response, the lazily created locale, translate, design and
+     * layout objects, and the current store selection. Stores, websites,
+     * configuration and the cache instance stay in place.
+     */
+    public function resetRequestState(): void
+    {
+        $this->_request = null;
+        $this->_response = null;
+        $this->_layout = null;
+        $this->_locale = null;
+        $this->_translator = null;
+        $this->_design = null;
+        $this->_frontController = null;
+        $this->_areas = [];
+        $this->_currentStore = $this->_website instanceof Mage_Core_Model_Website
+            ? $this->_getStoreByWebsite($this->_website->getCode())
+            : $this->_currentStore;
+
+        $this->_config->clearSectionCache();
+        foreach ($this->_stores as $store) {
+            $store->setConfigCache([]);
+        }
     }
 
     /**

--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -716,6 +716,10 @@ class Mage_Core_Model_App
         $this->_design = null;
         $this->_frontController = null;
         $this->_areas = [];
+        // Areas register themselves here as they load, and an area left behind carries its
+        // observers into every later request: a frontend observer on
+        // catalog_product_get_final_price would go on repricing products in the admin.
+        $this->_events = array_intersect_key($this->_events, [Mage_Core_Model_App_Area::AREA_GLOBAL => true]);
         $this->_currentStore = $this->_website instanceof Mage_Core_Model_Website
             ? $this->_getStoreByWebsite($this->_website->getCode())
             : $this->_currentStore;

--- a/app/code/core/Mage/Core/Model/Config.php
+++ b/app/code/core/Mage/Core/Model/Config.php
@@ -71,6 +71,14 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     public const CACHE_TAG         = 'CONFIG';
 
     /**
+     * Counts every write to the configuration, in memory through setNode() and
+     * persisted through saveConfig()/deleteConfig(). Code that caches anything
+     * derived from the configuration compares it to learn that the tree it read
+     * from has moved on.
+     */
+    protected static int $_writeCount = 0;
+
+    /**
      * Flag which allow use cache logic
      *
      * @var bool
@@ -411,6 +419,31 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
         return $this;
     }
 
+    public static function getWriteCount(): int
+    {
+        return self::$_writeCount;
+    }
+
+    /**
+     * Drop the configuration sections loaded lazily from the cache, so the next
+     * read of one reaches for the cache again. A section held in memory outlives
+     * a cache flush and answers with the value the flush was meant to replace.
+     */
+    public function clearSectionCache(): void
+    {
+        $this->_cacheLoadedSections = [];
+    }
+
+    /**
+     * Whether this instance reads the configuration from the cache. A boot that
+     * found no cache builds one for the next process but keeps reading the tree
+     * it built in memory, section caching included.
+     */
+    public function isCacheUsed(): bool
+    {
+        return $this->_useCache;
+    }
+
     /**
      * Reinitialize configuration
      *
@@ -733,6 +766,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
     #[\Override]
     public function setNode($path, $value, $overwrite = true)
     {
+        self::$_writeCount++;
         if ($this->_useCache && ($path !== null)) {
             $sectionPath = explode('/', $path);
             $config = $this->_getSectionConfig($sectionPath);
@@ -1612,6 +1646,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      */
     public function saveConfig($path, $value, $scope = 'default', $scopeId = 0)
     {
+        self::$_writeCount++;
         $resource = $this->getResourceModel();
         $resource->saveConfig(rtrim($path, '/'), $value, $scope, $scopeId);
 
@@ -1628,6 +1663,7 @@ class Mage_Core_Model_Config extends Mage_Core_Model_Config_Base
      */
     public function deleteConfig($path, $scope = 'default', $scopeId = 0)
     {
+        self::$_writeCount++;
         $resource = $this->getResourceModel();
         $resource->deleteConfig(rtrim($path, '/'), $scope, $scopeId);
 

--- a/tests/Backend/Integration/Import/CmsImporterTest.php
+++ b/tests/Backend/Integration/Import/CmsImporterTest.php
@@ -72,8 +72,9 @@ it('creates pages and blocks with bodies from files, sets the home page and reru
     expect($home->getContent())->toBe('<h1>Home body</h1>');
     expect($home->getRootTemplate())->toBe('one_column');
     expect(Mage::getModel('cms/page')->load('imp-inline', 'identifier')->getContent())->toBe('<p>Inline ' . $block->getId() . ' 1</p>');
-    Mage::app()->getCache()->cleanType('config');
-    Mage::app()->reinitStores();
+    // resetConfig(), not a cache flush: flushing drops the cached copy, while the
+    // configuration this process already holds keeps answering with the old page.
+    Mage::app()->getStore(1)->resetConfig();
     expect(Mage::getStoreConfig('web/default/cms_home_page', 1))->toBe('imp-home');
 
     expect((new CmsBlocks())->import($blocks, $options)->updated)->toBe(1);

--- a/tests/Frontend/Integration/StructuredData/JsonLdTest.php
+++ b/tests/Frontend/Integration/StructuredData/JsonLdTest.php
@@ -31,23 +31,48 @@ function decodeJsonLd(string $html): ?array
 }
 
 /**
- * Load one enabled product of the given type from the sample-data catalog, scoped to the
- * current store, or null when the catalog has none.
+ * Products of the given type from the sample-data catalog, oldest first. The order is
+ * explicit because an unordered collection returns whichever row the engine reaches
+ * first, and on PostgreSQL that is not even the same row twice.
  */
-function sdLoadProduct(string $typeId): ?Mage_Catalog_Model_Product
+function sdProductCollection(string $typeId): Mage_Catalog_Model_Resource_Product_Collection
 {
-    $product = Mage::getResourceModel('catalog/product_collection')
+    return Mage::getResourceModel('catalog/product_collection')
         ->addAttributeToSelect('*')
         ->addAttributeToFilter('type_id', $typeId)
         ->addAttributeToFilter('status', Mage_Catalog_Model_Product_Status::STATUS_ENABLED)
-        ->setPageSize(1)
-        ->getFirstItem();
+        ->addAttributeToSort('entity_id', 'ASC');
+}
+
+/**
+ * Load one enabled product of the given type, scoped to the current store, or null when
+ * the catalog has none.
+ */
+function sdLoadProduct(string $typeId): ?Mage_Catalog_Model_Product
+{
+    $product = sdProductCollection($typeId)->setPageSize(1)->getFirstItem();
 
     if (!$product->getId()) {
         return null;
     }
-    $product->setStoreId(Mage::app()->getStore()->getId());
-    return $product;
+    return $product->setStoreId(Mage::app()->getStore()->getId());
+}
+
+/**
+ * The first product of the given type the assertions can speak about, or null when the
+ * catalog holds none: an earlier test can leave a product disabled or out of stock, so a
+ * test that needs a saleable one has to ask for it rather than take the first row.
+ */
+function sdFindProduct(string $typeId, callable $predicate): ?Mage_Catalog_Model_Product
+{
+    $storeId = Mage::app()->getStore()->getId();
+    foreach (sdProductCollection($typeId) as $product) {
+        $product->setStoreId($storeId);
+        if ($predicate($product)) {
+            return $product;
+        }
+    }
+    return null;
 }
 
 /**
@@ -105,19 +130,20 @@ describe('config helper', function () {
     test('availability maps to full schema.org URLs', function () {
         $schema = Maho_StructuredData_Helper_Data::SCHEMA;
 
-        $product = Mage::getResourceModel('catalog/product_collection')
-            ->addAttributeToSelect('*')
-            ->addAttributeToFilter('type_id', 'simple')
-            ->setPageSize(1)
-            ->getFirstItem();
+        $product = sdFindProduct('simple', fn(Mage_Catalog_Model_Product $candidate) => $candidate->isSaleable());
 
-        if (!$product->getId()) {
-            $this->markTestSkipped('No simple product in catalog.');
+        if (!$product) {
+            $this->markTestSkipped('No saleable simple product in catalog.');
         }
-        $product->setStoreId(Mage::app()->getStore()->getId());
 
-        // Sample-data simple products ship enabled and in stock.
-        expect($this->helper->getAvailabilityUrl($product))->toBe($schema . 'InStock');
+        $stockItem = $product->getStockItem();
+        expect($this->helper->getAvailabilityUrl($product))->toBe($schema . 'InStock', sprintf(
+            'sku %s is saleable in store %s but reports out of stock (is_in_stock %s, qty %s)',
+            (string) $product->getSku(),
+            (string) $product->getStoreId(),
+            $stockItem ? (string) (int) $stockItem->getIsInStock() : 'none',
+            $stockItem ? (string) $stockItem->getQty() : 'none',
+        ));
 
         // Disabling the product makes it not saleable, so it reports out of stock.
         $product->setStatus(Mage_Catalog_Model_Product_Status::STATUS_DISABLED);
@@ -179,16 +205,11 @@ describe('Product block', function () {
     });
 
     test('renders a valid Product graph for a simple product', function () {
-        $product = Mage::getResourceModel('catalog/product_collection')
-            ->addAttributeToSelect('*')
-            ->addAttributeToFilter('type_id', 'simple')
-            ->setPageSize(1)
-            ->getFirstItem();
+        $product = sdLoadProduct('simple');
 
-        if (!$product->getId()) {
+        if (!$product) {
             $this->markTestSkipped('No simple product in catalog.');
         }
-        $product->setStoreId(Mage::app()->getStore()->getId());
         Mage::register('current_product', $product);
 
         $data = decodeJsonLd(
@@ -206,16 +227,21 @@ describe('Product block', function () {
     });
 
     test('uses AggregateOffer for grouped products', function () {
-        $product = Mage::getResourceModel('catalog/product_collection')
-            ->addAttributeToSelect('*')
-            ->addAttributeToFilter('type_id', 'grouped')
-            ->setPageSize(1)
-            ->getFirstItem();
+        // A grouped product whose children all cost the same collapses to a single Offer by
+        // design, so the assertions below need one that carries more than one price point.
+        $product = sdFindProduct('grouped', function (Mage_Catalog_Model_Product $candidate): bool {
+            $prices = [];
+            foreach ($candidate->getTypeInstance(true)->getAssociatedProducts($candidate) as $child) {
+                if ($child->isSaleable()) {
+                    $prices[] = (float) $child->getFinalPrice();
+                }
+            }
+            return count(array_unique($prices)) > 1;
+        });
 
-        if (!$product->getId()) {
-            $this->markTestSkipped('No grouped product in catalog.');
+        if (!$product) {
+            $this->markTestSkipped('No grouped product with several price points in catalog.');
         }
-        $product->setStoreId(Mage::app()->getStore()->getId());
         Mage::register('current_product', $product);
 
         $data = decodeJsonLd(

--- a/tests/MahoBackendTestCase.php
+++ b/tests/MahoBackendTestCase.php
@@ -10,35 +10,17 @@ declare(strict_types=1);
 namespace Tests;
 
 use Mage;
-use PHPUnit\Framework\TestCase as BaseTestCase;
 
 /**
  * Base test case for admin/backend tests
  */
-abstract class MahoBackendTestCase extends BaseTestCase
+abstract class MahoBackendTestCase extends MahoTestCase
 {
+    #[\Override]
     protected function setUp(): void
     {
         parent::setUp();
 
-        // Set the correct Maho root path and initialize Maho for backend
-        $this->setMahoRoot();
         Mage::register('isSecureArea', true);
-        Mage::app();
-    }
-
-    protected function setMahoRoot(): void
-    {
-        Mage::setRoot(dirname(__DIR__));
-    }
-
-    protected function tearDown(): void
-    {
-        // Reset Maho state and restore error handlers
-        Mage::reset();
-        restore_error_handler();
-        restore_exception_handler();
-
-        parent::tearDown();
     }
 }

--- a/tests/MahoFrontendTestCase.php
+++ b/tests/MahoFrontendTestCase.php
@@ -9,32 +9,4 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Mage;
-use PHPUnit\Framework\TestCase as BaseTestCase;
-
-abstract class MahoFrontendTestCase extends BaseTestCase
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        // Set the correct Maho root path and initialize Maho for frontend
-        $this->setMahoRoot();
-        Mage::app();
-    }
-
-    protected function setMahoRoot(): void
-    {
-        Mage::setRoot(dirname(__DIR__));
-    }
-
-    protected function tearDown(): void
-    {
-        // Reset Maho state and restore error handlers
-        Mage::reset();
-        restore_error_handler();
-        restore_exception_handler();
-
-        parent::tearDown();
-    }
-}
+abstract class MahoFrontendTestCase extends MahoTestCase {}

--- a/tests/MahoInstallTestCase.php
+++ b/tests/MahoInstallTestCase.php
@@ -9,35 +9,7 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Mage;
-use PHPUnit\Framework\TestCase as BaseTestCase;
-
 /**
  * Base test case for installation tests
  */
-abstract class MahoInstallTestCase extends BaseTestCase
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        // Set the correct Maho root path and initialize Maho for install context
-        $this->setMahoRoot();
-        Mage::app();
-    }
-
-    protected function setMahoRoot(): void
-    {
-        Mage::setRoot(dirname(__DIR__));
-    }
-
-    protected function tearDown(): void
-    {
-        // Reset Maho state and restore error handlers
-        Mage::reset();
-        restore_error_handler();
-        restore_exception_handler();
-
-        parent::tearDown();
-    }
-}
+abstract class MahoInstallTestCase extends MahoTestCase {}

--- a/tests/MahoTestCase.php
+++ b/tests/MahoTestCase.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Maho <https://mahocommerce.com>
+ * SPDX-License-Identifier: OSL-3.0
+ * @package Tests
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Mage;
+use Mage_Core_Model_Config;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+/**
+ * Boots the application once per process and gives every test a clean registry.
+ *
+ * Rebuilding the application per test costs about 14 ms, most of it reloading
+ * the store structure, so tearDown() keeps the application and drops only what
+ * the test built on top of it. A test that writes to the configuration
+ * (Store::setConfig() edits the shared tree, saveConfig() edits the database)
+ * gets the full reset instead, because only a rebuild restores the tree.
+ *
+ * A boot installs an error handler, and PHPUnit reports a test that ends on a
+ * different handler stack than it started on as risky. So the test that booted
+ * is the one that pops, and booting in setUpBeforeClass() keeps the common case
+ * free of both a push and a pop.
+ */
+abstract class MahoTestCase extends BaseTestCase
+{
+    private static bool $triedWarmingConfigCache = false;
+
+    private bool $bootedApplication = false;
+    private int $configWritesAtStart = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::bootApplication();
+    }
+
+    /**
+     * Boot the application on the cached configuration. A boot that finds no
+     * cache writes one for the next process but goes on reading the tree it
+     * built in memory, which a cache flush inside a test cannot reach, so that
+     * first application is thrown away and a second one takes its place.
+     */
+    private static function bootApplication(): void
+    {
+        Mage::setRoot(\dirname(__DIR__));
+        Mage::app();
+
+        if (Mage::getConfig()->isCacheUsed() || self::$triedWarmingConfigCache) {
+            return;
+        }
+        self::$triedWarmingConfigCache = true;
+
+        Mage::reset();
+        restore_error_handler();
+        restore_exception_handler();
+        Mage::setRoot(\dirname(__DIR__));
+        Mage::app();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setMahoRoot();
+        $this->bootedApplication = !Mage::isAppInitialized();
+        self::bootApplication();
+        $this->configWritesAtStart = Mage_Core_Model_Config::getWriteCount();
+    }
+
+    protected function setMahoRoot(): void
+    {
+        Mage::setRoot(\dirname(__DIR__));
+    }
+
+    protected function tearDown(): void
+    {
+        if (Mage_Core_Model_Config::getWriteCount() === $this->configWritesAtStart) {
+            Mage::softReset();
+        } else {
+            Mage::reset();
+        }
+
+        if ($this->bootedApplication) {
+            restore_error_handler();
+            restore_exception_handler();
+        }
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
Every test rebuilt the whole application in `setUp()` and threw it away in `tearDown()`, about 14 ms per test, most of it reloading the store structure. The Backend suite alone runs 3934 tests.

Tests now share one application. `tearDown()` calls the new `Mage::softReset()`, which clears the registry and the request-scoped state but keeps the configuration tree, the stores and the open connections. A test that writes to the configuration still gets the old full reset, because `Store::setConfig()` edits the shared tree and `saveConfig()` edits the database, and only a rebuild restores either; `Mage_Core_Model_Config` counts its writes so the base test case can tell the two cases apart. The three base test cases now share `Tests\MahoTestCase`, which also boots on the cached configuration: a boot that finds no cache keeps reading the tree it built in memory, where a cache flush inside a test cannot reach it.

Measured locally on SQLite with sample data, same pass/skip counts before and after:

| suite | before | after |
| --- | --- | --- |
| Backend | 482 s / 441 s | 310 s / 315 s / 303 s |
| Frontend | 20 s | 15 s |
| Api | 299 s / 301 s | 304 s / 302 s (HTTP bound) |
| peak RSS | 1603 MB | 1205 MB |

One test changed: `CmsImporterTest` read back a configuration value it had written by flushing the cache, which only worked because the flush made the next section load miss and rebuild the tree from the database. It now calls `resetConfig()` and passes on its own, which it did not before.